### PR TITLE
fix: card internal padding

### DIFF
--- a/libs/core-css/src/lib/styles/card-group/card-group.scss
+++ b/libs/core-css/src/lib/styles/card-group/card-group.scss
@@ -6,7 +6,7 @@
     vertical-align: top;
 
     .card-group-title {
-      font-size: 28px;
+      font-size: 24px;
       font-weight: bold;
       color: $goa-black;
     }

--- a/libs/core-css/src/lib/styles/card/card.scss
+++ b/libs/core-css/src/lib/styles/card/card.scss
@@ -8,7 +8,7 @@
   transition: opacity 300ms ease-in-out;
 
   .card-content {
-    padding: 24px 16px;
+    padding: 28px 16px;
     border-top: 8px solid $goa-blue-alberta;
 
     .goa-title,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11400938/133486417-184e847f-cbb2-4bcf-9496-3d6d3212caf5.png)
![image](https://user-images.githubusercontent.com/11400938/133486442-1fcda438-0cd0-46c3-a43b-1c68ed2ee382.png)

The card in the storybook uses small buttons which add 12px on top - if a regular button was used, the width between text and additional content (ie buttons) would be 28px