### PR TITLE
fix : remove prop-type in element-loader

### DIFF
--- a/libs/react-components/src/lib/element-loader/element-loader.tsx
+++ b/libs/react-components/src/lib/element-loader/element-loader.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import './element-loader.scss';
 
 export interface ElementLoaderProps {
@@ -90,11 +89,4 @@ export const GoAElementLoader = ({
       </svg>
     )
   );
-};
-
-GoAElementLoader.propTypes = {
-  visible: PropTypes.bool,
-  baseColour: PropTypes.string,
-  spinnerColour: PropTypes.string,
-  size: PropTypes.number,
 };


### PR DESCRIPTION
There is error in Create tenant page when element loader be called, the pr will fix the exception.


![image](https://user-images.githubusercontent.com/58053108/137367904-2ae47d4f-24a9-48cd-a0a3-fd771f10a9a7.png)
