### PR TITLE
chore: move badge styles to v2

### DIFF
--- a/libs/core-css/src/lib/styles/v2/badge.scss
+++ b/libs/core-css/src/lib/styles/v2/badge.scss
@@ -1,0 +1,67 @@
+@import './colors.scss';
+@import './values.scss';
+
+// This is a global class so that the class name isn't converted to a
+// generated value for encapsulation.
+:global .goa-badge-icon {
+  font-size: var(--fs-sm);
+}
+
+.goa-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.25rem;
+  padding: 0 0.5rem;
+  gap: 0.25rem;
+}
+
+.goa-badge + .goa-badge {
+  margin-left: 0.25rem;
+}
+
+.goa-badge-content {
+  text-transform: capitalize;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-regular);
+  line-height: var(--lh-base);
+}
+
+.goa-badge.badge-information {
+  background-color: var(--color-gray-100);
+  color: var(--color-tealblue-900);
+}
+
+.goa-badge.badge-success {
+  background-color: var(--color-green-500);
+  color: var(--color-white);
+}
+
+.goa-badge.badge-warning {
+  background-color: var(--color-orange-500);
+  color: var(--color-black);
+}
+
+.goa-badge.badge-emergency {
+  background-color: var(--color-red-500);
+  color: var(--color-white);
+}
+
+.goa-badge.badge-dark {
+  background-color: var(--color-black);
+  color: var(--color-white);
+}
+
+.goa-badge.badge-midtone {
+  background-color: var(--color-gray-600);
+  color: var(--color-white);
+}
+
+.goa-badge.badge-light {
+  background-color: var(--color-white);
+  color: var(--color-black);
+}
+
+.goa-badge.badge-inactive {
+  background-color: var(--color-white);
+  color: var(--color-black);
+}

--- a/libs/core-css/src/lib/styles/v2/colors.scss
+++ b/libs/core-css/src/lib/styles/v2/colors.scss
@@ -5,6 +5,7 @@
   --color-gray-100: #f1f1f1;
   --color-gray-200: #dcdcdc;
   --color-gray-500: #adadad;
+  --color-gray-600: #767676;
   --color-gray-700: #666;
   --color-gray-900: #333;
 

--- a/libs/react-components/src/experimental/badge/badge.module.scss
+++ b/libs/react-components/src/experimental/badge/badge.module.scss
@@ -1,1 +1,1 @@
-@import '../../../../core-css/src/lib/styles/badge/badge.scss';
+@import '../../../../core-css/src/lib/styles/v2/badge.scss';


### PR DESCRIPTION
Use the v2 variables in badge styles.

![image](https://user-images.githubusercontent.com/41582/138327353-a285099b-224c-436d-9447-bfb8c7b8f66a.png)
