### PR TITLE
chore: revert license text copyright template text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-2021 Government of Alberta
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Note that the copyright template in the license text is part of the appendix of the Apache 2.0 license and not the actual copyright notice for the files in the repository.

The appendix provides instructions on how to apply a copyright notice (NOTICE file in the repo), but this is not a requirement of applying the Apache 2.0 licence. It is a requirement for Apache foundation repositories under Apache 2.0. 

For this repository, don't worry about the copyright notices for now.

This reverts commit b6e90df8bbc6b863982fc9e844e95f03e7b6ed8e.