### PR TITLE
Update checkbox.scss

### DIFF
--- a/libs/core-css/src/lib/styles/checkbox/checkbox.scss
+++ b/libs/core-css/src/lib/styles/checkbox/checkbox.scss
@@ -27,6 +27,7 @@ $goa-checkbox-target-size: 46px;
   height: $goa-checkbox-target-size;
   display: flex;
   align-items: center;
+  flex:1;
 }
 
 @mixin goa-checkbox {


### PR DESCRIPTION
checkbox gets smaller than all the others. The reason :the label text for that checkbox is so long that it needs to be wrapped in the next line.
to fix this issue we need to add flex:1 to the checkbox label.