### PR TITLE
fix: context-store state issue

### DIFF
--- a/libs/web-components/src/components/dropdown/types.ts
+++ b/libs/web-components/src/components/dropdown/types.ts
@@ -1,17 +1,25 @@
-export interface BindSelectedMessage {
-  type:  "onPropChange";
+import type { Message } from "../../common/context-store";
+
+export const INIT = "init";
+export const INIT_RESPONSE = "init-response";
+export const CHANGE = "change";
+export const SELECT = "select";
+export const FILTER = "filter";
+
+export interface BindSelectedMessage extends Message {
+  type: "change";
   multiSelect: boolean;
   values: string[];
 }
 
-export interface ChangeSelectedMessage {
-  type:  "onChange";
+export interface ChangeSelectedMessage extends Message {
+  type:  "init-response" | "select";
   value: string;
   label: string;
   selected: boolean;
 }
 
-export interface ChangeFilterMessage {
-  type:  "onFilterChange";
+export interface ChangeFilterMessage extends Message {
+  type:  "filter";
   filter: string;
 }

--- a/libs/web-components/src/components/radio-group/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-group/RadioItem.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { getContext, ContextStore } from '../../common/context-store';
-  import type { RadioMessage } from "./types";
+  import { PROP_CHANGE, OPTION_CHANGE, RadioMessage } from "./types";
 
   export let value: string;
   export let label: string;
@@ -19,10 +19,15 @@
 
   onMount(() => {
     ctx = getContext(name);
-    ctx.subscribe<RadioMessage>("propChange", (state) => {
-      checked = state.value === value;
-      disabled = state.disabled;
-      error = state.error;
+    ctx.subscribe((state) => {
+      switch (state?.type) {
+        case PROP_CHANGE: {
+          const _state = state as RadioMessage;
+          checked = _state.value === value;
+          disabled = _state.disabled;
+          error = _state.error;
+        }
+      }
     });
   });
 
@@ -31,7 +36,8 @@
   function onChange(e) {
     checked = !checked;
     if (checked) {
-      ctx.notify("optionChange", {
+      ctx.notify({
+        type: OPTION_CHANGE,
         checked,
         disabled,
         value,

--- a/libs/web-components/src/components/radio-group/types.ts
+++ b/libs/web-components/src/components/radio-group/types.ts
@@ -1,5 +1,10 @@
-export interface RadioMessage {
-  type: "propChange" | "optionChange";
+import type { Message } from "../../common/context-store";
+
+export const PROP_CHANGE = "prop-change";
+export const OPTION_CHANGE = "option-change";
+
+export interface RadioMessage extends Message {
+  type: "prop-change" | "option-change";
   value: string;
   disabled?: boolean;
   error?: boolean;


### PR DESCRIPTION
The previous attempt at having a context store subscription unsubscribe
from itself after the first callback is handled worked in tests, but
fell apart when outside the tests and storybook.