### PR TITLE
fix(#638): use height rather than line-height

### DIFF
--- a/libs/styles/src/lib/vars.css
+++ b/libs/styles/src/lib/vars.css
@@ -43,6 +43,8 @@
   --input-border-radius: 0.25rem;
   --input-font-size: var(--fs-base);
 
+  --button-height: 2.625rem;  /* 42px */
+
   /* colors */
   --color-white: #fff;
   --color-black: #333;

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -60,7 +60,7 @@
     cursor: pointer;
     font-size: var(--fs-base, 1rem);
     font-weight: 700;
-    line-height: 2.375rem;
+    height: var(--button-height);
     padding: 0 0.75rem;
 
     display: flex;


### PR DESCRIPTION
The previously use line-height resulted in a different overall height
due to the difference in border-width used between the different buttons