### PR TITLE
fix: prevent radio and checkboxes from getting squishing

### DIFF
--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -115,6 +115,9 @@
     display: flex;
     justify-content: center;
     padding: 3px;
+
+    /* prevent squishing of checkbox */
+    flex: 0 0 auto; 
   }
   .goa-checkbox-container svg {
     fill: var(--color-white);

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -141,6 +141,9 @@
     border-radius: 50%;
     background-color: #fff;
     transition: box-shadow 100ms ease-in-out;
+
+    /* prevent squishing of radio button */
+    flex: 0 0 auto; 
   }
 
   .goa-radio:focus > input:not(:disabled) ~ .goa-radio-icon {


### PR DESCRIPTION
https://github.com/GovAlta/ui-components/issues/720

Before
![image](https://user-images.githubusercontent.com/41582/171505647-76a058e2-bf98-4617-a9d1-8f17f66460a4.png)
![image](https://user-images.githubusercontent.com/41582/171506287-b54daa0a-8db6-4845-ba78-9dc0824ef3d2.png)


After
![image](https://user-images.githubusercontent.com/41582/171506100-9f705e92-4700-468f-99e8-0f13674f0bd3.png)
![image](https://user-images.githubusercontent.com/41582/171506214-e147d1ab-51a3-4c35-a5b6-f70bf40ec1ac.png)