### PR TITLE
fix: show the user set title for the goa-icon and goa-icon-button

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ storybook-new:
 	cp libs/docs/src/_stories.mdx.template libs/docs/src/components/common/$(name).stories.mdx
 
 
+demo:
+	cd libs/web-components && npm run demo
+
 # TEST
 
 

--- a/libs/web-components/demo/src/App.svelte
+++ b/libs/web-components/demo/src/App.svelte
@@ -632,7 +632,7 @@
     </goa-button-group>
 
     <h2 id="section-icon-buttons">Icon Buttons</h2>
-    <goa-icon-button type="close" />
+    <goa-icon-button type="close" title="Close this thing" />
     <goa-icon-button type="close" variant="nocolor" />
 
     <h2 id="section-icon-buttons">Icon Buttons (Inverted)</h2>
@@ -641,7 +641,7 @@
     </div>
 
     <h2 id="section-icons">Icons</h2>
-    <goa-icon type="close" />
+    <goa-icon type="close" title="Closing Time" />
     <goa-icon size="small" type="close-circle" theme="filled" />
     <goa-icon size="medium" type="close-circle" theme="filled" />
     <goa-icon size="large" type="close-circle" theme="filled" />

--- a/libs/web-components/src/components/icon-button/IconButton.svelte
+++ b/libs/web-components/src/components/icon-button/IconButton.svelte
@@ -41,13 +41,13 @@
 
 <button
   style="--size: {_size}"
-  {title}
+  title={title}
   disabled={isDisabled}
   class={css}
   data-testid={testId}
   on:click={handleClick}
 >
-  <goa-icon {type} {size} {theme} inverted={isInverted} />
+  <goa-icon title={title} {type} {size} {theme} inverted={isInverted} />
 </button>
 
 <style>

--- a/libs/web-components/src/components/icon/Icon.svelte
+++ b/libs/web-components/src/components/icon/Icon.svelte
@@ -426,13 +426,17 @@
 <script lang="ts">
   import { toBoolean } from "../../common/utils";
 
+  // required
   export let type: GoAIconType;
+
+  // optional
   export let size: IconSize = "medium";
   export let theme: IconTheme = "outline";
   export let inverted: string;
   export let fillcolor: string;
   export let hovercolor: string;
   export let opacity: number = 1;
+  export let title: string = "";
 
   $: isInverted = toBoolean(inverted);
 
@@ -447,6 +451,7 @@
   class="goa-icon"
   class:inverted={isInverted}
   data-testid={`icon-${type}`}
+  title={title}
   style={`
     --size: ${_size};
     --fill-color: ${fillcolor};
@@ -455,8 +460,7 @@
   `}
 >
   {#if type}
-    <ion-icon style="width: 100%; height: 100%;" name={theme === "filled" ? type : `${type}-${theme}`}
-    />
+    <ion-icon name={theme === "filled" ? type : `${type}-${theme}`} />
   {/if}
 </div>
 
@@ -464,6 +468,12 @@
   :host {
     display: inline-flex;
     align-items: center;
+  }
+
+  ion-icon {
+    pointer-events: none; 
+    width: 100%; 
+    height: 100%;
   }
 
   .goa-icon {


### PR DESCRIPTION
There are a couple filed bugs on the ionic icons github for this issue.
To make things work on our side the pointer events are disabled on the
`ion-icon` component to allow our title to override it.

https://goa-dio.atlassian.net/browse/DDIDS-594