### PR TITLE
fix: remove web-component dependency from react lib

### DIFF
--- a/libs/docs/src/react-setup.stories.mdx
+++ b/libs/docs/src/react-setup.stories.mdx
@@ -23,6 +23,7 @@ Add Dependencies
 
 ```bash
 npm i @abgov/react-components@alpha
+npm i @abgov/web-components@alpha
 npm i @abgov/styles@alpha
 ```
 

--- a/libs/react-components/package.json
+++ b/libs/react-components/package.json
@@ -16,9 +16,6 @@
     "url": "https://github.com/GovAlta/ui-components.git",
     "directory": "libs/react-components"
   },
-  "dependencies": {
-    "@abgov/web-components": "^1.0.0-alpha.23"
-  },
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
For now the web component dependency will need to be added manually
until we release a 1.0 version