### PR TITLE
fix(DDI-969): Adding more examples of datetime input in stories

### DIFF
--- a/apps/angular-demo/src/app/input-component/input-component.component.html
+++ b/apps/angular-demo/src/app/input-component/input-component.component.html
@@ -14,12 +14,11 @@
 <goa-input name="foo" type="number"></goa-input>
 
 <h3>Date and time</h3>
-<goa-input name="foo" type="date"></goa-input>
-<goa-input name="foo" type="datetime-local"></goa-input>
-<goa-input name="foo" type="time"></goa-input>
-<goa-input name="foo" type="time" min="" max=""></goa-input>
+<goa-input name="foo" type="date" [value]="formatDate"></goa-input>
+<goa-input name="datetime" type="datetime-local" [value]="dateTime"></goa-input>
+<goa-input name="time" type="time" [value]="time" step="1"></goa-input>
 
-<goa-input type="date" name="Date with min max" [value]="valueDate" [min]="minDate" (_change)="onChange($event)"></goa-input>
+<goa-input type="date" name="Date with min max" [value]="formatDate" [min]="minDate" [max]="maxDate"></goa-input>
 
 <h3>Icon Buttons</h3>
 <goa-input

--- a/apps/angular-demo/src/app/input-component/input-component.component.ts
+++ b/apps/angular-demo/src/app/input-component/input-component.component.ts
@@ -7,12 +7,14 @@ import { format } from "date-fns";
   styleUrls: ['./input-component.component.css']
 })
 export class InputComponentComponent {
-
   constructor() { }
 
-  valueDate = format(new Date(), "yyyy-MM-dd");
-  minDate = format(new Date(), "yyyy-MM-dd");
-  maxDate = this.getDateWithMonthOffset(1);
+  date = new Date();
+  formatDate = format(this.date, "yyyy-MM-dd");
+  time = format(this.date, "HH:mm:ss");
+  dateTime = format(this.date, "yyyy-MM-dd HH:mm")
+  minDate = format(this.date, "yyyy-MM-dd");
+  maxDate = format(this.getDateWithMonthOffset(1), "yyyy-MM-dd");
 
   getDateWithMonthOffset(offset: number) {
     const d = new Date();
@@ -26,9 +28,5 @@ export class InputComponentComponent {
 
   handleTrailingIconClick() {
     console.log('handleTrailingIconClick');
-  }
-
-  onChange(e: any) {
-    this.valueDate = e.detail.value;
   }
 }

--- a/apps/react-demo/src/routes/input.tsx
+++ b/apps/react-demo/src/routes/input.tsx
@@ -65,6 +65,7 @@ export default function Input() {
         name="Time from string mm:ss value"
         value={format(date, "hh:mm")}
         onChange={noop}
+        step={1}
       />
 
       Time with a min and max 

--- a/libs/docs/src/components/common/Input.stories.mdx
+++ b/libs/docs/src/components/common/Input.stories.mdx
@@ -474,7 +474,7 @@ export const MinMaxTemplate = () => {
   </Tab>
 </Tabs>
 
-#### Date and time
+#### Date
 
 export const DateTemplate = () => {
   const [date, setDate] = useState(new Date());
@@ -496,7 +496,7 @@ export const DateTemplate = () => {
   )
 };
 
-<Story name="Date and time">
+<Story name="Date">
   {DateTemplate.bind({})}
 </Story>
 
@@ -508,7 +508,7 @@ export const DateTemplate = () => {
         export class MyComponent {
           date = format(new Date(), "yyyy-MM-dd");
           minDate = format(new Date(), "yyyy-MM-dd");
-          maxDate = this.getDateWithMonthOffset(1);
+          maxDate = format(this.getDateWithMonthOffset(1), "yyyy-MM-dd");
           getDateWithMonthOffset(offset) {
             const d = new Date();
             d.setMonth(d.getMonth() + offset);
@@ -522,14 +522,17 @@ export const DateTemplate = () => {
       lang="ts"
     />
     <CodeSnippet
-      code={`<goa-input
-        type="date"
-        name="withinTheNextMonth"
-        [min]="minDate"
-        [max]="maxDate"
-        [value]="date"
-        (_change)="onChange($event)">
-      </goa-input>`}
+      code={`
+        <goa-input
+          type="date"
+          name="withinTheNextMonth"
+          [min]="minDate"
+          [max]="maxDate"
+          [value]="date"
+          (_change)="onChange($event)"
+        >
+        </goa-input>
+      `}
       lang="html"
     />
   </Tab>
@@ -551,6 +554,121 @@ export const DateTemplate = () => {
             min={minDate}
             max={maxDate}
             onChange={(name, value) => setDate(value)}
+          />
+        )
+      `}
+      lang="tsx"
+    />
+  </Tab>
+</Tabs>
+
+#### Time
+
+Note: you can use the `step` attribute < 60 to allow for seconds
+
+export const TimeTemplate = () => {
+  const [date, setDate] = useState(new Date());
+  return (
+    <GoAInputTime
+      name="timeExample"
+      value={date}
+      step="1"
+    />
+  )
+};
+
+<Story name="Time">
+  {TimeTemplate.bind({})}
+</Story>
+
+<Tabs>
+  <Tab label="Angular">
+    <CodeSnippet
+      code={`
+        import { format } from "date-fns";
+        export class MyComponent {
+          time = format(new Date(), "HH:mm:ss");
+        }
+      `}
+      lang="ts"
+    />
+    <CodeSnippet
+      code={`
+        <goa-input
+          type="time"
+          name="timeExample"
+          [value]="time"
+          step="1"
+        >
+        </goa-input>
+      `}
+      lang="html"
+    />
+  </Tab>
+  <Tab label="React">
+    <CodeSnippet
+      code={`
+        const [date, setDate] = useState(new Date());
+        return (
+          <GoAInputTime
+            name="timeExample"
+            value={date}
+            step="1"
+          />
+        )
+      `}
+      lang="tsx"
+    />
+  </Tab>
+</Tabs>
+
+#### Date and Time
+
+export const DateTimeTemplate = () => {
+  const [date, setDate] = useState(new Date());
+  return (
+    <GoAInputDateTime
+      name="dateTimeExample"
+      value={date}
+    />
+  )
+};
+
+<Story name="Date and Time">
+  {DateTimeTemplate.bind({})}
+</Story>
+
+<Tabs>
+  <Tab label="Angular">
+    <CodeSnippet
+      code={`
+        import { format } from "date-fns";
+        export class MyComponent {
+          dateTime = format(new Date(), "yyyy-MM-dd HH:mm")
+        }
+      `}
+      lang="ts"
+    />
+    <CodeSnippet
+      code={`
+        <goa-input
+          type="datetime-local"
+          name="dateTimeExample"
+          [value]="date"
+        >
+        </goa-input>
+      `}
+      lang="html"
+    />
+  </Tab>
+  <Tab label="React">
+    <CodeSnippet
+      code={`
+        const [date, setDate] = useState(new Date());
+        return (
+          <GoAInputDateTime
+            name="dateTimeExample"
+            value={date}
           />
         )
       `}


### PR DESCRIPTION
Also updated the angular demo to include values in the input boxes. And updated the react demo to have seconds in one of the time inputs