### PR TITLE
chore: Remove web components from storybook overview page

### DIFF
--- a/libs/docs/src/main.stories.mdx
+++ b/libs/docs/src/main.stories.mdx
@@ -22,10 +22,6 @@ If you are using Angular check out the [Angular setup docs](./?path=/docs/setup-
 
 If you are using React check out the [React setup docs](./?path=/docs/setup-react--page)
 
-## Web Components
-
-If you are using simple html check out the [Web component setup docs](./?path=/docs/setup-web-component--page)
-
 ## UI Developers
 
 If you need to set up your environment because you are new to our team or you just want to contribute check out the [Development setup docs](./?path=/docs/setup-development--page)


### PR DESCRIPTION
Removed web components from storybook overview page, as we actually have no link to web components setup documentation, so it was a dead link anyways.