### PR TITLE
fix(DDI-960): Modified the container storybook page

### DIFF
--- a/apps/angular-demo/src/app/container/container.component.html
+++ b/apps/angular-demo/src/app/container/container.component.html
@@ -8,14 +8,14 @@
 
 
 <h2>Large accent bar</h2>
-<goa-container headingsize="large">
+<goa-container accentbar="large">
   <h2>Heading</h2>
   Content
 </goa-container>
 
 
 <h2>Small accent bar</h2>
-<goa-container headingsize="small">
+<goa-container accentbar="small">
   <h2>Heading</h2>
   Content
 </goa-container>
@@ -50,7 +50,7 @@
     <goa-button type="primary" size="compact">Assign to me</goa-button>
   </div>
   <h2>Custom H2</h2>
-  <goa-container type="primary" headingsize="small">
+  <goa-container type="primary" accentbar="small">
     <div>This is a sub container</div>
   </goa-container>
 </goa-container>
@@ -58,7 +58,7 @@
 
 <h2>Interactive</h2>
 <goa-container>
-  title="The container title" headingsize="large" type="primary" >
+  title="The container title" accentbar="large" type="primary" >
   <div slot="actions">
     <goa-button type="secondary" size="compact">Assign to me</goa-button>
   </div>

--- a/apps/angular-demo/src/app/container/container.component.html
+++ b/apps/angular-demo/src/app/container/container.component.html
@@ -8,14 +8,14 @@
 
 
 <h2>Large accent bar</h2>
-<goa-container accentbar="large">
+<goa-container accent="thick">
   <h2>Heading</h2>
   Content
 </goa-container>
 
 
 <h2>Small accent bar</h2>
-<goa-container accentbar="small">
+<goa-container accent="thin">
   <h2>Heading</h2>
   Content
 </goa-container>
@@ -50,15 +50,14 @@
     <goa-button type="primary" size="compact">Assign to me</goa-button>
   </div>
   <h2>Custom H2</h2>
-  <goa-container type="primary" accentbar="small">
+  <goa-container accent="thing">
     <div>This is a sub container</div>
   </goa-container>
 </goa-container>
 
 
 <h2>Interactive</h2>
-<goa-container>
-  title="The container title" accentbar="large" type="primary" >
+<goa-container title="The container title" accent="thick">
   <div slot="actions">
     <goa-button type="secondary" size="compact">Assign to me</goa-button>
   </div>
@@ -68,7 +67,7 @@
 
 
 <h2>Non-interactive</h2>
-<goa-container>
+<goa-container type="non-interactive">
   <h2>Heading</h2>
   Content
 </goa-container>

--- a/apps/angular-demo/src/app/container/container.component.html
+++ b/apps/angular-demo/src/app/container/container.component.html
@@ -50,7 +50,7 @@
     <goa-button type="primary" size="compact">Assign to me</goa-button>
   </div>
   <h2>Custom H2</h2>
-  <goa-container accent="thing">
+  <goa-container accent="thin">
     <div>This is a sub container</div>
   </goa-container>
 </goa-container>

--- a/libs/docs/src/components/common/Container.stories.mdx
+++ b/libs/docs/src/components/common/Container.stories.mdx
@@ -37,36 +37,14 @@ import {
   <Prop
     name="type"
     type="interactive | info | error | success | important | non-interactive"
-    defaultValue="non-interactive"
+    defaultValue="interactive"
     description="Choose the type of container the type of the accent bar"
   />
   <Prop
-    name="backgroundcolour"
-    lang="angular"
-    type="boolean"
-    defaultValue="false"
-    description="Gives the container background a colour"
-  />
-  <Prop
-    name="backgroundColour"
-    lang="react"
-    type="boolean"
-    defaultValue="false"
-    description="Gives the container background a colour"
-  />
-  <Prop
-    name="accentbar"
-    lang="angular"
-    type="large | small | none"
-    defaultValue="large"
-    description="Set the size of the accent bar"
-  />
-  <Prop
-    name="accentBar"
-    lang="react"
-    type="large | small | none"
-    defaultValue="large"
-    description="Set the size of the accent bar"
+    name="accent"
+    type="thick | thin | filled"
+    defaultValue="filled"
+    description="Sets the style of accent on the container"
   />
   <Prop
     name="padding"
@@ -76,110 +54,70 @@ import {
   />
   <Prop
     name="title"
-    type="string"
+    type="slot"
+    lang="angular"
     defaultValue=""
-    description="Sets the content in the top bar of a container"
+    description="Sets the content in the top left of the accent bar"
+  />
+  <Prop
+    name="title"
+    type="ReactNode"
+    lang="react"
+    defaultValue=""
+    description="Sets the content in the top left of the accent bar"
+  />
+  <Prop
+    name="action"
+    type="slot"
+    lang="angular"
+    defaultValue=""
+    description="Sets the content in the top right of the accent bar"
+  />
+  <Prop
+    name="action"
+    type="ReactNode"
+    lang="react"
+    defaultValue=""
+    description="Sets the content in the top right of the accent bar"
   />
 </Props>
 
-#### Basic, interactive, non-interactive
+#### Container types
 
-There are three main types of containers; interactive, non-interactive, and basic. Each of these 3 types of containers includes several possible types.
-
-#### Basic Container
-
-<Story name="Basic">
-  <GoAContainer accentBar="none">
-    <h2>Detach to use</h2>+ Add things inside me
-  </GoAContainer>
-  <GoAContainer backgroundColour={true} accentBar="none">
-    <h2>Detach to use</h2>
-    + Add things inside me
-  </GoAContainer>
-</Story>
-
-The basic container can be used on it’s own or within interactive or non-interactive containers.
-
-<Tabs>
-  <Tab label="Web Component" hidden={true}>
-    <CodeSnippet
-      lang="html"
-      code={`
-      <goa-container accentbar="none">
-        <h2>Detach to use</h2>
-        + Add things inside me
-      </goa-container>
-    `}
-    />
-  </Tab>
-  <Tab label="Angular">
-    <CodeSnippet
-      lang="html"
-      code={`
-      <goa-container accentbar="none">
-        <h2>Detach to use</h2>
-        + Add things inside me
-      </goa-container>
-    `}
-    />
-  </Tab>
-  <Tab label="React">
-    <CodeSnippet
-      lang="jsx"
-      code={`
-      <GoAContainer accentBar="none">
-        <h2>Detach to use</h2>
-        + Add things inside me
-      </GoAContainer>
-    `}
-    />
-  </Tab>
-</Tabs>
-
-#### Interactive Container
-
-<Story name="Interactive">
-  <GoAContainer type="interactive">
-    <h2>Heading</h2>
-    Content
-  </GoAContainer>
-</Story>
-
-Interactive containers to indicate that the content within is an action for the user to take. Use a blue accent to indicate that there is content in the container that needs to be interacted with.
-
-<Tabs>
-  <Tab label="Angular">
-    <CodeSnippet
-      lang="html"
-      code={`
-      <goa-container type="interactive">
-        <h2>Heading</h2>
-        Content
-      </goa-container>
-    `}
-    />
-  </Tab>
-  <Tab label="React">
-    <CodeSnippet
-      lang="jsx"
-      code={`
-      <GoAContainer type="interactive">
-        <h2>Heading</h2>
-        Content
-      </GoAContainer>
-    `}
-    />
-  </Tab>
-</Tabs>
-
-#### Non-interactive Container
-
-Non-interactive containers indicate that the content is only for the user to review. Use a grey accent to indicate that there is content in the container and that the content is not interactive.
-
-<Story name="Non-interactive">
-  <GoAContainer type="non-interactive">
-    <h2>Heading</h2>
-    Content
+<Story name="Container types">
+  <GoAFlexRow gap="medium">
+    <GoAContainer>
+      <h2>Interactive container</h2>
+      Content
+    </GoAContainer>
+    <GoAContainer type="non-interactive">
+      <h2>Non-Interactive container</h2>
+      Content
+    </GoAContainer>
+  </GoAFlexRow>
+  <GoAFlexRow gap="medium">
+    <GoAContainer type="info">
+      <h2>Info Container</h2>
+      Content
+    </GoAContainer>
+    <GoAContainer type="error">
+      <h2>Error Container</h2>
+      Content
+    </GoAContainer>
+  </GoAFlexRow>
+  <GoAFlexRow gap="medium">
+    <GoAContainer type="success">
+      <h2>Success Container</h2>
+      Content
+    </GoAContainer>
+    <GoAContainer type="important">
+      <h2>Important Container</h2>
+      Content
+    </GoAContainer>
+  </GoAFlexRow>
+  <GoAContainer accent="thin" type="interactive">
+    <h2>Interactive Container w/ Header</h2>
+    If you use an accent, the background colour won't be filled in
   </GoAContainer>
 </Story>
 
@@ -188,29 +126,89 @@ Non-interactive containers indicate that the content is only for the user to rev
     <CodeSnippet
       lang="html"
       code={`
-      <goa-container type="non-interactive">
-        <h2>Heading</h2>
-        Content
-      </goa-container>
-    `}
+        <goa-flex-row gap="medium">
+          <goa-container>
+            <h2>Interactive Container</h2>
+            Content
+          </goa-container>
+          <goa-container type="non-interactive">
+            <h2>Non-Interactive Container</h2>
+            Content
+          </goa-container>
+        </goa-flex-row>
+        <goa-flex-row gap="medium">
+          <goa-container type="info">
+            <h2>Info Container</h2>
+            Content
+          </goa-container>
+          <goa-container type="error">
+            <h2>Error Container</h2>
+            Content
+          </goa-container>
+        </goa-flex-row>
+        <goa-flex-row>
+          <goa-container type="success">
+            <h2>Success Container</h2>
+            Content
+          </goa-container>
+          <goa-container type="important">
+            <h2>Important Container</h2>
+            Content
+          </goa-container>
+        </goa-flex-row>
+        <goa-container accent="thin" type="success">
+          <h2>Success Container w/ Header</h2>
+          If you use an accent, the background colour won't be filled in
+        </goa-container>
+      `}
     />
   </Tab>
   <Tab label="React">
     <CodeSnippet
       lang="jsx"
       code={`
-      <GoAContainer type="non-interactive">
-        <h2>Heading</h2>
-        Content
-      </GoAContainer>
-    `}
+        <GoAFlexRow gap="medium">
+          <GoAContainer>
+            <h2>Interactive Container</h2>
+            Content
+          </GoAContainer>
+          <GoAContainer type="non-interactive">
+            <h2>Non-Interactive Container</h2>
+            Content
+          </GoAContainer>
+        </GoAFlexRow>
+        <GoAFlexRow gap="medium">
+          <GoAContainer type="info">
+            <h2>Info Container</h2>
+            Content
+          </GoAContainer>
+          <GoAContainer type="error">
+            <h2>Error Container</h2>
+            Content
+          </GoAContainer>
+        </GoAFlexRow>
+        <GoAFlexRow gap="medium">
+          <GoAContainer type="success">
+            <h2>Success Container</h2>
+            Content
+          </GoAContainer>
+          <GoAContainer type="important">
+            <h2>Important Container</h2>
+            Content
+          </GoAContainer>
+        </GoAFlexRow>
+        <GoAContainer accent="thin" type="success">
+          <h2>Success Container w/ Header</h2>
+          If you use an accent, the background colour won't be filled in
+        </GoAContainer>
+      `}
     />
   </Tab>
 </Tabs>
 
-#### Heading bar types (large, small, with text)
+#### Heading bar types (thick, thin, with text)
 
-There are three main types within the interactive and non-interactive container types: a large accent bar, a small accent bar, and an accent bar with text.
+There are three main types of headers within the interactive and non-interactive container types: a thick bar at the top, a thin bar at the top, and with text.
 
 export const HeadingTemplate = (args) => {
   return (
@@ -221,15 +219,15 @@ export const HeadingTemplate = (args) => {
   );
 };
 
-#### Use the large heading bar container for "primary" content.
+#### Use the thick accent bar container for "primary" content.
 
-<Story name="Large heading bar">
+<Story name="Thick accent bar">
   <GoAFlexRow gap="medium">
-    <GoAContainer type="interactive">
+    <GoAContainer accent="thick">
       <h2>Heading</h2>
       Content
     </GoAContainer>
-    <GoAContainer type="non-interactive">
+    <GoAContainer type="non-interactive" accent="thick">
       <h2>Heading</h2>
       Content
     </GoAContainer>
@@ -242,11 +240,11 @@ export const HeadingTemplate = (args) => {
       lang="html"
       code={`
         <goa-flex-row gap="medium">
-          <goa-container type="interactive">
+          <goa-container accent="thick">
             <h2>Heading</h2>
             Content
           </goa-container>
-          <goa-container type="non-interactive">
+          <goa-container type="non-interactive" accent="thick">
             <h2>Heading</h2>
             Content
           </goa-container>
@@ -259,11 +257,11 @@ export const HeadingTemplate = (args) => {
       lang="jsx"
       code={`
         <GoAFlexRow gap="medium">
-          <GoAContainer type="interactive">
+          <GoAContainer accent="thick">
             <h2>Heading</h2>
             Content
           </GoAContainer>
-          <GoAContainer type="non-interactive">
+          <GoAContainer type="non-interactive" accent="thick">
             <h2>Heading</h2>
             Content
           </GoAContainer>
@@ -273,16 +271,16 @@ export const HeadingTemplate = (args) => {
   </Tab>
 </Tabs>
 
-#### Use the small accent bar container for "secondary" content.
+#### Use the thin accent bar container for "secondary" content.
 
-<Story name="Small heading bar">
+<Story name="Thin accent bar">
   <>
     <GoAFlexRow gap="medium">
-      <GoAContainer type="interactive" accentBar="small">
+      <GoAContainer accent="thin">
         <h2>Heading</h2>
         Content
       </GoAContainer>
-      <GoAContainer type="non-interactive" accentBar="small">
+      <GoAContainer type="non-interactive" accent="thin">
         <h2>Heading</h2>
         Content
       </GoAContainer>
@@ -296,11 +294,11 @@ export const HeadingTemplate = (args) => {
       lang="html"
       code={`
         <goa-flex-row gap="medium">
-          <goa-container type="interactive" accentbar="small">
+          <goa-container accent="thin">
             <h2>Heading</h2>
             Content
           </goa-container>
-          <goa-container type="non-interactive" accentbar="small">
+          <goa-container type="non-interactive" accent="thin">
             <h2>Heading</h2>
             Content
           </goa-container>
@@ -313,11 +311,11 @@ export const HeadingTemplate = (args) => {
       lang="jsx"
       code={`
         <GoAFlexRow gap="medium">
-          <GoAContainer type="interactive" accentBar="small">
+          <GoAContainer accent="thin">
             <h2>Heading</h2>
             Content
           </GoAContainer>
-          <GoAContainer type="non-interactive" accentBar="small">
+          <GoAContainer type="non-interactive" accent="thin">
             <h2>Heading</h2>
             Content
           </GoAContainer>
@@ -327,16 +325,17 @@ export const HeadingTemplate = (args) => {
   </Tab>
 </Tabs>
 
-#### Use the accent bar with text for groupings of content where status or actions need to be applied to the whole container.
+#### Use the accent bar for groupings of content where status or actions need to be applied to the whole container.
 
-<Story name="Accent bar with text">
+<Story name="Accent bar with content">
   <>
     <GoAFlexRow gap="medium">
-      <GoAContainer type="interactive" title="Heading" >
+      <GoAContainer accent="thick" title="Heading">
         Content
       </GoAContainer>
       <GoAContainer
         type="non-interactive"
+        accent="thick"
         title="Heading"
         actions={<GoABadge type="success" content="Badge Text" icon={true} />}
       >
@@ -351,7 +350,7 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="html"
       code={`
-      <goa-container accentbar="large">
+      <goa-container>
         <h2>Heading</h2>
         Content
       </goa-container>
@@ -363,11 +362,12 @@ export const HeadingTemplate = (args) => {
       lang="html"
       code={`
         <goa-flex-row gap="medium">
-          <goa-container type="interactive" title="Heading" >
+          <goa-container accent="thick" title="Heading" >
             Content
           </goa-container>
           <goa-container
             type="non-interactive"
+            accent="thick"
             title="Heading"
           >
             <goa-badge slot="actions" type="success" content="Badge Text" icon="true" />
@@ -382,11 +382,12 @@ export const HeadingTemplate = (args) => {
       lang="jsx"
       code={`
         <GoAFlexRow gap="medium">
-          <GoAContainer type="interactive" title="Heading" >
+          <GoAContainer accent="thick" title="Heading">
             Content
           </GoAContainer>
           <GoAContainer
             type="non-interactive"
+            accent="thick"
             title="Heading"
             actions={
               <GoABadge type="success" content="Badge Text" icon={true} />
@@ -395,46 +396,6 @@ export const HeadingTemplate = (args) => {
             Content
           </GoAContainer>
         </GoAFlexRow>
-    `}
-    />
-  </Tab>
-</Tabs>
-
-#### Alternate colour for basic container
-
-<Story name="Alternate colour">
-  <GoAFlexRow gap="medium">
-    <GoAContainer backgroundColour={true} accentBar="none">
-      <h2>Non-interactive Container</h2>
-      Content
-    </GoAContainer>
-    <GoAContainer type="info" backgroundColour={true} accentBar="none">
-      <h2>Info Container</h2>
-      Content
-    </GoAContainer>
-  </GoAFlexRow>
-</Story>
-
-<Tabs>
-  <Tab label="Angular">
-    <CodeSnippet
-      lang="html"
-      code={`
-      <goa-container backgroundcolour accentbar="none">
-        <h2>Heading</h2>
-        Content
-      </goa-container>
-    `}
-    />
-  </Tab>
-  <Tab label="React">
-    <CodeSnippet
-      lang="jsx"
-      code={`
-        <GoAContainer backgroundColour={true} accentBar="none">
-          <h2>Heading</h2>
-          Content
-        </GoAContainer>
     `}
     />
   </Tab>
@@ -454,11 +415,11 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="html"
       code={`
-      <goa-container padding="compact">
-        <h2>Heading</h2>
-        Content
-      </goa-container>
-    `}
+        <goa-container padding="compact">
+          <h2>Heading</h2>
+          Content
+        </goa-container>
+      `}
     />
   </Tab>
   <Tab label="React">
@@ -474,13 +435,13 @@ export const HeadingTemplate = (args) => {
   </Tab>
 </Tabs>
 
-#### Additional examples (interactive container with content and basic container inside, non-interactive container with content and grey basic container inside)
+#### Container with container inside
 
-<Story name="Interactive container with basic container inside">
-  <GoAContainer>
+<Story name="Container with container inside">
+  <GoAContainer accent="thick">
     <h2>Heading</h2>
     <p>Content</p>
-    <GoAContainer accentBar="none">
+    <GoAContainer type="non-interactive">
       <h2>Heading</h2>
       <p>Content</p>
     </GoAContainer>
@@ -492,10 +453,10 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="html"
       code={`
-      <goa-container>
+      <goa-container accent="thick">
         <h2>Heading</h2>
         <p>Content</p>
-        <goa-container accentbar="none">
+        <goa-container type="non-interactive">
           <h2>Heading</h2>
           <p>Content</p>
         </goa-container>
@@ -507,10 +468,10 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="jsx"
       code={`
-        <GoAContainer>
+        <GoAContainer accent="thick">
           <h2>Heading</h2>
           <p>Content</p>
-          <GoAContainer accentBar="none">
+          <GoAContainer type="non-interactive">
             <h2>Heading</h2>
             <p>Content</p>
           </GoAContainer>
@@ -520,10 +481,10 @@ export const HeadingTemplate = (args) => {
   </Tab>
 </Tabs>
 
-#### Non-interactive container with complex content and basic grey container inside
+#### Container with complex content
 
-<Story name="Non-interactive container with complex content">
-  <GoAContainer>
+<Story name="Container with complex content">
+  <GoAContainer type="non-interactive">
     <h2>Heading</h2>
     <table width="100%">
       <tr>
@@ -546,20 +507,6 @@ export const HeadingTemplate = (args) => {
       Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum
       Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident.
     </GoACallout>
-    <GoAContainer accentBar="none" backgroundColour={true}>
-      <GoAFlexRow>
-        <section>
-          Topic
-          <br />
-          <strong>Content</strong>
-        </section>
-        <section>
-          Topic
-          <br />
-          <strong>Content</strong>
-        </section>
-      </GoAFlexRow>
-    </GoAContainer>
   </GoAContainer>
 </Story>
 
@@ -568,7 +515,7 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="html"
       code={`
-        <goa-container>
+        <goa-container type="non-interactive">
           <h2>Heading</h2>
           <table width="100%">
             <tr>
@@ -588,20 +535,6 @@ export const HeadingTemplate = (args) => {
           <goa-callout type="important">
             Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.
           </goa-callout>
-          <goa-container accentbar="none" backgroundcolour>
-            <goa-flex-row>
-              <section>
-                Topic
-                <br/>
-                <strong>Content</strong>
-              </section>
-              <section>
-                Topic
-                <br/>
-                <strong>Content</strong>
-              </section>
-            </goa-flex-row>
-          </goa-container>
         </goa-container>
     `}
     />
@@ -610,7 +543,7 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="jsx"
       code={`
-        <GoAContainer>
+        <GoAContainer type="non-interactive">
           <h2>Heading</h2>
           <table width="100%">
             <tr>
@@ -630,20 +563,6 @@ export const HeadingTemplate = (args) => {
           <GoACallout type="important">
             Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.
           </GoACallout>
-          <GoAContainer accentBar="none" backgroundColour={true}>
-            <GoAFlexRow>
-              <section>
-                Topic
-                <br/>
-                <strong>Content</strong>
-              </section>
-              <section>
-                Topic
-                <br/>
-                <strong>Content</strong>
-              </section>
-            </GoAFlexRow>
-          </GoAContainer>
         </GoAContainer>
     `}
     />

--- a/libs/docs/src/components/common/Container.stories.mdx
+++ b/libs/docs/src/components/common/Container.stories.mdx
@@ -57,28 +57,28 @@ import {
     type="slot"
     lang="angular"
     defaultValue=""
-    description="Sets the content in the top left of the accent bar"
+    description="Sets the content in the left of the accent bar"
   />
   <Prop
     name="title"
     type="ReactNode"
     lang="react"
     defaultValue=""
-    description="Sets the content in the top left of the accent bar"
+    description="Sets the content in the left of the accent bar"
   />
   <Prop
     name="action"
     type="slot"
     lang="angular"
     defaultValue=""
-    description="Sets the content in the top right of the accent bar"
+    description="Sets the content in the right of the accent bar"
   />
   <Prop
     name="action"
     type="ReactNode"
     lang="react"
     defaultValue=""
-    description="Sets the content in the top right of the accent bar"
+    description="Sets the content in the right of the accent bar"
   />
 </Props>
 
@@ -206,7 +206,7 @@ import {
   </Tab>
 </Tabs>
 
-#### Heading bar types (thick, thin, with text)
+#### Accent bar types (thick, thin, with text)
 
 There are three main types of headers within the interactive and non-interactive container types: a thick bar at the top, a thin bar at the top, and with text.
 

--- a/libs/docs/src/components/common/Container.stories.mdx
+++ b/libs/docs/src/components/common/Container.stories.mdx
@@ -41,30 +41,44 @@ import {
     description="Choose the type of container the type of the accent bar"
   />
   <Prop
-    name="colored"
+    name="backgroundcolour"
+    lang="angular"
     type="boolean"
     defaultValue="false"
     description="Gives the container background a colour"
   />
   <Prop
-    name="headingsize"
+    name="backgroundColour"
+    lang="react"
+    type="boolean"
+    defaultValue="false"
+    description="Gives the container background a colour"
+  />
+  <Prop
+    name="accentbar"
     lang="angular"
     type="large | small | none"
     defaultValue="large"
-    description="set the size of the accent bar"
+    description="Set the size of the accent bar"
   />
   <Prop
-    name="headingSize"
+    name="accentBar"
     lang="react"
     type="large | small | none"
     defaultValue="large"
-    description="set the size of the accent bar"
+    description="Set the size of the accent bar"
   />
   <Prop
     name="padding"
     type="relaxed | compact"
     defaultValue="relaxed"
-    description="sets the amount of white space in the container"
+    description="Sets the amount of white space in the container"
+  />
+  <Prop
+    name="title"
+    type="string"
+    defaultValue=""
+    description="Sets the content in the top bar of a container"
   />
 </Props>
 
@@ -75,10 +89,10 @@ There are three main types of containers; interactive, non-interactive, and basi
 #### Basic Container
 
 <Story name="Basic">
-  <GoAContainer>
+  <GoAContainer accentBar="none">
     <h2>Detach to use</h2>+ Add things inside me
   </GoAContainer>
-  <GoAContainer colored={true}>
+  <GoAContainer backgroundColour={true} accentBar="none">
     <h2>Detach to use</h2>
     + Add things inside me
   </GoAContainer>
@@ -91,7 +105,7 @@ The basic container can be used on it’s own or within interactive or non-inter
     <CodeSnippet
       lang="html"
       code={`
-      <goa-container>
+      <goa-container accentbar="none">
         <h2>Detach to use</h2>
         + Add things inside me
       </goa-container>
@@ -102,7 +116,7 @@ The basic container can be used on it’s own or within interactive or non-inter
     <CodeSnippet
       lang="html"
       code={`
-      <goa-container>
+      <goa-container accentbar="none">
         <h2>Detach to use</h2>
         + Add things inside me
       </goa-container>
@@ -113,7 +127,7 @@ The basic container can be used on it’s own or within interactive or non-inter
     <CodeSnippet
       lang="jsx"
       code={`
-      <GoAContainer>
+      <GoAContainer accentBar="none">
         <h2>Detach to use</h2>
         + Add things inside me
       </GoAContainer>
@@ -264,11 +278,11 @@ export const HeadingTemplate = (args) => {
 <Story name="Small heading bar">
   <>
     <GoAFlexRow gap="medium">
-      <GoAContainer type="interactive" headingSize="small">
+      <GoAContainer type="interactive" accentBar="small">
         <h2>Heading</h2>
         Content
       </GoAContainer>
-      <GoAContainer type="non-interactive" headingSize="small">
+      <GoAContainer type="non-interactive" accentBar="small">
         <h2>Heading</h2>
         Content
       </GoAContainer>
@@ -282,11 +296,11 @@ export const HeadingTemplate = (args) => {
       lang="html"
       code={`
         <goa-flex-row gap="medium">
-          <goa-container type="interactive" headingSize="small">
+          <goa-container type="interactive" accentbar="small">
             <h2>Heading</h2>
             Content
           </goa-container>
-          <goa-container type="non-interactive" headingSize="small">
+          <goa-container type="non-interactive" accentbar="small">
             <h2>Heading</h2>
             Content
           </goa-container>
@@ -299,11 +313,11 @@ export const HeadingTemplate = (args) => {
       lang="jsx"
       code={`
         <GoAFlexRow gap="medium">
-          <GoAContainer type="interactive" headingSize="small">
+          <GoAContainer type="interactive" accentBar="small">
             <h2>Heading</h2>
             Content
           </GoAContainer>
-          <GoAContainer type="non-interactive" headingSize="small">
+          <GoAContainer type="non-interactive" accentBar="small">
             <h2>Heading</h2>
             Content
           </GoAContainer>
@@ -337,7 +351,7 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="html"
       code={`
-      <goa-container headingsize="large">
+      <goa-container accentbar="large">
         <h2>Heading</h2>
         Content
       </goa-container>
@@ -386,15 +400,15 @@ export const HeadingTemplate = (args) => {
   </Tab>
 </Tabs>
 
-#### Alternate colour for default container
+#### Alternate colour for basic container
 
 <Story name="Alternate colour">
   <GoAFlexRow gap="medium">
-    <GoAContainer colored={true} headingSize="none">
+    <GoAContainer backgroundColour={true} accentBar="none">
       <h2>Non-interactive Container</h2>
       Content
     </GoAContainer>
-    <GoAContainer type="info" colored={true} headingSize="none">
+    <GoAContainer type="info" backgroundColour={true} accentBar="none">
       <h2>Info Container</h2>
       Content
     </GoAContainer>
@@ -406,7 +420,7 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="html"
       code={`
-      <goa-container colored>
+      <goa-container backgroundcolour accentbar="none">
         <h2>Heading</h2>
         Content
       </goa-container>
@@ -417,7 +431,7 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="jsx"
       code={`
-        <GoAContainer colored={true} headingSize="none">
+        <GoAContainer backgroundColour={true} accentBar="none">
           <h2>Heading</h2>
           Content
         </GoAContainer>
@@ -463,10 +477,10 @@ export const HeadingTemplate = (args) => {
 #### Additional examples (interactive container with content and basic container inside, non-interactive container with content and grey basic container inside)
 
 <Story name="Interactive container with basic container inside">
-  <GoAContainer headingSize="large">
+  <GoAContainer>
     <h2>Heading</h2>
     <p>Content</p>
-    <GoAContainer headingSize="none">
+    <GoAContainer accentBar="none">
       <h2>Heading</h2>
       <p>Content</p>
     </GoAContainer>
@@ -481,7 +495,7 @@ export const HeadingTemplate = (args) => {
       <goa-container>
         <h2>Heading</h2>
         <p>Content</p>
-        <goa-container headingsize="none">
+        <goa-container accentbar="none">
           <h2>Heading</h2>
           <p>Content</p>
         </goa-container>
@@ -493,10 +507,10 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="jsx"
       code={`
-        <GoAContainer headingSize="large">
+        <GoAContainer>
           <h2>Heading</h2>
           <p>Content</p>
-          <GoAContainer headingSize="none">
+          <GoAContainer accentBar="none">
             <h2>Heading</h2>
             <p>Content</p>
           </GoAContainer>
@@ -509,7 +523,7 @@ export const HeadingTemplate = (args) => {
 #### Non-interactive container with complex content and basic grey container inside
 
 <Story name="Non-interactive container with complex content">
-  <GoAContainer headingSize="large">
+  <GoAContainer>
     <h2>Heading</h2>
     <table width="100%">
       <tr>
@@ -532,7 +546,7 @@ export const HeadingTemplate = (args) => {
       Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum
       Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident.
     </GoACallout>
-    <GoAContainer headingSize="none" colored={true}>
+    <GoAContainer accentBar="none" backgroundColour={true}>
       <GoAFlexRow>
         <section>
           Topic
@@ -554,7 +568,7 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="html"
       code={`
-        <goa-container headingSize="large">
+        <goa-container>
           <h2>Heading</h2>
           <table width="100%">
             <tr>
@@ -574,7 +588,7 @@ export const HeadingTemplate = (args) => {
           <goa-callout type="important">
             Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.
           </goa-callout>
-          <goa-container headingSize="none" colored={true}>
+          <goa-container accentbar="none" backgroundcolour>
             <goa-flex-row>
               <section>
                 Topic
@@ -596,7 +610,7 @@ export const HeadingTemplate = (args) => {
     <CodeSnippet
       lang="jsx"
       code={`
-        <GoAContainer headingSize="large">
+        <GoAContainer>
           <h2>Heading</h2>
           <table width="100%">
             <tr>
@@ -616,7 +630,7 @@ export const HeadingTemplate = (args) => {
           <GoACallout type="important">
             Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat.
           </GoACallout>
-          <GoAContainer headingSize="none" colored={true}>
+          <GoAContainer accentBar="none" backgroundColour={true}>
             <GoAFlexRow>
               <section>
                 Topic

--- a/libs/docs/src/components/common/OneColumLayout.stories.mdx
+++ b/libs/docs/src/components/common/OneColumLayout.stories.mdx
@@ -8,7 +8,7 @@ import { GoAOneColumnLayout, GoAMicrositeHeader, GoAPageBlock, GoAAppHeader, GoA
 
 ### A one column layout to use as a starting point for your page.
 
-[Figma design component](https://www.figma.com/file/???)
+[Figma design component](https://www.figma.com/file/ylmHeuDMfxnDBnP1VaQYz8/%E2%9D%96-Styles-and-Content-%7C-DDI?node-id=3787%3A103173)
 
 ---
 

--- a/libs/docs/src/components/common/TwoColumnLayout.stories.mdx
+++ b/libs/docs/src/components/common/TwoColumnLayout.stories.mdx
@@ -8,7 +8,7 @@ import { GoATwoColumnLayout, GoAAppHeader, GoAAppFooter } from '@abgov/react-com
 
 ### A two column layout to use as a starting point for your page. Typically, this is used for a side navigation alongside the main content of a page.
 
-[Figma design component](https://www.figma.com/file/iCcynUIy2FtgaVd8ryS3ju/%5BDS-151%5D-Layouts-grids?node-id=1276%3A337306)
+[Figma design component](https://www.figma.com/file/ylmHeuDMfxnDBnP1VaQYz8/%E2%9D%96-Styles-and-Content-%7C-DDI?node-id=3787%3A103173)
 
 ---
 

--- a/libs/react-components/src/lib/container/container.spec.tsx
+++ b/libs/react-components/src/lib/container/container.spec.tsx
@@ -8,8 +8,8 @@ describe('Container', () => {
   it("should render the properties", () => {
     const { container } = render(<GoAContainer
       type="interactive"
-      colored={false}
-      headingSize="large"
+      backgroundcolour={false}
+      accentBar="large"
       padding="relaxed"
       title={"Text title"}
       actions={<GoAButton onClick={() => {}}>Save</GoAButton>}
@@ -21,8 +21,8 @@ describe('Container', () => {
     const el = container.querySelector("goa-container");
     expect(el).toBeTruthy();
     expect(el.getAttribute("type")).toEqual("interactive");
-    expect(el.getAttribute("colored")).toEqual("false");
-    expect(el.getAttribute("headingsize")).toEqual("large");
+    expect(el.getAttribute("backgroundcolour")).toEqual("false");
+    expect(el.getAttribute("accentbar")).toEqual("large");
     expect(el.getAttribute("padding")).toEqual("relaxed");
 
     expect(el.querySelector("*[slot=title]").innerHTML).toContain("Text title");

--- a/libs/react-components/src/lib/container/container.spec.tsx
+++ b/libs/react-components/src/lib/container/container.spec.tsx
@@ -8,8 +8,7 @@ describe('Container', () => {
   it("should render the properties", () => {
     const { container } = render(<GoAContainer
       type="interactive"
-      backgroundcolour={false}
-      accentBar="large"
+      accent="thick"
       padding="relaxed"
       title={"Text title"}
       actions={<GoAButton onClick={() => {}}>Save</GoAButton>}
@@ -21,8 +20,7 @@ describe('Container', () => {
     const el = container.querySelector("goa-container");
     expect(el).toBeTruthy();
     expect(el.getAttribute("type")).toEqual("interactive");
-    expect(el.getAttribute("backgroundcolour")).toEqual("false");
-    expect(el.getAttribute("accentbar")).toEqual("large");
+    expect(el.getAttribute("accent")).toEqual("thick");
     expect(el.getAttribute("padding")).toEqual("relaxed");
 
     expect(el.querySelector("*[slot=title]").innerHTML).toContain("Text title");

--- a/libs/react-components/src/lib/container/container.tsx
+++ b/libs/react-components/src/lib/container/container.tsx
@@ -1,13 +1,13 @@
 import React, { FC, ReactNode } from 'react';
 
 type ContainerType = 'interactive' | 'non-interactive' | 'info' | 'error' | 'success' | 'warning';
-type HeadingSize = 'large' | 'small' | 'none';
+type AccentBar = 'large' | 'small' | 'none';
 type ContainerPadding = "relaxed" | "compact";
 
 interface WCProps {
   type?: ContainerType;
-  headingsize?: HeadingSize;
-  colored?: boolean;
+  accentbar?: AccentBar;
+  backgroundcolour?: boolean;
   padding?: ContainerPadding;
 }
 
@@ -21,26 +21,26 @@ declare global {
 }
 
 interface Props {
-  headingSize?: HeadingSize;
+  accentBar?: AccentBar;
   type?: ContainerType;
   title?: ReactNode;
-  colored?: boolean;
+  backgroundColour?: boolean;
   padding?: ContainerPadding;
   actions?: ReactNode;
   children?: ReactNode;
 }
 
 export const GoAContainer: FC<Props> = ({
-  headingSize,
+  accentBar,
   title,
-  colored = false,
+  backgroundColour = false,
   padding,
   children,
   actions,
   type,
 }) => {
   return (
-    <goa-container type={type} padding={padding} headingsize={headingSize} colored={colored}>
+    <goa-container type={type} padding={padding} accentbar={accentBar} backgroundcolour={backgroundColour}>
       {title && <div slot="title">{title}</div>}
       {children}
       {actions && <div slot="actions">{actions}</div>}

--- a/libs/react-components/src/lib/container/container.tsx
+++ b/libs/react-components/src/lib/container/container.tsx
@@ -1,13 +1,12 @@
 import React, { FC, ReactNode } from 'react';
 
 type ContainerType = 'interactive' | 'non-interactive' | 'info' | 'error' | 'success' | 'warning';
-type AccentBar = 'large' | 'small' | 'none';
+type Accent = 'thick' | 'thin' | 'filled';
 type ContainerPadding = "relaxed" | "compact";
 
 interface WCProps {
   type?: ContainerType;
-  accentbar?: AccentBar;
-  backgroundcolour?: boolean;
+  accent?: Accent;
   padding?: ContainerPadding;
 }
 
@@ -21,26 +20,24 @@ declare global {
 }
 
 interface Props {
-  accentBar?: AccentBar;
+  accent?: Accent;
   type?: ContainerType;
   title?: ReactNode;
-  backgroundColour?: boolean;
   padding?: ContainerPadding;
   actions?: ReactNode;
   children?: ReactNode;
 }
 
 export const GoAContainer: FC<Props> = ({
-  accentBar,
+  accent,
   title,
-  backgroundColour = false,
   padding,
   children,
   actions,
   type,
 }) => {
   return (
-    <goa-container type={type} padding={padding} accentbar={accentBar} backgroundcolour={backgroundColour}>
+    <goa-container type={type} padding={padding} accent={accent}>
       {title && <div slot="title">{title}</div>}
       {children}
       {actions && <div slot="actions">{actions}</div>}

--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -5,11 +5,11 @@
   import { toBoolean } from "../../common/utils";
 
   export let type: 'interactive' | 'info' | 'error' | 'success' | 'important' | 'non-interactive' = 'non-interactive'
-  export let colored: string = "false";
-  export let headingsize: 'large' | 'small' | 'none' = 'large';
+  export let backgroundcolour: string = "false";
+  export let accentbar: 'large' | 'small' | 'none' = 'large';
   export let padding: "relaxed" | "compact" = "relaxed"
 
-  $: _colored = toBoolean(colored);
+  $: _backgroundcolour = toBoolean(backgroundcolour);
 </script>
 
 <!-- HTML -->
@@ -19,9 +19,9 @@
     goa-container--${type}
     padding--${padding}
   `}
-  class:colored={_colored}
+  class:backgroundcolour={_backgroundcolour}
 >
-  <header class="heading--{headingsize}">
+  <header class="heading--{accentbar}">
     <div class="title">
       <slot name="title" />
     </div>
@@ -73,25 +73,25 @@
     border-bottom-right-radius: var(--border-radius);
   }
 
-  /* Colored */
+  /* Background Colour */
 
-  .goa-container--non-interactive.colored .content {
+  .goa-container--non-interactive.backgroundcolour .content {
     border-color: var(--color-gray-200);
     background-color: var(--color-gray-100);
   }
-  .goa-container--important.colored .content {
+  .goa-container--important.backgroundcolour .content {
     border-color: var(--goa-color-status-warning);
     background-color: var(--goa-color-status-warning-50);
   }
-  .goa-container--error.colored .content {
+  .goa-container--error.backgroundcolour .content {
     border-color: var(--goa-color-status-emergency);
     background-color: var(--goa-color-status-emergency-50);
   }
-  .goa-container--success.colored .content {
+  .goa-container--success.backgroundcolour .content {
     border-color: var(--goa-color-status-success);
     background-color: var(--goa-color-status-success-50);
   }
-  .goa-container--info.colored .content {
+  .goa-container--info.backgroundcolour .content {
     border-color: var(--goa-color-status-info);
     background-color: var(--goa-color-status-info-50);
   }

--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -2,14 +2,9 @@
 
 <!-- Script -->
 <script lang="ts">
-  import { toBoolean } from "../../common/utils";
-
-  export let type: 'interactive' | 'info' | 'error' | 'success' | 'important' | 'non-interactive' = 'non-interactive'
-  export let backgroundcolour: string = "false";
-  export let accentbar: 'large' | 'small' | 'none' = 'large';
+  export let type: 'interactive' | 'info' | 'error' | 'success' | 'important' | 'non-interactive' = 'interactive'
+  export let accent: 'thick' | 'thin' | 'filled' = 'filled';
   export let padding: "relaxed" | "compact" = "relaxed"
-
-  $: _backgroundcolour = toBoolean(backgroundcolour);
 </script>
 
 <!-- HTML -->
@@ -18,10 +13,10 @@
     goa-container
     goa-container--${type}
     padding--${padding}
+    accent--${accent}
   `}
-  class:backgroundcolour={_backgroundcolour}
 >
-  <header class="heading--{accentbar}">
+  <header class="heading--{accent}">
     <div class="title">
       <slot name="title" />
     </div>
@@ -75,23 +70,23 @@
 
   /* Background Colour */
 
-  .goa-container--non-interactive.backgroundcolour .content {
+  .goa-container--non-interactive.accent--filled .content {
     border-color: var(--color-gray-200);
     background-color: var(--color-gray-100);
   }
-  .goa-container--important.backgroundcolour .content {
+  .goa-container--important.accent--filled .content {
     border-color: var(--goa-color-status-warning);
     background-color: var(--goa-color-status-warning-50);
   }
-  .goa-container--error.backgroundcolour .content {
+  .goa-container--error.accent--filled .content {
     border-color: var(--goa-color-status-emergency);
     background-color: var(--goa-color-status-emergency-50);
   }
-  .goa-container--success.backgroundcolour .content {
+  .goa-container--success.accent--filled .content {
     border-color: var(--goa-color-status-success);
     background-color: var(--goa-color-status-success-50);
   }
-  .goa-container--info.backgroundcolour .content {
+  .goa-container--info.accent--filled .content {
     border-color: var(--goa-color-status-info);
     background-color: var(--goa-color-status-info-50);
   }
@@ -174,31 +169,31 @@
   }
 
   /* Sizes */
-  .heading--large {
+  .heading--thick {
     padding: 0.5rem 1.5rem;
     max-height: 3rem;
     min-height: 1rem;
   }
 
-  .heading--large .title {
+  .heading--thick .title {
     line-height: 2rem;
   }
 
-  .heading--small {
+  .heading--thin {
     height: 0.5rem;
   }
 
-  .heading--none {
+  .heading--filled {
     display: none;
   }
-  .heading--none ~ .content {
+  .heading--filled ~ .content {
     border-top: 1px solid var(--color-gray-200);
     border-top-left-radius: var(--border-radius);
     border-top-right-radius: var(--border-radius);
   }
 
-  .heading--small .title,
-  .heading--small .actions {
+  .heading--thin .title,
+  .heading--thin .actions {
     display: none;
   }
 

--- a/libs/web-components/src/components/container/ContainerWrapper.test.svelte
+++ b/libs/web-components/src/components/container/ContainerWrapper.test.svelte
@@ -6,11 +6,11 @@
   export let actions = "";
   export let content;
   export let type = "default";
-  export let accentbar = "large";
+  export let accent = "thick";
 </script>
 
 <!-- HTML -->
-<goa-container type={type} accentbar={accentbar}>
+<goa-container type={type} accent={accent}>
   {#if title}
     <div slot="title" class="title">{title}</div>
   {/if}

--- a/libs/web-components/src/components/container/ContainerWrapper.test.svelte
+++ b/libs/web-components/src/components/container/ContainerWrapper.test.svelte
@@ -6,11 +6,11 @@
   export let actions = "";
   export let content;
   export let type = "default";
-  export let headingsize = "large";
+  export let accentbar = "large";
 </script>
 
 <!-- HTML -->
-<goa-container type={type} headingsize={headingsize}>
+<goa-container type={type} accentbar={accentbar}>
   {#if title}
     <div slot="title" class="title">{title}</div>
   {/if}


### PR DESCRIPTION
Made sure that the basic container had no accent bar. Changed default container to basic container.
Added title to the properties tabs
Modified headingSize to accentBar.
Modified colored to backgroundColour.
Also updated the figma link in the one-column and two-column layout pages.