### PR TITLE
fix: Modify padding for AppHeader

### DIFF
--- a/libs/docs/src/components/goa/AppFooter.stories.mdx
+++ b/libs/docs/src/components/goa/AppFooter.stories.mdx
@@ -38,7 +38,7 @@ The footer will not position itself on the bottom of the page, but must instead 
   <Prop
     name="maxContentWidth"
     type="string"
-    defaultValue="--layout-max-content-width defined within the styles lib"
+    defaultValue="1280px"
     description="The maximum width of the main content area"
   />
 </Props>

--- a/libs/docs/src/components/goa/AppFooter.stories.mdx
+++ b/libs/docs/src/components/goa/AppFooter.stories.mdx
@@ -38,7 +38,7 @@ The footer will not position itself on the bottom of the page, but must instead 
   <Prop
     name="maxContentWidth"
     type="string"
-    defaultValue="1280px"
+    defaultValue="100%"
     description="The maximum width of the main content area"
   />
 </Props>

--- a/libs/docs/src/components/goa/app-header.stories.mdx
+++ b/libs/docs/src/components/goa/app-header.stories.mdx
@@ -36,7 +36,7 @@ import { GoAAppHeader } from '@abgov/react-components';
   <Prop
     name="maxContentWidth"
     type="string"
-    defaultValue="1280px"
+    defaultValue="100%"
     description="Maximum width of the content area"
   />
 </Props>

--- a/libs/docs/src/components/goa/app-header.stories.mdx
+++ b/libs/docs/src/components/goa/app-header.stories.mdx
@@ -36,7 +36,7 @@ import { GoAAppHeader } from '@abgov/react-components';
   <Prop
     name="maxContentWidth"
     type="string"
-    defaultValue="--layout-max-content-width defined within the styles lib"
+    defaultValue="1280px"
     description="Maximum width of the content area"
   />
 </Props>
@@ -179,6 +179,53 @@ Custom content can be added to the header by passing it in as a child component(
       lang="tsx"
       code={`
       <GoAAppHeader url="https://example.com" heading="Ticket and Find Payments">
+        <a href="#">Login</a>
+        <a href="#">Help</a>
+      </GoAAppHeader>
+    `}
+    />
+  </Tab>
+</Tabs>
+
+#### Max Content Width
+
+You can change the maximum width of the app header
+
+<Story name="Max Content Width">
+  <GoAAppHeader url="https://example.com" heading="Ticket and Fine Payments" maxContentWidth="600px">
+    <a href="#">Login</a> &nbsp;
+    <a href="#">Help</a>
+  </GoAAppHeader>
+</Story>
+
+<Tabs>
+  <Tab label="Web Component" hidden={true}>
+    <CodeSnippet
+      lang="html"
+      code={`
+      <goa-app-header url="https://example.com" heading="Ticket and Find Payments" maxContentWidth="600px">
+        <a href="#">Login</a> &nbsp;
+        <a href="#">Help</a>
+      </goa-app-header>
+    `}
+    />
+  </Tab>
+  <Tab label="Angular">
+    <CodeSnippet
+      lang="html"
+      code={`
+      <goa-app-header url="https://example.com" heading="Ticket and Find Payments" maxContentWidth="600px">
+        <a href="#">Login</a> &nbsp;
+        <a href="#">Help</a>
+      </goa-app-header>
+    `}
+    />
+  </Tab>
+  <Tab label="React">
+    <CodeSnippet
+      lang="tsx"
+      code={`
+      <GoAAppHeader url="https://example.com" heading="Ticket and Find Payments" maxContentWidth="600px">
         <a href="#">Login</a>
         <a href="#">Help</a>
       </GoAAppHeader>

--- a/libs/styles/src/lib/vars.css
+++ b/libs/styles/src/lib/vars.css
@@ -3,7 +3,7 @@
   --font-family: acumin-pro-semi-condensed, sans-serif;
 
   --layout-nav-column-width: 256px;
-  --layout-max-content-width: 904px;
+  --layout-max-content-width: 1280px;
 
   /* font-size */
   --fs-xs: 0.75rem;     /* 12px */

--- a/libs/styles/src/lib/vars.css
+++ b/libs/styles/src/lib/vars.css
@@ -3,7 +3,6 @@
   --font-family: acumin-pro-semi-condensed, sans-serif;
 
   --layout-nav-column-width: 256px;
-  --layout-max-content-width: 1280px;
 
   /* font-size */
   --fs-xs: 0.75rem;     /* 12px */

--- a/libs/web-components/src/components/app-header/AppHeader.svelte
+++ b/libs/web-components/src/components/app-header/AppHeader.svelte
@@ -13,7 +13,7 @@
 <div 
   class="app-header" 
   data-testid={testid}
-  style={`--max-content-width: ${maxcontentwidth || "var(--layout-max-content-width)"}`}
+  style={`--max-content-width: ${maxcontentwidth || "100%"}`}
 >
   <div class="content">
     {#if url}

--- a/libs/web-components/src/components/app-header/AppHeader.svelte
+++ b/libs/web-components/src/components/app-header/AppHeader.svelte
@@ -74,7 +74,6 @@
   .content {
     margin: 0 auto;
     width: min(var(--max-content-width), 100%);
-
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/libs/web-components/src/components/footer/Footer.svelte
+++ b/libs/web-components/src/components/footer/Footer.svelte
@@ -36,7 +36,7 @@
   .content {
     padding: 2rem 1rem;
     margin: 0 auto;
-    width: min(var(--max-content-width), 100vw);
+    width: min(var(--max-content-width), 100%);
   }
   @media (min-width: 640px) {
     .content {

--- a/libs/web-components/src/components/footer/Footer.svelte
+++ b/libs/web-components/src/components/footer/Footer.svelte
@@ -117,7 +117,7 @@
 <div 
   class="app-footer" 
   bind:this={rootEl}
-  style={`--max-content-width: ${maxcontentwidth || "var(--layout-max-content-width)"}`}
+  style={`--max-content-width: ${maxcontentwidth || "100%"}`}
 >
   <div class="content">
     <div class="nav-links">

--- a/libs/web-components/src/components/modal/Modal.svelte
+++ b/libs/web-components/src/components/modal/Modal.svelte
@@ -21,10 +21,6 @@
   $: isScrollable = toBoolean(scrollable);
   $: isOpen = toBoolean(open);
 
-  onMount(() => {
-    console.log("in the modal v2");
-  })
-
   $: _transitionTime =
     transition === "none"
       ? 0

--- a/libs/web-components/src/layouts/two-column-layout/TwoColumnLayout.svelte
+++ b/libs/web-components/src/layouts/two-column-layout/TwoColumnLayout.svelte
@@ -154,7 +154,7 @@
 <div 
   class="page"
   style={`
-    --max-content-width: ${maxcontentwidth || "var(--layout-max-content-width)"};
+    --max-content-width: ${maxcontentwidth || "100%"};
     --nav-column-width: ${navcolumnwidth || "var(--layout-nav-column-width)"};
   `}
 >


### PR DESCRIPTION
Modified both the AppHeader and AppFooter stories to include the actual measurements for a property. Increased the max width in the CSS that's used for both AppHeader and AppFooter. Modified width of AppFooter to 100% of the container, instead of 100% of viewport. Removed a console onMount message for Modals.