### PR TITLE
fix(DDI-1122): Updated borders on prefix and suffix

### DIFF
--- a/apps/angular-demo/src/app/dropdown/dropdown.component.html
+++ b/apps/angular-demo/src/app/dropdown/dropdown.component.html
@@ -90,18 +90,10 @@
   placeholder="Select a color"
 >
   <goa-dropdown-item
-    value="red"
-    name="boundColor"
-    label="Red"
-  ></goa-dropdown-item>
-  <goa-dropdown-item
-    value="green"
-    name="boundColor"
-    label="Green"
-  ></goa-dropdown-item>
-  <goa-dropdown-item
-    value="blue"
-    name="boundColor"
-    label="Blue"
-  ></goa-dropdown-item>
+    name="colors"
+    *ngFor="let color of colors"
+    [value]="color"
+    [label]="color"
+  >
+  </goa-dropdown-item>
 </goa-dropdown>

--- a/apps/angular-demo/src/app/input-component/input-component.component.html
+++ b/apps/angular-demo/src/app/input-component/input-component.component.html
@@ -57,6 +57,9 @@
 <goa-input name="input" suffix="items"></goa-input>
 <goa-input name="input" prefix="$" suffix="per item"></goa-input>
 
+<h2>Disabled Prefix/Suffix</h2>
+<goa-input name="foo" disabled="true" prefix="$" suffix="per item"></goa-input>
+
 <h2>Auto capitalize</h2>
 <goa-input
   type="text"

--- a/apps/react-demo/src/routes/input.tsx
+++ b/apps/react-demo/src/routes/input.tsx
@@ -107,6 +107,16 @@ export default function Input() {
         suffix="per item"
         onChange={noop}
       />
+
+      <h2>Disabled Prefix/Suffix</h2>
+      <GoAInput
+        name="foo"
+        value=""
+        prefix="$"
+        suffix="per item"
+        disabled={true}
+        onChange={noop}
+      />
     </>
   );
 }

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -314,6 +314,12 @@
     border-bottom-right-radius: var(--input-border-radius);
     border-left: 1px solid var(--color-gray-600);
   }
+  .goa-input--disabled .prefix {
+    border-right: 1px solid var(--color-gray-200);
+  }
+  .goa-input--disabled .suffix {
+    border-left: 1px solid var(--color-gray-200);
+  }
 
   /* Themes */
   input.input--goa {


### PR DESCRIPTION
Updated the borders on the prefix and suffix of input components to be properly greyed out if the input is disabled.

Updated the angular and react demo to have this setup for testing purposes.

Also updated the dropdown component in the angular demo to be more inline with the storybook.