### PR TITLE
feat/DDI-1120: Adjust padding for Microsite Header

### DIFF
--- a/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
+++ b/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
@@ -83,7 +83,7 @@
     background-color: var(--color-gray-100);
     align-items: center;
     justify-content: space-between;
-    padding: 0.5rem 1.5rem;
+    padding: 0.25rem 1.5rem;
   }
     @media (max-width: 640px) {
       .goa-official-site-header {
@@ -104,7 +104,7 @@
 
   .service-type {
     font-weight: bold;
-    padding: 0.25rem;
+    padding: 0.125rem 0.25rem;
     display: flex;
     margin-right: 1rem;
     line-height: initial;


### PR DESCRIPTION
Currently the Microsite header is not inline with the design component created. The badge inside the header (Alpha, Beta, etc…) has too much padding on the top and the bottom. And the Microsite Header itself has too much padding on the top and the bottom.

Badge inside the Microsite Header has top and bottom padding reduced to 2px.

Microsite Header has padding reduced to 4px


Screenshots:
**Angular**
![image](https://user-images.githubusercontent.com/120135417/207150379-81a64b25-2cca-4f72-a6f1-6bc93bb1e12a.png)

![image](https://user-images.githubusercontent.com/120135417/207150446-c2e26c9e-7ec1-4eda-8956-7e46bf97c84d.png)

**React**
![image](https://user-images.githubusercontent.com/120135417/207150696-ffb27a69-3786-4e2c-9af9-9310c24e668a.png)

