### PR TITLE
[DDIDS-1141] Fix aria-label readout for Dropdown elements

### DIFF
--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -85,9 +85,9 @@
     return children.map((el: HTMLElement) => {
       const option = el as unknown as Option
       const value = el.getAttribute("value") || option.value;
-      const label = 
-        el.getAttribute("label") 
-        || option.label 
+      const label =
+        el.getAttribute("label")
+        || option.label
         || value;
       const selected = _values.includes(value);
       if (selected) {
@@ -310,7 +310,7 @@
       {placeholder}
       aria-controls="menu"
       aria-expanded={_isMenuVisible}
-      aria-label={arialabel || name}
+      arialabel={arialabel || name}
       data-testid={`${name}-dropdown-input`}
       readonly
       role="combobox"
@@ -318,6 +318,7 @@
       type="text"
       value={_selectedLabel}
       width="100%"
+      name={name}
     />
     <!-- list and filter -->
     <ul


### PR DESCRIPTION
## Description
* The aria label for the custom dropdown element wasn't being set correctly on the native `<input>` element within the shadow dom. 
* Instead, it was being set on the host `goa-input` element 
* This was tipping off the NVDA screen reader while it worked fine on other screen reader

## changes
* pass along the ariaLabel prop to `<goa-input>` and let that set the aria-lable on the native `input` element