### PR TITLE
[DDIDS-1167] Fix input background color

### DIFF
--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -37,7 +37,7 @@
 
   onMount(() => {
     // hold on to the initial value to prevent losing it on check changes
-    _value = value;  
+    _value = value;
   })
 
   function onChange(e: Event) {
@@ -45,7 +45,7 @@
     // out of sync with the events.
     const newCheckStatus = !isChecked;
     const newValue = newCheckStatus ? `${_value || "checked"}` : "";
- 
+
     // set the local state
     checked = fromBoolean(newCheckStatus);
 
@@ -127,8 +127,12 @@
   }
 
   /* disabled state */
-  .goa-checkbox--disabled {
+  .goa-checkbox--disabled .goa-checkbox-text{
     opacity: 40%;
+  }
+
+  .goa-checkbox--disabled:hover {
+    cursor: default;
   }
 
   .goa-checkbox-container {

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -208,6 +208,7 @@
   .goa-input,
   .goa-input * {
     box-sizing: border-box;
+    line-height: normal;
   }
 
   .goa-input {
@@ -221,6 +222,7 @@
     /* The vertical align fixes inputs with a leading icon to not be vertically offset */
     vertical-align: middle;
     min-width: 100%;
+    background-color: var(--color-white);
   }
 
   .goa-input:hover {

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -203,7 +203,7 @@
     box-shadow: 0 0 0 var(--goa-radio-outline-width) var(--goa-color-interactive--focus);
   }
 
-  .goa-radio--disabled {
+  .goa-radio--disabled .goa-radio-label{
     opacity: 0.4;
   }
   .goa-radio--disabled:hover {


### PR DESCRIPTION
## [DDIDS-1167](https://goa-dio.atlassian.net/browse/DDIDS-1167)


## Changes
* *AC* on the ticket requires to set the background color on the input element but doing so causes some amount of the background color bleeding out of the container. The PR now sets the background color on the `goa-input` container. 
* With this approach, the base level `line-height` seems to be breaking the input styles when leading and trailing content are present. The PR also overrides this line-height style on `goa-input`

## Screenshots
![img1](https://i.imgur.com/NmiR9oK.png)
![img1](https://i.imgur.com/gT1k8L7.png)

[DDIDS-1167]: https://goa-dio.atlassian.net/browse/DDIDS-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ