### PR TITLE
bug(DDIDS-1203): Textarea no horizontal resizing

### DIFF
--- a/libs/web-components/src/components/text-area/TextArea.svelte
+++ b/libs/web-components/src/components/text-area/TextArea.svelte
@@ -120,6 +120,7 @@
     font-size: var(--goa-font-size-4);
     font-family: var(--goa-font-family-sans);
     min-width: 100%;
+    resize: vertical;
   }
 
   @media (min-width: 640px) {


### PR DESCRIPTION
#### Changes
* Use css `resize` property
* Seems to be supported on most browsers https://caniuse.com/css-resize. ios-Safari being an exception as there is no resize gesture on ios interface. Meaning on ios-safari both verical and horizontal drag is disabled 