### PR TITLE
fix: Just to force a new release for angular components

### DIFF
--- a/libs/angular-components/README.md
+++ b/libs/angular-components/README.md
@@ -8,7 +8,7 @@ Add Dependencies
 
 ```bash
 npm i @abgov/web-components
-npm i @abgov/angular-components -f
+npm i @abgov/angular-components
 ```
 
 Link ionicons in app/index.html


### PR DESCRIPTION
This is being done mainly to force NPM to update to a new angular components release so that we can get updated documentation on NPM.

This has a side effect that I don't believe the `-f` is actually necessary