### PR TITLE
fix(DDI-1237): safari-focus-state for checkbox and radio

### DIFF
--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -162,7 +162,7 @@
     border: none;
   }
 
-  .goa-checkbox-container:focus-within {
+  .goa-checkbox-container:focus-within,.goa-checkbox-container:focus, .goa-checkbox-container:active {
     box-shadow: 0 0 0 3px var(--goa-color-interactive-focus);
     border: 1px solid var(--goa-color-greyscale-700);
     outline: none;
@@ -180,7 +180,7 @@
     box-shadow: none;
   }
 
-  .goa-checkbox--disabled, 
+  .goa-checkbox--disabled,
   input[type=checkbox][disabled]:hover {
     cursor: default;
   }

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -216,14 +216,14 @@
     box-shadow: 0 0 0 1px var(--goa-color-interactive-hover);
   }
 
-  /* Checked:hover */  
+  /* Checked:hover */
   input[type="radio"]:checked:hover ~ .goa-radio-icon {
     border: 7px solid var(--goa-color-interactive-hover);
     box-shadow: 0 0 0 1px var(--goa-color-interactive-hover);
   }
 
   /* Default:focus */
-  input[type="radio"]:focus ~ .goa-radio-icon {
+  input[type="radio"]:focus ~ .goa-radio-icon, input[type="radio"]:active ~ .goa-radio-icon {
     box-shadow: 0 0 0 var(--goa-radio-outline-width) var(--goa-color-interactive-focus);
   }
 


### PR DESCRIPTION
Check (holding action) on the radio checkbox and the checkbox, doesn't display a yellow border. This PR is to fix it.  
Task: https://goa-dio.atlassian.net/browse/DDIDS-1237


https://user-images.githubusercontent.com/120135417/221998533-8aacdcff-824a-4669-b98b-93d1f6ce2358.mov

