### PR TITLE
fix(DDI-1241): pass variant prop from react

### DIFF
--- a/libs/react-components/src/lib/table/table.tsx
+++ b/libs/react-components/src/lib/table/table.tsx
@@ -53,6 +53,7 @@ export function GoATable(props: TableProps) {
       ref={ref}
       width={props.width}
       stickyheader={false}
+      variant={props.variant}
       data-testid={props.testId}
       mt={props.mt}
       mb={props.mb}


### PR DESCRIPTION
Passing variant prop from React GoATable to the web component.