### PR TITLE
fix(DDI-1268): fix table sort header doesn't work with angular 15

### DIFF
--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -30,7 +30,7 @@
 
   onMount(() => {
     validateVariant(variant);
-    attachSortEventHandling();
+    setTimeout(attachSortEventHandling,0);
 
     const slot = _rootEl.querySelector("slot") as HTMLSlotElement;
     if (!slot || slot.assignedElements().length === 0) {


### PR DESCRIPTION
### Description
If you try to implement dynamic headers with goa-table, and then try to use goa-table-sort-header with those dynamic headers, sorting won’t work, but only in Angular v15, it works fine in v12 (did not test with v13 or v14).

### How to test
Step 1: Create your Angular project from https://github.com/GovAlta/ui-components-angular-template
Step 2: Add your table code: https://github.com/vanessatran-ddi/angular-ui-component-sample/blob/main/src/app/home/home.component.html#L7
Step 3: Add code under component ts like: https://github.com/vanessatran-ddi/angular-ui-component-sample/blob/main/src/app/home/home.component.ts#L14
Step 4: Change the path of this repo local dist folder https://github.com/vanessatran-ddi/angular-ui-component-sample/blob/main/package.json#L14
Step 5: Run the angular application 

### Stories/Tasks Link
https://goa-dio.atlassian.net/browse/DDIDS-1268

### What changed
I was doing a small experiment on Angular 12 (our angular demo app) and Angular 15 with the below step:
I added OnInit: 

![image](https://user-images.githubusercontent.com/120135417/225453868-9c9ecb96-a39d-48ec-bd5e-3cf536b7633a.png)

**Angular 15**
![image](https://user-images.githubusercontent.com/120135417/225454215-0a8e4a26-40b5-4099-9f5d-4ad0c52fd3fc.png)

You can see the OnInit happens after the onMount() of Svelte for Angular 15, and therefore, the `queryAllSelector` returns an empty NodeList, which means no event for the click action is added. 

**Angular 12**
![image](https://user-images.githubusercontent.com/120135417/225454377-c5baeee2-d67d-4547-9ad2-eeec3d2c0c4a.png)

While Angular 12 has a different lifecycle, when ngOnInit happens first, and onMount of Svelte happens later. 

It is a bit tricky because Svelte doesn't have any lifecycle that is specific to handle this "slow" rendering from Angular 15. 
https://stackoverflow.com/questions/55773988/queryselector-does-not-seem-to-find-elements-inside-ng-container In fact if we develop in Angular, we have other lifecycles to check. 

So I add `setTimeout` to deal with this case. 

