### PR TITLE
fix(DDI-1266): change current page number from input text to dropdown

### DIFF
--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -402,15 +402,8 @@
     position: relative;
     cursor: pointer;
     display: inline-block;
-    width: 100%;
+    width: var(--width, 100%);
   }
-
-  @media (min-width: 640px) {
-    .dropdown {
-      width: var(--width);
-    }
-  }
-
   .dropdown-background {
     cursor: default;
     position: fixed;

--- a/libs/web-components/src/components/pagination/Pagination.svelte
+++ b/libs/web-components/src/components/pagination/Pagination.svelte
@@ -23,7 +23,7 @@
   $: _pageCount = Math.ceil(itemcount / perpagecount)
 
   // private
-  let inputEl: HTMLInputElement = null;
+  let pageDropdownEl: HTMLElement = null;
   let hiddenEl: HTMLInputElement = null;  // needed to allow the inputEl's event to be cancelled
 
   // hooks
@@ -32,14 +32,10 @@
     validateRequired("GoAPagination", { itemcount, pagenumber })
     validateVariant(variant)
 
-    // prevent event propagation if value is non-numeric 
-    // (input[type=number] returns blank for non-numeric numbers)
-    inputEl && inputEl.addEventListener("_change", (e: CustomEvent) => {
+    // prevent event propagation
+    pageDropdownEl && pageDropdownEl.addEventListener("_change", (e: CustomEvent) => {
       const page = Number.parseInt(e.detail.value)
       e.stopPropagation();
-      if (isNaN(page)) {
-        return;
-      }
 
       hiddenEl.dispatchEvent(new CustomEvent("_change", {composed: true, bubbles: true, detail: { page }}))
     })
@@ -82,7 +78,11 @@
       <goa-block data-testid="page-selector" alignment="center" gap="s">
         <span>Page</span>
         <input bind:this={hiddenEl} type="hidden" />
-        <goa-input bind:this={inputEl} type="number" value={pagenumber} width="8ch" debounce="500" min="1" max={_pageCount} />
+        <goa-dropdown bind:this={pageDropdownEl} value="{pagenumber}" width="70px">
+          {#each {length: _pageCount} as _, i}
+            <goa-dropdown-item value="{i+1}" label="{i+1}"/>
+          {/each}
+        </goa-dropdown>
         <span>of {_pageCount}</span>
       </goa-block>
     {/if}

--- a/libs/web-components/src/components/pagination/pagination.spec.ts
+++ b/libs/web-components/src/components/pagination/pagination.spec.ts
@@ -8,12 +8,16 @@ describe("GoAPagination", () => {
     const pageSelector = getByTestId("page-selector");
     const pageLinks = getByTestId("page-links");
 
-    // input
-    const pageInput = pageSelector.querySelector("goa-input")
-    expect(pageInput.getAttribute("type")).toBe("number")
-    expect(pageInput.getAttribute("value")).toBe("1")
-    expect(pageInput.getAttribute("debounce")).toBe("500")
-
+    // page number dropdown
+    const pageNumberDropdown = pageSelector.querySelector("goa-dropdown");
+    expect(pageNumberDropdown.getAttribute("value")).toBe("1");
+    const pageDropdownItems = pageSelector.querySelectorAll('goa-dropdown-item');
+    expect(pageDropdownItems.length).toBe(10);
+    for (let pageNumber = 1; pageNumber < 10; pageNumber++) {
+      const pageDropdownItem = pageSelector.querySelector(`goa-dropdown-item:nth-child(${pageNumber})`);
+      expect(pageDropdownItem.getAttribute("value")).toBe(`${pageNumber}`);
+      expect(pageDropdownItem.getAttribute("label")).toBe(`${pageNumber}`);
+    }
     // links
     const prev = pageLinks.querySelector("goa-button:first-child");
     const next = pageLinks.querySelector("goa-button:last-child");
@@ -25,15 +29,15 @@ describe("GoAPagination", () => {
     expect(next.getAttribute("disabled")).toBe("false")
   })
 
-  it("handles the page input events", async () => {
+  it("handles the page dropdown select events", async () => {
     const { container } = render(Pagination, { pagenumber: 1, itemcount: 100 })
-    const pageInput = container.querySelector("goa-input")
+    const pageNumberDropdown = container.querySelector("goa-dropdown");
 
     const fn = jest.fn();
 
-    pageInput.addEventListener("_change", fn);
+    pageNumberDropdown.addEventListener("_change", fn);
 
-    await fireEvent(pageInput, new CustomEvent("_change", { detail: { page: 2 } }))
+    await fireEvent(pageNumberDropdown, new CustomEvent("_change", { detail: { page: 2 } }))
     await waitFor(() => {
       expect(fn).toBeCalledTimes(1);
     })
@@ -84,20 +88,6 @@ describe("GoAPagination", () => {
     container.addEventListener("_change", fn);
 
     await fireEvent.click(nextLink)
-    await waitFor(() => {
-      expect(fn).not.toBeCalled();
-    })
-  })
-
-  it("does not fire an event for a non-numeric page number", async () => {
-    const { container } = render(Pagination, { pagenumber: 1, itemcount: 100 })
-    const input = container.querySelector("goa-input");
-    const fn = jest.fn();
-
-    container.addEventListener("_change", fn);
-
-    // await fireEvent.keyUp(input, { target: { value: 2 }})
-    await fireEvent(input, new CustomEvent("_change", { detail: { page: "2abc" } }))
     await waitFor(() => {
       expect(fn).not.toBeCalled();
     })


### PR DESCRIPTION
### Description
There is no error if you type in a page that doesn't exist (Pagination Component)
AC: Change the page selection component to a dropdown

### Story/Task Link
- [DDIDS-1266](https://goa-dio.atlassian.net/browse/DDIDS-1266)

### Screenshot
For React app:

https://user-images.githubusercontent.com/120135417/227081765-4c49b3da-a432-47bc-9ecc-3f0e25d896ec.mov

For Angular app:

https://user-images.githubusercontent.com/120135417/227081792-8ad3f928-c002-444b-8bf2-f47869ec32de.mov



[DDIDS-1266]: https://goa-dio.atlassian.net/browse/DDIDS-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ