### PR TITLE
chore(DDI-1297): Change border-bottom of table's heading to greyscale…

### DIFF
--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -132,7 +132,7 @@
     color: var(--goa-color-text-secondary);
     padding: 1rem;
     text-align: left;
-    border-bottom: 2px solid var(--goa-color-greyscale-700);
+    border-bottom: 2px solid var(--goa-color-greyscale-600);
     vertical-align: bottom;
   }
 


### PR DESCRIPTION
### Description
Update the color of the table header underline to --goa-color-greyscale-600

### Screenshots
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/120135417/232783319-8d19e812-71f5-49a5-93bd-584bb46e3c67.png">
