### PR TITLE
chore(DDI-1320): update document to use dropdown native when it is in…

### DIFF
--- a/apps/angular-demo/src/app/form-stepper/form-stepper.component.html
+++ b/apps/angular-demo/src/app/form-stepper/form-stepper.component.html
@@ -13,6 +13,8 @@
   <div>/* Page 4 content */</div>
 </goa-pages>
 <div style="display: flex; justify-content: space-between">
-  <goa-button (_click)="setPage(step - 1)" type="secondary">Previous</goa-button>
+  <goa-button (_click)="setPage(step - 1)" type="secondary"
+    >Previous</goa-button
+  >
   <goa-button (_click)="setPage(step + 1)" type="primary">Next</goa-button>
 </div>

--- a/apps/angular-demo/src/app/modal/modal.component.html
+++ b/apps/angular-demo/src/app/modal/modal.component.html
@@ -244,12 +244,13 @@
   <goa-form-item label="First name" ml="xs">
     <goa-input name="firstName"></goa-input>
   </goa-form-item>
-  <p>
-    Lorem ipsum dolor sit amet consectetur adipisicing elit. Mollitia obcaecati
-    id molestiae, natus dicta, eaque qui iusto similique, libero explicabo
-    eligendi eius laboriosam! Repellendus ducimus officia asperiores. Eos, eius
-    numquam.
-  </p>
+  <goa-form-item label="Dropdown" ml="xs">
+    <goa-dropdown name="colors" error="true" native="true">
+      <goa-dropdown-item value="red" label="Red"></goa-dropdown-item>
+      <goa-dropdown-item value="green" label="Green"></goa-dropdown-item>
+      <goa-dropdown-item value="blue" label="Blue"></goa-dropdown-item>
+    </goa-dropdown>
+  </goa-form-item>
   <div slot="heading">Lorem <b>ipsum</b> dolor <b>sit</b> amet</div>
 </goa-modal>
 

--- a/apps/react-demo/src/routes/callout.tsx
+++ b/apps/react-demo/src/routes/callout.tsx
@@ -78,10 +78,7 @@ export default function Callout() {
       </GoACallout>
 
       <h2>Medium Callouts</h2>
-      <GoACallout
-        type="information"
-        size="medium"
-        heading="Small Callout">
+      <GoACallout type="information" size="medium" heading="Small Callout">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       </GoACallout>
     </>

--- a/libs/docs/src/components/common/Callout.stories.mdx
+++ b/libs/docs/src/components/common/Callout.stories.mdx
@@ -284,6 +284,7 @@ Event callouts are used to communiate information about upcoming and scheduled e
 </Tabs>
 
 #### Medium Callouts
+
 The medium callout has reduced padding and type size to adjust for a compact area and smaller viewport width when a smaller size is required. The large callout will responsively transform into the small callout below a 640px viewport width. The small callout may also be used on desktop.
 
 <Story name="Medium">

--- a/libs/docs/src/components/common/Dropdown.stories.mdx
+++ b/libs/docs/src/components/common/Dropdown.stories.mdx
@@ -88,7 +88,11 @@ import { useState } from "react";
     description="Callback function when dropdown value is changed"
   />
 </Props>
-
+<GoACallout>
+  When using a dropdown inside a modal where there is limited space for the menu
+  items to display, ensure the "native" property is set to "true" for the
+  dropdown to function properly.
+</GoACallout>
 <details>
   <summary>Additional Properties</summary>
   <Props showTabs={true}>

--- a/libs/docs/src/components/common/FormStepper.stories.mdx
+++ b/libs/docs/src/components/common/FormStepper.stories.mdx
@@ -240,7 +240,7 @@ export const ControlledTemplate = () => {
           <GoASkeleton type="lines" />
         </div>
       </GoAPages>
-      <div style={{display: "flex", justifyContent: "space-between"}}>
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
         <GoAButton type="secondary" onClick={() => setPage(step - 1)}>
           Previous
         </GoAButton>
@@ -360,7 +360,7 @@ export const StatusTemplate = () => {
           <GoASkeleton type="lines" />
         </div>
       </GoAPages>
-      <div style={{display: "flex", justifyContent: "space-between"}}>
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
         <GoAButton type="secondary" onClick={() => setPage(step - 1)}>
           Previous
         </GoAButton>

--- a/libs/docs/src/components/common/Modal.stories.mdx
+++ b/libs/docs/src/components/common/Modal.stories.mdx
@@ -101,6 +101,12 @@ import { useState } from "react";
   />
 </Props>
 
+<GoACallout>
+  When using a dropdown inside a modal where there is limited space for the menu
+  items to display, ensure the "native" property is set to "true" for the
+  dropdown to function properly.
+</GoACallout>
+
 #### Basic
 
 export const NoActionsTemplate = (args) => {


### PR DESCRIPTION
### Description: 
Currently when you use a GoADropdown component inside a GoAModal, none of the content in the Dropdown is actually visible. Instead it makes a scrolling bar appear on the side, but you can’t scroll at all, the only way to access the dropdown items is using your keyboard arrows.

### User Story
[DDI-1320](https://goa-dio.atlassian.net/browse/DDIDS-1320)

### What are changed
Eventually, the GoADropdown will re-use the GoAPopOver to display menu items (options). The Pop Over has the same error when displaying on the modal. The Jira ticket [DDI-1330](https://goa-dio.atlassian.net/browse/DDIDS-1330) is created to follow up and fix the pop over. 

* Add the message under Storybook Modal and Dropdown to let developers know that they can use native attribute now to display the dropdown inside the modal temporarily. 

![image](https://user-images.githubusercontent.com/120135417/234590282-36569688-dbad-4904-b231-abe4611efad2.png)
