### PR TITLE
feat(DDI-1328): Allow details component expand programmatically

### DIFF
--- a/apps/angular-demo/src/app/detail/detail.html
+++ b/apps/angular-demo/src/app/detail/detail.html
@@ -1,6 +1,9 @@
 <h2>Detail</h2>
 
+<goa-button (_click)="toggle()"> Toggle Details </goa-button>
+<br />
 <goa-details
+  [open]="isOpen1"
   heading="This is the titleThis is the titleThis is the titleThis is the titleThis is the titleThis is the titleThis is the titleThis is the title"
 >
   <p>

--- a/apps/angular-demo/src/app/detail/detail.ts
+++ b/apps/angular-demo/src/app/detail/detail.ts
@@ -5,5 +5,9 @@ import { Component } from "@angular/core";
   templateUrl: "./detail.html",
 })
 export class DetailComponent {
+  isOpen1 = true;
   constructor() {}
+  toggle() {
+    this.isOpen1 = !this.isOpen1;
+  }
 }

--- a/apps/react-demo/src/app/app.tsx
+++ b/apps/react-demo/src/app/app.tsx
@@ -103,6 +103,9 @@ export default function App() {
             <Link className="navigation-link" to="/three-column-layout">
               Three Column Layout
             </Link>
+            <Link className="navigation-link" to="/details">
+              Details
+            </Link>
           </nav>
         </div>
 

--- a/apps/react-demo/src/main.tsx
+++ b/apps/react-demo/src/main.tsx
@@ -35,6 +35,7 @@ import TextArea from "./routes/textarea";
 import ThreeColumnLayout from "./routes/threeColumnLayout";
 
 import "@abgov/web-components/index.css";
+import Details from "./routes/details";
 
 const rootElement = document.getElementById("root");
 ReactDOM.render(
@@ -71,6 +72,7 @@ ReactDOM.render(
         <Route path="table" element={<Table />} />
         <Route path="textarea" element={<TextArea />} />
         <Route path="three-column-layout" element={<ThreeColumnLayout />} />
+        <Route path="details" element={<Details />} />
       </Route>
     </Routes>
   </BrowserRouter>,

--- a/apps/react-demo/src/routes/details.tsx
+++ b/apps/react-demo/src/routes/details.tsx
@@ -1,0 +1,28 @@
+import { GoAButton, GoADetails } from "@abgov/react-components";
+import * as React from "react";
+import { useState } from "react";
+
+export default function Details() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <GoAButton onClick={() => setOpen(!open)}>Toggle Details</GoAButton>
+      <GoADetails
+        heading="This is the title"
+        open={open}
+      >
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel
+          lacinia metus, sed sodales lectus. Aliquam sed volutpat velit. Sed in
+          lacus ut dui placerat accumsan malesuada quis erat. Aenean mi diam,
+          rhoncus vitae justo eu, venenatis maximus nunc. In vel est commodo,
+          porttitor sem vel, tincidunt ipsum. In hac habitasse platea dictumst.
+          Mauris varius mollis dui. Aenean ut dui eu arcu rutrum auctor.
+          Curabitur cursus velit vel libero sollicitudin tincidunt. Proin
+          tincidunt, enim et ultrices rhoncus, nibh leo imperdiet sapien, sed
+          porttitor ipsum nulla non massa. Nulla facilisi.
+        </p>
+      </GoADetails>
+    </>
+  );
+}

--- a/libs/docs/src/components/common/Details.stories.mdx
+++ b/libs/docs/src/components/common/Details.stories.mdx
@@ -8,7 +8,8 @@ import {
   SupportInfo,
   Markdown,
 } from "@abgov/shared/storybook-common";
-import { GoADetails } from "@abgov/react-components";
+import { GoADetails, GoAButton } from "@abgov/react-components";
+import { useState } from "react";
 
 <Meta title="Components/Details" />
 
@@ -29,6 +30,13 @@ import { GoADetails } from "@abgov/react-components";
     description="The title heading"
     required="true"
   />
+  <Prop
+    name="open"
+    type="boolean"
+    defaultValue="false"
+    description="Controls if details is expanded or not"
+  />
+
 </Props>
 
 <details>
@@ -86,7 +94,7 @@ import { GoADetails } from "@abgov/react-components";
       code={`
       <goa-details heading="This is the title">
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel lacinia metus, sed sodales lectus. Aliquam sed volutpat velit. Sed in lacus ut dui placerat accumsan malesuada quis erat. Aenean mi diam, rhoncus vitae justo eu, venenatis maximus nunc. In vel est commodo, porttitor sem vel, tincidunt ipsum. In hac habitasse platea dictumst. Mauris varius mollis dui. Aenean ut dui eu arcu rutrum auctor. Curabitur cursus velit vel libero sollicitudin tincidunt. Proin tincidunt, enim et ultrices rhoncus, nibh leo imperdiet sapien, sed porttitor ipsum nulla non massa. Nulla facilisi. 
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel lacinia metus, sed sodales lectus. Aliquam sed volutpat velit. Sed in lacus ut dui placerat accumsan malesuada quis erat. Aenean mi diam, rhoncus vitae justo eu, venenatis maximus nunc. In vel est commodo, porttitor sem vel, tincidunt ipsum. In hac habitasse platea dictumst. Mauris varius mollis dui. Aenean ut dui eu arcu rutrum auctor. Curabitur cursus velit vel libero sollicitudin tincidunt. Proin tincidunt, enim et ultrices rhoncus, nibh leo imperdiet sapien, sed porttitor ipsum nulla non massa. Nulla facilisi.
         </p>
       </goa-details>
     `}
@@ -98,9 +106,94 @@ import { GoADetails } from "@abgov/react-components";
       code={`
       <GoADetails heading="This is the title">
         <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel lacinia metus, sed sodales lectus. Aliquam sed volutpat velit. Sed in lacus ut dui placerat accumsan malesuada quis erat. Aenean mi diam, rhoncus vitae justo eu, venenatis maximus nunc. In vel est commodo, porttitor sem vel, tincidunt ipsum. In hac habitasse platea dictumst. Mauris varius mollis dui. Aenean ut dui eu arcu rutrum auctor. Curabitur cursus velit vel libero sollicitudin tincidunt. Proin tincidunt, enim et ultrices rhoncus, nibh leo imperdiet sapien, sed porttitor ipsum nulla non massa. Nulla facilisi. 
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel lacinia metus, sed sodales lectus. Aliquam sed volutpat velit. Sed in lacus ut dui placerat accumsan malesuada quis erat. Aenean mi diam, rhoncus vitae justo eu, venenatis maximus nunc. In vel est commodo, porttitor sem vel, tincidunt ipsum. In hac habitasse platea dictumst. Mauris varius mollis dui. Aenean ut dui eu arcu rutrum auctor. Curabitur cursus velit vel libero sollicitudin tincidunt. Proin tincidunt, enim et ultrices rhoncus, nibh leo imperdiet sapien, sed porttitor ipsum nulla non massa. Nulla facilisi.
         </p>
       </GoADetails>
+    `}
+    />
+  </Tab>
+</Tabs>
+
+#### Expand/Hide Details
+
+export const BasicDetailsTemplate = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <GoAButton onClick={() => setOpen(!open)}>Toggle Details</GoAButton>
+      <GoADetails
+        heading="This is the title"
+        open={open}
+      >
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel
+          lacinia metus, sed sodales lectus. Aliquam sed volutpat velit. Sed in
+          lacus ut dui placerat accumsan malesuada quis erat. Aenean mi diam,
+          rhoncus vitae justo eu, venenatis maximus nunc. In vel est commodo,
+          porttitor sem vel, tincidunt ipsum. In hac habitasse platea dictumst.
+          Mauris varius mollis dui. Aenean ut dui eu arcu rutrum auctor.
+          Curabitur cursus velit vel libero sollicitudin tincidunt. Proin
+          tincidunt, enim et ultrices rhoncus, nibh leo imperdiet sapien, sed
+          porttitor ipsum nulla non massa. Nulla facilisi.
+        </p>
+      </GoADetails>
+    </>
+  );
+};
+
+<Story name="Expand/Hide Details">{BasicDetailsTemplate.bind({})}</Story>
+
+<Tabs>
+  <Tab label="Angular">
+    <CodeSnippet
+      lang="html"
+      code={`
+      <goa-button id="button" (_click)="toggle()">Toggle Details</goa-button>
+      <goa-details heading="This is the title" [open]="open">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel lacinia metus, sed sodales lectus. Aliquam sed volutpat velit. Sed in lacus ut dui placerat accumsan malesuada quis erat. Aenean mi diam, rhoncus vitae justo eu, venenatis maximus nunc. In vel est commodo, porttitor sem vel, tincidunt ipsum. In hac habitasse platea dictumst. Mauris varius mollis dui. Aenean ut dui eu arcu rutrum auctor. Curabitur cursus velit vel libero sollicitudin tincidunt. Proin tincidunt, enim et ultrices rhoncus, nibh leo imperdiet sapien, sed porttitor ipsum nulla non massa. Nulla facilisi.
+        </p>
+      </goa-details>
+    `}
+    />
+    <CodeSnippet
+      lang="ts"
+      code={`
+      export class DetailsComponent {
+        open = false;
+        toggle() {
+          this.open = !this.open;
+        }
+      }
+    `}
+    />
+  </Tab>
+  <Tab label="React">
+    <CodeSnippet
+      lang="tsx"
+      code={`
+      const [open, setOpen] = useState(false);
+      return (
+    <>
+      <GoAButton onClick={() => setOpen(!open)}>Toggle Details</GoAButton>
+      <GoADetails
+        heading="This is the title"
+        open={open}
+      >
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel
+          lacinia metus, sed sodales lectus. Aliquam sed volutpat velit. Sed in
+          lacus ut dui placerat accumsan malesuada quis erat. Aenean mi diam,
+          rhoncus vitae justo eu, venenatis maximus nunc. In vel est commodo,
+          porttitor sem vel, tincidunt ipsum. In hac habitasse platea dictumst.
+          Mauris varius mollis dui. Aenean ut dui eu arcu rutrum auctor.
+          Curabitur cursus velit vel libero sollicitudin tincidunt. Proin
+          tincidunt, enim et ultrices rhoncus, nibh leo imperdiet sapien, sed
+          porttitor ipsum nulla non massa. Nulla facilisi.
+        </p>
+      </GoADetails>
+    </>
+  );
     `}
     />
   </Tab>

--- a/libs/react-components/src/lib/details/details.spec.tsx
+++ b/libs/react-components/src/lib/details/details.spec.tsx
@@ -5,11 +5,12 @@ import { GoADetails } from "./details";
 describe("Detail", () => {
   it("should render successfully", () => {
     const { baseElement } = render(
-      <GoADetails heading="The heading">The content</GoADetails>
+      <GoADetails heading="The heading" open={true}>The content</GoADetails>
     );
 
     const el = baseElement.querySelector("goa-details");
     expect(el.getAttribute("heading")).toBe("The heading");
     expect(baseElement.innerHTML).toContain("The content");
+    expect(el.getAttribute("open")).toBe("true");
   });
 });

--- a/libs/react-components/src/lib/details/details.tsx
+++ b/libs/react-components/src/lib/details/details.tsx
@@ -3,6 +3,7 @@ import { Margins } from "../../common/styling";
 
 interface WCProps extends Margins {
   heading: string;
+  open?: boolean;
 }
 
 declare global {
@@ -18,6 +19,7 @@ declare global {
 /* eslint-disable-next-line */
 export interface DetailsProps extends Margins {
   heading: string;
+  open?: boolean;
   children: ReactNode;
 }
 
@@ -25,6 +27,7 @@ export function GoADetails(props: DetailsProps) {
   return (
     <goa-details
       heading={props.heading}
+      open={props.open}
       mt={props.mt}
       mr={props.mr}
       mb={props.mb}

--- a/libs/web-components/src/components/details/Details.html-data.json
+++ b/libs/web-components/src/components/details/Details.html-data.json
@@ -26,6 +26,11 @@
       "name": "ml",
       "description": "Left margin",
       "valueSet": "spacing"
+    },
+    {
+      "name": "open",
+      "description": "Controls if details is expanded or collapsed",
+      "valueSet": "boolean"
     }
   ],
   "references": [

--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -3,16 +3,21 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { calculateMargin, Spacing } from "../../common/styling";
-  import { validateRequired } from "../../common/utils";
+  import { toBoolean, validateRequired} from "../../common/utils";
 
   export let heading: string;
   export let mt: Spacing = null;
   export let mr: Spacing = null;
   export let mb: Spacing = null;
   export let ml: Spacing = null;
+  export let open: string = "false";
 
   let _isMouseOver: boolean = false
   let _summaryEl: HTMLElement;
+  let _detailsEl: HTMLElement;
+
+  $: _isOpen = toBoolean(open);
+
 
   onMount(() => {
     validateRequired("Details", { heading });
@@ -24,8 +29,7 @@
     _summaryEl.addEventListener("mouseout", () => {
       _isMouseOver = false;
     });
-  })
-
+  });
 </script>
 
 <style>
@@ -103,7 +107,11 @@
   }
 </style>
 
-<details style={calculateMargin(mt, mr, mb, ml)}>
+<details
+  bind:this={_detailsEl}
+  open={_isOpen}
+  on:toggle={({target}) => open = `${target.open}`}
+  style={calculateMargin(mt, mr, mb, ml)}>
   <summary bind:this={_summaryEl}>
     <goa-icon
       mt="1"

--- a/libs/web-components/src/components/details/details.spec.ts
+++ b/libs/web-components/src/components/details/details.spec.ts
@@ -2,7 +2,9 @@ import Details from './Details.svelte'
 import { render } from '@testing-library/svelte'
 
 it('it works', async () => {
-  const { container } = render(Details, { heading: "The title"})
+  const { container } = render(Details, { heading: "The title", open: true})
   const summary = container.querySelector("summary span")
   expect(summary.innerHTML).toContain("The title");
+  const details = container.querySelector("details");
+  expect(details.hasAttribute("open")).toBe(true);
 })

--- a/libs/web-components/src/components/details/doc.md
+++ b/libs/web-components/src/components/details/doc.md
@@ -8,4 +8,12 @@ Use it like this:
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   </p>
 </goa-details>
+
+Expand/Hide details:
+
+<goa-details heading="This is the title" [open]="true">
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vel lacinia metus, sed sodales lectus. Aliquam sed volutpat velit. Sed in lacus ut dui placerat accumsan malesuada quis erat. Aenean mi diam, rhoncus vitae justo eu, venenatis maximus nunc. In vel est commodo, porttitor sem vel, tincidunt ipsum. In hac habitasse platea dictumst. Mauris varius mollis dui. Aenean ut dui eu arcu rutrum auctor. Curabitur cursus velit vel libero sollicitudin tincidunt. Proin tincidunt, enim et ultrices rhoncus, nibh leo imperdiet sapien, sed porttitor ipsum nulla non massa. Nulla facilisi.
+  </p>
+</goa-details>
 ```


### PR DESCRIPTION
### Description
End users want to expand the additional information programmatically. This PR is to add a boolean attribute "open" that allows web component GoADetails expanded/hidden programmatically. 

### Story
[DDI-1328](https://goa-dio.atlassian.net/browse/DDIDS-1328)

### What changes:

- Add boolean "open"  to web component GoADetails
- Update React wrapper 
- Add storybook
- Update VS Code data. 

### Screenshots:

![image](https://github.com/GovAlta/ui-components/assets/120135417/bf0bb4e7-5d87-461d-aca9-79d505e8c4c6)


![image](https://github.com/GovAlta/ui-components/assets/120135417/e029e929-ed42-4fdf-bd1f-8dad49a659f1)
