### PR TITLE
chore: create playground template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ apps/angular-demo-e2e/src/cucumber-json/current-sprint-noop.cucumber.json
 apps/angular-demo-e2e/src/cucumber-json/button-component.cucumber.json
 
 .angular
+
+libs/web-components/playground/src/App.svelte

--- a/libs/web-components/playground/src/App.svelte.template
+++ b/libs/web-components/playground/src/App.svelte.template
@@ -1,9 +1,3 @@
-<!--
-************************************************************************************************
-* Do not commit anything in this file to the Alpha or Main branch, so please ensure that this 
-* file is reset before creating a PR.
-************************************************************************************************
--->
 <svelte:options tag={null} />
 <svelte:head>
   <title>GoA Component Playground</title>


### PR DESCRIPTION
Adds a svelte template file that allows a dev to copy to local env and make changes in it without having to worry about accidentally including changes in PRs