### PR TITLE
fix(DDI-1365): fix when clear button is hit on GoAInputDate (React), …

### DIFF
--- a/libs/react-components/src/lib/input/input.tsx
+++ b/libs/react-components/src/lib/input/input.tsx
@@ -216,7 +216,7 @@ export const GoAInput: FC<InputProps & { type?: GoAInputType }> = ({
 const onDateChangeHandler = (onChange: OnDateChange) => {
   return (name: string, value: string) => {
     if (!value) {
-      onChange(name, new Date(0));
+      onChange(name, "");
       return;
     }
     onChange(name, parseISO(value));


### PR DESCRIPTION
# Description
For  GoAInputDate (React) , click "Clear" after selecting a date that will return Wed Dec 31 1969 19:00:00.
Expected it should return "" same as Angular component. 

# Story [DDI-1365](https://goa-dio.atlassian.net/browse/DDIDS-1365)

# Screenshot
Angular returns "" when hitting the "Clear" button. 
![image](https://github.com/GovAlta/ui-components/assets/120135417/92952669-2dea-49e8-8cfc-09a5bbe5f149)

After fixing, React has the same behavior: 
![image](https://github.com/GovAlta/ui-components/assets/120135417/538a8991-2992-49f8-acaf-39cc852ac7bd)

