### PR TITLE
fix(#1258): emit change event for angular goavalue directives when va…

### DIFF
--- a/libs/angular-components/src/lib/value-directive.ts
+++ b/libs/angular-components/src/lib/value-directive.ts
@@ -23,12 +23,10 @@ export class ValueDirective implements ControlValueAccessor {
   }
 
   set value(val: string) {
-    if (val !== this._value) {
-      this._value = val;
-      this.onChange(this._value);
-      this.onTouched();
-      this.elementRef.nativeElement.value = val;
-    }
+    this._value = val;
+    this.onChange(this._value);
+    this.onTouched();
+    this.elementRef.nativeElement.value = val;
   }
 
   writeValue(value: string) {


### PR DESCRIPTION
…lue is unchanged

This allows the _change event to be fired for angular components using the goavalue directive when the value is changed outside the component.