### PR TITLE
chore(#1284): Update docs about button type=submit

### DIFF
--- a/libs/docs/src/components/common/Button.stories.mdx
+++ b/libs/docs/src/components/common/Button.stories.mdx
@@ -7,7 +7,7 @@ import {
   Props,
   Prop,
 } from "@abgov/shared/storybook-common";
-import { GoAButton, GoAButtonGroup } from "@abgov/react-components";
+import { GoAButton, GoAButtonGroup, GoACallout } from "@abgov/react-components";
 
 <Meta title="Components/Button" />
 
@@ -105,6 +105,11 @@ export const noop = () => {};
 #### Types
 
 There are three main button types: Primary, Secondary, and Tertiary. If there is only one button on a page, it should be a primary button. There should only ever be one primary button on a page
+
+<GoACallout type="information">
+  <i>type=submit</i> is only used for styling but doesn't auto submit a form
+  when placed inside a form.
+</GoACallout>
 
 <Story name="Types">
   <GoAButtonGroup alignment="start">

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -64,6 +64,7 @@
   disabled={isDisabled}
   on:click={clickHandler}
   data-testid={testid}
+  type={type == "submit" ? type : "button"}
 >
   {#if type === "start"}
     <span class="text">


### PR DESCRIPTION
There is no easy fix for this. 
For now, 
* making sure that the native button gets the `type=submit` prop
* updating the docs 