### PR TITLE
fix(#1327) Fix table sorting

### DIFF
--- a/libs/react-components/src/lib/table/table.spec.tsx
+++ b/libs/react-components/src/lib/table/table.spec.tsx
@@ -1,10 +1,38 @@
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import React from "react";
 import Table from "./table";
 
 describe("Table", () => {
+
   it("should render successfully", () => {
     const { baseElement } = render(<Table />);
     expect(baseElement).toBeTruthy();
+  });
+
+  it("should call onSort when _sort event is triggered", () => {
+    const onSort = jest.fn();
+    const { getByTestId } = render(<Table onSort={onSort} testId="test-table" />);
+
+    fireEvent(
+      getByTestId("test-table"),
+      new CustomEvent("_sort", {
+        detail: { sortBy: "name", sortDir: 1 }
+      })
+    );
+
+    expect(onSort).toHaveBeenCalledWith("name", 1);
+  });
+
+  it("should handle _sort event gracefully when no onSort prop is passed", () => {
+    const { getByTestId } = render(<Table testId="test-table-without-sort" />);
+
+    expect(() =>
+      fireEvent(
+        getByTestId("test-table-without-sort"),
+        new CustomEvent("_sort", {
+          detail: { sortBy: "age", sortDir: -1 }
+        })
+      )
+    ).not.toThrow();
   });
 });

--- a/libs/react-components/src/lib/table/table.tsx
+++ b/libs/react-components/src/lib/table/table.tsx
@@ -27,11 +27,11 @@ export interface TableProps extends Margins {
   // stickyHeader?: boolean; TODO: enable this later
   variant?: TableVariant;
   testId?: string;
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 export function GoATable(props: TableProps) {
-  const ref = useRef<HTMLElement>(null);
+  const ref = useRef<HTMLTableElement>(null);
   useEffect(() => {
     if (!ref.current) {
       return;

--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -47,8 +47,9 @@
 
   async function attachSortEventHandling() {
     await tick();
-    const headings = _rootEl.querySelectorAll("goa-table-sort-header");
-    headings.forEach(heading => {
+    const contentSlot = _rootEl.querySelector("slot") as HTMLSlotElement;
+    const headings = contentSlot.assignedElements().find(el => el.tagName==="THEAD" || el.tagName==="TABLE")?.querySelectorAll("goa-table-sort-header");
+    headings?.forEach(heading => {
       heading.addEventListener("click", () => {
         const sortBy = heading.getAttribute("name")
         let sortDir: number;
@@ -77,7 +78,7 @@
         setTimeout(() => {
           dispatch(heading, {sortBy: initialSortBy, sortDir: initialDirection === "asc" ? 1 : -1})
         }, 10)
-      } 
+      }
     })
   }
 
@@ -91,7 +92,7 @@
   }
 </script>
 
-<div 
+<div
   bind:this={_rootEl}
   class={`goatable ${variant}`}
   class:sticky={_stickyHeader}


### PR DESCRIPTION
* Couldn't add a test case to validate the `_sort` event firing, as the `goa-table-sort-header` is within a slot and was hard to test with`@testing-library/svelte`. Open to suggestions on this
* Added a small test case on the react component but that isn't the actual the issue 