### PR TITLE
fix(#1331): GoAFormItem(React) should not require label property

### DIFF
--- a/apps/react-demo/src/routes/formItem.tsx
+++ b/apps/react-demo/src/routes/formItem.tsx
@@ -53,7 +53,19 @@ export default function FormItem() {
           error
         ></GoAInput>
       </GoAFormItem>
-
+      <br/>
+      <GoAFormItem
+        helpText="No label is still valid"
+      >
+        <GoAInput
+          name="lasstName"
+          value=""
+          onChange={() => void 0}
+          type="text"
+          error
+          width="100%"
+        ></GoAInput>
+      </GoAFormItem>
       <br />
       <h2>Form row</h2>
       <GoAGrid minChildWidth="30ch">

--- a/libs/react-components/src/lib/form/form-item.tsx
+++ b/libs/react-components/src/lib/form/form-item.tsx
@@ -4,7 +4,7 @@ import { Margins } from "../../common/styling";
 type RequirementType = "optional" | "required";
 
 interface WCProps extends Margins {
-  label: string;
+  label?: string;
   requirement?: RequirementType;
   error?: string;
   helptext?: string;
@@ -21,7 +21,7 @@ declare global {
 }
 
 interface GoAFormItemProps extends Margins {
-  label: string;
+  label?: string;
   requirement?: RequirementType;
   error?: string;
   helpText?: string;


### PR DESCRIPTION
Remove the required label for GoaFormItem 

<img width="847" alt="image" src="https://github.com/GovAlta/ui-components/assets/120135417/f3b2fdb6-e229-4b68-83b8-7b5353d3d3e6">
