### PR TITLE
fix(#1359): prevent focus-trap from allowing element with a tabindex=…

### DIFF
--- a/libs/web-components/src/components/focus-trap/FocusTrap.spec.ts
+++ b/libs/web-components/src/components/focus-trap/FocusTrap.spec.ts
@@ -1,17 +1,29 @@
-import '@testing-library/jest-dom';
-import { render, cleanup, fireEvent } from '@testing-library/svelte';
-import FocusTrapTestComponent from './FocusTrapTestComponent.svelte';
+import "@testing-library/jest-dom";
+import {
+  render,
+  cleanup,
+  fireEvent,
+  createEvent,
+  waitFor,
+} from "@testing-library/svelte";
+import FocusTrapTestComponent from "./FocusTrapTestComponent.svelte";
 
 afterEach(cleanup);
 
 // This test is blocked due to JEST handling slot elements differently than web browser
 // For details, please refer https://goa-dio.atlassian.net/browse/DDIDS-704
-describe.skip('Focus Trap Component', () => {
-
-  it("Trap the tab key", async () => {
+describe("Focus Trap Component", () => {
+  it.skip("traps the tab key", async () => {
     const el = render(FocusTrapTestComponent);
-    fireEvent.keyUp(el.container.getElementsByClassName("email")[0], { key: 'Tab', keyCode: 9 });
-    expect(el.container.getElementsByClassName("email")[0]).toHaveFocus();
-  });
 
+    const userNameEl = el.queryByTestId("username");
+    const emailEl = el.queryByTestId("email");
+    userNameEl.focus();
+    const tabPressEvent = createEvent.keyDown(el.container, { key: "Tab" });
+
+    fireEvent(el.container, tabPressEvent);
+    await waitFor(() => {
+      expect(emailEl).toHaveFocus();
+    });
+  });
 });

--- a/libs/web-components/src/components/focus-trap/FocusTrap.svelte
+++ b/libs/web-components/src/components/focus-trap/FocusTrap.svelte
@@ -44,6 +44,7 @@
 
     if (isTabbable) return node;
     if (element["disabled"]) return null;
+    if (element.tabIndex < 0 || element.getAttribute?.("tabindex") === "-1") return null;
 
     switch (element.nodeName) {
       case 'A': {

--- a/libs/web-components/src/components/focus-trap/FocusTrapTestComponent.svelte
+++ b/libs/web-components/src/components/focus-trap/FocusTrapTestComponent.svelte
@@ -6,10 +6,10 @@
 <!-- HTML -->
 <div>
   <input type="text" class="description" name="description" />
-  <GoAFocusTrap open="true">
-    <input type="text" class="username" name="username" />
-    <input type="text" class="email" name="email" />
-    <input type="text" class="address" name="address" />
+  <GoAFocusTrap>
+    <input type="text" data-testid="username" name="username" />
+    <input type="text" data-testid="email" name="email" />
+    <input type="text" data-testid="address" name="address" />
   </GoAFocusTrap>
   <input type="submit" />
   <input type="reset" />


### PR DESCRIPTION
…-1 from attaining focus