### PR TITLE
chore: Update configuration for bugfix branch to publish under latest tag

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,10 @@
   "branches": [
     "+([0-9])?(.{+([0-9]),x}).x",
     "main",
-    "BUGFIX",
+    {
+      "name": "BUGFIX",
+      "channel": false
+    },
     {
       "name": "alpha",
       "prerelease": true


### PR DESCRIPTION
## Issue 
Commits to `BUGFIX` branch do not get published to the latest distribution tag on npm. Rather the [new version](https://www.npmjs.com/package/@abgov/react-components?activeTab=versions) gets published under the `BUGFIX` dist. 

## Changes
Update semantic release configuration to publish to latest tag. 
Docs for this configuration change can be found [here](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#channel)

## Testing
Will need to push a bugfix to test this