### PR TITLE
fix(#1360): Removed width from Pagination dropdown

### DIFF
--- a/libs/web-components/src/components/pagination/Pagination.svelte
+++ b/libs/web-components/src/components/pagination/Pagination.svelte
@@ -78,7 +78,7 @@
       <goa-block data-testid="page-selector" alignment="center" gap="s">
         <span>Page</span>
         <input bind:this={hiddenEl} type="hidden" />
-        <goa-dropdown bind:this={pageDropdownEl} value="{pagenumber}" width="70px">
+        <goa-dropdown bind:this={pageDropdownEl} value="{pagenumber}">
           {#each {length: _pageCount} as _, i}
             <goa-dropdown-item value="{i+1}" label="{i+1}"/>
           {/each}


### PR DESCRIPTION
This should make the Pagination page select dropdown autosize, which should mean that 2 character numbers should fit now.