### PR TITLE
chore: Add another name for GoATextArea vs GoATextarea.

### DIFF
--- a/libs/react-components/src/lib/textarea/textarea.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.tsx
@@ -40,7 +40,7 @@ export interface GoATextAreaProps extends Margins {
   onChange: (name: string, value: string) => void;
 }
 
-export function GoATextArea({
+export function GoATextarea({
   name,
   value,
   placeholder,
@@ -96,6 +96,7 @@ export function GoATextArea({
       ml={ml}
     ></goa-textarea>
   );
-};
+}
+export {GoATextarea as GoATextArea}
+export default GoATextarea;
 
-export default GoATextArea;


### PR DESCRIPTION
It follows up and unblocks the PR https://github.com/GovAlta/ui-components-docs/pull/42
With the logic of the Sandbox, if we use the React name as `GoATextArea`, The Angular code snippet will be `goa-text-area`. 

This PR is to add another name for Text Area component, which is `GoATextarea`, which helps generate the code in Angular correctly. 
After the change: 
![image](https://github.com/GovAlta/ui-components/assets/120135417/8a3c778b-ed94-4095-9cb2-55ffa2c53582)
![image](https://github.com/GovAlta/ui-components/assets/120135417/73c91beb-96e8-4dcb-8679-1175741eaeab)


