### PR TITLE
fix(#1476): not change current tab if it isn't focus

### DIFF
--- a/libs/web-components/playground/src/pg-tabs.svelte
+++ b/libs/web-components/playground/src/pg-tabs.svelte
@@ -1,16 +1,24 @@
 <svelte:options tag="pg-tabs" />
 
 <script lang="ts">
+  let value: string = "blue"
   function handleClick() {
     console.log("clicked");
   }
+  function setValue(e: CustomEvent) {
+    console.log("app dropdown handler", e.detail)
+    value = e.detail.value;
+  }
 </script>
 
-<goa-tabs initialtab="2">
+<goa-tabs>
   <goa-tab>
     <div slot="heading">Tab Slot 1<goa-badge type="important" content="3"></goa-badge></div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Perferendis, natus rerum.
-    <goa-button on:_click={handleClick}>Click Me</goa-button>
+    <goa-dropdown on:_change={(e) => setValue(e)} value={value} leadingicon="airplane">
+      <goa-dropdown-item value="red" label="red"></goa-dropdown-item>
+      <goa-dropdown-item value="blue" label="blue"></goa-dropdown-item>
+    </goa-dropdown>
   </goa-tab>
 
   <goa-tab>

--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -96,6 +96,12 @@
 
   function onKeyDown(e: KeyboardEvent) {
     let isHandled = false;
+    const isTabButtonFocused = e.target && _tabs.contains(e.target as Node);
+
+    if (!isTabButtonFocused) {
+      return;
+    }
+
     switch (e.key) {
       case 'ArrowUp':
       case 'ArrowLeft':


### PR DESCRIPTION
It shouldn't move to the new tab if the focus element isn't a tab button.

https://github.com/GovAlta/ui-components/assets/120135417/d9e63a94-c25d-43d3-b992-0ccd169628f4

