### PR TITLE
chore(#1550): footer meta section - change gap to l

### DIFF
--- a/libs/web-components/src/components/footer-meta-section/FooterMetaSection.svelte
+++ b/libs/web-components/src/components/footer-meta-section/FooterMetaSection.svelte
@@ -33,7 +33,7 @@
   ul {
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: var(--goa-space-l);
     padding-left: 0;
   }
 


### PR DESCRIPTION
Follow up with [Mark io link](https://app.markup.io/markup/9562b512-68d2-436a-966c-410d61fa8cf3#thread/c81df857-200a-4979-9e4a-a9dd738d3c6d)

Screenshots: 
![image](https://github.com/GovAlta/ui-components/assets/120135417/f939cf14-f406-4b5f-96ac-47477ec25bf5)

