### PR TITLE
fix(#1598): angular visually empty form control value by directive - needs review

### DIFF
--- a/libs/angular-components/src/lib/value-directive.ts
+++ b/libs/angular-components/src/lib/value-directive.ts
@@ -29,9 +29,7 @@ export class ValueDirective implements ControlValueAccessor {
   }
 
   writeValue(value: string) {
-    if (value) {
-      this.value = value;
-    }
+    this.value = value;
   }
 
   registerOnChange(fn: () => void) {


### PR DESCRIPTION
Allow angular input resetValue,patchValue or setValue and visually clear the input text value. 
Video as below: 

https://github.com/GovAlta/ui-components/assets/120135417/a4af4bf0-5d00-48c8-8211-39e25521c6f7

With the code snippet: 
```
export class FormItemComponent {
  formGroup = new FormGroup({
    txtRequesterName: new FormControl(),
  })
  constructor() {}
  searchRequesterClickIcon () {
    console.log("Current value ", this.formGroup.get("txtRequesterName")?.value);
    this.formGroup.get("txtRequesterName")?.patchValue("");
    console.log("New value ", this.formGroup.get("txtRequesterName")?.value);
  }
}

<goa-form-item [formGroup]="formGroup">
  <goa-input goaValue
             placeholder="Search requester"
             formControlName="txtRequesterName"
             trailingicon="close"
             [handletrailingiconclick]="true"
             (_trailingIconClick)="searchRequesterClickIcon()"
             width="434px">
  </goa-input>
</goa-form-item>
```