### PR TITLE
fix(#1597): textarea not calling 'change' callback on keypress - needs review

### DIFF
--- a/libs/web-components/src/components/text-area/TextArea.spec.ts
+++ b/libs/web-components/src/components/text-area/TextArea.spec.ts
@@ -45,6 +45,7 @@ describe("GoATextArea", () => {
 
   it("handles the keypress event", async () => {
     const onKeyPress = vi.fn();
+    const onChange = vi.fn();
     const result = render(GoATextArea, {
       name: "name",
       value: "foo",
@@ -59,11 +60,19 @@ describe("GoATextArea", () => {
       onKeyPress();
     });
 
+    textarea.addEventListener("_change", (e: CustomEvent) => {
+      expect(e.detail.name).toBe("name");
+      expect(e.detail.value).toBe("foo");
+      onChange();
+    });
+
     await fireEvent.keyUp(textarea, { target: { value: "foo" }, key: "o" });
 
     await waitFor(() => {
       expect(onKeyPress).toBeCalledTimes(1);
+      expect(onChange).toBeCalledTimes(1);
     });
+
   });
 
   it("can be disabled", async () => {

--- a/libs/web-components/src/components/text-area/TextArea.svelte
+++ b/libs/web-components/src/components/text-area/TextArea.svelte
@@ -41,23 +41,27 @@
 
   // functions
 
-  function onChange(
-    e: Event & { currentTarget: EventTarget & HTMLTextAreaElement },
-  ) {
+  function onChange(e: KeyboardEvent) {
     if (isDisabled) return;
-
-    const el = e.currentTarget;
-    _textareaEl.dispatchEvent(
-      new CustomEvent("_change", {
-        composed: true,
-        detail: { name, value: el.value },
-      }),
-    );
+    dispatchChange(e);
   }
 
   function onKeyPress(e: KeyboardEvent) {
     if (isDisabled) return;
+    dispatchKeyPress(e);
+    dispatchChange(e);
+  }
 
+  function dispatchChange(_: KeyboardEvent) {
+    _textareaEl.dispatchEvent(
+      new CustomEvent("_change", {
+        composed: true,
+        detail: { name, value: _textareaEl.value },
+      }),
+    );
+  }
+
+  function dispatchKeyPress(e: KeyboardEvent) {
     _textareaEl.dispatchEvent(
       new CustomEvent("_keyPress", {
         composed: true,


### PR DESCRIPTION
Fix issue https://github.com/GovAlta/ui-components/issues/1597

Screenshots: 
React works with onChange, and with counter
![image](https://github.com/GovAlta/ui-components/assets/120135417/7c57309b-0688-47d7-920f-16ff41b5c823)

Angular works  and with counter
![image](https://github.com/GovAlta/ui-components/assets/120135417/b6d41b75-56df-41c7-84c9-506dd6487697)
