### PR TITLE
fix(#1577): Incorrect border rendering on Text Field in the Error and Focus state

### DIFF
--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -188,8 +188,8 @@
   <div
     class="goa-input variant--{variant} type--{type}"
     class:input--disabled={isDisabled}
-    class:input-leading-content={_leadingContentSlot}
-    class:input-trailing-content={_trailingContentSlot}
+    class:leading-content={_leadingContentSlot}
+    class:trailing-content={_trailingContentSlot}
     class:error={isError}
   >
     {#if prefix}


### PR DESCRIPTION
This PR is my proposed fix for https://github.com/GovAlta/ui-components/issues/1577. 


The CSS targets the `.leading/trailing-content` class, not the `.input-leading/trailing-content` one. I've removed `input` from the class name. 

It resolves the issue but may cause other ones since this is my first time inspecting the code. 😂 Feel free to disregard this if I'm completely out to lunch.

![image](https://github.com/GovAlta/ui-components/assets/1479091/4ebebfa8-9092-47cb-9d95-5fef2786e168)
