### PR TITLE
fix(#1510): dispatch value filterable dropdown when browser autofil

### DIFF
--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -1,7 +1,7 @@
 <svelte:options customElement="goa-dropdown" />
 
 <script lang="ts">
-  import { onMount } from "svelte";
+  import {onMount, tick} from "svelte";
 
   import type { GoAIconType } from "../icon/Icon.svelte";
   import type { Spacing } from "../../common/styling";
@@ -305,6 +305,20 @@
     dispatchValue(option.value);
   }
 
+  /**
+   * When website autofill value without user keyboard
+   */
+  async function onChange() {
+    await tick();
+    syncFilteredOptions();
+    if (_filteredOptions.length === 1) {
+      dispatchValue(_filteredOptions[0].value);
+      setTimeout(() => {
+        hideMenu();
+      }, 100);
+    }
+  }
+
   function onInputKeyUp(e: KeyboardEvent) {
     if (_disabled) return;
     _eventHandler.handleKeyUp(e);
@@ -593,6 +607,7 @@
           {name}
           on:keydown={onInputKeyDown}
           on:keyup={onInputKeyUp}
+          on:change={onChange}
         />
 
         {#if _inputEl?.value && _filterable}


### PR DESCRIPTION
Issue described: https://github.com/GovAlta/ui-components/issues/1510 

I tested with Chrome. You can set the contacts as the below:
![image](https://github.com/GovAlta/ui-components/assets/120135417/eb91c742-2577-4805-afca-be2d133bd12d)

The code I referred to can be found here: 
https://stackblitz.com/edit/b1due8?file=src%2Fapp%2Fapp.component.html

**Notice**: In order to test it, you must use the code in an angular app that doesn't navigate by router. (Our playground example app.component.html) is a good place to start. 


https://github.com/GovAlta/ui-components/assets/120135417/c95e600d-7768-4163-b528-81ed4f3b4a61

