### PR TITLE
fix(#1528): Modal z-index bug

### DIFF
--- a/libs/web-components/src/components/modal/Modal.svelte
+++ b/libs/web-components/src/components/modal/Modal.svelte
@@ -244,6 +244,8 @@
   :host {
     box-sizing: border-box;
     font-family: var(--goa-font-family-sans);
+    position: relative;
+    z-index: 99999;
   }
 
   :host * {


### PR DESCRIPTION
#### React code to reproduce the issue

```jsx
const [showModal, setShowModal] = useState(false);

// 
<GoAButton onClick={() => setShowModal(true)}>Open Modal</GoAButton>
      <div
        style={{
          height: "50vh",
          width: "50vw",
          zIndex: 101,
          backgroundColor: "yellow",
          position: "relative",
        }}
      >
        TEST
      </div>
      <GoAModal
        heading="Do you agree?"
        open={showModal}
        onClose={() => setShowModal(false)}
      >
        <p>
          Lorem ipsum dolor sit amet consectetur adipisicing elit. Mollitia obcaecati id
          molestiae, natus dicta, eaque qui iusto similique, libero explicabo eligendi
          eius laboriosam! Repellendus ducimus officia asperiores. Eos, eius numquam.
        </p>
      </GoAModal>
```