### PR TITLE
fix(#1679): null querySelector errors in dropdown

### DIFF
--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -118,8 +118,9 @@
     // watch for DOM changes within the slot => dynamic binding
     const slot = _rootEl.querySelector("slot");
     slot?.addEventListener("slotchange", () => {
-      _options = getOptions();
+      if (!_rootEl) return;
 
+      _options = getOptions();
       syncFilteredOptions();
 
       if (!width) {


### PR DESCRIPTION
This seemed to be an angular issue only when changing routes from a page that contained a dropdown component.

The error was due to the Dropdown component responding to the `slotchanged` event, which made reference to one of the elements within the page. However, by the time the reference was made the html element had been removed from the DOM; resulting in the null exception.