### PR TITLE
fix: react import for production build

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@
 # This is disabled for existing workspaces to maintain compatibility
 # For more info, see: https://nx.dev/concepts/inferred-tasks
 NX_ADD_PLUGINS=false
+DEV=true

--- a/libs/react-components/src/index.ts
+++ b/libs/react-components/src/index.ts
@@ -1,10 +1,10 @@
 // Components
 
-if (import.meta.env.PROD) {
+if (import.meta.env.DEV) {
+  console.log("GoA UI Components DEV mode")
+} else {
   // @ts-expect-error ignore
   import("@abgov/web-components");
-} else {
-  console.log("GoA UI Components DEV mode")
 }
 
 export * from "./lib/accordion/accordion";


### PR DESCRIPTION
The web-components library needs to be imported for production releaase, but the import prevent live reloads when running in a dev environment.

The previous attempt at the work-around caused breaking builds; reversing the bool conditions should fix the issue.