### PR TITLE
fix(#1676): app-header menu should close after menu item is clicked

### DIFF
--- a/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
+++ b/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
@@ -43,6 +43,7 @@
     window.addEventListener("popstate", setCurrentLink, true);
   });
 
+
   onDestroy(() => {
     window.removeEventListener("popstate", setCurrentLink, true);
   });
@@ -83,11 +84,20 @@
     _popoverEl.addEventListener("_open", openMenu);
   }
 
-  function openMenu() {
+  async function openMenu() {
     _open = true;
+
+    await tick();
+
+    if (_slotParentEl) {
+      _slotParentEl.addEventListener("click", closeMenu);
+    }
   }
 
   function closeMenu() {
+    if (_slotParentEl) {
+      _slotParentEl.removeEventListener("click", closeMenu);
+    }
     // timeout is required to allow any other events to fire before DOM is changed
     setTimeout(() => {
       _open = false;
@@ -111,6 +121,7 @@
     tabindex="-1"
     width="16rem"
     position="below"
+    open="{_open}"
   >
     <button
       slot="target"

--- a/libs/web-components/src/components/app-header-menu/AppHeaderMenuWrapper.test.svelte
+++ b/libs/web-components/src/components/app-header-menu/AppHeaderMenuWrapper.test.svelte
@@ -6,10 +6,19 @@
 
   export let heading: string = "some label";
   export let leadingicon: GoAIconType;
+
+  function selectWithoutLoading() {
+    const target = document.querySelector("span[data-testid='test-without-loading']");
+    if (target) {
+      target.innerHTML = "Test without loading";
+    }
+  }
 </script>
 
 <GoAAppHeaderMenu {heading} {leadingicon}>
   <a href="#seniors">Seniors</a>
   <a href="#family">Family</a>
   <a href="#children">Children</a>
+  <a href="#special" on:click={selectWithoutLoading}>Test</a>
 </GoAAppHeaderMenu>
+<span data-testid="test-without-loading"></span>

--- a/libs/web-components/src/components/app-header-menu/app-header-menu.spec.ts
+++ b/libs/web-components/src/components/app-header-menu/app-header-menu.spec.ts
@@ -1,8 +1,9 @@
 import AppHeaderMenuWrapper from "./AppHeaderMenuWrapper.test.svelte"
-import { render, waitFor } from "@testing-library/svelte"
+import { render, waitFor, screen } from "@testing-library/svelte"
 import userEvent from "@testing-library/user-event"
 import type { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { it, describe } from "vitest";
+import {tick} from "svelte";
 
 let user: UserEvent;
 
@@ -54,9 +55,20 @@ describe("Desktop", () => {
     // the default slot
     await waitFor(() => {
       expect(links).toBeTruthy();
-      expect(links.length).toBe(3);
+      expect(links.length).toBe(4);
     })
-  })
+  });
+
+  it("close the menu if the link handles other function beside navigate to new page", async () => {
+    const specialLink = $("a[href='#special']");
+    await user.click(specialLink);
+    await tick();
+    const popover = $("goa-popover")
+    expect( popover.getAttribute("open")).toBe("false");
+    // Functionality is handled as usual
+    const text = await screen.findByTestId("test-without-loading");
+    expect((await text).innerHTML).toBe("Test without loading");
+  });
 
 })
 
@@ -98,7 +110,7 @@ describe("Mobile", () => {
     await user.click(btn)
     await waitFor(() => {
       const links = $$("a");
-      expect(links.length).toBe(3);
+      expect(links.length).toBe(4);
     })
 
     // close
@@ -117,7 +129,7 @@ describe("Mobile", () => {
     await user.keyboard(" ")
     await waitFor(() => {
       const links = $$("a");
-      expect(links.length).toBe(3);
+      expect(links.length).toBe(4);
     })
 
     // close
@@ -136,10 +148,10 @@ describe("Mobile", () => {
     await user.keyboard("{enter}")
     await waitFor(() => {
       const links = $$("a");
-      expect(links.length).toBe(3);
+      expect(links.length).toBe(4);
     })
 
-    // close
+    //close
     await user.keyboard("{enter}")
     await waitFor(() => {
       const links = $$("a");
@@ -154,7 +166,7 @@ describe("Mobile", () => {
     await user.keyboard("{enter}")
     await waitFor(async () => {
       const links = $$("a");
-      expect(links.length).toBe(3);
+      expect(links.length).toBe(4);
 
       await user.keyboard("{Tab}");
       expect(document.activeElement).toBe(links[0]);
@@ -164,6 +176,14 @@ describe("Mobile", () => {
       expect(document.activeElement).toBe(links[2]);
     })
   })
+
+  it("close the menu if the link handles other function beside navigate to new page", async () => {
+    const specialLink = $("a[href='#special']");
+    await user.click(specialLink);
+    await tick();
+    const links = $$("a");
+    expect(links.length).toBe(0);
+  });
 
   it.skip("follows the link on `enter`", () => {
     /* do nothing */
@@ -209,7 +229,7 @@ describe("Tablet", () => {
     await user.click(btn)
     await waitFor(() => {
       const links = $$("a");
-      expect(links.length).toBe(3);
+      expect(links.length).toBe(4);
     })
 
     // close
@@ -228,7 +248,7 @@ describe("Tablet", () => {
     await user.keyboard(" ")
     await waitFor(() => {
       const links = $$("a");
-      expect(links.length).toBe(3);
+      expect(links.length).toBe(4);
     })
 
     // close
@@ -247,7 +267,7 @@ describe("Tablet", () => {
     await user.keyboard("{enter}")
     await waitFor(() => {
       const links = $$("a");
-      expect(links.length).toBe(3);
+      expect(links.length).toBe(4);
     })
 
     // close
@@ -265,7 +285,7 @@ describe("Tablet", () => {
     await user.keyboard("{enter}")
     await waitFor(async () => {
       const links = $$("a");
-      expect(links.length).toBe(3);
+      expect(links.length).toBe(4);
 
       await user.keyboard("{Tab}");
       expect(document.activeElement).toBe(links[0]);
@@ -275,4 +295,12 @@ describe("Tablet", () => {
       expect(document.activeElement).toBe(links[2]);
     })
   })
+
+  it("close the menu if the link handles other function beside navigate to new page", async () => {
+    const specialLink = $("a[href='#special']");
+    await user.click(specialLink);
+    await tick();
+    const links = $$("a");
+    expect(links.length).toBe(0);
+  });
 })


### PR DESCRIPTION
Fixing #1676 

https://github.com/GovAlta/ui-components/assets/120135417/3f4d70e3-8305-47fe-a199-6ec6a4a72659

Angular code: 
```
<goa-app-header url="https://example.com" heading="Ticket and Fine Payments">
  <a href="#">Support</a>
  <goa-app-header-menu heading="Tickets" leadingIcon="ticket">
    <a href="#" (click)="selectMenu('Cases'); $event.preventDefault()">Cases</a>
    <a href="#" (click)="selectMenu('Payments'); $event.preventDefault()">Payments</a>
    <a href="#" (click)="selectMenu('Outstanding');$event.preventDefault()">Outstanding</a>
    <a href="#">Test</a>
  </goa-app-header-menu>
  <a href="#" class="interactive">Sign in</a>
</goa-app-header>

<span>Selected Menu: {{selectedMenu}}</span>
```

```
import { Component } from "@angular/core";

@Component({
  selector: "abgov-app-header",
  templateUrl: "./app-header.component.html"
})
export class AppHeaderComponent {
  selectedMenu: string = "";
  constructor() {}
  selectMenu(text: string): void {
    this.selectedMenu = text;
  }
}

```