### PR TITLE
fix: tabs are now links instead of buttons

### DIFF
--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -37,17 +37,21 @@
     setTimeout(() => {
       // HACK: this is done to get the initial tab set when using angular
       setCurrentTab(+initialtab);
-    }, 1)
+    }, 1);
     setCurrentTab(+initialtab);
   });
 
   function bindTabs(tabs: Element[]) {
+    const path = window.location.pathname;
+
     // create buttons (tabs) for each of the tab contents elements
     tabs.forEach((tab, index) => {
       // @ts-expect-error
       let headingEl = [...tab.children].find(
         (child) => child.getAttribute("slot") === "heading",
       ) as HTMLElement;
+
+      let tabSlug: string;
 
       if (headingEl) {
         // slot exists
@@ -64,19 +68,22 @@
           headingEl = document.createElement("div");
           headingEl.classList.add("tab");
           headingEl.textContent = heading;
-        }
+          tabSlug = heading;
+        } 
       }
 
+      tabSlug ||= "tab-" + index;
       if (headingEl) {
-        const button = document.createElement("button");
-        button.setAttribute("id", `tab-${index + 1}`);
-        button.setAttribute("data-testid", `tab-${index + 1}`);
-        button.setAttribute("role", "tab");
-        button.addEventListener("click", () => setCurrentTab(index + 1));
-        button.setAttribute("aria-controls", `tabpanel-${index + 1}`);
-        button.appendChild(headingEl);
+        const link = document.createElement("a");
+        link.setAttribute("id", `tab-${index + 1}`);
+        link.setAttribute("data-testid", `tab-${index + 1}`);
+        link.setAttribute("role", "tab");
+        link.setAttribute("href", path + "#" + tabSlug);
+        link.addEventListener("click", () => setCurrentTab(index + 1));
+        link.setAttribute("aria-controls", `tabpanel-${index + 1}`);
+        link.appendChild(headingEl);
 
-        _tabsEl.appendChild(button);
+        _tabsEl.appendChild(link);
       }
     });
   }
@@ -102,10 +109,11 @@
     // prevent tab from exceeding limits
     _currentTab = clamp(tab, 1, _tabs.length);
 
-    // HACK: this only exists due to the `setTimeout` on line , which is required to allow the 
+    // HACK: this only exists due to the `setTimeout` on line , which is required to allow the
     // initialtab to be properly set in Angular, causes null errors.
     if (!_tabsEl) return;
 
+    let currentLocation = "";
     // @ts-expect-error
     [..._tabsEl.querySelectorAll("[role=tab]")].map((el, index) => {
       const isCurrent = index + 1 === _currentTab; // currentTab is 1-based
@@ -113,14 +121,19 @@
       el.setAttribute("aria-selected", fromBoolean(isCurrent));
       el.setAttribute("tabindex", isCurrent ? "0" : "-1");
       if (isCurrent) {
+        currentLocation = (el as HTMLLinkElement).href;
         el.focus();
-        el.removeAttribute("tabindex"); // allow tabbing to the button when the tab is active
         _tabs[index].setAttribute("open", "true"); // display tab content
       }
     });
 
     _panelEl.setAttribute("aria-labelledby", `tab-${_currentTab}`);
     _panelEl.setAttribute("id", `tabpanel-${_currentTab}`);
+
+    // update the browswers url with the new hash
+    if (currentLocation) {
+      document.location = currentLocation
+    }
   }
 
   function handleKeydownEvents() {
@@ -207,6 +220,7 @@
     border: none;
     font: var(--goa-typography-body-m);
     color: var(--goa-color-text-default);
+    text-decoration: none;
     letter-spacing: 0.03125rem;
   }
 

--- a/libs/web-components/src/components/tabs/tabs.spec.ts
+++ b/libs/web-components/src/components/tabs/tabs.spec.ts
@@ -22,31 +22,31 @@ describe("Tabs", () => {
   it("should initialize the children and tab 1 as active", async () => {
     const { container, queryByTestId } = render(Tabs);
 
-    const tab1Button = queryByTestId("tab-1");
-    const tab = tab1Button?.querySelector("div.tab");
-    const tab2Button = container.querySelector("button#tab-2");
-    const tab2 = tab2Button?.querySelector("div.tab");
+    const tab1Link = queryByTestId("tab-1");
+    const tab = tab1Link?.querySelector("div.tab");
+    const tab2Link = container.querySelector("a#tab-2");
+    const tab2 = tab2Link?.querySelector("div.tab");
     const tabPanel = container.querySelector('div[role="tabpanel"]');
     const tab3 = tabPanel?.querySelector("goa-tab");
 
     await waitFor(() => {
-      expect(tab1Button).toBeTruthy();
-      expect(tab1Button?.getAttribute("aria-controls")).toBe("tabpanel-1");
-      expect(tab1Button?.getAttribute("aria-selected")).toBe("true");
-      expect(tab1Button?.getAttribute("role")).toBe("tab");
+      expect(tab1Link).toBeTruthy();
+      expect(tab1Link?.getAttribute("aria-controls")).toBe("tabpanel-1");
+      expect(tab1Link?.getAttribute("aria-selected")).toBe("true");
+      expect(tab1Link?.getAttribute("role")).toBe("tab");
 
       expect(tab).toBeTruthy();
       expect(tab?.innerHTML).toContain("Tab1");
 
       // Should add button tab-2
-      expect(tab2Button).toBeTruthy();
-      expect(tab2Button?.getAttribute("aria-controls")).toBe("tabpanel-2");
-      expect(tab2Button?.getAttribute("aria-selected")).toBe("false");
-      expect(tab2Button?.getAttribute("role")).toBe("tab");
+      expect(tab2Link).toBeTruthy();
+      expect(tab2Link?.getAttribute("aria-controls")).toBe("tabpanel-2");
+      expect(tab2Link?.getAttribute("aria-selected")).toBe("false");
+      expect(tab2Link?.getAttribute("role")).toBe("tab");
 
       expect(tab2).toBeTruthy();
       expect(tab2?.innerHTML).toContain("Tab2");
-      expect(tab2Button?.getAttribute("tabIndex")).toBe("-1");
+      expect(tab2Link?.getAttribute("tabIndex")).toBe("-1");
 
       // should replace content to the tabpanel for opening tab
       expect(tabPanel).toBeTruthy();
@@ -60,17 +60,17 @@ describe("Tabs", () => {
 
   it("should select specified tab if the tab property is set", async () => {
     const result = render(Tabs, { initialtab: 2 });
-    const tab1Button = result.container.querySelector("button#tab-1");
-    const tab2Button = result.container.querySelector("button#tab-2");
+    const tab1Link = result.container.querySelector("a#tab-1");
+    const tab2Link = result.container.querySelector("a#tab-2");
     const tabPanel = result.container.querySelector("div[role=tabpanel]");
     const goaTabs = result.container.querySelectorAll("goa-tab");
 
     await waitFor(() => {
-      expect(tab1Button).toBeTruthy();
-      expect(tab1Button?.getAttribute("aria-selected")).toBe("false");
+      expect(tab1Link).toBeTruthy();
+      expect(tab1Link?.getAttribute("aria-selected")).toBe("false");
 
-      expect(tab2Button).toBeTruthy();
-      expect(tab2Button?.getAttribute("aria-selected")).toBe("true");
+      expect(tab2Link).toBeTruthy();
+      expect(tab2Link?.getAttribute("aria-selected")).toBe("true");
 
       expect(tabPanel).toBeTruthy();
       expect(tabPanel?.getAttribute("id")).toBe("tabpanel-2");
@@ -85,7 +85,7 @@ describe("Tabs", () => {
 
     // last tab
     await waitFor(() => {
-      const tab = result.container.querySelector("button#tab-2");
+      const tab = result.container.querySelector("a#tab-2");
       expect(tab).toBeTruthy();
       expect(tab?.getAttribute("aria-selected")).toBe("true");
     });
@@ -96,9 +96,9 @@ describe("Tabs", () => {
 
     // first tab
     await waitFor(() => {
-      const tab1Button = result.container.querySelector("button#tab-1");
-      expect(tab1Button).toBeTruthy();
-      expect(tab1Button?.getAttribute("aria-selected")).toBe("true");
+      const tab1Link = result.container.querySelector("a#tab-1");
+      expect(tab1Link).toBeTruthy();
+      expect(tab1Link?.getAttribute("aria-selected")).toBe("true");
     });
   });
 });


### PR DESCRIPTION
Hash urls will allow the url to change when the tab is chaned, allowing for `popstate` events to be handled for any page updates required. At a later time this will also allow the tab's `open` status to be set if a url with one of hashes is opened directly.

To test this, if the previous Tab tests function as they did before then it is all good.