### PR TITLE
Bug/1689 accessibility modal open

### DIFF
--- a/libs/react-components/src/lib/icon-button/icon-button.spec.tsx
+++ b/libs/react-components/src/lib/icon-button/icon-button.spec.tsx
@@ -4,7 +4,7 @@ import { GoAIconButton, IconButtonVariant } from "./icon-button";
 describe("GoA IconButton", () => {
   it("should render the properties", () => {
     const { container } = render(
-      <GoAIconButton icon="information" mt="s" mr="m" mb="l" ml="xl" />
+      <GoAIconButton icon="information" mt="s" mr="m" mb="l" ml="xl" ariaLabel="information button" />
     );
     const el = container.querySelector("goa-icon-button");
 
@@ -13,6 +13,7 @@ describe("GoA IconButton", () => {
     expect(el?.getAttribute("mr")).toBe("m");
     expect(el?.getAttribute("mb")).toBe("l");
     expect(el?.getAttribute("ml")).toBe("xl");
+    expect(el?.getAttribute("arialabel")).toBe("information button");
   });
 
   describe("Variants", () => {

--- a/libs/react-components/src/lib/icon-button/icon-button.tsx
+++ b/libs/react-components/src/lib/icon-button/icon-button.tsx
@@ -14,6 +14,7 @@ interface WCProps extends Margins {
   variant?: GoAIconButtonVariant;
   title?: string;
   disabled?: boolean;
+  arialabel?: string;
 }
 
 declare global {
@@ -34,6 +35,7 @@ export interface GoAIconButtonProps extends Margins {
   children?: React.ReactNode;
   onClick?: () => void;
   testId?: string;
+  ariaLabel?: string;
 }
 
 export function GoAIconButton({
@@ -43,6 +45,7 @@ export function GoAIconButton({
   onClick,
   size = "medium",
   title,
+  ariaLabel,
   testId,
   children,
   mt,
@@ -77,6 +80,7 @@ export function GoAIconButton({
       variant={variant}
       size={size}
       title={title}
+      arialabel={ariaLabel}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/input/input.spec.tsx
+++ b/libs/react-components/src/lib/input/input.spec.tsx
@@ -26,6 +26,7 @@ describe("Input", () => {
       variant: "bare",
       disabled: true,
       readonly: true,
+      focused: true,
       placeholder: "placeholder",
       prefix: "foo",
       suffix: "bar",
@@ -54,6 +55,7 @@ describe("Input", () => {
     expect(input?.getAttribute("autocapitalize")).toBe("on");
     expect(input?.getAttribute("variant")).toBe("bare");
     expect(input?.getAttribute("disabled")).toBeTruthy();
+    expect(input?.getAttribute("focused")).toBe("true");
     expect(input?.getAttribute("readonly")).toBeTruthy();
     expect(input?.getAttribute("placeholder")).toBe("placeholder");
     expect(input?.getAttribute("prefix")).toBe("foo");

--- a/libs/react-components/src/lib/modal/modal.spec.tsx
+++ b/libs/react-components/src/lib/modal/modal.spec.tsx
@@ -8,6 +8,7 @@ describe("Modal Tests", () => {
       heading: "Modal Heading",
       open: true,
       maxWidth: "500px",
+      role: "alertdialog",
       actions: <GoAButton onClick={() => { /* do nothing */ }}>Close</GoAButton>,
       onClose: () => { /* do nothing */ },
     };
@@ -18,6 +19,7 @@ describe("Modal Tests", () => {
     const modal = baseElement.querySelector("goa-modal");
     const actionContent = modal?.querySelector("[slot='actions']");
     const heading = modal?.querySelector("[slot='heading']");
+    expect(modal?.getAttribute("role")).toBe("alertdialog");
 
     expect(heading?.textContent).toContain("Modal Heading");
     expect(modal?.getAttribute("open")).toBe("true");

--- a/libs/react-components/src/lib/modal/modal.tsx
+++ b/libs/react-components/src/lib/modal/modal.tsx
@@ -7,6 +7,7 @@ export type GoAModalCalloutVariant =
   | "emergency"
   | "success"
   | "event";
+export type GoAModalRole = "dialog" | "alertdialog";
 
 // leagcy type names
 export type ModalTransition = GoAModalTransition;
@@ -20,6 +21,7 @@ interface WCProps {
   closable?: boolean;
   transition?: GoAModalTransition;
   calloutvariant?: GoAModalCalloutVariant;
+  role?: GoAModalRole;
 }
 
 declare global {
@@ -41,7 +43,7 @@ export interface GoAModalProps {
   open?: boolean;
   calloutVariant?: GoAModalCalloutVariant;
   testId?: string;
-
+  role?: GoAModalRole;
   // @deprecated: use maxWidth
   width?: string;
   // @deprecated: use variant
@@ -59,7 +61,7 @@ export function GoAModal({
   calloutVariant,
   onClose,
   testId,
-
+  role,
   width,
 }: GoAModalProps): JSX.Element {
   const el = useRef<HTMLElement>(null);
@@ -101,6 +103,7 @@ export function GoAModal({
       transition={transition}
       calloutvariant={calloutVariant}
       data-testid={testId}
+      role={role}
     >
       {heading && <div slot="heading">{heading}</div>}
       {actions && <div slot="actions">{actions}</div>}

--- a/libs/web-components/src/components/focus-trap/FocusTrap.spec.ts
+++ b/libs/web-components/src/components/focus-trap/FocusTrap.spec.ts
@@ -6,10 +6,22 @@ import {
 } from "@testing-library/svelte";
 import FocusTrapTestComponent from "./FocusTrapTestComponent.svelte";
 import { it, describe } from "vitest";
+import {tick} from "svelte";
 
 // This test is blocked due to test slots being handling differently than web browser
 // For details, please refer https://goa-dio.atlassian.net/browse/DDIDS-704
 describe("Focus Trap Component", () => {
+
+  it.skip("should focus the first element", async () => {
+    const el = render(FocusTrapTestComponent);
+    await tick();
+    el.debug();
+    const userNameEl = el.queryByTestId("username");
+
+    expect(userNameEl).toBeTruthy();
+    expect(userNameEl).toHaveFocus();
+  });
+
   it.skip("traps the tab key", async () => {
     const el = render(FocusTrapTestComponent);
 

--- a/libs/web-components/src/components/focus-trap/FocusTrapTestComponent.svelte
+++ b/libs/web-components/src/components/focus-trap/FocusTrapTestComponent.svelte
@@ -7,6 +7,7 @@
 <div>
   <input type="text" class="description" name="description" />
   <GoAFocusTrap>
+    <button data-ignore-focus="true">Ignore Focus</button>
     <input type="text" data-testid="username" name="username" />
     <input type="text" data-testid="email" name="email" />
     <input type="text" data-testid="address" name="address" />

--- a/libs/web-components/src/components/icon-button/IconButton.html-data.json
+++ b/libs/web-components/src/components/icon-button/IconButton.html-data.json
@@ -54,6 +54,11 @@
       "default": "false"
     },
     {
+      "name": "arialabel",
+      "type": "string",
+      "description": "Sets the aria-label of the button"
+    },
+    {
       "name": "_click",
       "description": "Callback function when button is clicked"
     }

--- a/libs/web-components/src/components/icon-button/IconButton.spec.ts
+++ b/libs/web-components/src/components/icon-button/IconButton.spec.ts
@@ -12,6 +12,7 @@ describe("IconButton", () => {
         mr: "m",
         mb: "l",
         ml: "xl",
+        arialabel: "icon button test"
       });
       const iconButton = await baseElement.findByTestId("iconButton-test");
 
@@ -20,6 +21,7 @@ describe("IconButton", () => {
       expect(iconButton).toHaveStyle("margin-right:var(--goa-space-m)");
       expect(iconButton).toHaveStyle("margin-bottom:var(--goa-space-l)");
       expect(iconButton).toHaveStyle("margin-left:var(--goa-space-xl)");
+      expect(iconButton).toHaveAttribute("aria-label", "icon button test");
     });
   });
 

--- a/libs/web-components/src/components/icon-button/IconButton.svelte
+++ b/libs/web-components/src/components/icon-button/IconButton.svelte
@@ -27,6 +27,7 @@
   export let testid: string = "";
   export let disabled: string = "false";
   export let inverted: string = "false";
+  export let arialabel: string = "";
 
   // margin
   export let mt: Spacing = null;
@@ -62,6 +63,7 @@
   class={css}
   data-testid={testid}
   on:click={handleClick}
+  aria-label={arialabel}
 >
   <goa-icon {title} type={icon} {size} {theme} inverted={isInverted} />
 </button>

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -132,6 +132,7 @@
   }
 
   function onBlur(e: Event) {
+    focused = "false";
     const input = e.target as HTMLInputElement;
     input.dispatchEvent(
       new CustomEvent("_blur", {

--- a/libs/web-components/src/components/modal/Modal.html-data.json
+++ b/libs/web-components/src/components/modal/Modal.html-data.json
@@ -48,6 +48,12 @@
       "default": "none"
     },
     {
+      "name": "role",
+      "description": "Role of the modal",
+      "values": [{ "name": "dialog" }, { "name": "alertdialog" }],
+      "default": "dialog"
+    },
+    {
       "name": "_close",
       "description": "Dispatched when modal is closable and is closed"
     },

--- a/libs/web-components/src/components/modal/Modal.spec.ts
+++ b/libs/web-components/src/components/modal/Modal.spec.ts
@@ -37,6 +37,26 @@ describe("Modal Component", () => {
     });
   });
 
+  it("should have accessibility attributes by default", async() => {
+    const el = render(GoAModal, { open: "true", heading: "Test Modal" });
+
+    await waitFor(() => {
+      const modal = el.queryByRole("dialog");
+      expect(modal?.getAttribute("aria-modal")).toBe("true");
+      expect(modal?.getAttribute("aria-labelledby")).toBe("goa-modal-heading");
+      expect(modal?.getAttribute("tabindex")).toBe("-1");
+    });
+  });
+
+  it("should set role to alertdialog when alert is set", async () => {
+    const el = render(GoAModal, { open: "true", role: "alertdialog"});
+
+    await waitFor(() => {
+      const modal = el.queryByRole("alertdialog");
+      expect(modal?.getAttribute("aria-modal")).toBe("true");
+    });
+  });
+
   it("should open when the `open` attribute is set to true", async () => {
     const el = render(GoAModal, { open: "true" });
 
@@ -140,6 +160,16 @@ describe("Modal Component", () => {
       rootEl?.addEventListener("_close", handleClose);
       await fireEvent.keyDown(window, { key: "Escape", keyCode: 27 });
       expect(handleClose).toBeCalled();
+    });
+  });
+
+  it("should not focus on close button for accessibility", async () => {
+    const el = render(GoAModal, { open: "true", closable: "true" });
+    await waitFor(async () => {
+      const closeIcon = el.queryByTestId("modal-close-button");
+      await waitFor(() => {
+        closeIcon && expect(closeIcon).not.toHaveFocus();
+      });
     });
   });
 });

--- a/libs/web-components/src/components/modal/Modal.svelte
+++ b/libs/web-components/src/components/modal/Modal.svelte
@@ -8,6 +8,8 @@
 
   type CalloutVariant = (typeof CALLOUT_VARIANT)[number];
   type Transition = (typeof Transitions)[number];
+  type Role = (typeof Role)[number];
+
 
   // ******
   // Public
@@ -22,7 +24,8 @@
 
   // @deprecated: use maxwidth
   export let width: string = "";
-
+  // accessibility
+  export let role: Role = "dialog";
   // *******
   // Private
   // *******
@@ -44,6 +47,11 @@
     "fast",
     "slow",
     "none",
+  ]);
+
+  const [Role, validateRole] = typeValidator("Modal Role", [
+    "dialog",
+    "alertdialog",
   ]);
 
   // ********
@@ -96,8 +104,9 @@
     await tick();
     validateCalloutVariant(calloutvariant);
     validateTransition(transition);
+    validateRole(role);
 
-    // event listenerts
+    // event listeners
     window.addEventListener("keydown", onInputKeyDown);
 
     if (width) {
@@ -177,6 +186,7 @@
       data-testid="modal"
       class={`modal ${_scrollPos}`}
       style={`--maxwidth: ${maxwidth};`}
+      role="presentation"
       bind:this={_rootEl}
     >
       <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -186,6 +196,10 @@
         in:fly={{ duration: _transitionTime, y: 200 }}
         out:fly={{ delay: _transitionTime, duration: _transitionTime, y: -100 }}
         class="modal-pane"
+        tabindex="-1"
+        role={role}
+        aria-modal="true"
+        aria-labelledby="goa-modal-heading"
       >
         {#if calloutvariant !== null}
           <div class="callout-bar {calloutvariant}">
@@ -197,7 +211,7 @@
         {/if}
         <div class="content">
           <header bind:this={_headerEl} class:has-content={_requiresTopPadding}>
-            <div data-testid="modal-title" class="modal-title">
+            <div data-testid="modal-title" class="modal-title" id="goa-modal-heading">
               {#if heading}
                 {heading}
               {:else}
@@ -209,7 +223,9 @@
                 <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <!-- svelte-ignore a11y-no-static-element-interactions -->
                 <goa-icon-button
+                  data-ignore-focus="true"
                   data-testid="modal-close-button"
+                  arialabel="Close the modal"
                   icon="close"
                   on:click={close}
                   variant="nocolor"

--- a/libs/web-components/src/components/modal/doc.md
+++ b/libs/web-components/src/components/modal/doc.md
@@ -5,7 +5,7 @@ Use it like this:
 ```html
 <goa-button id="button" (_click)="openModal()">Open Modal</goa-button>
 
-<goa-modal id="modal" heading="Do you agree?" [open]="isOpen" (_close)="closeModal()" closable>
+<goa-modal id="modal" heading="Do you agree?" [open]="isOpen" (_close)="closeModal()" role="alertdialog" closable>
   <p>
     Lorem ipsum dolor sit.
   </p>


### PR DESCRIPTION
### Description:
This PR is trying to solve the issue reported at [Issue 1689](https://github.com/GovAlta/ui-components/issues/1689)
![image](https://github.com/GovAlta/ui-components/assets/120135417/f63a952e-6f78-44d3-8299-d14732851491)


### What changed: 
There is one new attribute introduced in this PR: 
* role: `dialog` or `alertdialog`, default will be `dialog`

Behind the scene:
*  our modal has added `aria-labelledby` to equal with the `heading` element of the modal. 
*  For the logic of modal role `dialog`, a dialog always have at least 1 focusable control. When the dialog appears on the screen, keyboard focus should be moved to the first focusable control inside the dialog. (Except close icon)
*  If the dialog has content that needs to announce to the user, consider making `alert` to be `true`, the role will be changed to `alertdialog`, the screen reader will read everything inside the modal. Also for the accessibility, the alertdialog modal will need at least 1 focusable control. 

### Example: 
In angular: 

1. A dialog has form fields: 
```
<goa-button id="dialog1-button" (_click)="openAddDeliveryAddressModal();">Add Delivery Address</goa-button>
<goa-modal [open]="isAddDeliveryAddressModalOpen"
           (_close)="closeAddDeliveryAddressModal()" heading="Add Delivery Address">
  <goa-form-item label="Street">
    <goa-input name="firstName"></goa-input>
  </goa-form-item>
  <goa-form-item label="City:">
    <goa-input name="city"></goa-input>
  </goa-form-item>
  <goa-form-item label="State:">
    <goa-input name="state"></goa-input>
  </goa-form-item>
  <goa-form-item label="Zip:">
    <goa-input name="zip"></goa-input>
  </goa-form-item>
  <goa-form-item label="Special instructions:">
    <goa-input name="special_instructions"></goa-input>
  </goa-form-item>

  <div slot="actions">
    <goa-button-group alignment="end">
      <goa-button type="secondary" (_click)="closeAddDeliveryAddressModal()">Cancel</goa-button>
      <goa-button type="primary" (_click)="closeAddDeliveryAddressModal()">Save</goa-button>
    </goa-button-group>
  </div>
</goa-modal>
```

Expected: 
* First field is focused 
* Screen reader announce that first field is focused, inside the dialog, the name of the dialog is the heading of the dialog. 

Case 2: 
```
<goa-button (_click)="openDialog3()">Address Added</goa-button>
<goa-modal [open]="isDialog3Open" closable (_close)="closeDialog3()" heading="Address Added" alert="true"
>
  <p id="dialog3_desc" class="dialog_desc">
    The address you provided has been added to your list of delivery addresses.
    It is ready for immediate use.
    If you wish to remove it, you can do so from <a href="#" onclick="openDialog('dialog4', this)">your profile.</a>
  </p>
  <div slot="actions">
    <goa-button type="primary" (_click)="closeDialog3()">OK</goa-button>
  </div>
</goa-modal>
```
Expected: 
* Link profile is focused. 
* Screen reader announces Your profile link, a short message is to be useful to announce users here, so setting `alert` true. 

Reference: 
[Dialog](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role)
[AlertDialog](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role)





