### PR TITLE
fix(#1718): microsite header background color be fullwidth

### DIFF
--- a/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
+++ b/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
@@ -44,7 +44,7 @@
 
 <!-- HTML -->
 <div id="container">
-  <div 
+  <div
     class="content-container"
     style={`--max-content-width: ${maxcontentwidth}`}
   >
@@ -98,6 +98,7 @@
 
   #container {
     container: self / inline-size;
+    background-color: var(--goa-color-greyscale-100);
   }
 
   a {
@@ -136,9 +137,8 @@
   .content-container {
 
     font-size: var(--goa-font-size-2);
-    background-color: var(--goa-color-greyscale-100);
     padding: 0.5rem 1rem;
-  
+
     display: flex;
     align-items: flex-start;
     justify-content: space-between;


### PR DESCRIPTION
Fixing #1718 
![image](https://github.com/GovAlta/ui-components/assets/120135417/3e018153-cb71-47ba-a65d-08240a84718f)

Code example in Angular:
```
<goa-microsite-header
      type="alpha"
      level="alpha"
      version="UAT"
      maxcontentwidth="1400px"
    ></goa-microsite-header>
```