### PR TITLE
fix(#1739): prevent popovers from appearing underneatch goa-container sibling components

### DIFF
--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -77,7 +77,6 @@
 <!-- Style -->
 <style>  
   .goa-container {
-    container: self / inline-size;
     box-sizing: border-box;
     display: flex;
     flex: 1 1 auto;


### PR DESCRIPTION
https://github.com/GovAlta/ui-components/issues/1739

Before:
![image](https://github.com/GovAlta/ui-components/assets/41582/a221858c-c24c-419f-a3aa-8e5bd740705d)

With fix:
![image](https://github.com/GovAlta/ui-components/assets/41582/fb294ff7-cf4c-43ff-ba2c-e176f26eaae4)

Code to replicate issue and see fix.
```
import { GoAContainer, GoADropdown, GoADropdownItem, GoAFormItem } from "@abgov/react-components";

export function Bug1739Page() {
  return <>
    <p>
      Popover within dropdown would appear underneath the following GoAContainer component only if
      the popover was also within a GoAContainer
      <a href="https://github.com/orgs/GovAlta/projects/35/views/1?filterQuery=assignee%3Achrisolsen&pane=issue&itemId=58028866">Link to issue</a>
    </p>  

    <GoAContainer>
      <GoAFormItem label="Basic dropdown">
        <GoADropdown name="item" onChange={() => {}} relative={true}>
          <GoADropdownItem value="red" label="Red"></GoADropdownItem>
          <GoADropdownItem value="green" label="Green"></GoADropdownItem>
          <GoADropdownItem value="blue" label="Blue"></GoADropdownItem>
        </GoADropdown>
      </GoAFormItem>
    </GoAContainer>
    <GoAContainer>
      <h2>
        Detach to use
      </h2>
      <p>
        Add things inside me
      </p>
    </GoAContainer>
  </> 
}

export default Bug1739Page;
```
