### PR TITLE
fix: replace no longer used @container query with @media

### DIFF
--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -174,7 +174,7 @@
   }
 
   /* Override padding in small screens to the compact value */
-  @container self (--mobile) {
+  @media (--mobile) {
     .padding--relaxed header {
       padding: 0 1rem;
     }


### PR DESCRIPTION
Before
![image](https://github.com/GovAlta/ui-components/assets/41582/e4cf68cd-c2b4-42ac-ad7f-b17ba601aed8)

After
![image](https://github.com/GovAlta/ui-components/assets/41582/b11bd4c2-97ef-4989-9133-4512801b6cf4)
