### PR TITLE
fix: re-add the cjs build for react

### DIFF
--- a/libs/react-components/vite.config.ts
+++ b/libs/react-components/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       entryRoot: "src",
       tsConfigFilePath: path.join(__dirname, "tsconfig.lib.json"),
       skipDiagnostics: false,
-      formats: ["es"],
+      formats: ["es", "cjs"],
       filename: "index.d.ts"
     }),
   ],
@@ -39,7 +39,7 @@ export default defineConfig({
       fileName: "index",
       // Change this to the formats you want to support.
       // Don't forget to update your package.json as well.
-      formats: ["es"],
+      formats: ["es", "cjs"],
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.


### PR DESCRIPTION
The build .js file is needed for unit tests