### PR TITLE
fix(#1758): allow popovers within goa-grids to display on top of other goa-grids

### DIFF
--- a/libs/web-components/src/components/grid/Grid.svelte
+++ b/libs/web-components/src/components/grid/Grid.svelte
@@ -3,7 +3,6 @@
 <!-- Script -->
 <script lang="ts">
   import { onMount } from "svelte";
-
   import { calculateMargin } from "../../common/styling";
   import { validateRequired } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
@@ -23,7 +22,6 @@
 </script>
 
 <!-- HTML -->
-<div id="container">
   <div
     class="goa-grid"
     style={`
@@ -34,7 +32,6 @@
   >
     <slot />
   </div>
-</div>
 
 <!-- Style -->
 <style>
@@ -43,17 +40,13 @@
     font-family: var(--goa-font-family-sans);
   }
 
-  #container {
-    container: self / inline-size;
-  }
-
   .goa-grid {
     display: flex;
     flex-direction: column;
     gap: var(--gap);
   }
 
-  @container self (--not-mobile) {
+  @media (--not-mobile) {
     .goa-grid {
       display: grid;
       grid-template-columns: repeat(


### PR DESCRIPTION
Before
![image](https://github.com/GovAlta/ui-components/assets/41582/a2b751bb-fb91-4540-a077-07a9f9669e8e)


After
![image](https://github.com/GovAlta/ui-components/assets/41582/486d727b-4e0d-421c-9973-a05c5fbec80a)



Test code
```
import { GoABlock, GoAContainer, GoADatePicker, GoADropdown, GoADropdownItem, GoAFormItem, GoAGrid, GoAInputText } from "@abgov/react-components";

export function Bug1739Page() {
  return <>

    <GoAContainer>
      <GoAGrid minChildWidth="12ch">
        <GoADatePicker onChange={() => { }} />
        <GoAFormItem
          label="Birthdate"
        >
          <GoADropdown
            name="gender"
            onChange={() => { }}
            ariaLabelledBy="gender"
          >
            {(["male", "female", "other"]).map((val) => {
              return <GoADropdownItem key={val} value={val} label={val} />;
            })}
          </GoADropdown>
        </GoAFormItem>
      </GoAGrid>
    </GoAContainer>

    <GoAContainer>
      <GoAGrid minChildWidth="12ch">
        <GoAFormItem
          label="Given name"
          id="givenName"
        >
          <GoAInputText name="givenName" maxLength={50} onChange={() => { }} />
        </GoAFormItem>
        <GoAFormItem
          label="Surname"
          id="surname"
        >
          <GoAInputText
            name="surname"
            onChange={() => { }}
            maxLength={50}
          />
        </GoAFormItem>
      </GoAGrid>
    </GoAContainer>

    <h4>Block</h4>

    <GoAContainer>
      <GoABlock>
        <GoADatePicker onChange={() => { }} />
        <GoAFormItem
          label="Birthdate"
        >
          <GoADropdown
            name="gender"
            onChange={() => { }}
            ariaLabelledBy="gender"
          >
            {(["male", "female", "other"]).map((val) => {
              return <GoADropdownItem key={val} value={val} label={val} />;
            })}
          </GoADropdown>
        </GoAFormItem>
      </GoABlock>
    </GoAContainer>

    <GoAContainer>
      <GoABlock>
        <GoAFormItem
          label="Given name"
          id="givenName"
        >
          <GoAInputText name="givenName" maxLength={50} onChange={() => { }} />
        </GoAFormItem>
        <GoAFormItem
          label="Surname"
          id="surname"
        >
          <GoAInputText
            name="surname"
            onChange={() => { }}
            maxLength={50}
          />
        </GoAFormItem>
      </GoABlock>
    </GoAContainer>

    <h4>Containers Only</h4>
    <GoAContainer>
      <GoADatePicker onChange={() => { }} />
      <GoAFormItem
        label="Birthdate"
      >
        <GoADropdown
          name="gender"
          onChange={() => { }}
          ariaLabelledBy="gender"
        >
          {(["male", "female", "other"]).map((val) => {
            return <GoADropdownItem key={val} value={val} label={val} />;
          })}
        </GoADropdown>
      </GoAFormItem>
    </GoAContainer>

    <GoAContainer>
      <GoAFormItem
        label="Given name"
        id="givenName"
      >
        <GoAInputText name="givenName" maxLength={50} onChange={() => { }} />
      </GoAFormItem>
      <GoAFormItem
        label="Surname"
        id="surname"
      >
        <GoAInputText
          name="surname"
          onChange={() => { }}
          maxLength={50}
        />
      </GoAFormItem>
    </GoAContainer>
  </>
}

export default Bug1739Page;
```