### PR TITLE
fix(#1592): Hide accordion secondary text if property is empty

### DIFF
--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -88,7 +88,9 @@
           class="heading heading-{headingsize}"
           data-testid={`${testid}-heading`}>{heading}</span
         >
-        <span class="secondary-text">{secondarytext}</span>
+        {#if secondarytext}
+          <span class="secondary-text">{secondarytext}</span>
+        {/if}
         <div
           class="heading-content"
           class:heading-content-top={_headingContentSlotChildren.length}
@@ -216,7 +218,7 @@
   .content :global(::slotted(*:last-child)) {
     margin-bottom: 0 !important;
   }
-  
+
   details[open] goa-icon {
     transform: rotate(90deg);
   }


### PR DESCRIPTION
**1. What this code change do:**
This PR is a proposed fix for https://github.com/GovAlta/ui-components/issues/1592. It hides the secondary text element in the accordion header if the `secondaryText` property is empty.

Without any secondary text:
![image](https://github.com/GovAlta/ui-components/assets/1479091/ca6023d9-10c1-4716-b2b3-ba93779ac6c8)

With secondary text:
![image](https://github.com/GovAlta/ui-components/assets/1479091/f99b1025-8e61-43f0-b004-f4aa2cd6477e)

- **2. Make sure that you've checked the boxes below before you submit MR:**

- [x] I have read and followed the [contribution guidelines](../../contributing.md)
- [x] I have run a build locally.
- [x] I have ran unit tests locally.
- [x] I have tested the functionality.

![image](https://github.com/GovAlta/ui-components/assets/1479091/56c6f257-c81e-41a4-8fef-36084ded6ce1)


## Reviewer Checklist

- [x] Appropriate unit test coverage.
- [x] [Coding Standards](../contribution_guidelines/coding_standards.md) followed.

When review is satisfactory reviewer will merge the changes.
