### PR TITLE
fix(#1607): remove max height from container with thick heading

### DIFF
--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -62,13 +62,17 @@
   `}
 >
   <header class="heading--{accent}">
-    <div class="title">
-      <slot name="title" />
-    </div>
+    {#if $$slots.title}
+      <div class="title">
+        <slot name="title" />
+      </div>
+    {/if}
 
-    <div class="actions">
-      <slot name="actions" />
-    </div>
+    {#if $$slots.actions}
+      <div class="actions">
+        <slot name="actions" />
+      </div>
+    {/if}
   </header>
   <div class="content">
     <slot />
@@ -77,12 +81,12 @@
 
 <!-- Style -->
 
-<style> 
+<style>
   :host {
     display: flex;
     flex: 1 1 auto;
   }
-   
+
   .goa-container {
     box-sizing: border-box;
     display: flex;
@@ -98,9 +102,8 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    font-weight: 700;
-
-    font-size: var(--goa-font-size-4);
+    gap: var(--goa-space-m);
+    font: var(--goa-typography-heading-s);
     border-width: 1px;
     border-style: solid;
     border-top-left-radius: var(--goa-border-radius-m);
@@ -147,7 +150,13 @@
 
   .title,
   .actions {
-    padding: 0.5rem 0;
+    padding: var(--goa-space-xs) 0;
+  }
+
+  .actions :global(::slotted(div)) {
+    display: flex;
+    align-items: center;
+    gap: var(--goa-space-m);
   }
 
   /* Padding variants */
@@ -225,13 +234,8 @@
 
   /* Sizes */
   .heading--thick {
-    padding: 0.5rem 1.5rem;
-    max-height: 3rem;
-    min-height: 1rem;
-  }
-
-  .heading--thick .title {
-    line-height: 2rem;
+    padding: var(--goa-space-xs) var(--goa-space-l);
+    min-height: var(--goa-space-m);
   }
 
   .heading--thin {


### PR DESCRIPTION
**1. What this code change do:**

This change allows a container with a thick heading to accommodate multi-line titles. It includes the following changes:
- Removes `max-height` from the thick heading
- Only renders `title` and `actions` slots if the slots are available. This avoids extra padding.
- Uses `flexbox` with a column gap for the `actions` slot to match the Figma component.
![image](https://github.com/GovAlta/ui-components/assets/1479091/29b19380-fbcc-4e2e-b5c1-8572b52976bd)
- Uses `--goa-typography-heading-s` for the heading title (see [comment](https://github.com/GovAlta/ui-components/issues/1607#issuecomment-1933540539)).
- Replaces `rem` values with design tokens.

**2. Make sure that you've checked the boxes below before you submit MR:**

- [x] I have read and followed the [contribution guidelines](../../contributing.md)
- [x] I have run a build locally.
- [x] I have ran unit tests locally.
![image](https://github.com/GovAlta/ui-components/assets/1479091/d15b3c20-17f6-42a9-99ed-178c293ebfce)

- [x] I have tested the functionality.

**3. Which issue and JIRA item does this PR fix (optional)**

**4. Additional notes for the reviewer**

## Reviewer Checklist

- [ ] [Coding Standards](../contribution_guidelines/coding_standards.md) followed.

When review is satisfactory reviewer will merge the changes.
