### PR TITLE
fix(#1761): radio group setValue doesn't work on angular

### DIFF
--- a/libs/web-components/src/components/radio-group/RadioGroup.spec.ts
+++ b/libs/web-components/src/components/radio-group/RadioGroup.spec.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import GoARadioGroup from "./RadioGroup.svelte";
 import GoARadioGroupWrapper from "./RadioGroupWrapper.test.svelte";
 import { describe, it, expect, vi } from "vitest";
@@ -32,6 +32,35 @@ describe("GoARadioGroup Component", () => {
         expect(goaRadioItems[index].getAttribute("checked")).toBe("false");
       }
     });
+  });
+
+  it("should select a value programmatically", async () => {
+    // Arrange
+    const name = "favcolor";
+    const items = ["red", "blue", "orange"];
+    const result = render(GoARadioGroupWrapper, {
+      name,
+      value: "orange",
+      testid: "test-id",
+      items,
+    });
+
+    await tick();
+    const goaRadioItems = result.container.querySelectorAll("goa-radio-item");
+    expect(goaRadioItems.length).toBe(3);
+    // Orange is selected at the beginning
+    expect(goaRadioItems[2].getAttribute("checked")).toBe("true");
+    expect(goaRadioItems[0].getAttribute("checked")).toBe("false");
+    expect(goaRadioItems[1].getAttribute("checked")).toBe("false");
+
+    // Act
+    // Select red value (1st option)
+    await fireEvent.click(await result.findByTestId("set-value"));
+    await tick();
+    // Assert
+    expect(goaRadioItems[0].getAttribute("checked")).toBe("true");
+    expect(goaRadioItems[1].getAttribute("checked")).toBe("false");
+    expect(goaRadioItems[2].getAttribute("checked")).toBe("false");
   });
 
   // FIXME: unable to get the progress check working. Child events aren't able to be triggered

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -39,6 +39,7 @@
 
   $: isDisabled = toBoolean(disabled);
   $: isError = toBoolean(error);
+  $: value && setCurrentSelectedOption();
 
   // Private
 

--- a/libs/web-components/src/components/radio-group/RadioGroupWrapper.test.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroupWrapper.test.svelte
@@ -14,6 +14,9 @@
 </script>
 
 <!-- HTML -->
+
+<button data-testid="set-value" on:click={() => (value = "red")}>Set Value</button>
+
 <GoARadioGroup {name} {value} {orientation} {disabled} {error} {testid}>
   {#each items as item (item)}
     <goa-radio-item value="{item}" label="{item}" />


### PR DESCRIPTION
**Description:** Fixing the issue [1761](https://github.com/GovAlta/ui-components/issues/1761)
**What are changed**
- radio-group doesn't render the `checked` value for its `radio-item` due to its `value` changed. 
**Code to test**

In Angular:
```
<goa-radio-group
  name="color"
  goaValue
  [formControl]="reactiveFormCtrl"
  value="reactiveFormCtrl.value"
>
  <goa-radio-item
    name="color"
    value="red"
  >
    <div slot="description">
      <span class="customized-description-title">Content description</span>
      <small> Another test?</small>
      <p>
        Help test
      </p>
    </div>
  </goa-radio-item>
  <goa-radio-item
    name="color"
    value="blue"
    description="Item description"
  ></goa-radio-item>
  <goa-radio-item name="color" value="orange"></goa-radio-item>
</goa-radio-group>

<br/>
<goa-button (_click)="onClick()">Select Value</goa-button>
<br/>
<h4>Value is {{reactiveFormCtrl.value}}</h4>
```
```
export class RadioComponent implements OnInit {
reactiveFormCtrl = new FormControl("red");
ngOnInit() {
    this.reactiveFormCtrl.setValue("orange");
    this.reactiveFormCtrl.registerOnChange((val: any) => {
      console.log("reactiveFormCtrl", val);
    });
  }
  onClick() {
    console.log("clicked");
    this.reactiveFormCtrl.setValue("red");
  }
  }
```

https://github.com/GovAlta/ui-components/assets/120135417/6f33ac3b-1ff2-4c8b-bb7a-3e1c7786c619



