### PR TITLE
fix(#1522): increase tooltip z-index so it renders above dropdown

### DIFF
--- a/libs/web-components/src/components/tooltip/Tooltip.svelte
+++ b/libs/web-components/src/components/tooltip/Tooltip.svelte
@@ -243,7 +243,7 @@
     text-align: center;
     border-radius: var(--goa-border-radius-m);
     position: absolute;
-    z-index: 1;
+    z-index: 2;
     opacity: 0;
     transition: opacity 0.3s;
     padding: var(--goa-space-xs) var(--goa-space-m);


### PR DESCRIPTION

**1. What this code change do:**
This code fixes https://github.com/GovAlta/ui-components/issues/1522 by increasing the z-index of the `tooltip` component.

In comparison, the input and dropdown components both have a z-index of `1`:
https://github.com/GovAlta/ui-components/blob/e59da1a6b5ec041339c746a90b4b0ca6254ef417/libs/web-components/src/components/input/Input.svelte#L357

https://github.com/GovAlta/ui-components/blob/e59da1a6b5ec041339c746a90b4b0ca6254ef417/libs/web-components/src/components/dropdown/Dropdown.svelte#L794

The stepper component has elements with z-index of `1` and `2`:
https://github.com/GovAlta/ui-components/blob/e59da1a6b5ec041339c746a90b4b0ca6254ef417/libs/web-components/src/components/form-stepper/FormStepper.svelte#L183

https://github.com/GovAlta/ui-components/blob/e59da1a6b5ec041339c746a90b4b0ca6254ef417/libs/web-components/src/components/form-stepper/FormStepper.svelte#L192

Other components with `z-index` use overlays and shouldn't be visible at the same time as a tooltip. The remaining components follow the standard [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) without z-index.



- **2. Make sure that you've checked the boxes below before you submit MR:**

- [x] I have read and followed the [contribution guidelines](../../contributing.md)
- [x] I have run a build locally.
- [x] I have ran unit tests locally.
![image](https://github.com/GovAlta/ui-components/assets/1479091/0f6a4cc2-94d6-4e09-abbb-93cef58c0010)

- [x] I have tested the functionality.

**3. Which issue and JIRA item does this PR fix (optional)**

**4. Additional notes for the reviewer**

## Reviewer Checklist

- [ ] [Coding Standards](../contribution_guidelines/coding_standards.md) followed.

When review is satisfactory reviewer will merge the changes.