### PR TITLE
fix(#1697): use width custom property for textarea root

### DIFF
--- a/libs/web-components/src/components/text-area/TextArea.svelte
+++ b/libs/web-components/src/components/text-area/TextArea.svelte
@@ -133,7 +133,7 @@
 
   .root {
     position: relative;
-    width: 100%;
+    width: var(--width, 100%);
     padding-bottom: var(--char-count-padding);
     border: var(--goa-border-width-s) solid var(--goa-color-greyscale-700);
     border-radius: 3px;
@@ -162,11 +162,11 @@
 
   @container self (--not-mobile) {
     .root {
-      max-width: var(--width);
+      max-width: var(--width, 100%);
     }
     textarea {
       min-width: 0;
-      width: var(--width);
+      width: var(--width, 100%);
     }
   }
 


### PR DESCRIPTION

**1. What this code change do:**
- Adds the `--width` custom property width to `.root`
- Adds a `100%` fallback to the other width custom properties in the component

- **2. Make sure that you've checked the boxes below before you submit MR:**

- [x] I have read and followed the [contribution guidelines](../../contributing.md)
- [x] I have run a build locally.
- [x] I have ran unit tests locally.
![image](https://github.com/GovAlta/ui-components/assets/1479091/e36c45e3-5eeb-4424-b54c-56656ec1aa06)
- [x] I have tested the functionality.

## Reviewer Checklist

- [ ] [Coding Standards](../contribution_guidelines/coding_standards.md) followed.

When review is satisfactory reviewer will merge the changes.
