### PR TITLE
fix(#1645): add error property to date picker

### DIFF
--- a/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
@@ -8,6 +8,7 @@ describe("DatePicker", () => {
   it("should render successfully", () => {
     const noop = () => { /* do nothing */ };
     const value = new Date();
+    const error = true;
     const min = addMonths(value, -1);
     const max = addMonths(value, 1);
 
@@ -17,6 +18,7 @@ describe("DatePicker", () => {
         min={min}
         max={max}
         value={value}
+        error={error}
         onChange={noop}
       />,
     );
@@ -27,6 +29,7 @@ describe("DatePicker", () => {
     expect(el).toBeTruthy();
     expect(el?.getAttribute("name")).toBe("foo");
     expect(el?.getAttribute("value")).toBe(value.toISOString());
+    expect(el?.getAttribute("error")).toBe("true");
     expect(el?.getAttribute("min")).toBe(min.toISOString());
     expect(el?.getAttribute("max")).toBe(max.toISOString());
   });

--- a/libs/react-components/src/lib/date-picker/date-picker.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.tsx
@@ -5,6 +5,7 @@ interface WCProps extends Margins {
   ref: React.RefObject<HTMLElement>;
   name?: string;
   value?: string;
+  error?: boolean;
   min?: string;
   max?: string;
 }
@@ -22,6 +23,7 @@ declare global {
 export interface GoADatePickerProps extends Margins {
   name?: string;
   value?: Date;
+  error?: boolean;
   min?: Date;
   max?: Date;
   onChange: (name: string, value: Date) => void;
@@ -30,6 +32,7 @@ export interface GoADatePickerProps extends Margins {
 export function GoADatePicker({
   name,
   value,
+  error,
   min,
   max,
   mt,
@@ -54,6 +57,7 @@ export function GoADatePicker({
       ref={ref}
       name={name}
       value={value?.toISOString()}
+      error={error}
       min={min?.toISOString()}
       max={max?.toISOString()}
       mt={mt}

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -18,6 +18,7 @@
   };
 
   export let value: string = "";
+  export let error: string = "false";
   export let min: string = "";
   export let max: string = "";
   export let relative: string = "false";
@@ -167,6 +168,7 @@
     readonly="true"
     trailingicon="calendar"
     value={formatDate(_date)}
+    error={error}
     on:click={showCalendar}
     on:keydown={handleKeyDown}
   />

--- a/libs/web-components/src/components/date-picker/date-picker.spec.ts
+++ b/libs/web-components/src/components/date-picker/date-picker.spec.ts
@@ -37,6 +37,15 @@ it("renders with props", async () => {
   expect(input?.getAttribute("value")).toBe(format(value, "PPP"));
 });
 
+it("shows an error state", async () => {
+  const value = new Date();
+  const error = "true";
+  const { container } = render(DatePicker, { value, error });
+  const input = container.querySelector("goa-input");
+
+  expect(input?.getAttribute("error")).toBe("true");
+});
+
 it("dispatches a value on date selection", async () => {
   const { container } = render(DatePicker);
   const popover = container.querySelector("goa-popover");


### PR DESCRIPTION
**1. What this code change do:**
This PR is a fix for https://github.com/GovAlta/ui-components/issues/1645 that adds an `error` property to the date picker.

- **2. Make sure that you've checked the boxes below before you submit MR:**

- [x] I have read and followed the [contribution guidelines](../../contributing.md)
- [x] I have run a build locally.
- [x] I have ran unit tests locally.
- [x] I have tested the functionality.

**3. Which issue and JIRA item does this PR fix (optional)**

**4. Additional notes for the reviewer**

## Reviewer Checklist

- [ ] [Coding Standards](../contribution_guidelines/coding_standards.md) followed.

When review is satisfactory reviewer will merge the changes.
