### PR TITLE
fix(#1466): apply padding when variant=relaxed

### DIFF
--- a/libs/web-components/src/assets/css/components.css
+++ b/libs/web-components/src/assets/css/components.css
@@ -80,10 +80,6 @@ goa-table table {
   border-collapse: collapse;
 }
 
-goa-table.relaxed td {
-  padding: 1rem;
-}
-
 goa-table.sticky thead {
   position: sticky;
   top: 0;
@@ -93,6 +89,10 @@ goa-table td {
   font: var(--goa-typography-body-m);
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--goa-color-greyscale-200);
+}
+
+goa-table[variant=relaxed] td {
+  padding: 1.25rem 1rem 1rem 1rem;
 }
 
 goa-table thead th {

--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -1,4 +1,9 @@
-<svelte:options customElement="goa-table" />
+<svelte:options customElement={{
+  tag: "goa-table",
+  props: {
+    variant: { reflect: true }
+  }
+}} />
 
 <script lang="ts">
   import { onMount, tick } from "svelte";


### PR DESCRIPTION
Instead of using JS for dom manipulation and adding 'relaxed' class to all eligible tds, the customElement <goa-table> is forced to spit out 'variant' attribute, and then the css selector goa-table[variant='relaxed'] td does work. See Chris' last comment below

![image](https://github.com/GovAlta/ui-components/assets/47701214/ee838265-4f28-4d40-93fa-720f7bd264aa)

