### PR TITLE
fix(#1461): table overflow-x should be auto

### DIFF
--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -120,6 +120,7 @@
   class={`goatable ${variant}`}
   class:sticky={_stickyHeader}
   style={`
+    overflow-x: auto;
     ${`width: ${width || "100%"};`}
     ${calculateMargin(mt, mr, mb, ml)}
   `}
@@ -135,9 +136,6 @@
 
 <style>
   /* other styles can be found in the assets/css/components.css file */
-  :host {
-    overflow-x: auto;
-  }
   .goatable {
     width: 0;
   }


### PR DESCRIPTION
Allow table to have scrolling bar 

Testing code: 
```
<div style="background-color: red; width:200px">
  <goa-table mb="xl" (_sort)="handleSort($event)">
    <thead>
    <tr>
      <th>
        <goa-table-sort-header name="firstName"
        >First name and really long header</goa-table-sort-header
        >
      </th>
      <th>
        <goa-table-sort-header name="lastName">Last name</goa-table-sort-header>
      </th>
      <th>
        Age
      </th>
      <th class="goa-table-number-header">
        Age
        <!--      <goa-table-sort-header name="age" direction="asc">-->
        <!--        Age</goa-table-sort-header>-->

      </th>
      <th>
        Age
      </th>
      <th>
        Age
      </th>
      <th>
        Age
      </th>
      <th>
        Age
      </th>
    </tr>
    </thead>
    <tbody>
    <tr *ngFor="let user of users; index as i">
      <td>{{ user.firstName }}</td>
      <td>{{ user.lastName }}</td>
      <td class="goa-table-number-column">{{ user.age }}</td>
      <td class="goa-table-number-column">{{ user.age }}</td>
      <td class="goa-table-number-column">{{ user.age }}</td>
      <td class="goa-table-number-column">{{ user.age }}</td>
      <td class="goa-table-number-column">{{ user.age }}</td>
      <td class="goa-table-number-column">{{ user.age }}</td>
    </tr>
    </tbody>
  </goa-table>

</div>
```

https://github.com/GovAlta/ui-components/assets/120135417/fc2a7afe-5bdd-48dc-bfa6-3e506c9f91eb

