### PR TITLE
fix(#1458): Fix Dropdown for Pagination

### DIFF
--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -97,7 +97,7 @@
     _options = getOptions();
 
     if (!_native) {
-      _inputEl.value = _options.find((o) => o.value === value)?.label ?? "";
+      setDisplayedValue();
 
       if (width) {
         _width = width;


### PR DESCRIPTION
There is an issue that can be seen on the website, where the Pagination component page dropdown doesn't show the selected page number.

This issue can be duplicated using the example code on the website for React (can't duplicate for Angular)

This should fix the issue. Components to be tested, Pagination and Dropdown (separately to make sure it still functions as expected).