### PR TITLE
fix(#1593): add testId attribute to react components

### DIFF
--- a/libs/react-components/src/lib/app-header-menu/app-header-menu.spec.tsx
+++ b/libs/react-components/src/lib/app-header-menu/app-header-menu.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/react";
+import { GoAIconType } from "../icon/icon";
 
 import GoAAppHeaderMenu from "./app-header-menu";
 
@@ -23,5 +24,19 @@ describe("AppHeaderMenu", () => {
     expect(el?.querySelector("a[href='#foo']")).toBeTruthy();
     expect(el?.querySelector("a[href='#bar']")).toBeTruthy();
     expect(el?.querySelector("a[href='#boom']")).toBeFalsy();
+  });
+
+  it("should set the props correctly", () => {
+    const { baseElement } = render(
+      <GoAAppHeaderMenu
+        heading="Some label"
+        leadingIcon="search"
+        testId="foo"
+        />);
+    const el = baseElement.querySelector("goa-app-header-menu");
+    expect(el).toBeTruthy();
+    expect(el?.getAttribute("heading")).toBe("Some label");
+    expect(el?.getAttribute("leadingIcon")).toBe("search");
+    expect(el?.getAttribute("data-testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/app-header-menu/app-header-menu.tsx
+++ b/libs/react-components/src/lib/app-header-menu/app-header-menu.tsx
@@ -10,6 +10,7 @@ interface WCProps {
 export interface GoAAppHeaderMenuProps {
   heading: string;
   leadingIcon?: GoAIconType;
+  testId?: string;
   children?: ReactNode;
 }
 
@@ -28,6 +29,7 @@ export function GoAAppHeaderMenu(props: GoAAppHeaderMenuProps) {
     <goa-app-header-menu
       heading={props.heading}
       leadingicon={props.leadingIcon}
+      data-testid={props.testId}
     >
       {props.children}
     </goa-app-header-menu>

--- a/libs/react-components/src/lib/calendar/calendar.spec.tsx
+++ b/libs/react-components/src/lib/calendar/calendar.spec.tsx
@@ -1,11 +1,13 @@
 import { fireEvent, render } from "@testing-library/react";
+import { addMonths } from "date-fns";
 import { describe, it, expect, vi } from "vitest";
 
 import Calendar from "./calendar";
 
+const noop = () => { /* do nothing */ };
+
 describe("Calendar", () => {
   it("should render successfully", () => {
-    const noop = () => { /* do nothing */ };
     const { baseElement, container } = render(<Calendar onChange={noop} />);
     expect(baseElement).toBeTruthy();
 
@@ -22,5 +24,28 @@ describe("Calendar", () => {
     const detail = { type: "date", value: new Date(), name };
     calendar && fireEvent(calendar, new CustomEvent("_change", { detail }));
     expect(onChange).toBeCalled();
+  });
+
+  it("should set the props correctly", () => {
+    const value = new Date();
+    const min = addMonths(value, -1);
+    const max = addMonths(value, 1);
+
+    const { baseElement } = render(
+      <Calendar
+        name="calendar"
+        value={value}
+        min={min}
+        max={max}
+        testId="foo"
+        onChange={noop}
+      />
+    );
+    const el = baseElement.querySelector("goa-calendar");
+    expect(baseElement).toBeTruthy();
+    expect(el?.getAttribute("value")).toBe(value.toISOString());
+    expect(el?.getAttribute("min")).toBe(min.toISOString());
+    expect(el?.getAttribute("max")).toBe(max.toISOString());
+    expect(el?.getAttribute("data-testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/calendar/calendar.tsx
+++ b/libs/react-components/src/lib/calendar/calendar.tsx
@@ -24,6 +24,7 @@ export interface GoACalendarProps extends Margins {
   value?: Date;
   min?: Date;
   max?: Date;
+  testId?: string;
   onChange: (name: string, value: Date) => void;
 }
 
@@ -32,6 +33,7 @@ export function GoACalendar({
   value,
   min,
   max,
+  testId,
   mt,
   mr,
   mb,
@@ -56,6 +58,7 @@ export function GoACalendar({
       value={value?.toISOString()}
       min={min?.toISOString()}
       max={max?.toISOString()}
+      data-testid={testId}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
@@ -18,6 +18,7 @@ describe("DatePicker", () => {
         min={min}
         max={max}
         value={value}
+        testId="foo"
         error={error}
         onChange={noop}
       />,
@@ -32,6 +33,7 @@ describe("DatePicker", () => {
     expect(el?.getAttribute("error")).toBe("true");
     expect(el?.getAttribute("min")).toBe(min.toISOString());
     expect(el?.getAttribute("max")).toBe(max.toISOString());
+    expect(el?.getAttribute("data-testid")).toBe("foo");
   });
 
   it("should handle event", async () => {

--- a/libs/react-components/src/lib/date-picker/date-picker.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.tsx
@@ -26,6 +26,7 @@ export interface GoADatePickerProps extends Margins {
   error?: boolean;
   min?: Date;
   max?: Date;
+  testId?: string;
   onChange: (name: string, value: Date) => void;
 }
 
@@ -35,6 +36,7 @@ export function GoADatePicker({
   error,
   min,
   max,
+  testId,
   mt,
   mr,
   mb,
@@ -60,6 +62,7 @@ export function GoADatePicker({
       error={error}
       min={min?.toISOString()}
       max={max?.toISOString()}
+      data-testid={testId}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/details/details.spec.tsx
+++ b/libs/react-components/src/lib/details/details.spec.tsx
@@ -5,14 +5,20 @@ import { GoADetails } from "./details";
 describe("Detail", () => {
   it("should render successfully", () => {
     const { baseElement } = render(
-      <GoADetails heading="The heading" open={true}>
+      <GoADetails
+        heading="The heading"
+        open={true}
+        testId="foo"
+      >
         The content
       </GoADetails>
     );
 
     const el = baseElement.querySelector("goa-details");
-    expect(el.getAttribute("heading")).toBe("The heading");
+    expect(el?.getAttribute("heading")).toBe("The heading");
     expect(baseElement.innerHTML).toContain("The content");
-    expect(el.getAttribute("open")).toBe("true");
+    expect(el?.getAttribute("open")).toBe("true");
+    expect(el?.getAttribute("data-testid")).toBe("foo");
   });
+
 });

--- a/libs/react-components/src/lib/details/details.tsx
+++ b/libs/react-components/src/lib/details/details.tsx
@@ -20,6 +20,7 @@ declare global {
 export interface GoADetailsProps extends Margins {
   heading: string;
   open?: boolean;
+  testId?: string;
   children: ReactNode;
 }
 
@@ -30,6 +31,7 @@ export function GoADetails(props: GoADetailsProps) {
     <goa-details
       heading={props.heading}
       open={props.open}
+      data-testid={props.testId}
       mt={props.mt}
       mr={props.mr}
       mb={props.mb}

--- a/libs/react-components/src/lib/file-upload-card/file-upload-card.spec.tsx
+++ b/libs/react-components/src/lib/file-upload-card/file-upload-card.spec.tsx
@@ -22,6 +22,7 @@ describe("FileUploadCard", () => {
         type="image/png"
         progress={23}
         error="true"
+        testId="foo"
       />
     );
 
@@ -31,6 +32,7 @@ describe("FileUploadCard", () => {
     expect(el?.getAttribute("type")).toBe("image/png");
     expect(el?.getAttribute("progress")).toBe("23");
     expect(el?.getAttribute("error")).toBe("true");
+    expect(el?.getAttribute("data-testid")).toBe("foo");
   });
 
   it("dispatches and event when cancel is clicked while uploading", () => {

--- a/libs/react-components/src/lib/file-upload-card/file-upload-card.tsx
+++ b/libs/react-components/src/lib/file-upload-card/file-upload-card.tsx
@@ -26,6 +26,7 @@ export interface GoAFileUploadCardProps {
   type?: string;
   progress?: number;
   error?: string;
+  testId?: string;
   onDelete?: () => void;
   onCancel?: () => void;
 }
@@ -36,6 +37,7 @@ export function GoAFileUploadCard({
   type,
   progress,
   error,
+  testId,
   onDelete,
   onCancel,
 }: GoAFileUploadCardProps) {
@@ -63,6 +65,7 @@ export function GoAFileUploadCard({
       type={type}
       progress={progress}
       error={error}
+      data-testid={testId}
     />
   );
 }

--- a/libs/react-components/src/lib/file-upload-input/file-upload-input.spec.tsx
+++ b/libs/react-components/src/lib/file-upload-input/file-upload-input.spec.tsx
@@ -13,6 +13,7 @@ describe("FileUploadInput", () => {
         maxFileSize="10MB"
         accept="image/*"
         variant="dragdrop"
+        testId="foo"
       />
     );
     const el = baseElement.querySelector("goa-file-upload-input");
@@ -20,6 +21,7 @@ describe("FileUploadInput", () => {
     expect(el?.getAttribute("maxfilesize")).toBe("10MB");
     expect(el?.getAttribute("accept")).toBe("image/*");
     expect(el?.getAttribute("variant")).toBe("dragdrop");
+    expect(el?.getAttribute("data-testid")).toBe("foo");
   });
 
   it("handles the onSelectFile event", () => {

--- a/libs/react-components/src/lib/file-upload-input/file-upload-input.tsx
+++ b/libs/react-components/src/lib/file-upload-input/file-upload-input.tsx
@@ -24,6 +24,7 @@ export interface GoAFileUploadInputProps {
   variant?: GoAFileUploadInputVariant;
   accept?: string;
   maxFileSize?: string;
+  testId?: string;
   onSelectFile: (file: File) => void;
 }
 
@@ -31,6 +32,7 @@ export function GoAFileUploadInput({
   variant,
   accept,
   maxFileSize,
+  testId,
   onSelectFile,
 }: GoAFileUploadInputProps) {
   const el = useRef<HTMLElement>(null);
@@ -54,6 +56,7 @@ export function GoAFileUploadInput({
       variant={variant}
       accept={accept}
       maxfilesize={maxFileSize}
+      data-testid={testId}
     />
   );
 }

--- a/libs/react-components/src/lib/footer-meta-section/footer-meta-section.spec.tsx
+++ b/libs/react-components/src/lib/footer-meta-section/footer-meta-section.spec.tsx
@@ -4,7 +4,9 @@ import FooterMetaSection from "./footer-meta-section";
 
 describe("FooterMetaSection", () => {
   it("should render successfully", () => {
-    const { baseElement } = render(<FooterMetaSection />);
+    const { baseElement } = render(<FooterMetaSection testId="foo" />);
+    const el = baseElement.querySelector("goa-app-footer-meta-section");
     expect(baseElement).toBeTruthy();
+    expect(el?.getAttribute("data-testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/footer-meta-section/footer-meta-section.tsx
+++ b/libs/react-components/src/lib/footer-meta-section/footer-meta-section.tsx
@@ -11,15 +11,19 @@ declare global {
 
 /* eslint-disable-next-line */
 export interface GoAAppFooterMetaSectionProps {
+  testId?: string;
   children?: ReactNode;
 }
 
 // legacy name
 export type FooterMetaSectionProps = GoAAppFooterMetaSectionProps;
 
-export function GoAAppFooterMetaSection({ children }: GoAAppFooterMetaSectionProps) {
+export function GoAAppFooterMetaSection({ testId, children }: GoAAppFooterMetaSectionProps) {
   return (
-    <goa-app-footer-meta-section slot="meta">
+    <goa-app-footer-meta-section
+      data-testid= {testId}
+      slot="meta"
+    >
       {children}
     </goa-app-footer-meta-section>
   );

--- a/libs/react-components/src/lib/side-menu-group/side-menu-group.spec.tsx
+++ b/libs/react-components/src/lib/side-menu-group/side-menu-group.spec.tsx
@@ -4,9 +4,10 @@ import SideMenuGroup from "./side-menu-group";
 
 describe("SideMenuGroup", () => {
   it("should render successfully", () => {
-    const { baseElement } = render(<SideMenuGroup heading="some header" />);
+    const { baseElement } = render(<SideMenuGroup heading="some header" testId="foo" />);
 
     const el = baseElement.querySelector("goa-side-menu-group");
     expect(el?.getAttribute("heading")).toBe("some header");
+    expect(el?.getAttribute("data-testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/side-menu-group/side-menu-group.tsx
+++ b/libs/react-components/src/lib/side-menu-group/side-menu-group.tsx
@@ -17,12 +17,16 @@ declare global {
 /* eslint-disable-next-line */
 export interface GoASideMenuGroupProps {
   heading: string;
+  testId?: string;
   children?: ReactNode;
 }
 
 export function GoASideMenuGroup(props: GoASideMenuGroupProps): JSX.Element {
   return (
-    <goa-side-menu-group heading={props.heading}>
+    <goa-side-menu-group
+      heading={props.heading}
+      data-testid={props.testId}
+    >
       {props.children}
     </goa-side-menu-group>
   );

--- a/libs/react-components/src/lib/side-menu-heading/side-menu-heading.spec.tsx
+++ b/libs/react-components/src/lib/side-menu-heading/side-menu-heading.spec.tsx
@@ -4,10 +4,11 @@ import SideMenuHeading from "./side-menu-heading";
 
 describe("SideMenuHeading", () => {
   it("should render successfully", () => {
-    const { baseElement } = render(<SideMenuHeading icon="home" />);
+    const { baseElement } = render(<SideMenuHeading icon="home" testId="foo" />);
 
     const el = baseElement.querySelector("goa-side-menu-heading");
     expect(el).toBeTruthy();
     expect(el?.getAttribute("icon")).toBe("home");
+    expect(el?.getAttribute("data-testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/side-menu-heading/side-menu-heading.tsx
+++ b/libs/react-components/src/lib/side-menu-heading/side-menu-heading.tsx
@@ -19,13 +19,17 @@ declare global {
 /* eslint-disable-next-line */
 export interface GoASideMenuHeadingProps {
   meta?: ReactNode;
-  icon?: GoAIconType
+  icon?: GoAIconType;
+  testId?: string;
   children?: ReactNode;
 }
 
 export function GoASideMenuHeading(props: GoASideMenuHeadingProps) {
   return (
-    <goa-side-menu-heading icon={props.icon}>
+    <goa-side-menu-heading
+      icon={props.icon}
+      data-testid={props.testId}
+    >
       {props.children}
       {props.meta && <span slot="meta">{props.meta}</span>}
     </goa-side-menu-heading>

--- a/libs/react-components/src/lib/side-menu/side-menu.spec.tsx
+++ b/libs/react-components/src/lib/side-menu/side-menu.spec.tsx
@@ -5,10 +5,12 @@ import SideMenu from "./side-menu";
 describe("SideMenu", () => {
   it("should render successfully", () => {
     const { baseElement } = render(
-      <SideMenu>
+      <SideMenu testId="foo">
         <a href="#foo">Link</a>
       </SideMenu>
     );
+    const el = baseElement.querySelector("goa-side-menu");
     expect(baseElement).toBeTruthy();
+    expect(el?.getAttribute("data-testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/side-menu/side-menu.tsx
+++ b/libs/react-components/src/lib/side-menu/side-menu.tsx
@@ -12,6 +12,7 @@ declare global {
 
 /* eslint-disable-next-line */
 export interface GoASideMenuProps {
+  testId?: string;
   children: ReactNode;
 }
 
@@ -19,7 +20,7 @@ export interface GoASideMenuProps {
 export type SideMenuProps = GoASideMenuProps;
 
 export function GoASideMenu(props: GoASideMenuProps): JSX.Element {
-  return <goa-side-menu>{props.children}</goa-side-menu>;
+  return <goa-side-menu data-testid={props.testId}>{props.children}</goa-side-menu>;
 }
 
 export default GoASideMenu;

--- a/libs/react-components/src/lib/tabs/tabs.spec.tsx
+++ b/libs/react-components/src/lib/tabs/tabs.spec.tsx
@@ -5,7 +5,7 @@ import GoATabs from "./tabs";
 describe("Tabs", () => {
   it("should render successfully", () => {
     const { baseElement } = render(
-      <GoATabs>
+      <GoATabs testId="foo" initialTab={1}>
         <GoATab heading="Profile">
           <p>
             <b>Profile:</b> Lorem ipsum dolor sit amet, consectetur adipiscing
@@ -17,6 +17,9 @@ describe("Tabs", () => {
     );
     const el = baseElement.querySelector("goa-tabs");
     expect(el).toBeTruthy();
+    expect(el?.getAttribute("initialTab")).toBe("1");
+    expect(el?.getAttribute("data-testid")).toBe("foo");
+
     const tabElements = baseElement.querySelectorAll("goa-tab");
     expect(tabElements.length).toBe(1);
   });

--- a/libs/react-components/src/lib/tabs/tabs.tsx
+++ b/libs/react-components/src/lib/tabs/tabs.tsx
@@ -13,10 +13,18 @@ declare global {
 export interface GoATabsProps {
   initialTab?: number;
   children?: React.ReactNode;
+  testId?: string;
 }
 
-export function GoATabs({ initialTab, children }: GoATabsProps): JSX.Element {
-  return <goa-tabs initialtab={initialTab}>{children}</goa-tabs>;
+export function GoATabs({ initialTab, children, testId }: GoATabsProps): JSX.Element {
+  return (
+    <goa-tabs
+      initialtab={initialTab}
+      data-testid={testId}
+    >
+      {children}
+    </goa-tabs>
+  );
 }
 
 export default GoATabs;


### PR DESCRIPTION
**1. What this code change do:**

This change addresses  https://github.com/GovAlta/ui-components/issues/1593 by adding a `testId` property to the following React components: 
- <del>Accordion</del> (I removed it because it is a [breaking change](https://github.com/GovAlta/ui-components/pull/1800#discussion_r1580034789))
- AppHeaderMenu
- Calendar
- DatePicker
- Details
- FileUploadCard
- FileUploadInput
- FooterMetaSection
- SideMenu
- SideMenuGroup
- SideMenuHeading
- Tabs

**2. Make sure that you've checked the boxes below before you submit MR:**

- [x] I have read and followed the [contribution guidelines](../../contributing.md)
- [x] I have run a build locally.
- [x] I have ran unit tests locally.
![image](https://github.com/GovAlta/ui-components/assets/1479091/89d832e1-4ddd-407d-b0c0-25184f4a977a)

- [x] I have tested the functionality.
