### PR TITLE
fix(#1796): update form item spacing and font

### DIFF
--- a/libs/web-components/src/components/form-item/FormItem.svelte
+++ b/libs/web-components/src/components/form-item/FormItem.svelte
@@ -81,39 +81,40 @@
 
   .label {
     display: block;
-    font-weight: var(--goa-font-weight-bold);
-    color: var(--goa-color-text-default);
-    font-size: var(--goa-font-size-4);
-    padding-bottom: 0.5rem;
+    font: var(--goa-typography-heading-s);
+    padding-bottom: var(--goa-space-xs);
   }
 
   .label.large {
     font: var(--goa-typography-heading-l);
+    padding-bottom: var(--goa-space-s);
   }
 
   .label em {
+    font: var(--goa-typography-body-xs);
     color: var(--goa-color-greyscale-700);
-    font-weight: var(--goa-font-weight-regular);
-    font-size: var(--goa-font-size-2);
-    line-height: var(--goa-line-height-1);
-    font-style: normal;
-  }
-
-  .form-item-input {
-    margin-bottom: 0.25rem;
-  }
-
-  .help-msg {
-    font-size: var(--goa-font-size-2);
-    color: var(--goa-color-text-default);
   }
 
   .error-msg {
-    display: inline-flex;
+    display: flex;
     align-items: flex-start;
-    gap: 0.25rem;
-    font-size: var(--goa-font-size-2);
+    gap: var(--goa-space-2xs);
+    font: var(--goa-typography-body-xs);
     color: var(--goa-color-interactive-error);
-    margin-bottom: 0.25rem;
+    margin-top: var(--goa-space-s);
+  }
+
+  .error-msg goa-icon {
+    transform: translateY(calc(var(--goa-space-2xs) * -1));
+  }
+
+  .help-msg {
+    font: var(--goa-typography-body-xs);
+    color: var(--goa-color-text-default);
+    margin-top: var(--goa-space-s);
+  }
+
+  .error-msg + .help-msg {
+    margin-top: var(--goa-space-xs);
   }
 </style>


### PR DESCRIPTION
This PR addresses https://github.com/GovAlta/ui-components/issues/1796 with the following changes:
- Adds extra spacing between a large label and the input
- Uses the proper font values for the error message
- Vertically aligns the error icon with the new line height using a transform
- Replaces other spacing values in the `FormItem` component with design tokens

Tasks:
- [x] I have run a build locally.
- [x] I have ran unit tests locally.
<img width="549" alt="image" src="https://github.com/GovAlta/ui-components/assets/1479091/176a379f-4eda-4061-8198-28556cdbf6c4">

- [x] I have tested the functionality.
