### PR TITLE
fix(#1818): Adding multiple back to File Upload

### DIFF
--- a/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
+++ b/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
@@ -202,6 +202,7 @@
       type="file"
       {accept}
       bind:this={_fileInput}
+      multiple
     />
   </div>
 {/if}


### PR DESCRIPTION
# Testing

Create a Drag and Drop variant of the File Upload. Make sure you can select multiple files using it, while using the file select window (not dragging and dropping).