### PR TITLE
fix(#1703): input add onChange,modify Keyup,make TextArea consistent

### DIFF
--- a/libs/web-components/src/components/input/Input.spec.ts
+++ b/libs/web-components/src/components/input/Input.spec.ts
@@ -179,7 +179,6 @@ describe("GoAInput Component", () => {
 
     await fireEvent.keyUp(input, { target: { value: "foobar" }, key: 'r' });
     await waitFor(() => {
-      expect(change).toBeCalledTimes(1);
       expect(keypress).toBeCalledTimes(1);
     });
   });
@@ -267,7 +266,7 @@ describe("GoAInput Component", () => {
       const input = await findByTestId("input-test");
       const search = vi.fn();
 
-      input.addEventListener("_change", () => {
+      input.addEventListener("_keyPress", () => {
         search();
       });
 
@@ -383,7 +382,7 @@ describe("GoAInput Component", () => {
       fn();
     });
 
-    await fireEvent.keyUp(input, { target: { value: "foobar" } });
+    await fireEvent.change(input, { target: { value: "foobar" } });
     await waitFor(
       () => {
         expect(fn).not.toBeCalled();

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -97,28 +97,41 @@
     if (!input) return;
     if (isReadonly) return;
 
-    if (_debounceId != null) {
-      clearTimeout(_debounceId);
-    }
+    dispatchKeyUp(e, input);
+    value = input.value;
+  }
 
-    _debounceId = setTimeout(() => {
-      input.dispatchEvent(
-        new CustomEvent("_change", {
-          composed: true,
-          bubbles: false,
-          cancelable: true,
-          detail: { name, value: input.value },
-        }),
-      );
-    }, debounce);
-
+  function dispatchKeyUp(e: Event, input: HTMLInputElement) {
     input.dispatchEvent(
       new CustomEvent("_keyPress", {
         composed: true,
         detail: { name, value: input.value, key: (e as KeyboardEvent).key },
       }),
     );
-    value = input.value;
+  }
+
+  function onChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    if (!input) return;
+
+    if (_debounceId != null) {
+      clearTimeout(_debounceId);
+    }
+
+    _debounceId = setTimeout(() => {
+      dispatchChange(e, input);
+    }, debounce);
+  }
+
+  function dispatchChange(_: Event, input: HTMLInputElement) {
+    input.dispatchEvent(
+      new CustomEvent("_change", {
+        composed: true,
+        bubbles: false,
+        cancelable: true,
+        detail: { name, value: input.value },
+      }),
+    );
   }
 
   function onFocus(e: Event) {
@@ -234,7 +247,7 @@
       aria-label={arialabel || name}
       aria-labelledby={arialabelledby}
       on:keyup={onKeyUp}
-      on:change={onKeyUp}
+      on:change={onChange}
       on:focus={onFocus}
       on:blur={onBlur}
     />

--- a/libs/web-components/src/components/text-area/TextArea.spec.ts
+++ b/libs/web-components/src/components/text-area/TextArea.spec.ts
@@ -70,7 +70,6 @@ describe("GoATextArea", () => {
 
     await waitFor(() => {
       expect(onKeyPress).toBeCalledTimes(1);
-      expect(onChange).toBeCalledTimes(1);
     });
 
   });

--- a/libs/web-components/src/components/text-area/TextArea.svelte
+++ b/libs/web-components/src/components/text-area/TextArea.svelte
@@ -49,7 +49,6 @@
   function onKeyPress(e: KeyboardEvent) {
     if (isDisabled) return;
     dispatchKeyPress(e);
-    dispatchChange(e);
   }
 
   function dispatchChange(_: KeyboardEvent) {


### PR DESCRIPTION
-For the input, modify the behavior of the KeyUp, add take the change event functionality out in a separate onChange handler. 
-Also, make the behavior of the TextArea consistent with this change wherein the keypress event isn't dealing with the change event anymore (so that both Textarea and input behave in similar way w.r.t. Keyup and Change).