### PR TITLE
fix(#1407): reduce max modal height when actions exist

### DIFF
--- a/libs/web-components/src/components/modal/Modal.svelte
+++ b/libs/web-components/src/components/modal/Modal.svelte
@@ -36,6 +36,7 @@
   let _headerEl: HTMLElement | null = null;
   let _isOpen: boolean = false;
   let _requiresTopPadding: boolean;
+  let _actionsHeight: number;
 
   // Type verification
   const [CALLOUT_VARIANT, validateCalloutVariant] = typeValidator(
@@ -237,14 +238,14 @@
             <goa-scrollable
               direction="vertical"
               hpadding="1.9rem"
-              maxheight="70vh"
+              maxheight="calc(70vh - {_actionsHeight}px)"
               bind:this={_scrollEl}
               on:_scroll={handleScroll}
             >
               <slot />
             </goa-scrollable>
           </div>
-          <div class="modal-actions" data-testid="modal-actions">
+          <div bind:clientHeight={_actionsHeight} class="modal-actions" data-testid="modal-actions">
             <slot name="actions" />
           </div>
         </div>


### PR DESCRIPTION
This PR fixes https://github.com/GovAlta/ui-components/issues/1407. It subtracts the height of the actions section from the max height of the modal scroll area. This lets a modal with actions fit vertically in a mobile viewport.

### Testing checklist
- [x] I have run a build locally.
- [x] I have ran unit tests locally.
![image](https://github.com/GovAlta/ui-components/assets/1479091/57ebbda1-7f46-4bb4-9b9f-bc4b0d9d2678)

- [x] I have tested the functionality.

### Scenarios to test
Modal has correct max height on mobile when... 
- [x] No actions exist
- [x] Actions with one button exists
- [x] Actions with two buttons exists
- [x] Actions with four buttons exists (Just in case?)