### PR TITLE
fix(#1837): radio doesn't work on mac and chrome browser

### DIFF
--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -84,7 +84,9 @@
     children.forEach((el, index) => {
       const option = el as unknown as RadioOption & { innerText: string };
       const optionValue = el.getAttribute("value") || option.value;
-      option.setAttribute("disabled", isDisabled);
+      if (isDisabled) {
+        option.setAttribute("disabled", isDisabled);
+      }
       option.setAttribute("error", isError);
       option.setAttribute("name", name);
       option.setAttribute("checked", optionValue === value);


### PR DESCRIPTION
Remove `disabled` attribute from `input` that is rendered even the value is false.

https://github.com/GovAlta/ui-components/assets/120135417/3d7e808a-4174-453e-93a7-a0954757d1d0

