### PR TITLE
fix(#1368,#1792,#1772,#1569):  fixing link active when router change 

### DIFF
--- a/libs/web-components/src/assets/css/components.css
+++ b/libs/web-components/src/assets/css/components.css
@@ -26,7 +26,7 @@ goa-app-header a.current.inside-collapse-menu,
 goa-app-header a.current.inside-collapse-menu:hover,
 goa-app-header-menu a.current,
 goa-app-header-menu a.current:hover {
-  color:  var(--goa-color-text-light);
+  color: var(--goa-color-text-light);
 }
 
 goa-app-header-menu a:first-of-type {
@@ -50,7 +50,7 @@ goa-table td {
   border-bottom: 1px solid var(--goa-color-greyscale-200);
 }
 
-goa-table[variant=relaxed] td {
+goa-table[variant="relaxed"] td {
   padding: 1.25rem 1rem 1rem 1rem;
 }
 

--- a/libs/web-components/src/assets/css/reset.css
+++ b/libs/web-components/src/assets/css/reset.css
@@ -41,10 +41,10 @@ ol {
   padding-left: 1rem;
 }
 
-li>ul,
-li>ol,
-li>ul,
-li>ol {
+li > ul,
+li > ol,
+li > ul,
+li > ol {
   padding-left: 0;
   margin-top: 0;
 }
@@ -110,7 +110,7 @@ h6 {
   font-weight: var(--goa-font-weight-bold);
 }
 
-h3+h1 {
+h3 + h1 {
   margin-top: -1rem;
 }
 

--- a/libs/web-components/src/components/app-header-menu/app-header-menu.spec.ts
+++ b/libs/web-components/src/components/app-header-menu/app-header-menu.spec.ts
@@ -1,27 +1,26 @@
-import AppHeaderMenuWrapper from "./AppHeaderMenuWrapper.test.svelte"
-import { render, waitFor, screen } from "@testing-library/svelte"
-import userEvent from "@testing-library/user-event"
+import AppHeaderMenuWrapper from "./AppHeaderMenuWrapper.test.svelte";
+import { render, waitFor, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
 import type { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { it, describe } from "vitest";
-import {tick} from "svelte";
+import { tick } from "svelte";
 
 let user: UserEvent;
 
 beforeEach(() => {
-  user = userEvent.setup()
-})
+  user = userEvent.setup();
+});
 
 type Query = (q: string) => HTMLElement;
 type QueryAll = (q: string) => NodeListOf<HTMLElement>;
 
 describe("Desktop", () => {
-
   let $: Query;
   let $$: QueryAll;
   let heading: string;
 
   beforeEach(() => {
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(window, "innerWidth", {
       writable: true,
       value: 1200,
     });
@@ -30,16 +29,15 @@ describe("Desktop", () => {
     const result = render(AppHeaderMenuWrapper, {
       heading,
       leadingicon: "add",
-    })
+    });
 
-    const c = result.container
+    const c = result.container;
     $ = c.querySelector.bind(c);
     $$ = c.querySelectorAll.bind(c);
-  })
+  });
 
   it("renders on desktop", async () => {
-
-    const popover = $("goa-popover")
+    const popover = $("goa-popover");
     const button = $("button");
     const leadingIcon = $("button goa-icon[type=add]");
     const chevronIcon = $("button goa-icon[type=chevron-down]");
@@ -56,30 +54,71 @@ describe("Desktop", () => {
     await waitFor(() => {
       expect(links).toBeTruthy();
       expect(links.length).toBe(4);
-    })
+    });
+  });
+
+  it("listen to appheader:current:change event and set link to be active", async () => {
+    const rootEl = screen.queryByTestId("rootEl");
+
+    // Listen to parent GoAAppHeader to dispatch event current:change
+    rootEl?.dispatchEvent(
+      new CustomEvent("app-header:changed", {
+        detail: "#seniors",
+      }),
+    );
+
+    await waitFor(() => {
+      const currentLink = $("a.current");
+      expect(currentLink?.getAttribute("href")).toBe("#seniors");
+      // We should make sure when router link is changed, the app-header-menu is closed
+      const popover = $("goa-popover");
+      expect(popover.getAttribute("open")).toBe("false");
+    });
+
+    // When parent dispatch event with empty link, means no link should be highlighted, we should remove the current class
+    rootEl?.dispatchEvent(
+      new CustomEvent("app-header:changed", {
+        detail: "",
+      }),
+    );
+
+    await waitFor(() => {
+      const currentLink = $("a.current");
+      expect(currentLink).toBeNull();
+    });
+
+    // When parent dispatch an event with parent's link, means no link under app-header-menu should be highlighted
+    rootEl?.dispatchEvent(
+      new CustomEvent("app-header:changed", {
+        detail: "parent-link",
+      }),
+    );
+
+    await waitFor(() => {
+      const currentLink = $("a.current");
+      expect(currentLink).toBeNull();
+    });
   });
 
   it("close the menu if the link handles other function beside navigate to new page", async () => {
     const specialLink = $("a[href='#special']");
     await user.click(specialLink);
     await tick();
-    const popover = $("goa-popover")
-    expect( popover.getAttribute("open")).toBe("false");
+    const popover = $("goa-popover");
+    expect(popover.getAttribute("open")).toBe("false");
     // Functionality is handled as usual
     const text = await screen.findByTestId("test-without-loading");
     expect((await text).innerHTML).toBe("Test without loading");
   });
-
-})
+});
 
 describe("Mobile", () => {
-
   let $: Query;
   let $$: QueryAll;
   let heading: string;
 
   beforeEach(() => {
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(window, "innerWidth", {
       writable: true,
       value: 400,
     });
@@ -88,12 +127,12 @@ describe("Mobile", () => {
     const result = render(AppHeaderMenuWrapper, {
       heading,
       leadingicon: "add",
-    })
+    });
 
-    const c = result.container
+    const c = result.container;
     $ = c.querySelector.bind(c);
     $$ = c.querySelectorAll.bind(c);
-  })
+  });
 
   it("renders on mobile", async () => {
     const button = $("button");
@@ -103,67 +142,67 @@ describe("Mobile", () => {
     expect(button.innerHTML).toContain(heading);
     expect(leadingIcon).toBeTruthy();
     expect(chevronIcon).toBeTruthy();
-  })
+  });
 
   it("opens/closes the menu on click", async () => {
     const btn = $("button");
-    await user.click(btn)
+    await user.click(btn);
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(4);
-    })
+    });
 
     // close
-    await user.click(btn)
+    await user.click(btn);
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(0);
-    })
-  })
+    });
+  });
 
   it("opens/closes on the space key", async () => {
     const btn = $("button");
 
-    btn.focus()
+    btn.focus();
     // open
-    await user.keyboard(" ")
+    await user.keyboard(" ");
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(4);
-    })
+    });
 
     // close
-    await user.keyboard("{enter}")
+    await user.keyboard("{enter}");
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(0);
-    })
-  })
+    });
+  });
 
   it("opens/closes on the enter key", async () => {
     const btn = $("button");
 
-    btn.focus()
+    btn.focus();
     // open
-    await user.keyboard("{enter}")
+    await user.keyboard("{enter}");
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(4);
-    })
+    });
 
     //close
-    await user.keyboard("{enter}")
+    await user.keyboard("{enter}");
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(0);
-    })
-  })
+    });
+  });
 
   it("focuses on the links on `tab`", async () => {
     const btn = $("button");
 
-    btn.focus()
-    await user.keyboard("{enter}")
+    btn.focus();
+    await user.keyboard("{enter}");
     await waitFor(async () => {
       const links = $$("a");
       expect(links.length).toBe(4);
@@ -174,8 +213,8 @@ describe("Mobile", () => {
       expect(document.activeElement).toBe(links[1]);
       await user.keyboard("{Tab}");
       expect(document.activeElement).toBe(links[2]);
-    })
-  })
+    });
+  });
 
   it("close the menu if the link handles other function beside navigate to new page", async () => {
     const specialLink = $("a[href='#special']");
@@ -187,18 +226,16 @@ describe("Mobile", () => {
 
   it.skip("follows the link on `enter`", () => {
     /* do nothing */
-  })
-
-})
+  });
+});
 
 describe("Tablet", () => {
-
   let $: Query;
   let $$: QueryAll;
   let heading: string;
 
   beforeEach(() => {
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(window, "innerWidth", {
       writable: true,
       value: 800,
     });
@@ -207,12 +244,12 @@ describe("Tablet", () => {
     const result = render(AppHeaderMenuWrapper, {
       heading,
       leadingicon: "add",
-    })
+    });
 
-    const c = result.container
+    const c = result.container;
     $ = c.querySelector.bind(c);
     $$ = c.querySelectorAll.bind(c);
-  })
+  });
 
   it("renders on tablet", async () => {
     const button = $("button");
@@ -222,67 +259,67 @@ describe("Tablet", () => {
     expect(button.innerHTML).toContain(heading);
     expect(leadingIcon).toBeTruthy();
     expect(chevronIcon).toBeTruthy();
-  })
+  });
 
   it("opens/closes the menu on click", async () => {
     const btn = $("button");
-    await user.click(btn)
+    await user.click(btn);
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(4);
-    })
+    });
 
     // close
-    await user.click(btn)
+    await user.click(btn);
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(0);
-    })
-  })
+    });
+  });
 
   it("opens/closes on the space key", async () => {
     const btn = $("button");
 
-    btn.focus()
+    btn.focus();
     // open
-    await user.keyboard(" ")
+    await user.keyboard(" ");
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(4);
-    })
+    });
 
     // close
-    await user.keyboard("{enter}")
+    await user.keyboard("{enter}");
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(0);
-    })
-  })
+    });
+  });
 
   it("opens/closes on the enter key", async () => {
     const btn = $("button");
 
-    btn.focus()
+    btn.focus();
     // open
-    await user.keyboard("{enter}")
+    await user.keyboard("{enter}");
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(4);
-    })
+    });
 
     // close
-    await user.keyboard("{enter}")
+    await user.keyboard("{enter}");
     await waitFor(() => {
       const links = $$("a");
       expect(links.length).toBe(0);
-    })
-  })
+    });
+  });
 
   it("focuses on the links on `tab`", async () => {
     const btn = $("button");
 
-    btn.focus()
-    await user.keyboard("{enter}")
+    btn.focus();
+    await user.keyboard("{enter}");
     await waitFor(async () => {
       const links = $$("a");
       expect(links.length).toBe(4);
@@ -293,8 +330,8 @@ describe("Tablet", () => {
       expect(document.activeElement).toBe(links[1]);
       await user.keyboard("{Tab}");
       expect(document.activeElement).toBe(links[2]);
-    })
-  })
+    });
+  });
 
   it("close the menu if the link handles other function beside navigate to new page", async () => {
     const specialLink = $("a[href='#special']");
@@ -303,4 +340,4 @@ describe("Tablet", () => {
     const links = $$("a");
     expect(links.length).toBe(0);
   });
-})
+});

--- a/libs/web-components/src/components/app-header/AppHeader.spec.ts
+++ b/libs/web-components/src/components/app-header/AppHeader.spec.ts
@@ -1,36 +1,40 @@
-import { render, waitFor } from '@testing-library/svelte';
-import userEvent from "@testing-library/user-event"
-import type { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
-import AppHeaderWrapper from './AppHeaderWrapper.test.svelte'
+import { render, waitFor } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import type { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
+import AppHeaderWrapper from "./AppHeaderWrapper.test.svelte";
 import { it, describe } from "vitest";
+import { tick } from "svelte";
 
 type QueryAll = (q: string) => NodeListOf<HTMLElement>;
 
 let user: UserEvent;
 
 beforeEach(() => {
-  user = userEvent.setup()
-})
+  user = userEvent.setup();
+});
 
-describe('AppHeader Desktop with children', () => {
-
+describe("AppHeader Desktop with children", () => {
   const heading = "Test heading";
-  const url = "http://localhost/foo"
+  const url = "http://localhost/foo";
 
   beforeEach(() => {
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(window, "innerWidth", {
       writable: true,
       value: 1200,
     });
-  })
+  });
 
-  it('should render', async () => {
-    const { container, queryByTestId } = render(AppHeaderWrapper, { heading, url, haschildren: true });
+  it("should render", async () => {
+    const { container, queryByTestId } = render(AppHeaderWrapper, {
+      heading,
+      url,
+      haschildren: true,
+    });
     const links = container.querySelectorAll("a");
 
     expect(queryByTestId("title")?.innerHTML).toBe(heading);
     expect((queryByTestId("url") as HTMLLinkElement)?.href).toBe(url);
-    expect(links.length).toBe(6);  // 5 custom links + 1 app header for the url
+    expect(links.length).toBe(6); // 5 custom links + 1 app header for the url
   });
 });
 
@@ -38,19 +42,24 @@ describe("AppHeader Desktop with a defined fullmenubreakpoint", () => {
   let $t: (query: string) => HTMLElement | null;
 
   const heading = "Test heading";
-  const url = "http://localhost/foo"
+  const url = "http://localhost/foo";
 
   beforeEach(async () => {
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(window, "innerWidth", {
       writable: true,
       value: 1500, // desktop width 1500 > 1024 tablet width, but want to collapse menu
     });
   });
 
-  it("should show menu toggle when fullmenubreakpoint = 1700", async() => {
-    const result = render(AppHeaderWrapper, {heading, url, haschildren: true, fullmenubreakpoint: 1700});
+  it("should show menu toggle when fullmenubreakpoint = 1700", async () => {
+    const result = render(AppHeaderWrapper, {
+      heading,
+      url,
+      haschildren: true,
+      fullmenubreakpoint: 1700,
+    });
 
-    const c = result.container
+    const c = result.container;
     $t = result.queryByTestId.bind(c);
     await waitFor(
       () => {
@@ -63,36 +72,44 @@ describe("AppHeader Desktop with a defined fullmenubreakpoint", () => {
     );
   });
 
-  it("should show desktop menu when fullmenubreakpoint = 1400", async() => {
-    const result = render(AppHeaderWrapper, {heading, url, haschildren: true, fullmenubreakpoint: 1400});
+  it("should show desktop menu when fullmenubreakpoint = 1400", async () => {
+    const result = render(AppHeaderWrapper, {
+      heading,
+      url,
+      haschildren: true,
+      fullmenubreakpoint: 1400,
+    });
 
-    const c = result.container
+    const c = result.container;
     $t = result.queryByTestId.bind(c);
 
     const toggleBtn = $t("menu-toggle");
     expect(toggleBtn).toBeFalsy();
     const links = c.querySelectorAll("a");
-    expect(links.length).toBe(6);  // 5 custom links + 1 app header url
+    expect(links.length).toBe(6); // 5 custom links + 1 app header url
   });
-})
+});
 
-describe('AppHeader Mobile', () => {
-
+describe("AppHeader Mobile", () => {
   let $t: (query: string) => HTMLElement | null;
 
   const heading = "Test heading";
-  const url = "http://localhost/foo"
+  const url = "http://localhost/foo";
 
   beforeEach(async () => {
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(window, "innerWidth", {
       writable: true,
       value: 400,
     });
 
-    const result = render(AppHeaderWrapper, { heading, url, haschildren: true });
-    const c = result.container
-    $t = result.queryByTestId.bind(c)
-  })
+    const result = render(AppHeaderWrapper, {
+      heading,
+      url,
+      haschildren: true,
+    });
+    const c = result.container;
+    $t = result.queryByTestId.bind(c);
+  });
 
   it("should show/hide the menu", async () => {
     const toggleBtn = $t("menu-toggle");
@@ -104,22 +121,22 @@ describe('AppHeader Mobile', () => {
     await waitFor(() => {
       const hasMenuItems = $t("slot");
       expect(hasMenuItems).toBeFalsy();
-    })
+    });
 
     // open
     user.click(toggleBtn);
     await waitFor(() => {
       const hasMenuItems = $t("slot");
       expect(hasMenuItems).toBeTruthy();
-    })
+    });
 
     // close
     user.click(toggleBtn);
     await waitFor(() => {
       const hasMenuItems = $t("slot");
       expect(hasMenuItems).toBeFalsy();
-    })
-  })
+    });
+  });
 
   it("toggles the menu with the space key", async () => {
     const toggleBtn = $t("menu-toggle");
@@ -132,15 +149,15 @@ describe('AppHeader Mobile', () => {
     await waitFor(() => {
       const hasMenuItems = $t("slot");
       expect(hasMenuItems).toBeTruthy();
-    })
+    });
 
     // close
     user.keyboard(" ");
     await waitFor(() => {
       const hasMenuItems = $t("slot");
       expect(hasMenuItems).toBeFalsy();
-    })
-  })
+    });
+  });
 
   it("toggles the menu with the enter key", async () => {
     const toggleBtn = $t("menu-toggle");
@@ -153,36 +170,39 @@ describe('AppHeader Mobile', () => {
     await waitFor(() => {
       const hasMenuItems = $t("slot");
       expect(hasMenuItems).toBeTruthy();
-    })
+    });
 
     // close
     user.keyboard("{enter}");
     await waitFor(() => {
       const hasMenuItems = $t("slot");
       expect(hasMenuItems).toBeFalsy();
-    })
-  })
-})
+    });
+  });
+});
 
-describe('AppHeader Tablet', () => {
-
+describe("AppHeader Tablet", () => {
   let $$: QueryAll;
   let $t: (query: string) => HTMLElement | null;
 
   const heading = "Test heading";
-  const url = "http://localhost/foo"
+  const url = "http://localhost/foo";
 
   beforeEach(async () => {
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(window, "innerWidth", {
       writable: true,
       value: 800,
     });
 
-    const result = render(AppHeaderWrapper, { heading, url, haschildren: true });
-    const c = result.container
+    const result = render(AppHeaderWrapper, {
+      heading,
+      url,
+      haschildren: true,
+    });
+    const c = result.container;
     $$ = c.querySelectorAll.bind(c);
-    $t = result.queryByTestId.bind(c)
-  })
+    $t = result.queryByTestId.bind(c);
+  });
 
   it("should show/hide the menu", async () => {
     const toggleBtn = $t("menu-toggle");
@@ -194,22 +214,22 @@ describe('AppHeader Tablet', () => {
     await waitFor(() => {
       const hasMenuItems = $$("goa-popover a");
       expect(hasMenuItems.length).toBeFalsy();
-    })
+    });
 
     // open
     user.click(toggleBtn);
     await waitFor(() => {
       const hasMenuItems = $$("goa-popover a");
       expect(hasMenuItems.length).toBeTruthy();
-    })
+    });
 
     // close
     user.click(toggleBtn);
     await waitFor(() => {
       const hasMenuItems = $$("goa-popover a");
       expect(hasMenuItems.length).toBeFalsy();
-    })
-  })
+    });
+  });
 
   it("toggles the menu with the space key", async () => {
     const toggleBtn = $t("menu-toggle");
@@ -222,15 +242,15 @@ describe('AppHeader Tablet', () => {
     await waitFor(() => {
       const hasMenuItems = $$("goa-popover a");
       expect(hasMenuItems.length).toBeTruthy();
-    })
+    });
 
     // close
     user.keyboard(" ");
     await waitFor(() => {
       const hasMenuItems = $$("goa-popover a");
       expect(hasMenuItems.length).toBeFalsy();
-    })
-  })
+    });
+  });
 
   it("toggles the menu with the enter key", async () => {
     const toggleBtn = $t("menu-toggle");
@@ -243,13 +263,74 @@ describe('AppHeader Tablet', () => {
     await waitFor(() => {
       const hasMenuItems = $$("goa-popover a");
       expect(hasMenuItems.length).toBeTruthy();
-    })
+    });
 
     // close
     user.keyboard("{enter}");
     await waitFor(() => {
       const hasMenuItems = $$("goa-popover a");
       expect(hasMenuItems.length).toBeFalsy();
-    })
-  })
-})
+    });
+  });
+});
+
+describe.skip("AppHeader with correct highlighted link", () => {
+  const heading = "Test heading";
+  const url = "http://localhost/foo";
+
+  beforeEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      value: 1200,
+    });
+
+    // Mock window.location
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    delete window.location;
+  });
+
+  it("should set #learnmore to be highlighted when navigating to /foo#learnmore", async () => {
+    // Bug 1772
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    window.location = new URL("http://localhost/foo#learnmore");
+    const { container } = render(AppHeaderWrapper, {
+      heading,
+      url,
+      haschildren: true,
+    });
+
+    // Simulate route change
+    const event = new PopStateEvent("popstate", { state: {} });
+    window.dispatchEvent(event);
+
+    // Check if the correct link has the "current" class
+    const currentLink = container.querySelector("a.current");
+    expect(currentLink).toBeTruthy();
+    expect(currentLink?.getAttribute("href")).toBe("#aboutus");
+  });
+
+  it("should set #seniors under app-header-menu to be highlighted when navigating to /foo#seniors", async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    window.location = new URL("http://localhost/foo#seniors");
+    const { container } = render(AppHeaderWrapper, {
+      heading,
+      url,
+      haschildren: true,
+    });
+
+    // Simulate route change
+    const event = new PopStateEvent("popstate", { state: {} });
+    window.dispatchEvent(event);
+
+    await tick();
+    await waitFor(() => {
+      // Check if the correct link has the "current" class
+      const currentLink = container.querySelector("a.current");
+      expect(currentLink).toBeTruthy();
+      expect(currentLink?.getAttribute("href")).toBe("#seniors");
+    });
+  });
+});

--- a/libs/web-components/src/components/side-menu/SideMenuWrapper.test.svelte
+++ b/libs/web-components/src/components/side-menu/SideMenuWrapper.test.svelte
@@ -1,0 +1,15 @@
+<svelte:options customElement="test-side-menu-wrapper" />
+
+<script lang="ts">
+  import GoASideMenu from "./SideMenu.svelte";
+</script>
+
+<GoASideMenu>
+  <goa-side-menu-heading>Get started</goa-side-menu-heading>
+  <a href="get-started">Overview</a>
+  <a href="get-started/designers">UX designers</a>
+  <goa-side-menu-group heading="Developers">
+    <a href="get-started/developers">Overview</a>
+    <a href="get-started/developers/setup">Setup</a>
+  </goa-side-menu-group>
+</GoASideMenu>

--- a/libs/web-components/src/components/side-menu/side-menu.spec.ts
+++ b/libs/web-components/src/components/side-menu/side-menu.spec.ts
@@ -1,5 +1,22 @@
-// import SideMenu from "./SideMenu.svelte";
-// import { render } from "@testing-library/svelte";
 import { it } from "vitest";
+import { render } from "@testing-library/svelte";
+import SideMenuWrapper from "./SideMenuWrapper.test.svelte";
 
-it.skip("test", async () => { /* do nothing */ });
+describe.skip("SideMenu should render with children and set highlighted menu item correctly", () => {
+  it("should render", async () => {
+    // Mock window.location
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    delete window.location;
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    window.location = new URL("http://localhost/get-started");
+    const { container } = render(SideMenuWrapper);
+
+    const links = container.querySelectorAll("a");
+    expect(links.length).toBe(4);
+    const currentLink = container.querySelector("a.current");
+    expect(currentLink).toBeTruthy();
+    expect(currentLink?.getAttribute("href")).toBe("get-started");
+  });
+});

--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -50,7 +50,7 @@
   }
 
   function bindChildren() {
-    const path = window.location.href;
+    const path = window.location.pathname;
 
     // create buttons (tabs) for each of the tab contents elements
     _tabProps.forEach((tabProps, index) => {


### PR DESCRIPTION
### Scope:

1. Fixing #1772 
2. Fixing #1792 
3. Fixing #1386 
4. Fixing #1569 

### What are changed:

- [x] AppHeader active link on mobile and tablet, now has the blue background color and white text color like [Figma]([https://www.figma.com/file/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-D[…]=design&node-id=41625-1768678&mode=design&t=lhSWXodPoMc7UAHy-4](https://www.figma.com/file/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?type=design&node-id=41625-1768678&mode=design&t=lhSWXodPoMc7UAHy-4)) described 
- [x] AppHeaderMenu active link now has the blue background color and white text color like Figma above. 
- [x] Move as much as possible CSS of GoAAppHeader and GoAAppHeaderMenu under `components.css` to component itself, using `::slottted`
- [x] Add `getMatchedLink` to make sure if AppHeader and AppHeaderMenu links have the same weight, then no menu should be active. Change the logic to make sure the highest weight item will be active. Add tests. 
- [x] When URL is changed (routerLink) on single page applications, the link class `current` should be updated. The current link should be correct. 
- [x] AppHeaderMenu should be closed if router is changed. 
- [x] Tab `href` is fixed in order to work with Angular. 

### Demo link: [https://vanessatran-ddi.github.io/ui-components/#/](https://vanessatran-ddi.github.io/ui-components/#/)

### Video demo: 

https://github.com/GovAlta/ui-components/assets/120135417/87c963bf-3e85-40cf-a20c-d4d8089dadbc


https://github.com/GovAlta/ui-components/assets/120135417/a96160ae-1d03-41fd-be3a-eb31c0c76382

