### PR TITLE
feat(#1816): width property for container

### DIFF
--- a/libs/react-components/src/lib/container/container.spec.tsx
+++ b/libs/react-components/src/lib/container/container.spec.tsx
@@ -10,6 +10,7 @@ describe("Container", () => {
         accent="thick"
         padding="relaxed"
         title={"Text title"}
+        width="content"
         mt="s"
         mr="m"
         mb="l"
@@ -30,6 +31,7 @@ describe("Container", () => {
     expect(el?.getAttribute("mr")).toBe("m");
     expect(el?.getAttribute("mb")).toBe("l");
     expect(el?.getAttribute("ml")).toBe("xl");
+    expect(el?.getAttribute("width")).toBe("content");
 
     expect(el?.querySelector("*[slot=title]")?.innerHTML).toContain("Text title");
     expect(

--- a/libs/react-components/src/lib/container/container.tsx
+++ b/libs/react-components/src/lib/container/container.tsx
@@ -10,11 +10,13 @@ export type GoAContainerType =
   | "important";
 export type GoAContainerAccent = "thick" | "thin" | "filled";
 export type GoAContainerPadding = "relaxed" | "compact";
+export type GoAContainerWidth = "full" | "content";
 
 interface WCProps extends Margins {
   type?: GoAContainerType;
   accent?: GoAContainerAccent;
   padding?: GoAContainerPadding;
+  width?: GoAContainerWidth;
 }
 
 declare global {
@@ -34,6 +36,7 @@ export interface GoAContainerProps extends Margins {
   padding?: GoAContainerPadding;
   actions?: ReactNode;
   children?: ReactNode;
+  width?: GoAContainerWidth;
   testId?: string;
 }
 
@@ -45,6 +48,7 @@ export function GoAContainer({
   children,
   actions,
   type,
+  width,
   mt,
   mr,
   mb,
@@ -57,6 +61,7 @@ export function GoAContainer({
       type={type}
       padding={padding}
       accent={accent}
+      width={width}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/web-components/src/components/container/Container.spec.ts
+++ b/libs/web-components/src/components/container/Container.spec.ts
@@ -13,13 +13,27 @@ describe("GoA Container", () => {
     });
 
     const title = document.querySelector(".title");
-    expect(title.innerHTML).toContain("Test Title");
+    expect(title?.innerHTML).toContain("Test Title");
 
     const content = document.querySelector(".content");
-    expect(content.innerHTML).toContain("Test Content");
+    expect(content?.innerHTML).toContain("Test Content");
 
     const actions = document.querySelector(".actions");
-    expect(actions.innerHTML).toContain("Test Actions");
+    expect(actions?.innerHTML).toContain("Test Actions");
+  });
+
+  describe("Widths", () => {
+    it(`should set the width`, async () => {
+      const baseElement = render(GoAContainer, {
+        testid: "container-test",
+        width: "content",
+      });
+      const container = await baseElement.findByTestId("container-test");
+
+      expect(container).toBeTruthy();
+      expect(container?.classList).toContain('width--content');
+
+    });
   });
 
   describe("Margins", () => {

--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -25,15 +25,21 @@
     "relaxed",
     "compact",
   ]);
+  const [Widths, validateWidth] = typeValidator("Container width", [
+    "full",
+    "content",
+  ]);
 
   // Types
   type Type = (typeof Types)[number];
   type Accent = (typeof Accents)[number];
   type Padding = (typeof Paddings)[number];
+  type Width = (typeof Widths)[number];
 
   export let type: Type = "interactive";
   export let accent: Accent = "filled";
   export let padding: Padding = "relaxed";
+  export let width: Width = "full";
   export let testid: string = "";
 
   // margin
@@ -46,6 +52,7 @@
     validateType(type);
     validateAccent(accent);
     validatePadding(padding);
+    validateWidth(width);
   });
 </script>
 
@@ -59,6 +66,7 @@
     goa-container--${type}
     padding--${padding}
     accent--${accent}
+    width--${width}
   `}
 >
   <header class="heading--{accent}">
@@ -259,5 +267,9 @@
   .actions {
     display: flex;
     align-items: center;
+  }
+
+  .width--content {
+    flex-grow: 0;
   }
 </style>


### PR DESCRIPTION
This PR for https://github.com/GovAlta/ui-components/issues/1816 adds a width property to the Container component. It has two values:

| Name | Description | Screenshot |
|--------|--------|--------|
| Full | Expand to fit available horizontal width (default) | <img width="529" alt="image" src="https://github.com/GovAlta/ui-components/assets/1479091/e8605794-1546-46b8-bf9a-375b291b25c1"> |
| Content| Shrink to width of content. | <img width="525" alt="image" src="https://github.com/GovAlta/ui-components/assets/1479091/88eec10d-8967-4d29-b163-00a066d9b51f"> |

- [x] I have run a build locally.
- [x] I have ran unit tests locally.
- [x] I have tested the functionality.
