### PR TITLE
fix(#1876, #1856, #1863, #1771): checkbox aria label & layout fixes

### DIFF
--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -84,7 +84,7 @@
         disabled={isDisabled}
         type="checkbox"
         value={`${value}`}
-        aria-label={arialabel || name}
+        aria-label={arialabel || text || name}
         aria-describedby={description ? _descriptionId : null}
         on:change={onChange}
       />
@@ -127,11 +127,12 @@
   :host {
     box-sizing: border-box;
     font-family: var(--goa-font-family-sans);
-    display: inline-block;
+    display: block;
   }
 
   .root {
-    min-height: calc(3rem - 0.25rem);
+    display: inline-block;
+    padding-bottom: var(--goa-space-m);
   }
 
   input[type="checkbox"] {
@@ -149,7 +150,6 @@
 
   label {
     display: flex;
-    align-items: center;
     cursor: pointer;
   }
 
@@ -173,8 +173,9 @@
     border: var(--goa-border-width-s) solid var(--goa-color-greyscale-700);
     border-radius: 2px;
     background-color: var(--goa-color-greyscale-white);
-    height: 1.5rem;
-    width: 1.5rem;
+    height: var(--goa-space-l);
+    width: var(--goa-space-l);
+    margin-top: var(--goa-space-3xs);
     display: flex;
     justify-content: center;
 
@@ -223,7 +224,7 @@
 
   /* Disabled */
   .disabled {
-    cursor: default;    
+    cursor: default;
   }
   .disabled .text {
     opacity: 40%;


### PR DESCRIPTION
This PR address several issues with the checkbox component (https://github.com/GovAlta/ui-components/issues/1876, https://github.com/GovAlta/ui-components/issues/1856, https://github.com/GovAlta/ui-components/issues/1863, https://github.com/GovAlta/ui-components/issues/1771). It includes the following changes:
- Uses the following priority for setting `aria-label`:
  1. `arialabel` property
  2. `text` property
  3. `name` property
  4. nothing
- Aligns the checkbox to the top when the label wraps
- Replaces min height with bottom padding
- Replaces some `rem` spacing values with design tokens
- Multiple checkboxes vertically stack
- The clickable label is the width of the text, not the full width of the available space

Here's a comparison of the difference with the below example in playground:

```html
<div style="width: 386px">
  <goa-checkbox name="name" text="I consent to this thing auris mauris mattis molestie lorem. Facilisis tortor posuere tristique scelerisque. Vivamus vitae urna accumsan id. Risus nulla commodo cursus egestas odio ac faucibus. Molestie vitae in id dictum consectetur pellentesque sem et congue. "></goa-checkbox>
</div>
``` 

| Before | After |
|--------|--------|
| ![image](https://github.com/GovAlta/ui-components/assets/1479091/2942c4ff-df26-4ed3-a5c5-3673d14e12e5) | ![image](https://github.com/GovAlta/ui-components/assets/1479091/457bb116-d5d1-48ca-b3ce-3be7eb3da50e) |
| ![image](https://github.com/GovAlta/ui-components/assets/1479091/93e4990b-e874-4832-ad51-39601920eafd) | ![image](https://github.com/GovAlta/ui-components/assets/1479091/c109ef5a-24b2-467d-81cb-289cd25a4b59) |
| ![image](https://github.com/GovAlta/ui-components/assets/1479091/7d6ea120-bb3e-49ff-b810-e078566b435e) | ![image](https://github.com/GovAlta/ui-components/assets/1479091/e28cbdbe-2006-4c4f-9df5-7daf2505216f) | 
 
#### PR Tasks
- [x] I have run a build locally.
- [x] I have ran unit tests locally.
- [x] I have tested the functionality.