### PR TITLE
fix(#1814): allow form-item slotted content for helptext and error

### DIFF
--- a/libs/react-components/src/lib/form-item/form-item.tsx
+++ b/libs/react-components/src/lib/form-item/form-item.tsx
@@ -25,8 +25,8 @@ export interface GoAFormItemProps extends Margins {
   label?: string;
   labelSize?: GoAFormItemLabelSize;
   requirement?: GoAFormItemRequirement;
-  error?: string;
-  helpText?: string;
+  error?: React.ReactNode;
+  helpText?: React.ReactNode;
   children?: React.ReactNode;
   testId?: string;
   id?: string;


### PR DESCRIPTION
GoAFormItemProps also need to be updated...in the form-item.tsx

```
error?: React.ReactNode;
helpText?: React.ReactNode;

```