### PR TITLE
fix(#1868): enhance accordion & details accessibility

### DIFF
--- a/libs/web-components/src/common/utils.ts
+++ b/libs/web-components/src/common/utils.ts
@@ -113,3 +113,7 @@ export function clamp(value: number, min: number, max: number): number {
       ? min
       : value
 }
+
+export function generateRandomId() {
+  return `${Math.random().toString(36).substring(2, 9)}`;
+}

--- a/libs/web-components/src/components/accordion/Accordion.spec.ts
+++ b/libs/web-components/src/components/accordion/Accordion.spec.ts
@@ -1,39 +1,45 @@
-import Accordion from "./Accordion.svelte"
-import AccordionWithHeadingContent from "./AccordionWithHeadingContentWrapper.test.svelte"
-import { fireEvent, render, waitFor } from "@testing-library/svelte"
+import Accordion from "./Accordion.svelte";
+import AccordionWithHeadingContent from "./AccordionWithHeadingContentWrapper.test.svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { it, describe } from "vitest";
 
-describe("Accordian", () => {
+describe("Accordion", () => {
   it("renders", async () => {
-    const { container } = render(Accordion, { heading: "Title", secondarytext: "sub title" });
+    const { container } = render(Accordion, {
+      heading: "Title",
+      secondarytext: "sub title",
+    });
     const heading = container.querySelector("summary .heading");
     const secondaryText = container.querySelector("summary .secondary-text");
     expect(heading).toBeTruthy();
     expect(heading?.innerHTML).toContain("Title");
     expect(secondaryText).toBeTruthy();
     expect(secondaryText?.innerHTML).toContain("sub title");
-  })
+  });
 
   it("renders larger heading text", async () => {
-    const { container } = render(Accordion, { heading: "Title", headingsize: "medium" });
+    const { container } = render(Accordion, {
+      heading: "Title",
+      headingsize: "medium",
+    });
     const heading = container.querySelector("summary .heading");
     expect(heading).toBeTruthy();
     expect(heading?.classList.contains("heading-medium"));
-  })
+  });
 
   it("should expand the container when open prop is set", async () => {
     const { container } = render(Accordion, { heading: "Title", open: "true" });
     const details = container.querySelector("details");
     expect(details).toBeTruthy();
     expect(details?.getAttribute("open")).not.toBeNull();
-  })
+  });
 
   it("should not expand the container when open prop is not set", async () => {
     const { container } = render(Accordion, { heading: "Title" });
     const details = container.querySelector("details");
     expect(details).toBeTruthy();
     expect(details?.getAttribute("open")).toBeNull();
-  })
+  });
 
   // Although this test passes, it doesn't fail with the `position: relative` fix is removed.
   // This test will need to be moved to Cypress
@@ -42,13 +48,38 @@ describe("Accordian", () => {
     const button = queryByTestId("slot-button");
     const handler = vitest.fn();
 
-    container.addEventListener("testClick", handler)
+    container.addEventListener("testClick", handler);
 
     expect(button).toBeTruthy();
-    button && await fireEvent(button, new CustomEvent("_click"))
+    button && (await fireEvent(button, new CustomEvent("_click")));
 
     await waitFor(() => {
       expect(handler).toBeCalled();
-    })
-  })
-})
+    });
+  });
+
+  it("handle accessibility features", async () => {
+    const { container } = render(Accordion, {
+      heading: "Title",
+    });
+
+    // Summary div accessibility's attributes
+    const summary = container.querySelector("summary");
+    expect(summary?.getAttribute("aria-expanded")).toBe("false");
+    expect(summary?.getAttribute("aria-controls")).length.greaterThan(0);
+    const accordionId = summary?.getAttribute("aria-controls")?.split("-content")[0]; // generate random id
+    expect(summary?.getAttribute("aria-controls")).toBe(
+      `${accordionId}-content`,
+    );
+    // Content div accessibility attributes
+    const contentDiv = container.querySelector("div.content");
+    expect(contentDiv?.getAttribute("id")).toBe(`${accordionId}-content`);
+    expect(contentDiv?.getAttribute("role")).toBe("region");
+    // announce by heading
+    expect(contentDiv?.getAttribute("aria-labelledby")).toBe(
+      `${accordionId}-heading`,
+    );
+    const title = container.querySelector("summary .title");
+    expect(title?.getAttribute("id")).toBe(`${accordionId}-heading`);
+  });
+});

--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -8,6 +8,7 @@
     typeValidator,
     toBoolean,
     validateRequired,
+    generateRandomId,
   } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
 
@@ -24,6 +25,7 @@
   export let heading: string = "";
   export let secondarytext: string = "";
   export let headingsize: HeadingSize = "small";
+  export let id: string = "";
   export let testid: string = "";
   export let mt: Spacing = null;
   export let mr: Spacing = null;
@@ -35,7 +37,7 @@
   let _hovering: boolean = false;
   let _titleEl: HTMLElement;
   let _headingContentSlotChildren: Element[] = [];
-
+  let _accordionId: string = "";
   // Reactive
 
   $: isOpen = toBoolean(open);
@@ -46,6 +48,7 @@
     validateRequired("GoAAccordion", { heading });
     validateHeadingSize(headingsize);
     _headingContentSlotChildren = getChildren();
+    _accordionId = `accordion-${generateRandomId()}`;
   });
 
   function getChildren(): Element[] {
@@ -68,7 +71,7 @@
   class="goa-accordion"
   data-testid={testid}
 >
-  <details open={isOpen}>
+  <details open={isOpen} on:toggle={({target}) => open = `${target?.open}`}>
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <summary
       class={`container-${headingsize}`}
@@ -76,6 +79,8 @@
       on:mouseout={() => (_hovering = false)}
       on:focus={() => (_hovering = false)}
       on:blur={() => (_hovering = false)}
+      aria-controls={`${_accordionId}-content`}
+      aria-expanded={open === "true"}
     >
       <goa-icon
         type="chevron-forward"
@@ -83,7 +88,7 @@
           ? "var(--goa-color-interactive-hover)"
           : "var(--goa-color-interactive-default)"}
       ></goa-icon>
-      <div class="title" bind:this={_titleEl}>
+      <div class="title" bind:this={_titleEl} id={`${_accordionId}-heading`}>
         <span
           class="heading heading-{headingsize}"
           data-testid={`${testid}-heading`}>{heading}</span
@@ -99,7 +104,12 @@
         </div>
       </div>
     </summary>
-    <div class="content">
+    <div
+      class="content"
+      role="region"
+      aria-labelledby={`${_accordionId}-heading`}
+      id={`${_accordionId}-content`}
+    >
       <slot />
     </div>
   </details>

--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { calculateMargin } from "../../common/styling";
-  import { toBoolean, validateRequired} from "../../common/utils";
+  import { toBoolean, validateRequired, generateRandomId } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
 
   export let heading: string;
@@ -13,14 +13,15 @@
   export let ml: Spacing = null;
   export let open: string = "false";
 
-  let _isMouseOver: boolean = false
+  let _isMouseOver: boolean = false;
   let _summaryEl: HTMLElement;
+  let _detailsId: string = "";
 
   $: _isOpen = toBoolean(open);
 
-
   onMount(() => {
     validateRequired("Details", { heading });
+    _detailsId = `details-${generateRandomId()}`;
 
     _summaryEl.addEventListener("mouseover", () => {
       _isMouseOver = true;
@@ -34,18 +35,30 @@
 
 <details
   open={_isOpen}
-  on:toggle={({target}) => open = `${target.open}`}
-  style={calculateMargin(mt, mr, mb, ml)}>
-  <summary bind:this={_summaryEl}>
+  on:toggle={({ target }) => (open = `${target?.open}`)}
+  style={calculateMargin(mt, mr, mb, ml)}
+>
+  <summary
+    bind:this={_summaryEl}
+    aria-expanded={open === "true"}
+    aria-controls={`${_detailsId}-content`}
+  >
     <goa-icon
       mt="1"
       mr="2"
       type="chevron-forward"
-      fillcolor={_isMouseOver ? "var(--goa-color-interactive-hover)" : "var(--goa-color-interactive-default)"}
+      fillcolor={_isMouseOver
+        ? "var(--goa-color-interactive-hover)"
+        : "var(--goa-color-interactive-default)"}
     />
-    <span>{heading}</span>
+    <span id={`${_detailsId}-heading`}>{heading}</span>
   </summary>
-  <div class="content">
+  <div
+    class="content"
+    role="region"
+    aria-labelledby={`${_detailsId}-heading`}
+    id={`${_detailsId}-content`}
+  >
     <slot />
   </div>
 </details>
@@ -54,7 +67,6 @@
   :host {
     font-family: var(--goa-font-family-sans);
   }
-
 
   details {
     max-width: 75ch;
@@ -69,9 +81,8 @@
   }
   /* Hide native icon on iOS */
   details summary::-webkit-details-marker {
-    display:none;
+    display: none;
   }
-
 
   summary {
     padding: 0.5rem;
@@ -80,7 +91,7 @@
     list-style: none;
     display: flex;
     align-items: flex-start;
-    border-radius: var(--goa-border-radius-m);    
+    border-radius: var(--goa-border-radius-m);
   }
   summary:focus-visible {
     outline: 3px solid var(--goa-color-interactive-focus);
@@ -106,7 +117,6 @@
     color: var(--goa-color-interactive-hover);
   }
 
-
   .content {
     border-left: 4px solid var(--goa-color-greyscale-200);
     padding: 1rem;
@@ -117,7 +127,6 @@
     margin-bottom: 0 !important;
   }
 
-  
   goa-icon {
     /* transition: transform 80ms ease; */
     position: absolute;

--- a/libs/web-components/src/components/details/details.spec.ts
+++ b/libs/web-components/src/components/details/details.spec.ts
@@ -2,12 +2,27 @@ import Details from './Details.svelte'
 import { render } from '@testing-library/svelte'
 import { it } from "vitest";
 
+
 it('it works', async () => {
   const { container } = render(Details, { heading: "The title", open: true })
 
-  const summary = container.querySelector("summary span")
+  const summary = container.querySelector("summary")
   expect(summary?.innerHTML).toContain("The title");
+  expect(summary?.getAttribute("aria-controls")).length.greaterThan(0);
+  const randomId = summary?.getAttribute("aria-controls")?.split("-content")[0];
+
+  expect(summary?.getAttribute("aria-controls")).toBe(`${randomId}-content`);
+  expect(summary?.getAttribute("aria-expanded")).toBe("false");
+
+  const heading = summary?.querySelector("span");
+  expect(heading?.getAttribute("id")).toBe(`${randomId}-heading`);
 
   const details = container.querySelector("details");
   expect(details?.hasAttribute("open")).toBe(true);
+
+  // Content's accessibility attributes
+  const content = container.querySelector("div.content");
+  expect(content?.getAttribute("role")).toBe("region");
+  expect(content?.getAttribute("id")).toBe(`${randomId}-content`);
+  expect(content?.getAttribute("aria-labelledby")).toBe(heading?.getAttribute("id"));
 })


### PR DESCRIPTION
Ticket is https://github.com/GovAlta/ui-components/issues/1868
**Note: The AC "Body content in an accordion and detail components should be read by a screen reader when the Accordion is expanded" cannot be fulfilled because this is against what NVDA suggested.**

Reference: [Should Accordion Header expanding read Accordion Panel by default?](https://github.com/w3c/aria-practices/issues/1280)

What this ticket is doing:
* We will follow the standard practice at https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/
* Also the asking to fix is https://goa-dio.slack.com/archives/C02PLLT9HQ9/p1716488793498059 mentioned as they need `aria-label`, `aria-labelledby`

Screenshot: 
![image](https://github.com/GovAlta/ui-components/assets/120135417/8c2efe5b-333e-4c72-b66a-10483610bb5f)

![image](https://github.com/GovAlta/ui-components/assets/120135417/5a00bfef-1b56-4745-8428-b396b6a869e0)
