### PR TITLE
fix(#1883): not render extra tab links

### DIFF
--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -46,6 +46,7 @@
         bindChildren();
         setCurrentTab(initialtab || 1);
       });
+      e.stopPropagation();
     });
   }
 
@@ -53,6 +54,7 @@
     const path = window.location.pathname;
 
     // create buttons (tabs) for each of the tab contents elements
+    _tabsEl.replaceChildren();
     _tabProps.forEach((tabProps, index) => {
       let tabSlug: string = "";
       let headingEl: HTMLElement;


### PR DESCRIPTION
Fixing #1883 
<img width="1312" alt="image" src="https://github.com/GovAlta/ui-components/assets/120135417/f075ff40-4467-4cdf-9aca-a959b104b8ac">
