### PR TITLE
fix(#1840): link form-item to Input for accessibility

### DIFF
--- a/libs/web-components/src/components/form-item/FormItem.spec.ts
+++ b/libs/web-components/src/components/form-item/FormItem.spec.ts
@@ -95,7 +95,6 @@ describe("GoA FormItem", () => {
 
     const label = document.querySelector(".label");
     expect(label.innerHTML).toContain("the label");
-    expect(label.getAttribute("id")).toBe("labelId");
 
     const requirement = document.querySelector("em");
     expect(requirement.innerHTML).toContain("optional");
@@ -124,7 +123,9 @@ describe("GoA FormItem", () => {
   });
 
   it("should not show any text for a field when requirement value is mispelled/invalid", async () => {
-    const mock = vi.spyOn(console, "error").mockImplementation(() => { /* do nothing */ });
+    const mock = vi.spyOn(console, "error").mockImplementation(() => {
+      /* do nothing */
+    });
 
     render(GoAFormItem, {
       label: "Credit Card Number",

--- a/libs/web-components/src/components/form-item/FormItem.svelte
+++ b/libs/web-components/src/components/form-item/FormItem.svelte
@@ -1,6 +1,12 @@
 <svelte:options customElement="goa-form-item" />
 
 <!-- Script -->
+<script lang="ts" context="module">
+  export type FormItemChannelProps = {
+    el: HTMLElement;
+  };
+</script>
+
 <script lang="ts">
   import { onMount } from "svelte";
   import type { Spacing } from "../../common/styling";
@@ -36,23 +42,41 @@
   export let helptext: string = "";
   export let error: string = "";
   export let requirement: RequirementType = "";
-  export let id: string = "";
+  export let id: string = ""; // @deprecated: no longer used
+
+  let _rootEl: HTMLElement;
 
   onMount(() => {
     validateRequirementType(requirement);
     validateLabelSize(labelsize);
+
+    _rootEl?.addEventListener("input:mounted", handleInputMounted);
   });
+
+  function handleInputMounted(e: Event) {
+    const ce = e as CustomEvent<FormItemChannelProps>;
+
+    // Check if aria-label is present and has a value in the child element
+    const ariaLabel = ce.detail.el.getAttribute("aria-label");
+    if (!ariaLabel || ariaLabel.trim() === "") {
+      ce.detail.el.setAttribute("aria-label", label);
+    }
+  }
 </script>
 
 <!-- HTML -->
-<div data-testid={testid} style={calculateMargin(mt, mr, mb, ml)}>
+<div
+  data-testid={testid}
+  style={calculateMargin(mt, mr, mb, ml)}
+  bind:this={_rootEl}
+>
   {#if label}
-    <div class={`label ${labelsize}`} {id}>
+    <label class={`label ${labelsize}`}>
       {label}
       {#if requirement && REQUIREMENT_TYPES.includes(requirement)}
         <em>({requirement})</em>
       {/if}
-    </div>
+    </label>
   {/if}
   <div class="form-item-input">
     <slot />

--- a/libs/web-components/src/components/input/Input.spec.ts
+++ b/libs/web-components/src/components/input/Input.spec.ts
@@ -1,6 +1,7 @@
 import { render, fireEvent, waitFor, cleanup } from "@testing-library/svelte";
 import GoAInput from "./Input.svelte";
 import GoAInputWrapper from "./Input.test.svelte";
+import GoAInputFormItemWrapper from "./InputFormItemWrapper.test.svelte";
 import { it, describe } from "vitest";
 
 afterEach(cleanup);
@@ -8,7 +9,7 @@ afterEach(cleanup);
 describe("GoAInput Component", () => {
   it("should render", async () => {
     const el = render(GoAInput, { testid: "input-test", id: "test" });
-    const input = await el.findByTestId('input-test');
+    const input = await el.findByTestId("input-test");
     expect(input).toBeTruthy();
     expect(input.getAttribute("id")).toBe("test");
   });
@@ -107,14 +108,42 @@ describe("GoAInput Component", () => {
       expect(root).toBeTruthy();
     });
 
-    it("defaults to the name property if arialabel is not supplied", async () => {
-      const el = render(GoAInput, { testid: "input-test", name: "firstName" });
-      const root = el.container.querySelector('[aria-label="firstName"]');
-      expect(root).toBeTruthy();
+    it("should generate an aria-label value when not provided", async () => {
+      const result = render(GoAInputFormItemWrapper, {
+        inputId: "",
+        inputName: "inputName",
+        label: "DDD Alberta",
+        testIdFormItem: "formItem-testid",
+        testIdInput: "input-testid",
+      });
+      const inputEl = result.queryByTestId("input-testid");
+
+      await waitFor(() => {
+        expect(inputEl?.getAttribute("aria-label")).toBe("DDD Alberta");
+      });
+    });
+
+    it("shouldn't overwrite aria-label if a value has already been assigned", async () => {
+      const result = render(GoAInputFormItemWrapper, {
+        inputId: "inputId",
+        inputName: "inputName",
+        arialabel: "DONT OVERWRITE ME",
+        label: "DDD Alberta",
+        testIdFormItem: "formItem-testid",
+        testIdInput: "input-testid",
+      });
+      const inputEl = result.queryByTestId("input-testid");
+
+      await waitFor(() => {
+        expect(inputEl?.getAttribute("aria-label")).toBe("DONT OVERWRITE ME");
+      });
     });
 
     it("accepts an arialabelledby property", async () => {
-      const el = render(GoAInput, { testid: "input-test", arialabelledby: "firstName" });
+      const el = render(GoAInput, {
+        testid: "input-test",
+        arialabelledby: "firstName",
+      });
       const root = el.container.querySelector('[aria-labelledby="firstName"]');
       expect(root).toBeTruthy();
     });
@@ -177,7 +206,7 @@ describe("GoAInput Component", () => {
       keypress();
     });
 
-    await fireEvent.keyUp(input, { target: { value: "foobar" }, key: 'r' });
+    await fireEvent.keyUp(input, { target: { value: "foobar" }, key: "r" });
     await waitFor(() => {
       expect(change).toBeCalledTimes(1);
       expect(keypress).toBeCalledTimes(1);
@@ -302,7 +331,9 @@ describe("GoAInput Component", () => {
       expect(container.querySelector(".suffix")).toBeNull();
     });
     it("shows prefix text and also a warning message in console", async () => {
-      const mock = vi.spyOn(console, "warn").mockImplementation(() => { /* do nothing */ });
+      const mock = vi.spyOn(console, "warn").mockImplementation(() => {
+        /* do nothing */
+      });
       const { container } = render(GoAInput, { type: "text", prefix: "$" });
       const prefix = container.querySelector(".prefix");
 
@@ -314,12 +345,16 @@ describe("GoAInput Component", () => {
       mock.mockRestore();
     });
     it("shows suffix text and also a warning message in console", async () => {
-      const mock = vi.spyOn(console, "warn").mockImplementation(() => { /* do nothing */ });
+      const mock = vi.spyOn(console, "warn").mockImplementation(() => {
+        /* do nothing */
+      });
       const { container } = render(GoAInput, {
         type: "text",
         suffix: "per item",
       });
-      expect(container.querySelector(".suffix")?.innerHTML).toContain("per item");
+      expect(container.querySelector(".suffix")?.innerHTML).toContain(
+        "per item",
+      );
       await waitFor(() => {
         expect(console.warn["mock"].calls.length).toBeGreaterThan(0);
       });
@@ -358,7 +393,9 @@ describe("GoAInput Component", () => {
       const el = render(GoAInputWrapper, { leadingContent: content });
       expect(el.container.innerHTML).toContain(content);
 
-      const leadingContent = el.container.querySelector("[slot=leadingContent]");
+      const leadingContent = el.container.querySelector(
+        "[slot=leadingContent]",
+      );
       expect(leadingContent).toBeTruthy();
       expect(leadingContent?.innerHTML).toContain(content);
     });
@@ -366,7 +403,9 @@ describe("GoAInput Component", () => {
     it("should have a slot for the trailing content", async () => {
       const content = "items";
       const el = render(GoAInputWrapper, { trailingContent: content });
-      const trailingContent = el.container.querySelector("[slot=trailingContent]");
+      const trailingContent = el.container.querySelector(
+        "[slot=trailingContent]",
+      );
 
       expect(el.container.innerHTML).toContain(content);
       expect(trailingContent?.innerHTML).toContain(content);

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -10,6 +10,7 @@
   import type { Spacing } from "../../common/styling";
   import { calculateMargin } from "../../common/styling";
   import { onMount, tick } from "svelte";
+  import { FormItemChannelProps } from "../form-item/FormItem.svelte";
 
   // Validators
   const [Types, validateType] = typeValidator("Input type", [
@@ -176,6 +177,16 @@
     if (trailingContentSlot && trailingContentSlot.assignedNodes().length > 0) {
       _trailingContentSlot = true;
     }
+
+    setTimeout(() => {
+      _rootEl?.dispatchEvent(
+        new CustomEvent<FormItemChannelProps>("input:mounted", {
+          composed: true,
+          bubbles: true,
+          detail: { el: inputEl },
+        }),
+      );
+    }, 10);
   });
 </script>
 
@@ -231,7 +242,7 @@
       {maxlength}
       id={id || name}
       role="textbox"
-      aria-label={arialabel || name}
+      aria-label={arialabel}
       aria-labelledby={arialabelledby}
       on:keyup={onKeyUp}
       on:change={onKeyUp}
@@ -291,7 +302,6 @@
     }
   }
 
-
   .goa-input,
   .goa-input * {
     box-sizing: border-box;
@@ -318,7 +328,6 @@
     box-shadow: 0 0 0 var(--goa-border-width-m)
       var(--goa-color-interactive-hover);
   }
-
 
   /* type=range does not have an outline/box-shadow */
   .goa-input.type--range {
@@ -366,11 +375,9 @@
     cursor: pointer;
   }
 
-
   .leading-icon + input {
     padding-left: 0.5rem;
   }
-
 
   .input--disabled,
   .input--disabled:hover,
@@ -390,7 +397,6 @@
   .input--disabled input:hover {
     cursor: default !important;
   }
-
 
   .prefix,
   .suffix,
@@ -424,7 +430,6 @@
     border-left: 1px solid var(--goa-color-greyscale-700);
   }
 
-
   .input--disabled .prefix,
   .input--disabled .leading-content-slot :global(::slotted(div)) {
     border-right: 1px solid var(--goa-color-greyscale-200);
@@ -433,7 +438,6 @@
   .input--disabled .trailing-content-slot :global(::slotted(div)) {
     border-left: 1px solid var(--goa-color-greyscale-200);
   }
-
 
   /* Themes */
   input.input--goa {
@@ -466,8 +470,7 @@
   .error .input-leading-content:hover,
   .error .input-trailing-content,
   .error .input-trailing-content:hover {
-    outline: var(--goa-border-width-s) solid
-      var(--goa-color-interactive-error);
+    outline: var(--goa-border-width-s) solid var(--goa-color-interactive-error);
     box-shadow: inset 0 0 0 var(--goa-border-width-m)
       var(--goa-color-interactive-error);
   }
@@ -475,20 +478,16 @@
   .error .input-trailing-content:focus,
   .error .input-leading-content:active,
   .error .input-trailing-content:active {
-    outline: var(--goa-border-width-s) solid
-      var(--goa-color-interactive-error);
+    outline: var(--goa-border-width-s) solid var(--goa-color-interactive-error);
     box-shadow: 0 0 0 var(--goa-border-width-l)
       var(--goa-color-interactive-focus);
   }
-
-
 
   .input-leading-content:hover,
   .input-trailing-content:hover {
     box-shadow: inset 0 0 0 var(--goa-border-width-m)
       var(--goa-color-interactive-hover);
-    outline: var(--goa-border-width-s) solid
-      var(--goa-color-interactive-hover);
+    outline: var(--goa-border-width-s) solid var(--goa-color-interactive-hover);
   }
   .input-leading-content:active,
   .input-leading-content:focus,
@@ -500,7 +499,6 @@
       var(--goa-color-interactive-focus);
     outline: var(--goa-border-width-s) solid var(--goa-color-greyscale-700);
   }
-
 
   .error .input-trailing-content,
   .input-trailing-content:hover,

--- a/libs/web-components/src/components/input/InputFormItemWrapper.test.svelte
+++ b/libs/web-components/src/components/input/InputFormItemWrapper.test.svelte
@@ -1,0 +1,22 @@
+<svelte:options customElement="test-input-formitem-wrapper" />
+
+<!-- Script -->
+<script lang="ts">
+  import GoAFormItem from "../form-item/FormItem.svelte";
+  import GoAInput from "./Input.svelte";
+
+  export let label: string = "";
+  export let helptext: string = "";
+  export let testIdFormItem: string = "";
+
+  export let inputId: string = "";
+  export let testIdInput: string = "";
+  export let arialabel: string = "";
+  export let inputName: string = "";
+</script>
+
+<!-- HTML -->
+
+<GoAFormItem {label} {helptext} testid={testIdFormItem}>
+  <GoAInput id={inputId} name={inputName} {arialabel} testid={testIdInput} />
+</GoAFormItem>


### PR DESCRIPTION
The parent element sets the aria-label in the child (Input) element, but only when aria-label wasn't supplied in the input element i.e. it will not be overwritten.

Note: We decided not to set the 'for' attribute of the <label> tag in the parent i.e. FormItem... to be same as the id of the input. Because setting aria-label is enough. Tested locally with Chrome and Firefox using NVDA.

Some example code for angular playground. The `<div>` is added b/c `<goa-input>` may or may not always be the immediate child of `<goa-form-item>`
```
<h2>Case 1a - No arialabel provided (Expected: aria-lable gets set)</h2>
<goa-form-item label="DDD Id Provided" helptext="Maximum characters allowed are 10.">
  <div>
    <goa-input name="inputNameDesignAlberta1" maxlength="10" id="abcd-1234"></goa-input>
  </div>
</goa-form-item>

<h2>Case 1b - aria-label NOT provided (Expected: aria-lable gets set irrespective of whether input element's Id was provided or not)</h2>
<goa-form-item label="DDD No Id" helptext="Maximum characters allowed are 10.">
  <div>
    <goa-input name="inputNameDesignAlberta2" maxlength="10"></goa-input>
  </div>
</goa-form-item>

<h2>Case 2 - Both the (label and arialabel) provided at the same time - (Expected: Aria-label in the child should be the winner)</h2>
<goa-form-item label="Some Label" helptext="Maximum characters allowed are 10.">
  <div>
    <goa-input name="inputNameDesignAlberta4" maxlength="10" arialabel="aria label from child element"></goa-input>
  </div>
</goa-form-item>
```