### PR TITLE
fix(#1867): allow child element 100% width inside block

### DIFF
--- a/libs/web-components/src/components/block/Block.svelte
+++ b/libs/web-components/src/components/block/Block.svelte
@@ -6,14 +6,16 @@
 
   export let gap: Spacing = "m";
   export let direction: "row" | "column" = "row";
-  export let alignment: "center" | "start" | "end" = "start";
+  export let alignment: "center" | "start" | "end" | "normal" = "normal";
 
   $: _alignment =
     alignment === "start"
       ? "flex-start"
       : alignment === "end"
         ? "flex-end"
-        : "center";
+        : alignment === "center"
+          ? "center"
+          : "normal";
 
   // margin
   export let mt: Spacing = null;
@@ -41,4 +43,5 @@
     align-items: var(--alignment);
     gap: var(--gap);
   }
+
 </style>


### PR DESCRIPTION
allow `input` 100% inside `block`

Example code: 
```
<goa-block gap="xl" direction="column">
  <goa-container>Test</goa-container>
  <goa-form-item label="Phone number">
    <goa-input width="100%" (_change)="onChange($event)" [value]="value" name="phone">
      <div slot="leadingContent">
        <goa-block direction="row" alignment="center" gap="none">
          <goa-icon type="add" size="small"></goa-icon> <span class="medium-text">1</span>
        </goa-block>
      </div>
    </goa-input>
  </goa-form-item>
  </goa-block>
```

For the `ui-components-docs`:

Before fix: 
<img width="780" alt="image" src="https://github.com/GovAlta/ui-components/assets/120135417/90f9dcf7-e4f3-4600-91cb-8806c1b70913">


After fix: 
<img width="929" alt="image" src="https://github.com/GovAlta/ui-components/assets/120135417/7da955d3-f204-4559-ae48-7d289094058d">
