### PR TITLE
fix(#1859): add arialabel to radio group and radio item

### DIFF
--- a/libs/react-components/src/lib/radio-group/radio-group.spec.tsx
+++ b/libs/react-components/src/lib/radio-group/radio-group.spec.tsx
@@ -47,6 +47,7 @@ describe("RadioGroup", () => {
         mr="m"
         mb="l"
         ml="xl"
+        ariaLabel={"please select fruit"}
         onChange={noop}
       >
         {data.radios.map((radio) => (
@@ -56,6 +57,7 @@ describe("RadioGroup", () => {
             name="fruits"
             checked={data.value === radio.value}
             value={radio.value}
+            ariaLabel={"you are choosing " + radio.value}
           >
             {radio.text}
           </GoARadioItem>
@@ -70,6 +72,15 @@ describe("RadioGroup", () => {
       expect(el?.getAttribute("mr")).toBe("m");
       expect(el?.getAttribute("mb")).toBe("l");
       expect(el?.getAttribute("ml")).toBe("xl");
+      expect(el?.getAttribute("name")).toBe("fruits");
+      expect(el?.getAttribute("arialabel")).toBe("please select fruit");
+      expect(el?.getAttribute("disabled")).toBe("false");
+      expect(el?.getAttribute("error")).toBe("false");
+
+      const radios = document.querySelectorAll<HTMLInputElement>("input[type=radio]");
+      radios.forEach((radio) => {
+       expect(radio.getAttribute("arialabel")).toBe("you are choosing " + radio.value);
+      });
     });
   });
 

--- a/libs/react-components/src/lib/radio-group/radio.tsx
+++ b/libs/react-components/src/lib/radio-group/radio.tsx
@@ -6,6 +6,7 @@ interface RadioItemProps {
   disabled?: boolean;
   checked?: boolean;
   error?: boolean;
+  arialabel?: string;
 }
 
 declare global {
@@ -27,6 +28,7 @@ export interface GoARadioItemProps {
   error?: boolean;
   children?: React.ReactNode;
   testId?: string;
+  ariaLabel?: string;
 }
 
 export function GoARadioItem({
@@ -38,6 +40,7 @@ export function GoARadioItem({
   checked,
   error,
   testId,
+  ariaLabel,
   children,
 }: GoARadioItemProps): JSX.Element {
   return (
@@ -50,6 +53,7 @@ export function GoARadioItem({
       disabled={disabled}
       checked={checked}
       data-testid={testId}
+      arialabel={ariaLabel}
     >
       {description && typeof description !== "string" && <div slot="description">{description}</div>}
       {children}

--- a/libs/web-components/src/components/radio-group/RadioGroup.html-data.json
+++ b/libs/web-components/src/components/radio-group/RadioGroup.html-data.json
@@ -35,7 +35,7 @@
     {
       "name": "arialabel",
       "type": "string",
-      "description": "Defines how the text will be translated for the screen reader. It not specified it will fall back to the name"
+      "description": "Defines how the radio group will be translated for the screen reader."
     }
   ],
   "references": [

--- a/libs/web-components/src/components/radio-group/RadioGroup.spec.ts
+++ b/libs/web-components/src/components/radio-group/RadioGroup.spec.ts
@@ -14,18 +14,47 @@ describe("GoARadioGroup Component", () => {
       testid: "test-id",
       items,
     });
+    const radioGroupDiv = result.container.querySelector("[role='radiogroup']");
+    expect(radioGroupDiv?.getAttribute("aria-label")).toBe(""); // If no aria-label is defined, we don't fall back to name
 
     const goaRadioItems = result.container.querySelectorAll("goa-radio-item");
     expect(goaRadioItems.length).toBe(3);
-
     await waitFor(() => {
       items.forEach((item, index) => {
         const el = goaRadioItems[index];
 
         expect(el.getAttribute("value")).toBe(item);
-        expect(el.getAttribute("ariadescribedby")).toBe(`description-favcolor-${index}`);
-        expect(el.getAttribute("arialabel")).toBe("favcolor");
+        if (index === 2) {
+          expect(el.getAttribute("checked")).toBe("true");
+        } else {
+          expect(el.getAttribute("checked")).toBe("false");
+        }
+      });
+    });
+  })
 
+  it("should render with accessibility attributes", async () => {
+    const name = "favcolor";
+    const items = ["red", "blue", "orange"];
+    const result = render(GoARadioGroupWrapper, {
+      name,
+      value: "orange",
+      testid: "test-id",
+      items,
+      radioGroupAriaLabel: "please choose a color"
+    });
+
+    const radioGroupDiv = result.container.querySelector("[role='radiogroup']");
+    expect(radioGroupDiv?.getAttribute("aria-label")).toBe("please choose a color");
+
+    const goaRadioItems = result.container.querySelectorAll("goa-radio-item");
+    expect(goaRadioItems.length).toBe(3);
+    await waitFor(() => {
+      items.forEach((item, index) => {
+        const el = goaRadioItems[index];
+
+        expect(el.getAttribute("value")).toBe(item);
+        expect(el.getAttribute("arialabel")).toBe("you are choosing color " + item);
         if (index === 2) {
           expect(el.getAttribute("checked")).toBe("true");
         } else {

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -58,7 +58,7 @@
 
   function getChildren() {
     _rootEl.addEventListener("radio-item:mounted", (e: Event) => {
-      const radioItemProps = (e as CustomEvent<GoARadioItemProps>).detail;  
+      const radioItemProps = (e as CustomEvent<GoARadioItemProps>).detail;
       _radioItems = [..._radioItems, radioItemProps];
 
       // call bindOptions once all children are attained
@@ -68,11 +68,11 @@
       _bindTimeoutId = setTimeout(() => {
         bindOptions();
       }, 1)
-    })    
+    })
   }
 
   function bindOptions() {
-    _radioItems.forEach((props, index) => {
+    _radioItems.forEach(props => {
       props.el.dispatchEvent(new CustomEvent<Partial<GoARadioItemProps>>("radio-group:init", {
         composed: true,
         detail: {
@@ -81,8 +81,6 @@
           description: props.description,
           name,
           checked: props.value === value,
-          ariaLabel: arialabel || name,
-          ariaDescribedBy: `description-${name}-${index}`,
         }
       }));
     });
@@ -112,7 +110,7 @@
       item.el.dispatchEvent(new CustomEvent<RadioItemSelectProps>("radio-group:select", {
         composed: true,
         detail: {
-          checked: item.value === value 
+          checked: item.value === value
         }
       }))
     });
@@ -125,6 +123,8 @@
   style={calculateMargin(mt, mr, mb, ml)}
   class={`goa-radio-group--${orientation}`}
   data-testid={testid}
+  role="radiogroup"
+  aria-label={arialabel}
 >
     <slot />
 </div>

--- a/libs/web-components/src/components/radio-group/RadioGroupWrapper.test.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroupWrapper.test.svelte
@@ -11,14 +11,15 @@
   export let error: string = "false";
   export let testid: string = "";
   export let items: string[] = [];
+  export let radioGroupAriaLabel: string = "";
 </script>
 
 <!-- HTML -->
 
 <button data-testid="set-value" on:click={() => (value = "red")}>Set Value</button>
 
-<GoARadioGroup {name} {value} {orientation} {disabled} {error} {testid}>
+<GoARadioGroup {name} {value} {orientation} {disabled} {error} {testid} arialabel={radioGroupAriaLabel}>
   {#each items as item (item)}
-    <goa-radio-item value="{item}" label="{item}" />
+    <goa-radio-item value="{item}" label="{item}" arialabel="{`you are choosing color ${item}`}" />
   {/each}
 </GoARadioGroup>

--- a/libs/web-components/src/components/radio-group/doc.md
+++ b/libs/web-components/src/components/radio-group/doc.md
@@ -4,9 +4,13 @@ Radios allow users to select one option from a set.
 Use it like this:
 
 ```html
-<goa-radio-group name="color"
-                 goaValue [formControl]="reactiveFormCtrl"
-                 [value]="reactiveFormCtrl.value">
-  <goa-radio-item value="red"></goa-radio-item>
+<goa-radio-group
+  name="color"
+  arialabel="please select color"
+  goaValue
+  [formControl]="reactiveFormCtrl"
+  [value]="reactiveFormCtrl.value"
+>
+  <goa-radio-item value="red" arialabel="you are choosing color red"></goa-radio-item>
 </goa-radio-group>
 ```

--- a/libs/web-components/src/components/radio-item/RadioItem.html-data.json
+++ b/libs/web-components/src/components/radio-item/RadioItem.html-data.json
@@ -15,6 +15,11 @@
       "name": "description",
       "description": "Text added below the label text",
       "type": "string"
+    },
+    {
+      "name": "arialabel",
+      "type": "string",
+      "description": "Defines how the radio item will be translated for the screen reader."
     }
   ],
   "references": [

--- a/libs/web-components/src/components/radio-item/RadioItem.spec.ts
+++ b/libs/web-components/src/components/radio-item/RadioItem.spec.ts
@@ -10,7 +10,7 @@ describe("RadioItem", () => {
       value: "radio-item-1",
       name: "radio-item-1-name",
       arialabel: "radio-item-1-label",
-      ariadescribedby: "radio-item-1-described-by",
+      description: "test description"
     });
 
     expect(result.getByTestId("radio-option-radio-item-1")).toBeTruthy();
@@ -19,10 +19,13 @@ describe("RadioItem", () => {
     expect(input.getAttribute("name")).toBe("radio-item-1-name");
     expect(input.getAttribute("value")).toBe("radio-item-1");
     expect(input.getAttribute("aria-label")).toBe("radio-item-1-label");
-    expect(input.getAttribute("aria-describedby")).toBe(
-      "radio-item-1-described-by",
-    );
+    expect(input.getAttribute("aria-checked")).toBe("false");
+    expect(input.getAttribute("type")).toBe("radio");
     expect(result.getByText("Radio Item 1")).toBeTruthy();
+    const radioDescriptionDiv = result.container.querySelector(".goa-radio-description");
+    expect(radioDescriptionDiv?.innerHTML).toContain("test description");
+    expect(radioDescriptionDiv?.getAttribute("id")).toContain(`${input.getAttribute("name")}-${input.getAttribute("value")}-description`);
+    expect(input.getAttribute("aria-describedby")).toBe(radioDescriptionDiv?.getAttribute("id"));
   });
 
   it("should render the radio item with slot description", async () => {
@@ -42,7 +45,6 @@ describe("RadioItem", () => {
       value: "radio-item-1",
       name: "radio-item-1-name",
       arialabel: "radio-item-1-label",
-      ariadescribedby: "radio-item-1-described-by",
       disabled: true,
     });
 

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -4,14 +4,13 @@
     value: { reflect: true },
     description: { reflect: true },
     checked: { reflect: true },
-    ariadescribedby: { reflect: true },
     arialabel: { reflect: true },
   }
 }}/>
 
 <script lang="ts" context="module">
   export type GoARadioItemProps = {
-    el: HTMLElement,
+    el: HTMLElement;
     value: string;
     label: string;
     description: string;
@@ -20,18 +19,16 @@
     name: string;
     checked: boolean;
     ariaLabel: string;
-    ariaDescribedBy: string;
-  }
+  };
 
   export type RadioItemSelectProps = {
     checked: boolean;
-  }
-
+  };
 </script>
 
 <script lang="ts">
   import { onMount } from "svelte";
-  import {fromBoolean, toBoolean} from "../../common/utils";
+  import { fromBoolean, toBoolean } from "../../common/utils";
 
   export let value: string;
   export let name: string = "";
@@ -41,10 +38,8 @@
   export let error: string = "false";
   export let checked: string = "false";
   export let arialabel: string = "";
-  export let ariadescribedby: string = "";
 
   let _radioItemEl: HTMLElement;
-
   // Reactive
 
   $: isDisabled = toBoolean(disabled);
@@ -57,29 +52,29 @@
     dispatchInit();
     addInitListener();
     addSelectListener();
-  })
+  });
 
   // Functions
-
   function dispatchInit() {
     setTimeout(() => {
-      _radioItemEl?.dispatchEvent(new CustomEvent<GoARadioItemProps>("radio-item:mounted", {
-        composed: true,
-        bubbles: true,
-        detail: {
-          el: _radioItemEl,
-          name,
-          value,
-          label,
-          description,
-          disabled: isDisabled,
-          error: isError,
-          checked: isChecked,
-          ariaLabel: arialabel,
-          ariaDescribedBy: ariadescribedby,
-        }
-      }))
-    }, 10)
+      _radioItemEl?.dispatchEvent(
+        new CustomEvent<GoARadioItemProps>("radio-item:mounted", {
+          composed: true,
+          bubbles: true,
+          detail: {
+            el: _radioItemEl,
+            name,
+            value,
+            label,
+            description,
+            disabled: isDisabled,
+            error: isError,
+            checked: isChecked,
+            ariaLabel: arialabel,
+          },
+        }),
+      );
+    }, 10);
   }
 
   function addInitListener() {
@@ -90,15 +85,13 @@
       checked = fromBoolean(data.checked);
       description = data.description;
       name = data.name;
-      arialabel = data.ariaLabel;
-      ariadescribedby = data.ariaDescribedBy;
-    })  
+    });
   }
 
   function addSelectListener() {
     _radioItemEl.addEventListener("radio-group:select", (e: Event) => {
       isChecked = (e as CustomEvent<RadioItemSelectProps>).detail.checked;
-    })
+    });
   }
 
   function onChange() {
@@ -129,7 +122,10 @@
       disabled={isDisabled}
       checked={isChecked}
       aria-label={arialabel}
-      aria-describedby={ariadescribedby}
+      aria-describedby={$$slots.description || description
+        ? `${name}-${value}-description`
+        : undefined}
+      aria-checked={isChecked}
       on:click={onChange}
     />
     <div class="goa-radio-icon" />
@@ -138,7 +134,7 @@
     </span>
   </label>
   {#if $$slots.description || description}
-    <div class="goa-radio-description">
+    <div class="goa-radio-description" id={`${name}-${value}-description`}>
       <slot name="description" />
       {description}
     </div>


### PR DESCRIPTION
Fixing bug #1859 

Example: 
1. Adding aria-label: 
```
<goa-radio-group name="color" arialabel="please select color" value="orange" (_change)="onChange($event)">
  <goa-radio-item name="color" arialabel="you are choosing color red" value="red"></goa-radio-item>
  <goa-radio-item name="color" arialabel="you are choosing color blue" value="blue">
        <div slot="description">
          <span class="customized-description-title">Content description</span>
          <small> Another test?</small>
          <p>
            Help test
          </p>
        </div>
  </goa-radio-item>
  <goa-radio-item name="color" arialabel="you are choosing color orange" value="orange" description="Orange description">
  </goa-radio-item>
</goa-radio-group>
```

2. Adding arialabelled-by:


```
<h2 id="radio-group-label">Basic with accessibility</h2>
<goa-radio-group name="color" arialabelledby="radio-group-label" value="orange" (_change)="onChange($event)">
  <goa-radio-item name="color" arialabel="you are choosing color red" value="red"></goa-radio-item>
  <goa-radio-item name="color" arialabel="you are choosing color blue" value="blue">
        <div slot="description">
          <span class="customized-description-title">Content description</span>
          <small> Another test?</small>
          <p>
            Help test
          </p>
        </div>
  </goa-radio-item>
  <goa-radio-item name="color" arialabel="you are choosing color orange" value="orange" description="Orange description">
  </goa-radio-item>
</goa-radio-group>
```

<img width="1187" alt="image" src="https://github.com/GovAlta/ui-components/assets/120135417/f2b34f38-6341-4b8d-816b-42d1de51ea9e">

Reference: https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio-activedescendant/#rps_label