### PR TITLE
fix(#1713): minwidth and maxwidth for app header menu

### DIFF
--- a/libs/react-components/src/lib/popover/popover.spec.tsx
+++ b/libs/react-components/src/lib/popover/popover.spec.tsx
@@ -19,6 +19,7 @@ describe("Popover", () => {
       <GoAPopover
         target="Click Action"
         maxWidth="500px"
+        minWidth="100px"
         testId="foo"
         padded={false}
       >
@@ -28,6 +29,7 @@ describe("Popover", () => {
 
     const el = baseElement.querySelector("goa-popover");
     expect(el?.getAttribute("maxwidth")).toBe("500px");
+    expect(el?.getAttribute("minwidth")).toBe("100px");
     expect(el?.getAttribute("padded")).toBe("false");
   });
 });

--- a/libs/react-components/src/lib/popover/popover.tsx
+++ b/libs/react-components/src/lib/popover/popover.tsx
@@ -5,6 +5,7 @@ export type GoAPosition = "above" | "below" | "auto";
 
 interface WCProps extends Margins {
   maxwidth?: string;
+  minwidth?: string;
   padded?: boolean;
   position?: GoAPosition;
   relative?: boolean;
@@ -23,6 +24,7 @@ export interface GoAPopoverProps extends Margins {
   target?: ReactNode;
   testId?: string;
   maxWidth?: string;
+  minWidth?: string;
   padded?: boolean;
   position?: GoAPosition;
   children: ReactNode;
@@ -33,6 +35,7 @@ export function GoAPopover({
   target,
   testId,
   maxWidth,
+  minWidth,
   padded,
   position,
   relative,
@@ -46,6 +49,7 @@ export function GoAPopover({
     <goa-popover
       data-testid={testId}
       maxwidth={maxWidth}
+      minwidth={minWidth}
       padded={padded}
       position={position}
       relative={relative}

--- a/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
+++ b/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
@@ -160,7 +160,8 @@
       borderradius="0"
       padded="false"
       tabindex="-1"
-      width="16rem"
+      maxwidth="16rem"
+      minwidth="8rem"
       position="below"
       open={_open}
     >
@@ -248,7 +249,6 @@
     padding: calc((3rem - var(--goa-line-height-3)) / 2) 1rem;
     text-decoration: none;
   }
-
   .not-desktop :global(::slotted(a)) {
     padding: calc((3rem - var(--goa-line-height-3)) / 2) 2.75rem;
   }

--- a/libs/web-components/src/components/app-header-menu/app-header-menu.spec.ts
+++ b/libs/web-components/src/components/app-header-menu/app-header-menu.spec.ts
@@ -44,6 +44,8 @@ describe("Desktop", () => {
     const links = $$("a");
 
     expect(popover).toBeTruthy();
+    expect(popover.getAttribute("maxwidth")).toBe("16rem");
+    expect(popover.getAttribute("minwidth")).toBe("8rem");
     expect(button.innerHTML).toContain(heading);
     expect(leadingIcon).toBeTruthy();
     expect(chevronIcon).toBeTruthy();

--- a/libs/web-components/src/components/popover/Popover.html-data.json
+++ b/libs/web-components/src/components/popover/Popover.html-data.json
@@ -8,6 +8,12 @@
       "default": "320px"
     },
     {
+      "name": "minwidth",
+      "description": "The min width of the popover container",
+      "type": "string",
+      "default": ""
+    },
+    {
       "name": "padded",
       "description": "Whether the popover should have padding",
       "type": "boolean",

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -20,6 +20,7 @@
   export let testid: string = "popover";
   // prevents the popover from exceeding this width
   export let maxwidth: string = "320px";
+  export let minwidth: string = "";
   // allow width to be hardcoded
   export let width: string = "";
   // allows to override the default padding when content needs to be flush with boundries
@@ -253,6 +254,7 @@
         class="popover-content"
         style={`
           ${cssVar("width", width)}
+          min-width: ${minwidth};
           max-width: ${maxwidth};
           padding: ${_padded ? "var(--goa-space-m)" : "0"};
         `}

--- a/libs/web-components/src/components/popover/popover.spec.ts
+++ b/libs/web-components/src/components/popover/popover.spec.ts
@@ -24,13 +24,18 @@ it("should render", async () => {
 });
 
 it("should open content when target is clicked", async () => {
-  const result = render(Popover);
+  const result = render(Popover, {minwidth: "8rem", maxwidth: "16rem"});
   const target = result.queryByTestId("popover-target");
   expect(target).toBeTruthy();
 
   expect(result.queryByTestId("popover-content")).toBeNull();
   target && await fireEvent.click(target);
-  expect(result.queryByTestId("popover-content")).toBeTruthy();
+  const popOverContent = result.queryByTestId("popover-content");
+  expect(popOverContent).toBeTruthy();
+  const style = popOverContent?.getAttribute("style");
+  expect(style).toContain("min-width: 8rem");
+  expect(style).toContain("max-width: 16rem");
+  expect(style).toContain("padding: var(--goa-space-m)");
 });
 
 it("should close content when clicked outside the content container", async () => {


### PR DESCRIPTION
Fixing #1713 
<img width="524" alt="image" src="https://github.com/GovAlta/ui-components/assets/120135417/7ad324de-a814-40da-ae72-fddf82ab91fa">

<img width="640" alt="image" src="https://github.com/GovAlta/ui-components/assets/120135417/b8f64a25-bd50-46fc-a203-a4636616985f">
