### PR TITLE
fix(#1698): dropdown width % should respect width container

### DIFF
--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -223,6 +223,7 @@
     ${cssVar("--offset-right", hoffset)}
     ${cssVar("--focus-border-width", focusborderwidth)}
     ${cssVar("--border-radius", borderradius)}
+    ${cssVar("width", width)}
 `}
 >
   <!-- svelte-ignore a11y-no-static-element-interactions -->


### PR DESCRIPTION
# Before (the change)
Resize browser and width of the dropdown isn't updated. 
[Bug 1698](https://github.com/GovAlta/ui-components/issues/1698)
# After (the change)
https://jam.dev/c/fc041636-9167-40c9-82ae-8fb85a7eaad9

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Code snippet: 
```
 <div style={{width: "80%", border: "2px solid red"}}>
        <GoAFormItem label="Input" requirement="required">
          <GoAInput name="input" placeholder="This is input" width="100%" onChange={onChange}></GoAInput>
          {/*<GoADropdown name="item"  onChange={onChange} width="100%">*/}
          {/*  <GoADropdownItem value="red" label="Red" />*/}
          {/*  <GoADropdownItem value="green" label="Green" />*/}
          {/*  <GoADropdownItem value="blue" label="Blue" />*/}
          {/*</GoADropdown>*/}
        </GoAFormItem>
        <GoAFormItem label="Item" requirement="required">
        <GoADropdown name="item"  onChange={onChange} placeholder="This is a dropdown width 100%" width="100%">
          <GoADropdownItem value="red" label="Red" />
          <GoADropdownItem value="green" label="Green" />
          <GoADropdownItem value="blue" label="Blue" />
        </GoADropdown>
        </GoAFormItem>

        <GoAFormItem label="Item" requirement="required">
          <GoADropdown name="item"  onChange={onChange} placeholder="Normal dropdown">
            <GoADropdownItem value="red" label="Red" />
            <GoADropdownItem value="green" label="Green" />
            <GoADropdownItem value="blue" label="Blue" />
          </GoADropdown>
        </GoAFormItem>
      </div>
```