### PR TITLE
fix: allow tabs to be dynamically added

### DIFF
--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -13,8 +13,7 @@
   let _tabsEl: HTMLElement;
   let _panelEl: HTMLElement;
   let _currentTab: number = 1;
-
-  let _tabProps: GoATabProps[] = [];
+  let _tabProps: (GoATabProps & {bound: boolean})[] = [];
   let _bindTimeoutId: any;
 
   // ========
@@ -22,7 +21,7 @@
   // ========
 
   onMount(() => {
-    getChildren();
+    addChildMountListener();
     addKeyboardEventListeners();
   });
 
@@ -34,10 +33,12 @@
   // Functions
   // =========
 
-  function getChildren() {
+  function addChildMountListener() {
     _rootEl.addEventListener("tab:mounted", (e: Event) => {
       const detail = (e as CustomEvent<GoATabProps>).detail;
-      _tabProps = [..._tabProps, detail];
+
+      // tabs initially marked as unbound
+      _tabProps = [..._tabProps, {...detail, bound: false }];
 
       if (_bindTimeoutId) {
         clearTimeout(_bindTimeoutId);
@@ -57,6 +58,12 @@
     _tabProps.forEach((tabProps, index) => {
       let tabSlug: string = "";
       let headingEl: HTMLElement;
+
+      // ensure that any previously bound tabs are not re-bound
+      if (tabProps.bound) return;
+
+      // set bound status to prevend possible later rebinding
+      tabProps.bound = true;
 
       // sync all tabs to open tab
       tabProps.el.dispatchEvent(


### PR DESCRIPTION
### React
```
export default function Tabs() {

  const [isReport, setIsReport] = useState(false);

  function onClick() {
    setIsReport(true);
  }
  
  return (
    <>
      <GoATabs>
        <GoATab heading="1">Content 1</GoATab>
        <GoATab heading="2">Content 2</GoATab>
        <GoATab heading="3">Content 3</GoATab>
        {isReport ? <GoATab heading="Report">Some Random Content</GoATab> : <></>}
      </GoATabs>

      <GoAButton onClick={onClick} mt="3xl">
        Add
      </GoAButton>
   </>
  )
}
```

### Angular
```
<h3>Dynamic</h3>
<goa-tabs>
  <goa-tab heading="1">Content 1</goa-tab>
  <goa-tab heading="2">Content 2</goa-tab>
  <goa-tab heading="3">Content 3</goa-tab>
  <goa-tab *ngIf="isReport" heading="Report">Some Random Content</goa-tab>
</goa-tabs>

<goa-button (_click)="onClick()" mt="3xl">
  Add
</goa-button>
```

```
export class TabsComponent {
  isReport = false;

  onClick() {
    this.isReport = true;
  }
}
```