### PR TITLE
feat(#1797): add max width property to components

### DIFF
--- a/libs/react-components/src/lib/accordion/accordion.spec.tsx
+++ b/libs/react-components/src/lib/accordion/accordion.spec.tsx
@@ -22,6 +22,7 @@ describe("Accordion", () => {
         headingContent={
           <GoABadge type="success" content="test-badge"></GoABadge>
         }
+        maxWidth="480px"
       >
         Accordion Content
       </GoAAccordion>
@@ -32,5 +33,6 @@ describe("Accordion", () => {
     expect(el?.getAttribute("open")).toBe("true");
     const badge = headingContent?.querySelector("goa-badge");
     expect(badge?.getAttribute("content")).toBe("test-badge");
+    expect(el?.getAttribute("maxwidth")).toBe("480px");
   });
 });

--- a/libs/react-components/src/lib/accordion/accordion.tsx
+++ b/libs/react-components/src/lib/accordion/accordion.tsx
@@ -9,6 +9,7 @@ interface WCProps extends Margins {
   heading: string;
   secondaryText?: string;
   headingContent?: ReactNode;
+  maxwidth?: string;
 }
 
 declare global {
@@ -26,6 +27,7 @@ export interface GoAAccordionProps extends Margins {
   secondaryText?: string;
   heading: string;
   headingContent?: ReactNode;
+  maxWidth?: string;
   testid?: string;
   children: ReactNode;
 }
@@ -36,6 +38,7 @@ export function GoAAccordion({
   headingSize,
   secondaryText,
   headingContent,
+  maxWidth,
   testid,
   children,
   mt,
@@ -49,6 +52,7 @@ export function GoAAccordion({
       headingSize={headingSize}
       heading={heading}
       secondaryText={secondaryText}
+      maxwidth={maxWidth}
       data-testid={testid}
       mt={mt}
       mr={mr}

--- a/libs/react-components/src/lib/callout/callout.spec.tsx
+++ b/libs/react-components/src/lib/callout/callout.spec.tsx
@@ -8,6 +8,7 @@ describe("Callout", () => {
         type="information"
         heading="Callout Title"
         size="medium"
+        maxWidth="480px"
         mt="s"
         mr="m"
         mb="l"
@@ -22,6 +23,7 @@ describe("Callout", () => {
     expect(el?.getAttribute("heading")).toContain("Callout Title");
     expect(el?.getAttribute("type")).toContain("information");
     expect(el?.getAttribute("size")).toContain("medium");
+    expect(el?.getAttribute("maxwidth")).toBe("480px");
     expect(el?.getAttribute("mt")).toBe("s");
     expect(el?.getAttribute("mr")).toBe("m");
     expect(el?.getAttribute("mb")).toBe("l");

--- a/libs/react-components/src/lib/callout/callout.tsx
+++ b/libs/react-components/src/lib/callout/callout.tsx
@@ -13,6 +13,7 @@ interface WCProps extends Margins {
   heading?: string;
   type?: GoACalloutType;
   size?: GoACalloutSize;
+  maxwidth?: string;
 }
 
 declare global {
@@ -28,6 +29,7 @@ export interface GoACalloutProps extends Margins {
   heading?: string;
   type?: GoACalloutType;
   size?: GoACalloutSize;
+  maxWidth?: string;
   testId?: string;
   children?: React.ReactNode;
 }
@@ -38,6 +40,7 @@ export const GoACallout = ({
   heading,
   type = "information",
   size = "large",
+  maxWidth,
   testId,
   children,
   mt,
@@ -50,6 +53,7 @@ export const GoACallout = ({
       heading={heading}
       type={type}
       size={size}
+      maxwidth={maxWidth}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/checkbox/checkbox.spec.tsx
+++ b/libs/react-components/src/lib/checkbox/checkbox.spec.tsx
@@ -12,6 +12,7 @@ describe("GoA Checkbox", () => {
       name: "foo",
       value: "bar",
       text: "to display",
+      maxWidth: "480px",
       disabled: false,
       checked: true,
       error: false,
@@ -30,6 +31,7 @@ describe("GoA Checkbox", () => {
     expect(checkbox?.getAttribute("name")).toBe("foo");
     expect(checkbox?.getAttribute("value")).toBe("bar");
     expect(checkbox?.getAttribute("text")).toBe("to display");
+    expect(checkbox?.getAttribute("maxwidth")).toBe("480px");
     expect(checkbox?.getAttribute("disabled")).toBe("false");
     expect(checkbox?.getAttribute("checked")).toBe("true");
     expect(checkbox?.getAttribute("error")).toBe("false");
@@ -41,7 +43,7 @@ describe("GoA Checkbox", () => {
   });
 
   it("should render with text description", () => {
-    render(<GoACheckbox name={"foo"} checked={false} description={"description text"}/>);
+    render(<GoACheckbox name={"foo"} checked={false} description={"description text"} />);
 
     const checkbox = document.querySelector("goa-checkbox");
     expect(checkbox?.getAttribute("description")).toBe("description text");

--- a/libs/react-components/src/lib/checkbox/checkbox.tsx
+++ b/libs/react-components/src/lib/checkbox/checkbox.tsx
@@ -21,6 +21,7 @@ interface WCProps extends Margins {
   value?: string | number | boolean;
   arialabel?: string;
   description?: string | React.ReactNode;
+  maxwidth?: string;
 }
 
 /* eslint-disable-next-line */
@@ -36,6 +37,7 @@ export interface GoACheckboxProps extends Margins {
   testId?: string;
   ariaLabel?: string;
   description?: string | React.ReactNode;
+  maxWidth?: string;
   onChange?: (name: string, checked: boolean, value: string) => void;
 }
 
@@ -52,6 +54,7 @@ export function GoACheckbox({
   value,
   text,
   description,
+  maxWidth,
   children,
   onChange,
   ariaLabel,
@@ -91,6 +94,7 @@ export function GoACheckbox({
       value={value}
       arialabel={ariaLabel}
       description={typeof description === "string" ? description : undefined}
+      maxwidth={maxWidth}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/container/container.spec.tsx
+++ b/libs/react-components/src/lib/container/container.spec.tsx
@@ -11,6 +11,7 @@ describe("Container", () => {
         padding="relaxed"
         title={"Text title"}
         width="content"
+        maxWidth="480px"
         mt="s"
         mr="m"
         mb="l"
@@ -32,6 +33,7 @@ describe("Container", () => {
     expect(el?.getAttribute("mb")).toBe("l");
     expect(el?.getAttribute("ml")).toBe("xl");
     expect(el?.getAttribute("width")).toBe("content");
+    expect(el?.getAttribute("maxwidth")).toBe("480px");
 
     expect(el?.querySelector("*[slot=title]")?.innerHTML).toContain("Text title");
     expect(

--- a/libs/react-components/src/lib/container/container.tsx
+++ b/libs/react-components/src/lib/container/container.tsx
@@ -17,6 +17,7 @@ interface WCProps extends Margins {
   accent?: GoAContainerAccent;
   padding?: GoAContainerPadding;
   width?: GoAContainerWidth;
+  maxwidth?: string;
 }
 
 declare global {
@@ -37,6 +38,7 @@ export interface GoAContainerProps extends Margins {
   actions?: ReactNode;
   children?: ReactNode;
   width?: GoAContainerWidth;
+  maxWidth?: string;
   testId?: string;
 }
 
@@ -49,6 +51,7 @@ export function GoAContainer({
   actions,
   type,
   width,
+  maxWidth,
   mt,
   mr,
   mb,
@@ -62,6 +65,7 @@ export function GoAContainer({
       padding={padding}
       accent={accent}
       width={width}
+      maxwidth={maxWidth}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/details/details.spec.tsx
+++ b/libs/react-components/src/lib/details/details.spec.tsx
@@ -8,6 +8,7 @@ describe("Detail", () => {
       <GoADetails
         heading="The heading"
         open={true}
+        maxWidth="480px"
         testId="foo"
       >
         The content
@@ -18,6 +19,7 @@ describe("Detail", () => {
     expect(el?.getAttribute("heading")).toBe("The heading");
     expect(baseElement.innerHTML).toContain("The content");
     expect(el?.getAttribute("open")).toBe("true");
+    expect(el?.getAttribute("maxwidth")).toBe("480px");
     expect(el?.getAttribute("data-testid")).toBe("foo");
   });
 

--- a/libs/react-components/src/lib/details/details.tsx
+++ b/libs/react-components/src/lib/details/details.tsx
@@ -4,6 +4,7 @@ import { Margins } from "../../common/styling";
 interface WCProps extends Margins {
   heading: string;
   open?: boolean;
+  maxwidth?: string;
 }
 
 declare global {
@@ -20,6 +21,7 @@ declare global {
 export interface GoADetailsProps extends Margins {
   heading: string;
   open?: boolean;
+  maxWidth?: string;
   testId?: string;
   children: ReactNode;
 }
@@ -31,6 +33,7 @@ export function GoADetails(props: GoADetailsProps) {
     <goa-details
       heading={props.heading}
       open={props.open}
+      maxwidth={props.maxWidth}
       data-testid={props.testId}
       mt={props.mt}
       mr={props.mr}

--- a/libs/react-components/src/lib/form-item/form-item.spec.tsx
+++ b/libs/react-components/src/lib/form-item/form-item.spec.tsx
@@ -8,17 +8,21 @@ describe("GoAFormItem", () => {
     const { baseElement } = render(
       <GoAFormItem
         label="First Name"
+        labelSize="large"
         requirement="optional"
         error="This is an error"
         helpText="This is some help text"
+        maxWidth="480px"
         id="firstName"
       />
     );
     const el = baseElement.querySelector("goa-form-item");
     expect(el?.getAttribute("label")).toEqual("First Name");
+    expect(el?.getAttribute("labelsize")).toEqual("large");
     expect(el?.getAttribute("requirement")).toEqual("optional");
     expect(el?.getAttribute("error")).toEqual("This is an error");
     expect(el?.getAttribute("helptext")).toEqual("This is some help text");
+    expect(el?.getAttribute("maxwidth")).toEqual("480px");
     expect(el?.getAttribute("id")).toEqual("firstName");
   });
 });

--- a/libs/react-components/src/lib/form-item/form-item.tsx
+++ b/libs/react-components/src/lib/form-item/form-item.tsx
@@ -9,6 +9,7 @@ interface WCProps extends Margins {
   requirement?: GoAFormItemRequirement;
   error?: string;
   helptext?: string;
+  maxwidth?: string;
   id?: string;
 }
 
@@ -27,6 +28,7 @@ export interface GoAFormItemProps extends Margins {
   requirement?: GoAFormItemRequirement;
   error?: React.ReactNode;
   helpText?: React.ReactNode;
+  maxWidth?: string;
   children?: React.ReactNode;
   testId?: string;
   id?: string;
@@ -39,6 +41,7 @@ export function GoAFormItem({
   requirement,
   label,
   labelSize,
+  maxWidth,
   mt,
   mr,
   mb,
@@ -53,6 +56,7 @@ export function GoAFormItem({
       error={typeof error === "string" ? error : undefined}
       requirement={requirement}
       helptext={typeof helpText === "string" ? helpText : undefined}
+      maxwidth={maxWidth}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/radio-group/radio.tsx
+++ b/libs/react-components/src/lib/radio-group/radio.tsx
@@ -4,6 +4,7 @@ interface RadioItemProps extends Margins {
   value?: string;
   description?: string | React.ReactNode;
   label?: string;
+  maxwidth?: string;
   disabled?: boolean;
   checked?: boolean;
   error?: boolean;
@@ -24,6 +25,7 @@ export interface GoARadioItemProps extends Margins {
   label?: string;
   name?: string;
   description?: string | React.ReactNode;
+  maxWidth?: string;
   disabled?: boolean;
   checked?: boolean;
   error?: boolean;
@@ -37,6 +39,7 @@ export function GoARadioItem({
   label,
   value,
   description,
+  maxWidth,
   disabled,
   checked,
   error,
@@ -54,6 +57,7 @@ export function GoARadioItem({
       label={label}
       value={value}
       description={typeof description === "string" ? description : undefined}
+      maxwidth={maxWidth}
       error={error}
       disabled={disabled}
       checked={checked}

--- a/libs/react-components/src/lib/textarea/textarea.spec.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.spec.tsx
@@ -14,6 +14,7 @@ describe("TextArea", () => {
         disabled={true}
         countBy="word"
         maxCount={50}
+        maxWidth="100px"
         mt="s"
         mr="m"
         mb="l"
@@ -30,6 +31,7 @@ describe("TextArea", () => {
     expect(el.getAttribute("disabled")).toBe("true");
     expect(el.getAttribute("countby")).toBe("word");
     expect(el.getAttribute("maxcount")).toBe("50");
+    expect(el.getAttribute("maxwidth")).toBe("100px");
     expect(el.getAttribute("mt")).toBe("s");
     expect(el.getAttribute("mr")).toBe("m");
     expect(el.getAttribute("mb")).toBe("l");

--- a/libs/react-components/src/lib/textarea/textarea.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.tsx
@@ -13,6 +13,7 @@ interface WCProps extends Margins {
   error?: boolean;
   disabled?: boolean;
   width?: string;
+  maxwidth?: string;
   arialabel?: string;
   countby?: CountBy;
   maxcount?: number;
@@ -36,6 +37,7 @@ export interface GoATextAreaProps extends Margins {
   error?: boolean;
   disabled?: boolean;
   width?: string;
+  maxWidth?: string;
   testId?: string;
   ariaLabel?: string;
   countBy?: CountBy;
@@ -54,6 +56,7 @@ export function GoATextarea({
   countBy,
   maxCount,
   width,
+  maxWidth,
   testId,
   error,
   ariaLabel,
@@ -110,6 +113,7 @@ export function GoATextarea({
       countby={countBy}
       maxcount={maxCount}
       width={width}
+      maxwidth={maxWidth}
       error={error}
       data-testid={testId}
       arialabel={ariaLabel}

--- a/libs/web-components/src/components/accordion/Accordion.html-data.json
+++ b/libs/web-components/src/components/accordion/Accordion.html-data.json
@@ -4,18 +4,18 @@
   "attributes": [
     {
       "name": "heading",
-      "description": "Sets the heading text",
+      "description": "Sets the heading text.",
       "type": "string"
     },
     {
-      "name": "secondaryText",
-      "description": "Sets secondary text",
+      "name": "secondarytext",
+      "description": "Sets the secondary text.",
       "type": "string"
     },
     {
       "name": "open",
       "default": "false",
-      "description": "Sets the state of the accordion container open or closed",
+      "description": "Sets the state of the accordion container open or closed.",
       "values": [
         {
           "name": "false",
@@ -29,25 +29,30 @@
       "type": "boolean"
     },
     {
-      "name": "headingSize",
+      "name": "headingsize",
       "default": "small",
-      "description": "Sets the heading size of the accordion container heading",
+      "description": "Sets the heading size of the accordion container heading.",
       "values": [
         {
           "name": "small",
-          "description": "Heading size of the accordion container is small"
+          "description": "Heading size of the accordion container is small."
         },
         {
           "name": "medium",
-          "description": "Heading size of the accordion container is medium"
+          "description": "Heading size of the accordion container is medium."
         }
       ],
       "type": "string"
     },
     {
       "name": "headingcontent",
-      "description": "Add components to the accordion container heading such as badges",
+      "description": "Add components to the accordion container heading such as badges.",
       "type": "slot"
+    },
+    {
+      "name": "maxwidth",
+      "description": "Sets the maximum width of the accordion.",
+      "type": "string"
     },
     {
       "name": "mt",

--- a/libs/web-components/src/components/accordion/Accordion.spec.ts
+++ b/libs/web-components/src/components/accordion/Accordion.spec.ts
@@ -27,6 +27,16 @@ describe("Accordion", () => {
     expect(heading?.classList.contains("heading-medium"));
   });
 
+  it("renders with max width", async () => {
+    const { container } = render(Accordion, {
+      heading: "Title",
+      maxwidth: "480px",
+      testid: "accordion"
+    });
+    const elm = container.querySelector("[data-testid=accordion]");
+    expect(elm?.getAttribute("style")).toContain("max-width: 480px;");
+  });
+
   it("should expand the container when open prop is set", async () => {
     const { container } = render(Accordion, { heading: "Title", open: "true" });
     const details = container.querySelector("details");

--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -26,6 +26,7 @@
   export let secondarytext: string = "";
   export let headingsize: HeadingSize = "small";
   export let id: string = "";
+  export let maxwidth: string = "none";
   export let testid: string = "";
   export let mt: Spacing = null;
   export let mr: Spacing = null;
@@ -67,11 +68,14 @@
 
 <!-- HTML -->
 <div
-  style={calculateMargin(mt, mr, mb, ml)}
+  style={`
+    ${calculateMargin(mt, mr, mb, ml)};
+    max-width: ${maxwidth};
+  `}
   class="goa-accordion"
   data-testid={testid}
 >
-  <details open={isOpen} on:toggle={({target}) => open = `${target?.open}`}>
+  <details open={isOpen} on:toggle={({ target }) => (open = `${target?.open}`)}>
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <summary
       class={`container-${headingsize}`}

--- a/libs/web-components/src/components/callout/Callout.html-data.json
+++ b/libs/web-components/src/components/callout/Callout.html-data.json
@@ -4,18 +4,23 @@
   "attributes": [
     {
       "name": "type",
-      "description": "Define the context and colour of the callout",
+      "description": "Define the context and colour of the callout.",
       "values": [{ "name": "information" }, { "name": "important"}, { "name": "emergency"}, { "name": "success"}, { "name": "event"}]
     },
     {
       "name": "heading",
       "type": "string",
-      "description": "Callout heading text"
+      "description": "Callout heading text."
     },
     {
       "name": "size",
       "description": "Define the size of the callouts.",
       "values": [{"name": "medium"}, {"name": "large"}]
+    },
+    {
+      "name": "maxwidth",
+      "description": "Sets the maximum width of the callout.",
+      "type": "string"
     },
     {
       "name": "mt",

--- a/libs/web-components/src/components/callout/Callout.spec.ts
+++ b/libs/web-components/src/components/callout/Callout.spec.ts
@@ -96,6 +96,13 @@ describe('GoACalloutComponent', () => {
     });
   });
 
+  it("should render - with max width", async () => {
+    const baseElement = render(GoACallout, { type: "emergency", maxwidth:"480px", testid: "testid" });
+    const el = baseElement.queryByTestId("testid");
+    expect(el?.getAttribute("style")).toContain("max-width: 480px;");
+  });
+
+
   describe("Margins", () => {
     it(`should add the margin`, async () => {
       const baseElement = render(GoACallout, {

--- a/libs/web-components/src/components/callout/Callout.svelte
+++ b/libs/web-components/src/components/callout/Callout.svelte
@@ -20,7 +20,6 @@
   ]);
 
   // Types
-
   type CalloutType = (typeof Types)[number];
   type CalloutSize = (typeof CalloutSizes)[number];
 
@@ -29,9 +28,11 @@
   export let mr: Spacing = null;
   export let mb: Spacing = "l";
   export let ml: Spacing = null;
+
   export let size: CalloutSize = "large";
   export let type: CalloutType;
   export let heading: string = "";
+  export let maxwidth: string = "none";
   export let testid: string = "";
 
   // Private
@@ -68,7 +69,10 @@
 <!-- HTML -->
 <svelte:window bind:innerWidth={screenSize} />
 <div
-  style={calculateMargin(mt, mr, mb, ml)}
+  style={`
+    ${calculateMargin(mt, mr, mb, ml)};
+    max-width: ${maxwidth};
+  `}
   class="notification"
   class:medium={isMediumCallout}
   data-testid={testid}

--- a/libs/web-components/src/components/checkbox/Checkbox.html-data.json
+++ b/libs/web-components/src/components/checkbox/Checkbox.html-data.json
@@ -5,47 +5,52 @@
     {
       "name": "name",
       "type": "string",
-      "description": "Must match the name assigned to the children"
+      "description": "Must match the name assigned to the children."
     },
     {
       "name": "checked",
       "type": "boolean",
-      "description": "Mark the checkbox item as selected",
+      "description": "Marks the checkbox item as selected.",
       "valueSet": "boolean"
     },
     {
       "name": "text",
       "type": "string",
-      "description": "Content to display as the label for the Checkbox"
+      "description": "Content to display as the label for the checkbox."
     },
     {
       "name": "value",
       "type": "string",
-      "description": "The value binding to the checkbox"
+      "description": "The value binding to the checkbox."
     },
     {
       "name": "description",
       "type": "string",
-      "description": "The description added below the label text"
+      "description": "The description added below the label text."
     },
     {
       "name": "disabled",
       "type": "boolean",
-      "description": "Disable this control. It will not receive focus or events",
+      "description": "Disable this control. It will not receive focus or events.",
       "valueSet": "boolean",
       "default": "false"
     },
     {
       "name": "error",
       "type": "boolean",
-      "description": "Show an error on the checkbox item",
+      "description": "Show an error on the checkbox item.",
       "valueSet": "boolean",
       "default": "false"
     },
     {
-      "name": "ariaLabel",
+      "name": "arialabel",
       "type": "string",
-      "description": "Defines how the text will be translated for the screen reader. If not specified it will fall back to the name\n"
+      "description": "Defines how the text will be translated for the screen reader. If not specified it will fall back to the name.\n"
+    },
+    {
+      "name": "maxwidth",
+      "description": "Sets the maximum width of the checkbox.",
+      "type": "string"
     },
     {
       "name": "mt",

--- a/libs/web-components/src/components/checkbox/Checkbox.spec.ts
+++ b/libs/web-components/src/components/checkbox/Checkbox.spec.ts
@@ -17,26 +17,32 @@ describe('GoACheckbox Component', () => {
   });
 
   describe("properties", () => {
-    it("allows for setting of the value", async () => {
+    it("can set value", async () => {
       const el = await createElement({ value: "foobar" });
       const checkbox = el.container.querySelector("input");
       expect((checkbox as HTMLInputElement).value).toBe("foobar");
     });
 
-    it("allows for setting of the name", async () => {
+    it("can set name", async () => {
       const el = await createElement();
       const checkbox = el.container.querySelector("input");
       expect((checkbox as HTMLInputElement).name).toBe("checkbox-test-name");
       expect((checkbox as HTMLInputElement).id).toBe("checkbox-test-name");
     });
 
-    it("allows for setting of the text", async () => {
+    it("can set text", async () => {
       const el = await createElement({ text: "foobar" });
       const div = await el.findByTestId('text');
       expect(div).toHaveTextContent("foobar");
     });
 
-    it("allows setting checkbox description", async () => {
+    it("can set max width", async () => {
+      const el = await createElement({ text: "foobar", maxwidth: "480px" });
+      const root = await el.container.querySelector(".root");
+      expect(root?.getAttribute("style")).toContain("max-width: 480px;")
+    });
+
+    it("can set description", async () => {
       const el = await createElement({ description: "foobar" });
       const div = await el.findByTestId('description');
       expect(div).toHaveTextContent("foobar");
@@ -62,7 +68,7 @@ describe('GoACheckbox Component', () => {
       expect((checkbox as HTMLInputElement).disabled).toBeTruthy();
     });
 
-    it("allows the checkbox to be set to an error state", async () => {
+    it("can set error state", async () => {
       const el = await createElement({ error: "true" });
       const root = el.container.querySelector('.error');
       expect(root).toBeTruthy();

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -19,6 +19,7 @@
   export let testid: string = "";
   export let arialabel: string = "";
   export let description: string = "";
+  export let maxwidth: string = "none";
 
   // margin
   export let mt: Spacing = null;
@@ -65,7 +66,13 @@
 
 <!-- View -->
 
-<div style={calculateMargin(mt, mr, mb, ml)} class="root">
+<div
+  class="root"
+  style={`
+    ${calculateMargin(mt, mr, mb, ml)}
+    max-width: ${maxwidth};
+  `}
+>
   <label
     data-testid={testid}
     for={name}

--- a/libs/web-components/src/components/container/Container.html-data.json
+++ b/libs/web-components/src/components/container/Container.html-data.json
@@ -30,6 +30,11 @@
       "description": "Sets the content in the right of the accent bar"
     },
     {
+      "name": "maxwidth",
+      "description": "Sets the maximum width of the container.",
+      "type": "string"
+    },
+    {
       "name": "mt",
       "description": "Top margin",
       "valueSet": "spacing"

--- a/libs/web-components/src/components/container/Container.spec.ts
+++ b/libs/web-components/src/components/container/Container.spec.ts
@@ -34,6 +34,15 @@ describe("GoA Container", () => {
       expect(container?.classList).toContain('width--content');
 
     });
+
+    it('should set a max width', async () => {
+      const baseElement = render(GoAContainer, {
+        testid: "container-test",
+        maxwidth: "480px",
+      });
+      const container = await baseElement.findByTestId("container-test");
+      expect(container?.getAttribute("style")).toContain("max-width: 480px;")
+    });
   });
 
   describe("Margins", () => {

--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -40,6 +40,7 @@
   export let accent: Accent = "filled";
   export let padding: Padding = "relaxed";
   export let width: Width = "full";
+  export let maxwidth: string = "none";
   export let testid: string = "";
 
   // margin
@@ -60,7 +61,10 @@
 
 <div
   data-testid={testid}
-  style={calculateMargin(mt, mr, mb, ml)}
+  style={`
+    ${calculateMargin(mt, mr, mb, ml)}
+    max-width: ${maxwidth};
+  `}
   class={`
     goa-container
     goa-container--${type}

--- a/libs/web-components/src/components/details/Details.html-data.json
+++ b/libs/web-components/src/components/details/Details.html-data.json
@@ -5,7 +5,7 @@
     {
       "name": "heading",
       "type": "string",
-      "description": "The title heading"
+      "description": "The title heading."
     },
     {
       "name": "mt",
@@ -29,8 +29,13 @@
     },
     {
       "name": "open",
-      "description": "Controls if details is expanded or collapsed",
+      "description": "Controls if details is expanded or collapsed.",
       "valueSet": "boolean"
+    },
+    {
+      "name": "maxwidth",
+      "description": "Sets the maximum width of the details.",
+      "type": "string"
     }
   ],
   "references": [

--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -3,10 +3,15 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { calculateMargin } from "../../common/styling";
-  import { toBoolean, validateRequired, generateRandomId } from "../../common/utils";
+  import {
+    toBoolean,
+    validateRequired,
+    generateRandomId,
+  } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
 
   export let heading: string;
+  export let maxwidth: string = "75ch";
   export let mt: Spacing = null;
   export let mr: Spacing = null;
   export let mb: Spacing = null;
@@ -36,7 +41,10 @@
 <details
   open={_isOpen}
   on:toggle={({ target }) => (open = `${target?.open}`)}
-  style={calculateMargin(mt, mr, mb, ml)}
+  style={`
+    ${calculateMargin(mt, mr, mb, ml)}
+    max-width: ${maxwidth};
+  `}
 >
   <summary
     bind:this={_summaryEl}
@@ -69,7 +77,6 @@
   }
 
   details {
-    max-width: 75ch;
     position: relative;
   }
   details :global(::slotted(*)) {

--- a/libs/web-components/src/components/details/details.spec.ts
+++ b/libs/web-components/src/components/details/details.spec.ts
@@ -3,7 +3,7 @@ import { render } from '@testing-library/svelte'
 import { it } from "vitest";
 
 
-it('it works', async () => {
+it('should render', async () => {
   const { container } = render(Details, { heading: "The title", open: true })
 
   const summary = container.querySelector("summary")
@@ -26,3 +26,9 @@ it('it works', async () => {
   expect(content?.getAttribute("id")).toBe(`${randomId}-content`);
   expect(content?.getAttribute("aria-labelledby")).toBe(heading?.getAttribute("id"));
 })
+
+it('should render - with max width', async () => {
+  const { container } = render(Details, { heading: "The title", maxwidth: "480px" });
+  const details = container.querySelector("details");
+  expect(details?.getAttribute("style")).toContain("max-width: 480px;");
+});

--- a/libs/web-components/src/components/form-item/FormItem.html-data.json
+++ b/libs/web-components/src/components/form-item/FormItem.html-data.json
@@ -24,17 +24,17 @@
     {
       "name": "label",
       "type": "string",
-      "description": "Creates a label for a form item"
+      "description": "Creates a label for a form item."
     },
     {
       "name": "labelsize",
       "type": "regular | large",
-      "description": "Set a regular or large label size"
+      "description": "Set a regular or large label size."
     },
     {
-      "name": "helpText",
+      "name": "helptext",
       "type": "string",
-      "description": "Help text displayed under the form field to provide an additional explanation"
+      "description": "Help text displayed under the form field to provide an additional explanation."
     },
     {
       "name": "error",
@@ -51,6 +51,11 @@
       "name": "id",
       "type": "string",
       "description": "ID of the label."
+    },
+    {
+      "name": "maxwidth",
+      "description": "Sets the maximum width of the form item.",
+      "type": "string"
     }
   ],
   "references": [

--- a/libs/web-components/src/components/form-item/FormItem.spec.ts
+++ b/libs/web-components/src/components/form-item/FormItem.spec.ts
@@ -9,7 +9,7 @@ describe("GoA FormItem", () => {
     const result = render(GoAFormItem, { testid: "foo" });
     const el = result.queryByTestId("foo");
 
-    const label = el.querySelector(".label");
+    const label = el?.querySelector(".label");
     expect(label).toBeFalsy();
 
     const requirement = document.querySelector("em");
@@ -29,7 +29,7 @@ describe("GoA FormItem", () => {
     });
     const el = result.queryByTestId("foo");
 
-    const label = el.querySelector(".label");
+    const label = el?.querySelector(".label");
     expect(label).toBeTruthy();
 
     const requirement = document.querySelector("em");
@@ -50,11 +50,11 @@ describe("GoA FormItem", () => {
     });
     const el = result.queryByTestId("foo");
 
-    const label = el.querySelector(".label");
+    const label = el?.querySelector(".label");
     expect(label).toBeTruthy();
 
     const requirement = document.querySelector("em");
-    expect(requirement.innerHTML).toContain("optional");
+    expect(requirement?.innerHTML).toContain("optional");
 
     const helpText = document.querySelector(".help-msg");
     expect(helpText).toBeFalsy();
@@ -71,11 +71,11 @@ describe("GoA FormItem", () => {
     });
     const el = result.queryByTestId("foo");
 
-    const label = el.querySelector(".label");
+    const label = el?.querySelector(".label");
     expect(label).toBeTruthy();
 
     const requirement = document.querySelector("em");
-    expect(requirement.innerHTML).toContain("required");
+    expect(requirement?.innerHTML).toContain("required");
 
     const helpText = document.querySelector(".help-msg");
     expect(helpText).toBeFalsy();
@@ -85,25 +85,31 @@ describe("GoA FormItem", () => {
   });
 
   it("should render all params", async () => {
-    render(GoAFormItem, {
+    const baseElement = render(GoAFormItem, {
       label: "the label",
+      labelsize: "large",
+      maxwidth: "480px",
       helptext: "the helptext",
       requirement: "optional",
       error: "the error",
-      id: "labelId",
+      testid: "formitem-test",
     });
 
+    const formitem = await baseElement.findByTestId("formitem-test");
     const label = document.querySelector(".label");
-    expect(label.innerHTML).toContain("the label");
+
+    expect(formitem?.getAttribute("style")).toContain("max-width: 480px;");
+    expect(label?.innerHTML).toContain("the label");
+    expect(label?.classList).toContain("large");
 
     const requirement = document.querySelector("em");
-    expect(requirement.innerHTML).toContain("optional");
+    expect(requirement?.innerHTML).toContain("optional");
 
     const helpText = document.querySelector(".help-msg");
-    expect(helpText.innerHTML).toContain("the helptext");
+    expect(helpText?.innerHTML).toContain("the helptext");
 
     const errMsg = document.querySelector(".error-msg");
-    expect(errMsg.innerHTML).toContain("the error");
+    expect(errMsg?.innerHTML).toContain("the error");
   });
 
   it("should not render options if not provided", async () => {

--- a/libs/web-components/src/components/form-item/FormItem.svelte
+++ b/libs/web-components/src/components/form-item/FormItem.svelte
@@ -42,6 +42,7 @@
   export let helptext: string = "";
   export let error: string = "";
   export let requirement: RequirementType = "";
+  export let maxwidth: string = "none";
   export let id: string = ""; // @deprecated: no longer used
 
   let _rootEl: HTMLElement;
@@ -67,7 +68,10 @@
 <!-- HTML -->
 <div
   data-testid={testid}
-  style={calculateMargin(mt, mr, mb, ml)}
+  style={`
+    ${calculateMargin(mt, mr, mb, ml)}
+    max-width: ${maxwidth};
+  `}
   bind:this={_rootEl}
 >
   {#if label}

--- a/libs/web-components/src/components/radio-item/RadioItem.html-data.json
+++ b/libs/web-components/src/components/radio-item/RadioItem.html-data.json
@@ -3,23 +3,28 @@
   "attributes": [
     {
       "name": "label",
-      "description": "Text to show to the user",
+      "description": "Text to show to the user.",
       "type": "string"
     },
     {
       "name": "value",
-      "description": "Value of the item that will be returned when selected",
+      "description": "Value of the item that will be returned when selected.",
       "type": "string"
     },
     {
       "name": "description",
-      "description": "Text added below the label text",
+      "description": "Text added below the label text.",
       "type": "string"
     },
     {
       "name": "arialabel",
       "type": "string",
       "description": "Defines how the radio item will be translated for the screen reader."
+    },
+    {
+      "name": "maxwidth",
+      "description": "Sets the maximum width of the radio item.",
+      "type": "string"
     }
   ],
   "references": [

--- a/libs/web-components/src/components/radio-item/RadioItem.spec.ts
+++ b/libs/web-components/src/components/radio-item/RadioItem.spec.ts
@@ -11,6 +11,7 @@ describe("RadioItem", () => {
       name: "radio-item-1-name",
       arialabel: "radio-item-1-label",
       description: "test description",
+      maxwidth: "480px",
     });
 
     expect(result.getByTestId("radio-option-radio-item-1")).toBeTruthy();
@@ -30,6 +31,8 @@ describe("RadioItem", () => {
     expect(input.getAttribute("aria-describedby")).toBe(
       radioDescriptionDiv?.getAttribute("id"),
     );
+    const radioContainerDiv = result.container.querySelector(".goa-radio-container");
+    expect(radioContainerDiv?.getAttribute("style")).toContain("max-width: 480px;");
   });
 
   it("should render the radio item with slot description", async () => {

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -20,6 +20,7 @@
     name: string;
     checked: boolean;
     ariaLabel: string;
+    maxWidth: string;
   };
 
   export type RadioItemSelectProps = {
@@ -41,6 +42,7 @@
   export let error: string = "false";
   export let checked: string = "false";
   export let arialabel: string = "";
+  export let maxwidth: string = "none";
 
   // margin
   export let mt: Spacing = null;
@@ -80,6 +82,7 @@
             error: isError,
             checked: isChecked,
             ariaLabel: arialabel,
+            maxWidth: maxwidth,
           },
         }),
       );
@@ -116,7 +119,13 @@
   }
 </script>
 
-<div style={calculateMargin(mt, mr, mb, ml)} class="goa-radio-container">
+<div
+  style={`
+    ${calculateMargin(mt, mr, mb, ml)}
+    max-width: ${maxwidth};
+  `}
+  class="goa-radio-container"
+>
   <label
     bind:this={_radioItemEl}
     data-testid="radio-option-{value}"


### PR DESCRIPTION
This PR adds a max width property to the following components:

- Accordion
- Callout
- Checkbox
- Container
- Details
- Form item
- Radio item

#### Questions

1. I don't see a test file for a React radio item, just a [radio group](https://github.com/GovAlta/ui-components/blob/alpha/libs/react-components/src/lib/radio-group/radio-group.spec.tsx). Is there a reason for this? Should I add tests to the radio group?
2. I didn't include the dropdown component because I'm not sure where and how to add the max width. Any suggestions? I was thinking we could add it to a separate PR.

#### PR checklist
- [x] I have run a build locally.
- [x] I have ran unit tests locally.
![image](https://github.com/GovAlta/ui-components/assets/1479091/c161e089-5766-48fc-8fea-e07c164a15c3)

- [x] I have tested the functionality.
