### PR TITLE
fix: dispatch change event for native dropdown

### DIFF
--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -137,7 +137,7 @@
   }
 
   function setSelected() {
-    _selectedOption = _options.find(o => o.value == _values[0])  
+    _selectedOption = _options.find(o => o.value == _values[0])
   }
 
   // parse and convert values to strings to avoid later type comparison issues
@@ -263,7 +263,7 @@
 
   function onSelect(option: Option) {
     if (_disabled) return;
-  
+
     if (!_native) {
       hideMenu();
       _selectedOption = option;
@@ -315,6 +315,7 @@
   function onNativeSelect(e: Event) {
     const target = e.currentTarget as HTMLSelectElement;
     const option = _options[target.selectedIndex];
+    _isDirty = true;
     onSelect(option);
   }
 
@@ -355,7 +356,7 @@
 
     onEscape(e: KeyboardEvent) {
       reset();
-      // FIXME: on escape should allow the next tab click to move to the next element, currently 
+      // FIXME: on escape should allow the next tab click to move to the next element, currently
       // clicking tab after esc will refocus onto the Dropdown
 
       // _inputEl.focus();


### PR DESCRIPTION
# Before (the change)
Change a selection on native dropdown doesn't trigger onChange event
# After (the change)
<img width="1625" alt="image" src="https://github.com/GovAlta/ui-components/assets/120135417/e94ac501-d829-43e6-b044-830531d9ca47">

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

```
 onChangeNativeSelect(event: Event) {
    // handle change
    console.log((event as CustomEvent).detail.value);
  }
```

```
<goa-form-item label="Basic dropdown">
  <goa-dropdown native name="item" value="" (_change)="onChangeNativeSelect($event)">
    <goa-dropdown-item value="red" label="Red"></goa-dropdown-item>
    <goa-dropdown-item value="green" label="Green"></goa-dropdown-item>
    <goa-dropdown-item value="blue" label="Blue"></goa-dropdown-item>
  </goa-dropdown>
</goa-form-item>
```

