### PR TITLE
feat(#1966): radio & checkbox bottom margin

### DIFF
--- a/libs/react-components/src/lib/radio-group/radio.tsx
+++ b/libs/react-components/src/lib/radio-group/radio.tsx
@@ -1,4 +1,5 @@
-interface RadioItemProps {
+import { Margins } from "../../common/styling";
+interface RadioItemProps extends Margins {
   name?: string;
   value?: string;
   description?: string | React.ReactNode;
@@ -18,7 +19,7 @@ declare global {
   }
 }
 
-export interface GoARadioItemProps {
+export interface GoARadioItemProps extends Margins {
   value?: string;
   label?: string;
   name?: string;
@@ -42,6 +43,10 @@ export function GoARadioItem({
   testId,
   ariaLabel,
   children,
+  mt,
+  mr,
+  mb,
+  ml,
 }: GoARadioItemProps): JSX.Element {
   return (
     <goa-radio-item
@@ -54,6 +59,10 @@ export function GoARadioItem({
       checked={checked}
       data-testid={testId}
       arialabel={ariaLabel}
+      mt={mt}
+      mr={mr}
+      mb={mb}
+      ml={ml}
     >
       {description && typeof description !== "string" && <div slot="description">{description}</div>}
       {children}

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -23,7 +23,7 @@
   // margin
   export let mt: Spacing = null;
   export let mr: Spacing = null;
-  export let mb: Spacing = null;
+  export let mb: Spacing = "m";
   export let ml: Spacing = null;
 
   // Private
@@ -132,7 +132,6 @@
 
   .root {
     display: inline-block;
-    padding-bottom: var(--goa-space-m);
   }
 
   input[type="checkbox"] {

--- a/libs/web-components/src/components/radio-item/RadioItem.spec.ts
+++ b/libs/web-components/src/components/radio-item/RadioItem.spec.ts
@@ -68,6 +68,24 @@ describe("RadioItem", () => {
     expect(label.getAttribute("class")).toContain("error");
   });
 
+  it(`should render with margins`, async () => {
+    const baseElement = render(GoARadioItem, {
+      label: "Radio Item 1",
+      value: "radio-item-1",
+      name: "radio-item-1-name",
+      arialabel: "radio-item-1-label",
+      mt: "s",
+      mr: "m",
+      mb: "l",
+      ml: "xl",
+    });
+    const radio = baseElement.container.querySelector(".goa-radio-container");
+    expect(radio?.getAttribute("style")).toContain("margin-top:var(--goa-space-s)");
+    expect(radio?.getAttribute("style")).toContain("margin-right:var(--goa-space-m)");
+    expect(radio?.getAttribute("style")).toContain("margin-bottom:var(--goa-space-l)");
+    expect(radio?.getAttribute("style")).toContain("margin-left:var(--goa-space-xl)");
+  });
+
   it("should handle the change event and emit _click event", async () => {
     const mockOnChange = vi.fn();
     const result = render(GoARadioItem, {

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -30,6 +30,8 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { fromBoolean, toBoolean } from "../../common/utils";
+  import { calculateMargin } from "../../common/styling";
+  import type { Spacing } from "../../common/styling";
 
   export let value: string;
   export let name: string = "";
@@ -39,6 +41,12 @@
   export let error: string = "false";
   export let checked: string = "false";
   export let arialabel: string = "";
+
+  // margin
+  export let mt: Spacing = null;
+  export let mr: Spacing = null;
+  export let mb: Spacing = "m";
+  export let ml: Spacing = null;
 
   let _radioItemEl: HTMLElement;
   // Reactive
@@ -108,7 +116,7 @@
   }
 </script>
 
-<div class="goa-radio-container">
+<div style={calculateMargin(mt, mr, mb, ml)} class="goa-radio-container">
   <label
     bind:this={_radioItemEl}
     data-testid="radio-option-{value}"
@@ -150,10 +158,6 @@
     --goa-radio-border-width--checked: 7px;
     box-sizing: border-box;
     display: flex;
-  }
-
-  .goa-radio-container {
-    padding-bottom: 1rem;
   }
 
   .goa-radio:hover {


### PR DESCRIPTION
This PR for https://github.com/GovAlta/ui-components/issues/1966 makes the following changes:

- Adds calculated margins to the radio item
- Removes bottom padding from the checkbox and radio item
- Uses a default medium bottom margin for the checkbox and radio item

### Before

<img width="492" alt="image" src="https://github.com/GovAlta/ui-components/assets/1479091/5baf6037-a0f8-4ddb-9840-4ba9c5d041eb">

<img width="280" alt="image" src="https://github.com/GovAlta/ui-components/assets/1479091/2260d28c-1eb3-4eef-b2ab-af95b9b88d53">

### After

<img width="492" alt="image" src="https://github.com/GovAlta/ui-components/assets/1479091/b257c4cf-d35d-46e9-bbdd-567be8eac48d">

<img width="286" alt="image" src="https://github.com/GovAlta/ui-components/assets/1479091/e30b4df7-96b9-448e-bdbf-2330e7eb4d45">

