### PR TITLE
fix(#1954): prevent dropdown firing _change event  when the value is reselected

### DIFF
--- a/libs/web-components/src/components/dropdown/Dropdown.spec.ts
+++ b/libs/web-components/src/components/dropdown/Dropdown.spec.ts
@@ -121,9 +121,7 @@ describe("GoADropdown", () => {
         expect(inputField?.getAttribute("type")).toBe("text");
         expect(inputField?.getAttribute("aria-owns")).toBeNull(); // Menu is hidden
 
-        expect(dropdownIcon?.getAttribute("ariacontrols")).toBe(
-          "menu-favcolor",
-        );
+        expect(dropdownIcon?.getAttribute("ariacontrols")).toBe("menu-favcolor");
         expect(dropdownIcon?.getAttribute("ariaexpanded")).toBe("false");
         expect(dropdownIcon?.getAttribute("arialabel")).toBe("favcolor");
         expect(dropdownIcon?.getAttribute("role")).toBe("button");
@@ -140,9 +138,7 @@ describe("GoADropdown", () => {
         const option = result.container.querySelector("li#orange");
         expect(option).toBeTruthy();
         expect(option?.getAttribute("aria-selected")).toBe("true");
-        expect(option?.getAttribute("data-testid")).toBe(
-          "dropdown-item-orange",
-        );
+        expect(option?.getAttribute("data-testid")).toBe("dropdown-item-orange");
         expect(option?.getAttribute("data-value")).toBe("orange");
         expect(option?.getAttribute("role")).toBe("option");
         expect(option).toHaveTextContent("orange");
@@ -199,8 +195,11 @@ describe("GoADropdown", () => {
       const input = result.container.querySelector("input");
       expect(input).toBeTruthy();
 
-      input && (await fireEvent.change(input, { target: { value: "b" } }));
+      input && (await fireEvent.focus(input));
       input && (await fireEvent.keyUp(input, { key: "b", code: "b" }));
+      input && (await fireEvent.input(input, { target: { value: "b" } }));
+
+      expect(input?.value).toBe("b");
 
       await waitFor(async () => {
         // When type in the input, will open the suggestion
@@ -260,9 +259,7 @@ describe("GoADropdown", () => {
                 "dropdown-item-not-found",
               );
             } else {
-              expect(liElements[0].getAttribute("data-value")).toBe(
-                expectedOption,
-              );
+              expect(liElements[0].getAttribute("data-value")).toBe(expectedOption);
             }
           });
         },
@@ -276,9 +273,7 @@ describe("GoADropdown", () => {
       expect(button).toBeTruthy();
       button && (await fireEvent.click(button));
       await waitFor(async () => {
-        const selected = result.container.querySelector(
-          "li[aria-selected=true]",
-        );
+        const selected = result.container.querySelector("li[aria-selected=true]");
         expect(selected).not.toBeNull();
         expect(selected?.innerHTML).toContain("orange");
       });
@@ -398,9 +393,7 @@ describe("GoADropdown", () => {
 
       // show menu
       inputField && (await fireEvent.focus(inputField));
-      const inputGroupDiv = result.container.querySelector(
-        "div.dropdown-input-group",
-      );
+      const inputGroupDiv = result.container.querySelector("div.dropdown-input-group");
       expect(inputGroupDiv?.getAttribute("class")).not.toContain("error");
     });
 
@@ -418,9 +411,7 @@ describe("GoADropdown", () => {
 
       // show menu
       inputField && (await fireEvent.focus(inputField));
-      const inputGroupDiv = result.container.querySelector(
-        "div.dropdown-input-group",
-      );
+      const inputGroupDiv = result.container.querySelector("div.dropdown-input-group");
       expect(inputGroupDiv?.getAttribute("class")).toContain("error");
     });
   });
@@ -725,9 +716,7 @@ describe("GoADropdown", () => {
         native: true,
         items,
       });
-      expect(container?.querySelector("select")?.getAttribute("id")).toBe(
-        "favcolor",
-      );
+      expect(container?.querySelector("select")?.getAttribute("id")).toBe("favcolor");
       await waitFor(() => {
         const options = container.querySelectorAll("select option");
         expect(options.length).toBe(3);
@@ -863,6 +852,84 @@ describe("GoADropdown", () => {
       await waitFor(() => {
         const children = container.querySelectorAll("li");
         expect(children.length).toBe(1);
+      });
+    });
+  });
+
+  it("should not fire an event if a new value is selected by the keyboard that is the same as the previous value", async () => {
+    const result = render(GoADropdownWrapper, { name, items });
+    const onClick = vi.fn();
+    const dropdown = result.queryByTestId("favcolor-dropdown");
+    const dropdownIcon = result.container.querySelector("goa-icon");
+
+    await waitFor(async () => {
+      expect(dropdown).toBeTruthy();
+
+      dropdown?.addEventListener("_change", (e: Event) => {
+        const ce = e as CustomEvent;
+        console.log("in the onclick");
+        onClick(ce.detail.name, ce.detail.value);
+      });
+
+      // open menu
+      dropdownIcon && (await fireEvent.click(dropdownIcon));
+
+      // select the orange value, event should be dispatched
+      await waitFor(async () => {
+        const option = result.queryByTestId("dropdown-item-orange");
+        option && (await fireEvent.click(option));
+        expect(onClick).toBeCalledTimes(1);
+      });
+
+      onClick.mockClear();
+
+      // reselect the orange value, no event should be dispatched
+      await waitFor(async () => {
+        const option = result.queryByTestId("dropdown-item-orange");
+        option && (await fireEvent.click(option));
+        expect(onClick).not.toBeCalled();
+      });
+    });
+  });
+
+  it("should fire an event when clearing the filter value", async () => {
+    const result = render(GoADropdownWrapper, {
+      name,
+      items,
+      filterable: true,
+    });
+
+    const onClick = vi.fn();
+    const dropdown = result.queryByTestId("favcolor-dropdown");
+    const dropdownIcon = result.container.querySelector("goa-icon");
+
+    await waitFor(async () => {
+      expect(dropdown).toBeTruthy();
+
+      dropdown?.addEventListener("_change", (e: Event) => {
+        const ce = e as CustomEvent;
+        onClick(ce.detail.name, ce.detail.value);
+      });
+
+      // open menu
+      dropdownIcon && (await fireEvent.click(dropdownIcon));
+
+      // select the orange value, event should be dispatched
+      const option = result.queryByTestId("dropdown-item-orange");
+      expect(option).toBeTruthy();
+      option && (await fireEvent.click(option));
+      await waitFor(async () => {
+        expect(onClick).toBeCalledWith(name, "orange");
+      });
+
+      onClick.mockClear();
+
+      // reselect the orange value, no event should be dispatched
+      const clearIcon = result.queryByTestId("clear-icon");
+      expect(clearIcon).toBeTruthy();
+      clearIcon && (await fireEvent.click(clearIcon));
+      await waitFor(async () => {
+        expect(onClick).toBeCalledWith(name, "");
       });
     });
   });

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -19,7 +19,7 @@
   export let name: string;
   export let arialabel: string = "";
   export let arialabelledby: string = "";
-  export let value: string = "";
+  export let value: string | undefined = "";
   export let filterable: string = "false";
   export let leadingicon: GoAIconType | null = null;
   export let maxheight: string = "276px";
@@ -73,7 +73,7 @@
     : undefined;
 
   $: {
-    _values = parseValues(value);
+    _values = parseValues(value || "");
     setSelected();
   }
 
@@ -201,7 +201,7 @@
 
   function syncFilteredOptions() {
     _filteredOptions = _filterable
-      ? _options.filter((option) => isFilterMatch(option, _inputEl?.value ?? ""))
+      ? _options.filter((option) => isFilterMatch(option, _inputEl?.value || ""))
       : _options;
   }
 
@@ -232,13 +232,21 @@
     return value.startsWith(filter) || value.includes(" " + filter);
   }
 
-  function dispatchValue(value?: string) {
+  // update the value show to the user in the <input> element
+  function setDisplayedValue() {
+    _inputEl.value = _selectedOption?.label || _selectedOption?.value || "";
+  }
+
+  function dispatchValue(newValue?: string) {
     const detail = _multiselect
-      ? { name, values: [value, ..._values] }
-      : { name, value: value };
+      ? { name, values: [newValue, ..._values] }
+      : { name, value: newValue };
+
+    if (!_isDirty) {
+      return;  
+    }
 
     setTimeout(() => {
-      if (!_isDirty) return;
       _rootEl?.dispatchEvent(
         new CustomEvent("_change", { composed: true, detail }),
       );
@@ -253,37 +261,49 @@
   function onSelect(option: Option) {
     if (_disabled) return;
 
+    _isDirty = option.value !== _selectedOption?.value;
+    _selectedOption = option;
+  
     if (!_native) {
       hideMenu();
-      _selectedOption = option;
       syncFilteredOptions();
+      setDisplayedValue();
     }
     dispatchValue(option.value);
   }
 
-  /**
-   * When website autofill value without user keyboard
-   */
-  async function onChange() {
+  // Fires when on blur and changes have been made AND when the browser auto-fill is performed
+  async function onChange(_e: Event) {
+    if (!_filterable) return;
+
     await tick();
     syncFilteredOptions();
+
     if (_filteredOptions.length === 1) {
       const option = _filteredOptions[0];
-      dispatchValue(option.value);
       _selectedOption = option;
+      dispatchValue(option.value);
+      setDisplayedValue();
       setTimeout(() => {
         hideMenu();
-      }, 100);
-    }
+      }, 10);
+
+    } else {
+      _selectedOption = undefined;
+      setDisplayedValue();
+      dispatchValue("");
+    }  
   }
 
   function onInputKeyUp(e: KeyboardEvent) {
     if (_disabled) return;
+    _isDirty = true
     _eventHandler.handleKeyUp(e);
   }
 
   function onInputKeyDown(e: KeyboardEvent) {
     if (_disabled) return;
+    _isDirty = true
     _eventHandler.handleKeyDown(e);
   }
 
@@ -314,10 +334,11 @@
     _activeDescendantId = undefined;
     _highlightedIndex = -1;
     _selectedOption = undefined;
-    _isDirty = false;
-    syncFilteredOptions();
+    _isDirty = true;
 
+    syncFilteredOptions();
     dispatchValue("");
+    setDisplayedValue();
   }
 
   async function onChevronClick(e: Event) {
@@ -327,23 +348,9 @@
   }
 
   class ComboboxKeyUpHandler implements EventHandler {
-    constructor(private input: HTMLInputElement) {
-      input.addEventListener("blur", async (e) => {
-        if (!_filterable) return;
+    constructor(private input: HTMLInputElement) { }
 
-        const input = e.target as HTMLInputElement;
-        const selectedOption = _filteredOptions.find(
-          (o) => o.label === input.value,
-        );
-
-        if (!selectedOption) {
-          dispatchValue("");
-          input.value = "";
-        }
-      });
-    }
-
-    onEscape(e: KeyboardEvent) {
+    onEscape(_e: KeyboardEvent) {
       reset();
       // FIXME: on escape should allow the next tab click to move to the next element, currently
       // clicking tab after esc will refocus onto the Dropdown
@@ -356,7 +363,7 @@
     onEnter(e: KeyboardEvent) {
       const option = _filteredOptions[_highlightedIndex];
       if (option) {
-        _isDirty = true;
+        _isDirty = option.value !== _selectedOption?.value;
         onSelect(option);
       }
 
@@ -371,6 +378,7 @@
 
     onArrow(e: KeyboardEvent, direction: "up" | "down") {
       if (!_isMenuVisible) showMenu();
+
       changeHighlightedOption(direction === "up" ? -1 : 1);
       e.stopPropagation();
     }
@@ -378,17 +386,18 @@
     onTab(_: KeyboardEvent) {
       const matchedOption = _filteredOptions.find(
         (option) =>
-          option.label.toLowerCase() === this.input.value.toLowerCase(),
+          option.label?.toLowerCase() === this.input.value.toLowerCase(),
       );
+
       if (matchedOption) {
         onSelect(matchedOption);
       }
+
       hideMenu();
     }
 
     onKeyUp(_: KeyboardEvent) {
       showMenu();
-      _isDirty = true;
     }
 
     handleKeyUp(e: KeyboardEvent) {
@@ -550,11 +559,11 @@
 
         <input
           style={`
-              cursor: ${!_disabled ? (_filterable ? "auto" : "pointer") : "default"};
-            `}
+            cursor: ${!_disabled ? (_filterable ? "auto" : "pointer") : "default"};
+          `}
           data-testid="input"
           bind:this={_inputEl}
-          value={_selectedOption?.label ?? _selectedOption?.value ?? ""}
+          value={_selectedOption?.label || _selectedOption?.value || ""}
           type="text"
           role="combobox"
           autocomplete="off"
@@ -580,6 +589,7 @@
         {#if _inputEl?.value && _filterable}
           <goa-icon
             id={name}
+            data-testid="clear-icon"
             tabindex={_disabled ? -1 : 0}
             role="button"
             arialabel={`clear ${arialabel || name}`}


### PR DESCRIPTION
# Before (the change)
https://jam.dev/c/9a8ae231-c3d9-4762-bff1-34ee4c03efe8

# After (the change)
https://jam.dev/c/8db31b77-a73a-4fe8-9c69-c0ede712b240

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

- [ ] For non-filterable dropdown validate that when selecting the same value repeatedly, that events are only fired the first time.
- [ ] For the filterable dropdown validate that the when clearing the selection that events are fired with a blank value and that an event is fired when you delete the filter text and Tab away
