### PR TITLE
fix(#1395): eliminate duplicate events being fired on formstep change

### DIFF
--- a/libs/web-components/src/components/form-step/FormStep.svelte
+++ b/libs/web-components/src/components/form-step/FormStep.svelte
@@ -42,22 +42,8 @@
   // ========
 
   $: _isEnabled = enabled || status === "complete";
-
+  
   onMount(() => {
-    // handle click events
-    _rootEl.addEventListener("click", () => {
-      if (!_isEnabled) return;
-
-      _checkbox.checked = !_checkbox.checked;
-      _rootEl.dispatchEvent(
-        new CustomEvent("_click", {
-          composed: true,
-          bubbles: true,
-          detail: { step: +childindex },
-        }),
-      );
-    });
-
     // receive notification from parent of resize
     _rootEl.addEventListener("form-stepper:resized", (e: Event) => {
       const { mobile } = (e as CustomEvent).detail;
@@ -104,6 +90,20 @@
       );
     }, 10);
   }
+
+  function onClick(e: Event) {
+    if (!_isEnabled) return;
+
+    _checkbox.checked = !_checkbox.checked;
+    _rootEl.dispatchEvent(
+      new CustomEvent("_click", {
+        composed: true,
+        bubbles: true,
+        detail: { step: +childindex },
+      }),
+    );
+    e.stopPropagation();
+  }
 </script>
 
 <label
@@ -127,6 +127,7 @@
     aria-disabled={!_isEnabled}
     disabled={!_isEnabled}
     data-testid="checkbox"
+    on:click={onClick}
   />
   <div data-testid="status" class="status">
     {#if current}

--- a/libs/web-components/src/components/form-step/form-step.spec.ts
+++ b/libs/web-components/src/components/form-step/form-step.spec.ts
@@ -1,155 +1,172 @@
-import FormStep from './FormStep.svelte'
-import { fireEvent, render, waitFor } from '@testing-library/svelte'
-import { tick } from 'svelte';
+import FormStep from "./FormStep.svelte";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { describe, it, expect, vi } from "vitest";
 
 describe("FormStep", () => {
+  it("it renders the default step", async () => {
+    const { queryByTestId } = render(FormStep, { text: "Some text" });
+    const rootEl = queryByTestId("label");
 
-  it('it renders the default step', async () => {
-    const { queryByTestId } = render(FormStep, { text: "Some text" })
-    const rootEl = queryByTestId("label")
-
-    rootEl?.dispatchEvent(new CustomEvent("formstepper:init", {
-      detail: {
-        ariaLabel: "some label",
-        enabled: true,
-        childIndex: 1,
-        current: false,
-      }
-    }))
+    rootEl?.dispatchEvent(
+      new CustomEvent("formstepper:init", {
+        detail: {
+          ariaLabel: "some label",
+          enabled: true,
+          childIndex: 1,
+          current: false,
+        },
+      }),
+    );
 
     await waitFor(() => {
-      expect(queryByTestId("text")?.innerHTML).toContain("Some text")
+      expect(queryByTestId("text")?.innerHTML).toContain("Some text");
       expect(queryByTestId("step-number")?.innerHTML).toBe("1");
-    })
-  })
+    });
+  });
 
   it("requires a text value", async () => {
-    const mock = vi.spyOn(console, "warn").mockImplementation(() => { /* do nothing */ });
-    render(FormStep, { /* no text */ })
+    const mock = vi.spyOn(console, "warn").mockImplementation(() => {
+      /* do nothing */
+    });
+    render(FormStep, {
+      /* no text */
+    });
 
     // 1 warning
     await waitFor(() => {
       expect(console.warn["mock"].calls.length).toBe(1);
     });
     mock.mockRestore();
-  })
+  });
 
   it("emits a _click event", async () => {
-    const click = vi.fn()
-    const el = render(FormStep, { text: "Some form" })
+    const click = vi.fn();
+    const el = render(FormStep, { text: "Some form" });
     const rootEl = el.queryByTestId("label");
 
-    rootEl?.dispatchEvent(new CustomEvent("formstepper:init", {
-      detail: {
-        ariaLabel: "some label",
-        enabled: true,
-        childIndex: 1,
-        current: false,
-      }
-    }))
+    rootEl?.dispatchEvent(
+      new CustomEvent("formstepper:init", {
+        detail: {
+          ariaLabel: "some label",
+          enabled: true,
+          childIndex: 1,
+          current: false,
+        },
+      }),
+    );
 
     await tick();
-    el.container.addEventListener("_click", click)
-    rootEl && await fireEvent.click(rootEl)
+    el.container.addEventListener("_click", click);
+    rootEl && (await fireEvent.click(rootEl));
 
     await waitFor(() => {
-      expect(click).toBeCalled()
-    })
-  })
+      expect(click).toHaveBeenCalledOnce();
+    });
+  });
 
   it("won't emit event when clicked if disabled", async () => {
-    const click = vi.fn()
-    const el = render(FormStep, { text: "Some form" })
+    const click = vi.fn();
+    const el = render(FormStep, { text: "Some form" });
     const rootEl = el.queryByTestId("label");
 
-    rootEl?.dispatchEvent(new CustomEvent("formstepper:init", {
-      detail: {
-        ariaLabel: "some label",
-        enabled: false,
-        childIndex: 1,
-        current: false,
-      }
-    }))
+    rootEl?.dispatchEvent(
+      new CustomEvent("formstepper:init", {
+        detail: {
+          ariaLabel: "some label",
+          enabled: false,
+          childIndex: 1,
+          current: false,
+        },
+      }),
+    );
 
-    el.container?.addEventListener("_click", click)
+    el.container?.addEventListener("_click", click);
     await tick();
-    rootEl && await fireEvent.click(rootEl)
+    rootEl && (await fireEvent.click(rootEl));
 
-    expect(click).not.toBeCalled()
-  })
+    expect(click).not.toBeCalled();
+  });
 
   it("renders a current status", async () => {
-    const el = render(FormStep, { text: "Some form" })
+    const el = render(FormStep, { text: "Some form" });
     const rootEl = el.queryByTestId("label");
 
-    rootEl?.dispatchEvent(new CustomEvent("formstepper:init", {
-      detail: {
-        ariaLabel: "some label",
-        enabled: true,
-        childIndex: 1,
-        current: true,
-      }
-    }))
+    rootEl?.dispatchEvent(
+      new CustomEvent("formstepper:init", {
+        detail: {
+          ariaLabel: "some label",
+          enabled: true,
+          childIndex: 1,
+          current: true,
+        },
+      }),
+    );
 
     await tick();
-    expect(rootEl?.getAttribute("aria-current")).toBe("step")
-  })
+    expect(rootEl?.getAttribute("aria-current")).toBe("step");
+  });
 
   it("renders a complete status", async () => {
-    const el = render(FormStep, { text: "Some form" })
+    const el = render(FormStep, { text: "Some form" });
     const rootEl = el.queryByTestId("label");
 
-    rootEl?.dispatchEvent(new CustomEvent("formstepper:init", {
-      detail: {
-        ariaLabel: "some label",
-        enabled: true,
-        childIndex: 1,
-        current: false,
-        status: "complete",
-      }
-    }))
+    rootEl?.dispatchEvent(
+      new CustomEvent("formstepper:init", {
+        detail: {
+          ariaLabel: "some label",
+          enabled: true,
+          childIndex: 1,
+          current: false,
+          status: "complete",
+        },
+      }),
+    );
 
     await tick();
-    expect(rootEl?.dataset["status"]).toBe("complete")
-  })
+    expect(rootEl?.dataset["status"]).toBe("complete");
+  });
 
   it("renders an incomplete status", async () => {
-    const el = render(FormStep, { text: "Some form", status: "incomplete" })
+    const el = render(FormStep, { text: "Some form", status: "incomplete" });
     const rootEl = el.queryByTestId("label");
 
-    rootEl?.dispatchEvent(new CustomEvent("formstepper:init", {
-      detail: {
-        ariaLabel: "some label",
-        enabled: true,
-        childIndex: 1,
-        current: false,
-        status: "incomplete",
-      }
-    }))
+    rootEl?.dispatchEvent(
+      new CustomEvent("formstepper:init", {
+        detail: {
+          ariaLabel: "some label",
+          enabled: true,
+          childIndex: 1,
+          current: false,
+          status: "incomplete",
+        },
+      }),
+    );
 
     await tick();
 
-    expect(rootEl?.dataset["status"]).toBe("incomplete")
-  })
+    expect(rootEl?.dataset["status"]).toBe("incomplete");
+  });
 
   it("renders the aria label", async () => {
     const { queryByTestId } = render(FormStep, {
       text: "Some form",
     });
-    const rootEl = queryByTestId("label")
+    const rootEl = queryByTestId("label");
 
-    rootEl?.dispatchEvent(new CustomEvent("formstepper:init", {
-      detail: {
-        ariaLabel: "1 of 4",
-        enabled: true,
-        childIndex: 1,
-        current: true,
-      }
-    }))
+    rootEl?.dispatchEvent(
+      new CustomEvent("formstepper:init", {
+        detail: {
+          ariaLabel: "1 of 4",
+          enabled: true,
+          childIndex: 1,
+          current: true,
+        },
+      }),
+    );
 
     await tick();
-    const label = rootEl?.getAttribute("aria-label")
-    expect(label).toContain("1 of 4")
-  })
-})
+    const label = rootEl?.getAttribute("aria-label");
+    expect(label).toContain("1 of 4");
+  });
+});


### PR DESCRIPTION
# Before (the change)

Fired events twice on each form step change

# After (the change)

Event is only fired once

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use steps in reported issue.
