### PR TITLE
fix(#1737): textarea to show 0 characters remaining

### DIFF
--- a/libs/web-components/src/components/text-area/TextArea.spec.ts
+++ b/libs/web-components/src/components/text-area/TextArea.spec.ts
@@ -72,7 +72,6 @@ describe("GoATextArea", () => {
       expect(onKeyPress).toBeCalledTimes(1);
       expect(onChange).toBeCalledTimes(1);
     });
-
   });
 
   it("can be disabled", async () => {
@@ -166,6 +165,17 @@ describe("GoATextArea", () => {
       expect(counterEl.innerHTML).toContain("7 characters too many");
     });
 
+    it("shows zero characters remaining", async () => {
+      const { container } = render(GoATextArea, {
+        name: "test-name",
+        value: "Jim is super funny",
+        countby: "character",
+        maxcount: "18",
+      });
+      const counterEl = container.querySelector(".counter");
+      expect(counterEl.innerHTML).toContain("0 characters remaining");
+    });
+
     it("shows the number of words remaining", async () => {
       const { container } = render(GoATextArea, {
         name: "test-name",
@@ -186,6 +196,17 @@ describe("GoATextArea", () => {
       });
       const counterEl = container.querySelector(".counter");
       expect(counterEl.innerHTML).toContain("1 word too many");
+    });
+
+    it("shows zero words remaining", async () => {
+      const { container } = render(GoATextArea, {
+        name: "test-name",
+        value: "Jim is super funny",
+        countby: "word",
+        maxcount: "4",
+      });
+      const counterEl = container.querySelector(".counter");
+      expect(counterEl.innerHTML).toContain("0 words remaining");
     });
 
     it("shows the count in an error state when the char count exceeds the max value allowed", async () => {

--- a/libs/web-components/src/components/text-area/TextArea.svelte
+++ b/libs/web-components/src/components/text-area/TextArea.svelte
@@ -102,7 +102,7 @@
       <div class="counter" class:counter-error={count > maxcount}>
         {#if countby && count > maxcount}
           {count - maxcount} {pluralize(countby, count - maxcount)} too many
-        {:else if countby && count < maxcount}
+        {:else if countby && count <= maxcount}
           {maxcount - count} {pluralize(countby, maxcount - count)} remaining
         {/if}
       </div>


### PR DESCRIPTION
# Before (the change)
Textarea doesnt show '0 characters remaining'

# After (the change)
Textarea does show '0 characters remaining'
![image](https://github.com/GovAlta/ui-components/assets/47701214/e48616d9-148c-46f4-a817-5080243d3839)

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
