### PR TITLE
fix(#1680): fix paginaton issue when page count is changed

### DIFF
--- a/libs/web-components/src/components/pagination/Pagination.svelte
+++ b/libs/web-components/src/components/pagination/Pagination.svelte
@@ -27,6 +27,11 @@
   // reactive
 
   $: _pageCount = Math.ceil(itemcount / perpagecount);
+  $: if (_pageCount) {
+    tick().then(() => {
+      setupPageDropdownListener();
+    });
+  }
 
   // private
 
@@ -39,25 +44,7 @@
     await tick();
     validateRequired("GoAPagination", { itemcount, pagenumber });
     validateVariant(variant);
-
-    // prevent event propagation
-    if (!pageDropdownEl) {
-      console.error("Missing pageDropdownEl");
-      return;
-    }
-    pageDropdownEl?.addEventListener("_change", (e: Event) => {
-      const ce = e as CustomEvent;
-      const page = Number.parseInt(ce.detail.value);
-      e.stopPropagation();
-
-      hiddenEl.dispatchEvent(
-        new CustomEvent("_change", {
-          composed: true,
-          bubbles: true,
-          detail: { page },
-        }),
-      );
-    });
+    setupPageDropdownListener();
   });
 
   // functions
@@ -76,6 +63,25 @@
     }
     e.preventDefault();
   }
+
+  function setupPageDropdownListener() {
+    if (!pageDropdownEl) {
+      console.error("Missing pageDropdownEl");
+      return;
+    }
+    pageDropdownEl.addEventListener("_change", (e: Event) => {
+      const ce = e as CustomEvent;
+      const page = Number.parseInt(ce.detail.value);
+      e.stopPropagation();
+      hiddenEl.dispatchEvent(
+        new CustomEvent("_change", {
+          composed: true,
+          bubbles: true,
+          detail: { page },
+        }),
+      );
+    });
+  }
 </script>
 
 <goa-block id="root" {ml} {mr} {mb} {mt}>
@@ -84,11 +90,13 @@
       <goa-block data-testid="page-selector" alignment="center" gap="s">
         <span>Page</span>
         <input bind:this={hiddenEl} type="hidden" />
-        <goa-dropdown bind:this={pageDropdownEl} value={pagenumber}>
-          {#each { length: _pageCount } as _, i}
-            <goa-dropdown-item value={i + 1} label={i + 1} />
-          {/each}
-        </goa-dropdown>
+        {#key _pageCount}
+          <goa-dropdown bind:this={pageDropdownEl} value={pagenumber}>
+            {#each { length: _pageCount } as _, i}
+              <goa-dropdown-item value={i + 1} label={i + 1} />
+            {/each}
+          </goa-dropdown>
+        {/key}
         <span>of {_pageCount}</span>
       </goa-block>
     {/if}


### PR DESCRIPTION
Associated docs PR https://github.com/GovAlta/ui-components-docs/pull/194 
# Before (the change)

### Steps to reproduce the bug
Copy paste the code from the comment below, in your Angular playground.

Scenario 1- Change the 'Show X of N' dropdown from 10 to 30
Bug: The 'Page 1 of N' dropdown still contains the range of 1 - 10. 
It should have been 1-4 only b/c 100 divided by 30 is 4 pages

Scenario 2- Now, change the 'Show X of N' dropdown from 30 to 20
Bug: The 'Page 1 of N' dropdown now shows 1 - 10 ...plus a new entry '5'...so a total of 11 items. 
It should have been 1-5 only.


# After (the change)
The` {#key _pageCount}` rebinds the dropdown whenever the _pageCount is updated taking care of both the bugs mentioned above. With this change, the values in the dropdown are accurate.

Scneario 1 now contains 1,2,3,4 
Scenario 2 now contains 1,2,3,4,5

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
