### PR TITLE
fix/1802: filter dropdown has popover wrong position

### DIFF
--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -196,6 +196,8 @@
       _popoverEl.style.top = _relative
         ? `${-popoverRect.height}px`
         : `${targetRect.y - popoverRect.height + window.scrollY}px`;
+    } else {
+      _popoverEl.style.top = ''; // In case this is triggered by _sectionHeight is changed
     }
 
     // Move the popover to the left if it is too far to the right and only if there is space to the left


### PR DESCRIPTION
# Before (the change)
https://jam.dev/c/562fbffa-d1b1-4a66-8ff4-6c01f3562d08

# After (the change)
https://jam.dev/c/6e547bb3-f60c-4ae9-9998-975c0799c836
## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
Just make the window short, to make sure the option list of dropdown is on the top position. 