### PR TITLE
fix(#1716): Removed '.' from default file upload text

### DIFF
--- a/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
+++ b/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
@@ -200,7 +200,7 @@
 
     {#if maxfilesize}
       <em class="max-file-size" data-testid="max-file-size"
-        >Maximum file size is {maxfilesize}.</em
+        >Maximum file size is {maxfilesize}</em
       >
     {/if}
 
@@ -223,7 +223,7 @@
 
     {#if maxfilesize}
       <em class="max-file-size" data-testid="max-file-size">
-        Maximum file size is {maxfilesize}.
+        Maximum file size is {maxfilesize}
       </em>
     {/if}
   </div>


### PR DESCRIPTION
# Before (the change)

Text in File Upload Card will say "Maximum file size is `x`."

# After (the change)

Text in File Upload Card will say "Maximum file size is 'x'"

Note the missing "." at the end.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Just use a File Upload Card
