### PR TITLE
fix(#1974): fix radio reset angular issue

### DIFF
--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -39,10 +39,13 @@
   // Reactive
 
   $: isDisabled = toBoolean(disabled);
-  $: value && setCurrentSelectedOption(value);
+
+  // call the method when 'value' is null, except when undefined.
+  $: value !== undefined && setCurrentSelectedOption(value);
+
   $: {
     isError = toBoolean(error);
-    bindOptions()
+    bindOptions();
   }
 
   // Private


### PR DESCRIPTION
# Before (the change)
![Issue-1974-before](https://github.com/user-attachments/assets/d6c95dec-deb6-4e28-9f22-645be0430dd5)

When reset is clicked, the radio item remained selected although the form values were reset.

# After (the change)
Issue is fixed. See sample angular code below for testing.

An alternate solution (BUT **NOT A PREFERRED** SOLUTION) would be like below where we introduce a reset method in the svelte comp, and call it explicitly from angular.
```
Svelte
export function reset() {
    setCurrentSelectedOption("");
  }

Angular
<goa-radio-group #radioGroup goaValue formControlName="radioFormCtrl">

@ViewChild("radioGroup") radioGroup!: ElementRef; 
this.radioGroup.nativeElement.reset();
```

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

### Angular Code
Copy paste the code below in your angular playground for testing. 

**html** 
```
<form [formGroup]="testForm">
 <goa-form-item label="Input Test" mb="l">
  <goa-input goaValue formControlName="inputFormCtrl" />
</goa-form-item>
<goa-form-item label="Radio Test" mb="l">
<goa-radio-group goaValue formControlName="radioFormCtrl">
  <goa-radio-item value="1" label="Label 1"></goa-radio-item>
  <goa-radio-item value="2" label="Label 2"></goa-radio-item>
  <goa-radio-item value="3" label="Label 3"></goa-radio-item>
</goa-radio-group>
</goa-form-item>
</form>

<br />
<goa-button (_click)="resetForm()">Reset Form</goa-button>

<div>
  <h3>Form Values:</h3>
  <pre>{{ testForm.value | json }}</pre>
</div>
```

**ts**
```
import { Component, ElementRef, ViewChild } from "@angular/core";
import { FormBuilder, FormGroup, Validators } from "@angular/forms";

@Component({
  selector: "abgov-radio",
  templateUrl: "./radio.component.html",
  styleUrls: ["./radio.component.css"],
})
export class RadioComponent {
  testForm: FormGroup;

  constructor(private fb: FormBuilder) {
    this.testForm = this.fb.group({
      inputFormCtrl: ["", Validators.required],
      radioFormCtrl: [""],
    });
  }

  resetForm() {
    //this.testForm.controls["radioFormCtrl"].reset();
    this.testForm.reset();
  }
}
```