### PR TITLE
fix(#1530): table bottom align headers

### DIFF
--- a/libs/web-components/src/assets/css/components.css
+++ b/libs/web-components/src/assets/css/components.css
@@ -57,15 +57,11 @@ goa-table[variant="relaxed"] td {
 goa-table thead th {
   background-color: var(--goa-color-greyscale-white);
   color: var(--goa-color-text-secondary);
-  padding: 1rem;
+  padding: var(--goa-space-s) var(--goa-table-header-padding, var(--goa-space-m)) var(--goa-space-xs) var(--goa-table-header-padding, var(--goa-space-m));
   text-align: left;
   border-bottom: 2px solid var(--goa-color-greyscale-600);
   vertical-align: bottom;
-}
-
-goa-table th:has(goa-table-sort-header) {
-  padding: 0;
-}
+  }
 
 .goa-table-number-column {
   font: var(--goa-typography-number-m);
@@ -74,6 +70,10 @@ goa-table th:has(goa-table-sort-header) {
 
 .goa-table-number-header {
   text-align: right;
+}
+
+.goa-table-number-header:not(:has(goa-table-sort-header)) {
+  padding-bottom: 0.5rem;
 }
 
 goa-table tfoot td {

--- a/libs/web-components/src/components/table/TableSortHeader.svelte
+++ b/libs/web-components/src/components/table/TableSortHeader.svelte
@@ -14,9 +14,13 @@
     if (_rootEl) {
       // Add styling if an ancestor has a class to style number columns,
       const hostEl = _rootEl.getRootNode().host;
+      const parentThead = hostEl?.closest("th");
+      parentThead?.style.setProperty("--goa-table-header-padding", "0");
+
       const ancestor = hostEl?.closest("th.goa-table-number-header");
       if (ancestor) {
         _rootEl.style.setProperty("--header-text-align", "flex-end");
+        _rootEl.style.setProperty("--header-align", "right");
       }
     }
   });
@@ -55,7 +59,8 @@
     padding: 0 1rem;
     justify-content: var(--header-text-align, flex-start);
     gap: 0.25rem;
-    align-items: center;
+    align-items: flex-end;
+    text-align: var(--header-align, left);
   }
 
   /* User set classes */


### PR DESCRIPTION
# Before (the change)

# After (the change)
-Table headers are bottom aligned, 
-Text headers are left aligned
-Headers `<th>` having `class="goa-table-number-header"` like below are **right** aligned (example below)
```
<th class="goa-table-number-header">Reg Column</th>
<th class="goa-table-number-header">
   <goa-table-sort-header name="age" direction="asc">Sortable Column</goa-table-sort-header>
</th>
```


## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
