### PR TITLE
fix(#1147): fix checkbox visual design issues

### DIFF
--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -189,16 +189,7 @@
     flex: 0 0 auto;
   }
   .container:hover {
-    box-shadow: 0 0 0 var(--goa-border-width-m) var(--goa-color-interactive-hover);
-    border: var(--goa-border-width-s) solid var(--goa-color-greyscale-700);
-  }
-  .container:focus-visible,
-  .container:active {
-    border: var(--goa-border-width-s) solid var(--goa-color-greyscale-700);
-    outline: none;
-  }
-  .container:focus-within:has(:focus-visible) {
-    box-shadow: 0 0 0 3px var(--goa-color-interactive-focus);
+    box-shadow: inset 0 0 0 var(--goa-border-width-m) var(--goa-color-interactive-hover);
   }
   .container svg {
     fill: var(--goa-color-greyscale-white);
@@ -215,17 +206,19 @@
 
   /* Error Container */
   .error .container,
-  .error .container:hover,
-  .error .container:focus-within {
+  .error .container:hover {
+    border: var(--goa-border-width-m) solid var(--goa-color-interactive-error);
     background-color: var(--goa-color-greyscale-white);
-    border: var(--goa-border-width-s) solid var(--goa-color-emergency-default);
-    box-shadow: inset 0 0 0 1px var(--goa-color-emergency-default);
-  }
-  .error .container:focus-within {
-    box-shadow: 0 0 0 3px var(--goa-color-interactive-focus);
+    box-shadow: none;
   }
   .error .container svg {
-    fill: var(--goa-color-emergency-default);
+    fill: var(--goa-color-interactive-error);
+  }
+
+  /* Focus Container */
+  .container:has(:focus-visible) {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--goa-color-interactive-focus);
   }
 
   /* Disabled */
@@ -233,22 +226,19 @@
     cursor: default;
   }
   .disabled .text {
-    opacity: 40%;
+    color: var(--goa-color-greyscale-500);
   }
   /* override base settings */
-  .disabled .container,
-  .disabled .container:hover {
+  .disabled:not(.error) .container {
     border: var(--goa-border-width-s) solid var(--goa-color-greyscale-400);
     box-shadow: none;
-    opacity: 40%;
   }
-  .disabled .container.selected,
-  .disabled .container.selected:hover {
+  .disabled:not(.error) .container.selected {
     border: none;
-    background-color: var(--goa-color-interactive-default);
+    background-color: var(--goa-color-interactive-disabled);
   }
   .disabled.error .container.selected {
-    border: var(--goa-border-width-s) solid var(--goa-color-emergency-default);
-    box-shadow: inset 0 0 0 1px var(--goa-color-emergency-default);
+    border: var(--goa-border-width-s) solid var(--goa-color-interactive-error);
+    box-shadow: inset 0 0 0 1px var(--goa-color-interactive-error);
   }
 </style>


### PR DESCRIPTION
This PR addresses #1147 with the following changes to the checkbox component:

When the checkbox is unselected...
- Hover:  Box uses an inner border
- Disabled: Label colour is `grey-500`
- Error: Box border colour is `interactive-error`

When the checkbox is selected...
- Hover:  Box uses an inner border
- Disabled:
  - Label colour is `grey-500`
  - Box colour is `interactive-disabled`
- Disabled & Hover: Box border doesn't change colour
- Error & Hover: Box border doesn't change colour

### Note

I couldn't find a fix for the below item in the issue:

> Focus ring needs to stay applied on focused option when user clicks the option

I don't think the issue is a CSS issue. Here's what I think is happening:

![checkbox-focus-issue](https://github.com/user-attachments/assets/6e61a544-7fbe-465f-bb7f-36bd13d00007)

1. I focus on `input` using a keyboard so it has `focus-visible`.
2. I click `label` to toggle the checkbox.
3. `label` cannot receive focus so the focus changes from `input` to `body`.
4. The checkbox state changes.
5. The component code returns the focus to `input` but it's no longer `focus-visible`.

Out of curiosity, I checked the latest [Material Angular checkbox](https://material.angular.io/components/checkbox/overview). It has the same issue when you toggle the checkbox by clicking the label...

![angular-focus-issue](https://github.com/user-attachments/assets/764b195e-bcc9-41b5-9419-a866382a0d5e)

But it doesn't have the issue when you toggle by clicking the checkbox itself. 🤔 

![angular-no-focus-issue-on-box](https://github.com/user-attachments/assets/0d3d9289-c313-4ce6-99af-e9c7cb0fe546)

It's because they make the invisible `input` the size of the checkbox. Maybe we could do that with ours? 

<img width="335" alt="image" src="https://github.com/user-attachments/assets/e83ee71d-6b97-4d9e-9844-f8a954b71c79">

