### PR TITLE
chore: update textarea onchange & onkeypress params

### DIFF
--- a/libs/react-components/src/lib/textarea/textarea.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.tsx
@@ -1,4 +1,9 @@
-import { GoABTextAreaCountBy, Margins } from "@abgov/ui-components-common";
+import {
+  GoABTextAreaCountBy,
+  GoABTextAreaOnChangeDetail,
+  GoABTextAreaOnKeyPressDetail,
+  Margins,
+} from "@abgov/ui-components-common";
 import { useEffect, useRef } from "react";
 
 interface WCProps extends Margins {
@@ -40,8 +45,8 @@ export interface GoABTextAreaProps extends Margins {
   countBy?: GoABTextAreaCountBy;
   maxCount?: number;
 
-  onChange: (name: string, value: string) => void;
-  onKeyPress?: (name: string, value: string, key: string) => void;
+  onChange: (event: GoABTextAreaOnChangeDetail) => void;
+  onKeyPress?: (event: GoABTextAreaOnKeyPressDetail) => void;
 }
 
 export function GoABTextarea({
@@ -71,9 +76,10 @@ export function GoABTextarea({
       return;
     }
     const current = el.current;
-    const listener: EventListener = (e: unknown) => {
-      const { name, value } = (e as CustomEvent).detail;
-      onChange(name, value);
+    const listener: EventListener = (e: Event) => {
+      const detail = (e as CustomEvent<GoABTextAreaOnChangeDetail>).detail;
+
+      onChange(detail);
     };
 
     current.addEventListener("_change", listener);
@@ -88,8 +94,8 @@ export function GoABTextarea({
     }
     const current = el.current;
     const keypressListener = (e: unknown) => {
-      const { name, value, key } = (e as CustomEvent).detail;
-      onKeyPress?.(name, value, key);
+      const detail = (e as CustomEvent<GoABTextAreaOnKeyPressDetail>).detail;
+      onKeyPress?.(detail);
     };
 
     current.addEventListener("_keyPress", keypressListener);


### PR DESCRIPTION
# Before (the change)
Doing a quick test with our React template demo app, I recognize our TextArea `onChange` and `onKeyPress` are not using our `GoABTextArea..` interface. 

# After (the change)
Can use it now. 

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
```
<GoABFormItem label="Text area" error={errors.textarea} helpText="The text area can count the number of characters a user inputs.">
          <GoABTextArea
            width="100%" 
            name="textarea" 
            value={state.textarea} 
            error={!!errors.textarea}
            countBy="character"
            maxCount={200}
            onChange={(event: GoABTextAreaOnChangeDetail) =>
              dispatch({ type: "textarea", payload: {"textarea": event.value} })
            } 
          />
        </GoABFormItem>
```
<img width="985" alt="image" src="https://github.com/user-attachments/assets/d9e6a327-4e7a-4a16-8fa2-e3759a024f50">
