### PR TITLE
chore(#1980): add mountType to angular dropdown-item

### DIFF
--- a/libs/angular-components/src/lib/components/dropdown-item/dropdown-item.ts
+++ b/libs/angular-components/src/lib/components/dropdown-item/dropdown-item.ts
@@ -1,4 +1,5 @@
 import { CUSTOM_ELEMENTS_SCHEMA, Component, Input } from "@angular/core";
+import { GoabDropdownItemMountType } from "@abgov/ui-components-common";
 
 @Component({
   standalone: true,
@@ -10,6 +11,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, Component, Input } from "@angular/core";
       [label]="label"
       [attr.filter]="filter"
       [attr.name]="name"
+      [attr.mount]="mountType"
     >
     </goa-dropdown-item>
   `,
@@ -20,6 +22,7 @@ export class GoabDropdownItem {
   @Input() filter?: string;
   @Input() label?: string;
   @Input() name?: string;
+  @Input() mountType?: GoabDropdownItemMountType;
   @Input() testId?: string;
 }
 

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -37,6 +37,8 @@ export type GoabFileUploadOnDeleteDetail = {
   filename: string;
 }
 
+export type GoabDropdownItemMountType = "append" | "prepend" | "reset";
+
 export type GoabDropdownOnChangeDetail = {
   name?: string;
   value?: string;

--- a/libs/react-components/src/lib/dropdown/dropdown-item.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown-item.tsx
@@ -1,16 +1,15 @@
 import { useEffect } from "react";
+import { GoabDropdownItemMountType } from "@abgov/ui-components-common";
 
 interface WCProps {
   value: string;
   label?: string;
   filter?: string;
-  mount?: DropdownItemMountType;
+  mount?: GoabDropdownItemMountType;
 
   // @deprecated
   name?: string;
 }
-
-export type DropdownItemMountType = "append" | "prepend" | "reset";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -27,7 +26,7 @@ export interface GoabDropdownItemProps {
   label?: string;
   filter?: string;
   testId?: string;
-  mountType?: DropdownItemMountType;
+  mountType?: GoabDropdownItemMountType;
 
   // @deprecated
   name?: string;


### PR DESCRIPTION
# Before (the change)
React has `mountType` but `angular-components` doesn't.
# After (the change)
Angular component `goa-dropdown-item` has `mountType`

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
![image](https://github.com/user-attachments/assets/60c7c170-495f-4608-9463-dd40dfbde485)
