### PR TITLE
feat(#2080): Adding icontheme to Chip

### DIFF
--- a/libs/react-components/src/lib/chip/chip.tsx
+++ b/libs/react-components/src/lib/chip/chip.tsx
@@ -2,10 +2,12 @@ import { useEffect, useRef } from "react";
 import { Margins } from "../../common/styling";
 
 export type GoAChipVariant = "filter";
+export type GoAChipTheme = "outline" | "filled" | "sharp";
 
 interface WCProps extends Margins {
   ref: React.RefObject<HTMLElement>;
   leadingicon: string;
+  icontheme: GoAChipTheme;
   error: boolean;
   deletable: boolean;
   content: string;
@@ -25,6 +27,7 @@ export interface GoAChipProps extends Margins {
   onClick?: () => void;
   deletable?: boolean;
   leadingIcon?: string;
+  iconTheme?: GoAChipTheme;
   error?: boolean;
   content: string;
   variant?: GoAChipVariant;
@@ -33,6 +36,7 @@ export interface GoAChipProps extends Margins {
 
 export const GoAChip = ({
   leadingIcon = "",
+  iconTheme = "outline",
   deletable = false,
   error = false,
   variant,
@@ -64,6 +68,7 @@ export const GoAChip = ({
     <goa-chip
       ref={el}
       leadingicon={leadingIcon}
+      icontheme={iconTheme}
       error={error}
       deletable={deletable}
       content={content}
@@ -75,6 +80,6 @@ export const GoAChip = ({
       data-testid={testId}
     />
   );
-}
+};
 
 export default GoAChip;

--- a/libs/web-components/src/components/chip/Chip.html-data.json
+++ b/libs/web-components/src/components/chip/Chip.html-data.json
@@ -9,10 +9,27 @@
       "default": "filter"
     },
     {
-      "name": "leadingIcon",
+      "name": "leadingicon",
       "type": "string",
       "description": "Show an icon to the left of the text",
       "valueSet": "goaIconType"
+    },
+    {
+      "name": "icontheme",
+      "type": "string",
+      "description": "Styles the icon to show outline or filled",
+      "values": [
+        {
+          "name": "outline"
+        },
+        {
+          "name": "filled"
+        },
+        {
+          "name": "sharp"
+        }
+      ],
+      "default": "outline"
     },
     {
       "name": "error",

--- a/libs/web-components/src/components/chip/Chip.svelte
+++ b/libs/web-components/src/components/chip/Chip.svelte
@@ -3,7 +3,7 @@
 <!-- Script -->
 <script lang="ts">
   import { toBoolean } from "../../common/utils";
-  import type { GoAIconType } from "../icon/Icon.svelte";
+  import type { GoAIconType, IconTheme } from "../icon/Icon.svelte";
   import type { Spacing } from "../../common/styling";
   import { calculateMargin } from "../../common/styling";
 
@@ -16,6 +16,7 @@
   export let ml: Spacing = null;
 
   export let leadingicon: GoAIconType | null = null;
+  export let icontheme: IconTheme = "outline";
   export let error: string = "false";
   export let deletable: string = "false";
   export let content: string;
@@ -60,7 +61,7 @@
   on:blur={() => (_hovering = false)}
 >
   {#if leadingicon}
-    <goa-icon class="leading-icon" size="medium" type={leadingicon} />
+    <goa-icon class="leading-icon" size="medium" type={leadingicon} theme={icontheme} />
   {/if}
   <div class="text">
     {content}


### PR DESCRIPTION
# Before (the change)

No way to change the theme of the `leadingicon` in the Chip component

# After (the change)

`icontheme` property exists for Chip component, that modifies the theme of the icon included in `leadingicon`.

This can be tested with the following code:

## Angular

```html
<goa-chip leadingicon="checkmark-circle" icontheme="filled" content="Chip text"></goa-chip>
<goa-chip leadingicon="checkmark-circle" content="Chip text"></goa-chip>
```

## React

```javascript
<GoAChip leadingIcon="checkmark-circle" content="Chip text"></GoAChip>
<GoAChip
  leadingIcon="checkmark-circle"
  iconTheme="filled"
  content="Chip text"
  error
></GoAChip>
```

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.
