### PR TITLE
fix(#2079): Changed mountType value

### DIFF
--- a/libs/web-components/global.html-data.json
+++ b/libs/web-components/global.html-data.json
@@ -10,7 +10,7 @@
           "name": "prepend"
         },
         {
-          "name": "replace"
+          "name": "reset"
         }
       ]
     },

--- a/libs/web-components/src/components/dropdown/Dropdown.html-data.json
+++ b/libs/web-components/src/components/dropdown/Dropdown.html-data.json
@@ -99,12 +99,6 @@
       "description": "When true, the dropdown will be filterable. Non-native only",
       "valueSet": "boolean",
       "default": "false"
-    },
-    {
-      "name": "mount",
-      "description": "How newly added items will be added to the existing list",
-      "valueSet": "mountType",
-      "default": "append"
     }
   ],
   "references": [

--- a/libs/web-components/src/components/dropdown/DropdownItem.html-data.json
+++ b/libs/web-components/src/components/dropdown/DropdownItem.html-data.json
@@ -15,6 +15,12 @@
       "name": "filter",
       "type": "string",
       "description": "When true the dropdown will have the ability to filter options by typing into the input field."
+    },
+    {
+      "name": "mount",
+      "description": "How newly added items will be added to the existing list",
+      "valueSet": "mountType",
+      "default": "append"
     }
   ],
   "references": [


### PR DESCRIPTION
# Before (the change)

Using Angular in VSCode, the options for `mountType` were listed as "append", "prepend", and "replace"

# After (the change)

The options for `mountType` should now be listed as "append", "prepend", and "reset"

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.
