### PR TITLE
feat(#2053): allow slotted content in microsite header version

### DIFF
--- a/libs/react-components/src/lib/microsite-header/microsite-header.spec.tsx
+++ b/libs/react-components/src/lib/microsite-header/microsite-header.spec.tsx
@@ -16,10 +16,21 @@ describe("Header", () => {
     const el = document.querySelector("goa-microsite-header");
     expect(el?.getAttribute("version")).toEqual("v1.2.3");
   });
+
   it("should set self url target", () => {
     render(<GoAMicrositeHeader type="alpha" headerUrlTarget="self" feedbackUrlTarget="self" />);
     const el = document.querySelector("goa-microsite-header");
     expect(el?.getAttribute("headerUrlTarget")).toBe("self");
     expect(el?.getAttribute("feedbackUrlTarget")).toBe("self");
-  })
+  });
+
+  it("should render slotted version", () => {
+    render(<GoAMicrositeHeader type="alpha" version={<span>foo</span>} />);
+    const el = document.querySelector("goa-microsite-header");
+    const slot = el?.querySelector("[slot='version']");
+    const slotContent = slot?.querySelector("span");
+    expect(slot).toBeTruthy();
+    expect(slotContent).toBeTruthy();
+    expect(slotContent?.innerHTML).toContain("foo");
+  });
 });

--- a/libs/react-components/src/lib/microsite-header/microsite-header.tsx
+++ b/libs/react-components/src/lib/microsite-header/microsite-header.tsx
@@ -25,7 +25,7 @@ interface WCProps {
 
 export interface GoAHeaderProps {
   type: GoAServiceLevel;
-  version?: string;
+  version?: React.ReactNode;
   feedbackUrl?: string;
   testId?: string;
   maxContentWidth?: string;
@@ -48,13 +48,15 @@ export function GoAMicrositeHeader({
   return (
     <goa-microsite-header
       type={type}
-      version={version}
+      version={typeof version === "string" ? version : undefined}
       feedbackurl={feedbackUrl}
       data-testid={testId}
       maxcontentwidth={maxContentWidth}
       feedbackurltarget={feedbackUrlTarget}
       headerurltarget={headerUrlTarget}
-    />
+    >
+      {version && typeof version !== "string" && <div slot="version">{version}</div>}
+    </goa-microsite-header>
   );
 }
 

--- a/libs/web-components/src/components/microsite-header/MicrositeHeader.spec.ts
+++ b/libs/web-components/src/components/microsite-header/MicrositeHeader.spec.ts
@@ -1,6 +1,9 @@
-import { render } from '@testing-library/svelte';
-import GoAMicrositeHeader from './MicrositeHeader.svelte'
+import { render, cleanup } from '@testing-library/svelte';
+import GoAMicrositeHeader from './MicrositeHeader.svelte';
+import GoAMicrositeHeaderWrapper from "./MicrositeHeaderWrapper.test.svelte";
 import { it, describe } from "vitest";
+
+afterEach(cleanup);
 
 describe('GoAMicrositeHeader', () => {
 
@@ -27,6 +30,15 @@ describe('GoAMicrositeHeader', () => {
     const version = queryByTestId('version');
 
     expect(version).toContainHTML("1.2.3");
+  });
+
+  it('should render slotted version', () => {
+    const el = render(GoAMicrositeHeaderWrapper, { hasSlottedVersion: true });
+    const slot = el?.container.querySelector("[slot=version]");
+    const slotContent = slot?.querySelector("span");
+    expect(slot).toBeTruthy();
+    expect(slotContent).toBeTruthy();
+    expect(slotContent?.innerHTML).toContain("foo");
   });
 
   ['alpha', 'beta'].forEach(type => {
@@ -64,12 +76,13 @@ describe('GoAMicrositeHeader', () => {
     const headerURL = queryByTestId('site-text').querySelector('a');
     expect(feedbackURL).toHaveAttribute('target', '_blank');
     expect(headerURL).toHaveAttribute('target', '_blank');
-  })
+  });
+
   it('should set target=_self when specified', () => {
     const { queryByTestId } = render(GoAMicrositeHeader, { type: 'alpha', feedbackurl: 'http://example.com', feedbackurltarget: "self", headerurltarget: "self" });
     const feedbackURL = queryByTestId('feedback').querySelector('a');
     const headerURL = queryByTestId('site-text').querySelector('a');
     expect(feedbackURL).toHaveAttribute('target', '_self');
     expect(headerURL).toHaveAttribute('target', '_self');
-  })
+  });
 });

--- a/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
+++ b/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
@@ -81,9 +81,11 @@
       </div>
     {/if}
     <div class="spacer" />
-    {#if version}
+    {#if $$slots.version || version}
       <div data-testid="version" class="version">
-        {version}
+        <slot name="version">
+          {version}
+        </slot>
       </div>
     {/if}
   </div>
@@ -165,15 +167,21 @@
 
   .version {
     color: var(--goa-color-text-secondary);
-    padding-left: 1rem;
-    line-height: 1.25rem;
+    padding-left: var(--goa-space-m);
+    line-height: var(--goa-line-height-1);
+  }
+
+  :global(::slotted([slot="version"])) {
+    display: flex;
+    gap: var(--goa-space-m);
+    align-items: center;
   }
 
   .service-type {
     font-weight: bold;
-    padding: 0.125rem 0.25rem;
+    padding: var(--goa-space-3xs) var(--goa-space-2xs);
     display: flex;
-    margin-right: 1rem;
+    margin-right: var(--goa-space-m);
     line-height: initial;
   }
 
@@ -189,6 +197,6 @@
 
   .site-text {
     color: var(--goa-color-text-default);
-    line-height: 1.25rem;
+    line-height: var(--goa-line-height-1);
   }
 </style>

--- a/libs/web-components/src/components/microsite-header/MicrositeHeaderWrapper.test.svelte
+++ b/libs/web-components/src/components/microsite-header/MicrositeHeaderWrapper.test.svelte
@@ -1,0 +1,26 @@
+<svelte:options customElement="test-microsite-wrapper" />
+
+<script lang="ts">
+  export let type: string = "alpha";
+  export let version: string = "";
+  export let feedbackurl: string = "";
+  export let maxcontentwidth: string = "";
+  export let headerurltarget: string = "";
+  export let feedbackurltarget: string = "";
+  export let hasSlottedVersion: boolean = false;
+</script>
+
+<goa-microsite-header
+  {type}
+  {version}
+  {feedbackurl}
+  {maxcontentwidth}
+  {headerurltarget}
+  {feedbackurltarget}
+>
+  {#if hasSlottedVersion}
+    <div slot="version">
+      <span>foo</span>
+    </div>
+  {/if}
+</goa-microsite-header>


### PR DESCRIPTION
This PR allows slotted content in the "version" section of the microsite header. It's based off the previous work in the https://github.com/GovAlta/ui-components/pull/1853.

## Before the change
The `version` property on the microsite header only accepts a string.
![image](https://github.com/user-attachments/assets/341f6f82-cbb3-456c-8c28-a68b33bf0b50)

## After the change
The `version` property accepts slotted content...
![image](https://github.com/user-attachments/assets/fa61eec0-234d-41cf-95f9-794ec4661b16)

...or a string.
![image](https://github.com/user-attachments/assets/341f6f82-cbb3-456c-8c28-a68b33bf0b50)

The slotted `div` has the following layout to align with the [Figma design](https://www.figma.com/design/c7d7OviJ2Z04CrM66KLuiW/Enable-switching-between-library-versions-on-the-design-system-website?node-id=26-31830&t=hPQ9A3Y7Qpv7ucJJ-1):
- Is placed in a `flex` row
- Has a `space-m` gap
- Items are vertically aligned `center`

![image](https://github.com/user-attachments/assets/cedc64c8-e949-45e7-9a3a-5e58e6aef765)

I also did a bit of tech debt. I replaced any stray `rem` values CSS with GOA space custom properties.

## Markup used for testing

### Angular
```html
<goa-microsite-header type="alpha" version="UAT"></goa-microsite-header>
    
<goa-microsite-header type="alpha">
  <div slot="version">
     <a href="#" id="microsite-version-angular">Angular</a>
     <a href="#">v2.3.4</a>
  </div>
</goa-microsite-header>
``` 

### React
```html
<GoAMicrositeHeader type="alpha" version="UAT" />

<GoAMicrositeHeader type="alpha" version={<><a href="#">Angular</a><a href="#">v1.2.3</a></>} />
``` 

## Checklist
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Outstanding questions
- Do we have unit tests for slotted components? I couldn't see any for `formItem`. 🤔 
- I'm assuming that we almost always want the content of `version` in a flex row with a gap between items. Is this true? If not, I can remove the styling.