### PR TITLE
fix(#2071): use testid property in react components

### DIFF
--- a/libs/react-components/src/lib/accordion/accordion.tsx
+++ b/libs/react-components/src/lib/accordion/accordion.tsx
@@ -10,6 +10,7 @@ interface WCProps extends Margins {
   secondaryText?: string;
   headingContent?: ReactNode;
   maxwidth?: string;
+  testid?: string;
 }
 
 declare global {
@@ -53,7 +54,7 @@ export function GoAAccordion({
       heading={heading}
       secondaryText={secondaryText}
       maxwidth={maxWidth}
-      data-testid={testid}
+      testid={testid}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/app-header-menu/app-header-menu.spec.tsx
+++ b/libs/react-components/src/lib/app-header-menu/app-header-menu.spec.tsx
@@ -37,6 +37,6 @@ describe("AppHeaderMenu", () => {
     expect(el).toBeTruthy();
     expect(el?.getAttribute("heading")).toBe("Some label");
     expect(el?.getAttribute("leadingIcon")).toBe("search");
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/app-header-menu/app-header-menu.tsx
+++ b/libs/react-components/src/lib/app-header-menu/app-header-menu.tsx
@@ -4,6 +4,7 @@ import { GoAIconType } from "../icon/icon";
 interface WCProps {
   heading: string;
   leadingicon?: GoAIconType;
+  testid?: string;
 }
 
 /* eslint-disable-next-line */
@@ -29,7 +30,7 @@ export function GoAAppHeaderMenu(props: GoAAppHeaderMenuProps) {
     <goa-app-header-menu
       heading={props.heading}
       leadingicon={props.leadingIcon}
-      data-testid={props.testId}
+      testid={props.testId}
     >
       {props.children}
     </goa-app-header-menu>

--- a/libs/react-components/src/lib/app-header/app-header.tsx
+++ b/libs/react-components/src/lib/app-header/app-header.tsx
@@ -3,6 +3,7 @@ interface WCProps {
   url?: string;
   maxcontentwidth?: string;
   fullmenubreakpoint?: number;
+  testid?: string;
 }
 
 declare global {
@@ -37,7 +38,7 @@ export function GoAAppHeader({
       url={url}
       fullmenubreakpoint={fullMenuBreakpoint}
       maxcontentwidth={maxContentWidth}
-      data-testid={testId}
+      testid={testId}
     >
       {children}
     </goa-app-header>

--- a/libs/react-components/src/lib/badge/badge.tsx
+++ b/libs/react-components/src/lib/badge/badge.tsx
@@ -14,6 +14,7 @@ interface WCProps extends Margins {
   icon?: boolean;
   content?: string;
   arialabel?: string;
+  testid?: string;
 }
 
 declare global {
@@ -50,7 +51,7 @@ export function GoABadge({
       type={type}
       content={content}
       icon={icon}
-      data-testid={testId}
+      testid={testId}
       arialabel={ariaLabel}
       mt={mt}
       mr={mr}

--- a/libs/react-components/src/lib/block/block.tsx
+++ b/libs/react-components/src/lib/block/block.tsx
@@ -5,6 +5,7 @@ export interface WCProps extends Margins {
   gap?: Spacing;
   direction?: Direction;
   alignment?: Alignment;
+  testid?: string;
 }
 
 declare global {
@@ -39,7 +40,7 @@ export function GoABlock(props: GoABlockProps) {
       mr={props.mr}
       mb={props.mb}
       ml={props.ml}
-      data-testid={props.testId}
+      testid={props.testId}
     >
       {props.children}
     </goa-block>

--- a/libs/react-components/src/lib/button-group/button-group.tsx
+++ b/libs/react-components/src/lib/button-group/button-group.tsx
@@ -9,6 +9,7 @@ export type Gap = GoAButtonGroupGap;
 interface WCProps extends Margins {
   alignment: GoAButtonGroupAlignment;
   gap?: GoAButtonGroupGap;
+  testid?: string;
 }
 
 declare global {
@@ -45,7 +46,7 @@ export function GoAButtonGroup({
       mr={mr}
       mb={mb}
       ml={ml}
-      data-testid={testId}
+      testid={testId}
     >
       {children}
     </goa-button-group>

--- a/libs/react-components/src/lib/button/button.tsx
+++ b/libs/react-components/src/lib/button/button.tsx
@@ -24,6 +24,7 @@ interface WCProps extends Margins {
   disabled?: boolean;
   leadingicon?: string;
   trailingicon?: string;
+  testid?: string;
   ref: React.RefObject<HTMLElement>;
 }
 
@@ -92,7 +93,7 @@ export function GoAButton({
       disabled={disabled}
       leadingicon={leadingIcon}
       trailingicon={trailingIcon}
-      data-testid={testId}
+      testid={testId}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/calendar/calendar.spec.tsx
+++ b/libs/react-components/src/lib/calendar/calendar.spec.tsx
@@ -46,6 +46,6 @@ describe("Calendar", () => {
     expect(el?.getAttribute("value")).toBe(value.toISOString());
     expect(el?.getAttribute("min")).toBe(min.toISOString());
     expect(el?.getAttribute("max")).toBe(max.toISOString());
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/calendar/calendar.tsx
+++ b/libs/react-components/src/lib/calendar/calendar.tsx
@@ -7,6 +7,7 @@ interface WCProps extends Margins {
   value?: string;
   min?: string;
   max?: string;
+  testid?: string;
 }
 
 declare global {
@@ -58,7 +59,7 @@ export function GoACalendar({
       value={value?.toISOString()}
       min={min?.toISOString()}
       max={max?.toISOString()}
-      data-testid={testId}
+      testid={testId}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/callout/callout.spec.tsx
+++ b/libs/react-components/src/lib/callout/callout.spec.tsx
@@ -32,7 +32,7 @@ describe("Callout", () => {
     expect(el?.getAttribute("mb")).toBe("l");
     expect(el?.getAttribute("ml")).toBe("xl");
     expect(el?.getAttribute("arialive")).toBe("polite");
-    expect(el?.getAttribute("data-testid")).toBe("test-callout");
+    expect(el?.getAttribute("testid")).toBe("test-callout");
     expect(el?.textContent).toContain("Information to the user goes");
   });
 

--- a/libs/react-components/src/lib/callout/callout.tsx
+++ b/libs/react-components/src/lib/callout/callout.tsx
@@ -16,6 +16,7 @@ interface WCProps extends Margins {
   size?: GoACalloutSize;
   maxwidth?: string;
   arialive?: GoACalloutAriaLive;
+  testid?: string;
 }
 
 declare global {
@@ -63,7 +64,7 @@ export const GoACallout = ({
       mr={mr}
       mb={mb}
       ml={ml}
-      data-testid={testId}
+      testid={testId}
     >
       {children}
     </goa-callout>

--- a/libs/react-components/src/lib/checkbox/checkbox.spec.tsx
+++ b/libs/react-components/src/lib/checkbox/checkbox.spec.tsx
@@ -35,7 +35,7 @@ describe("GoA Checkbox", () => {
     expect(checkbox?.getAttribute("disabled")).toBe("false");
     expect(checkbox?.getAttribute("checked")).toBe("true");
     expect(checkbox?.getAttribute("error")).toBe("false");
-    expect(checkbox?.getAttribute("data-testid")).toBe(testId);
+    expect(checkbox?.getAttribute("testid")).toBe(testId);
     expect(checkbox?.getAttribute("mt")).toBe("s");
     expect(checkbox?.getAttribute("mr")).toBe("m");
     expect(checkbox?.getAttribute("mb")).toBe("l");

--- a/libs/react-components/src/lib/checkbox/checkbox.tsx
+++ b/libs/react-components/src/lib/checkbox/checkbox.tsx
@@ -22,6 +22,7 @@ interface WCProps extends Margins {
   arialabel?: string;
   description?: string | React.ReactNode;
   maxwidth?: string;
+  testid?: string;
 }
 
 /* eslint-disable-next-line */
@@ -83,7 +84,7 @@ export function GoACheckbox({
 
   return (
     <goa-checkbox
-      data-testid={testId}
+      testid={testId}
       ref={el}
       id={id}
       name={name}

--- a/libs/react-components/src/lib/chip/chip.tsx
+++ b/libs/react-components/src/lib/chip/chip.tsx
@@ -12,6 +12,7 @@ interface WCProps extends Margins {
   deletable: boolean;
   content: string;
   variant?: GoAChipVariant;
+  testid?: string;
 }
 
 declare global {
@@ -77,7 +78,7 @@ export const GoAChip = ({
       mr={mr}
       mb={mb}
       ml={ml}
-      data-testid={testId}
+      testid={testId}
     />
   );
 };

--- a/libs/react-components/src/lib/circular-progress/circular-progress.tsx
+++ b/libs/react-components/src/lib/circular-progress/circular-progress.tsx
@@ -11,6 +11,7 @@ interface WCProps {
   message?: string;
   visible?: string;
   progress?: number;
+  testid?: string;
 }
 
 declare global {
@@ -46,7 +47,7 @@ export const GoACircularProgress = ({
       progress={progress}
       variant={variant}
       size={size}
-      data-testid={testId}
+      testid={testId}
     />
   );
 }

--- a/libs/react-components/src/lib/container/container.tsx
+++ b/libs/react-components/src/lib/container/container.tsx
@@ -18,6 +18,7 @@ interface WCProps extends Margins {
   padding?: GoAContainerPadding;
   width?: GoAContainerWidth;
   maxwidth?: string;
+  testid?: string;
 }
 
 declare global {
@@ -70,7 +71,7 @@ export function GoAContainer({
       mr={mr}
       mb={mb}
       ml={ml}
-      data-testid={testId}
+      testid={testId}
     >
       {headingContent && <div slot="title">{headingContent}</div>}
       {children}

--- a/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
@@ -33,7 +33,7 @@ describe("DatePicker", () => {
     expect(el?.getAttribute("error")).toBe("true");
     expect(el?.getAttribute("min")).toBe(min.toISOString());
     expect(el?.getAttribute("max")).toBe(max.toISOString());
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 
   it("should handle event", async () => {

--- a/libs/react-components/src/lib/date-picker/date-picker.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.tsx
@@ -8,6 +8,7 @@ interface WCProps extends Margins {
   error?: boolean;
   min?: string;
   max?: string;
+  testid?: string;
 }
 
 declare global {
@@ -69,7 +70,7 @@ export function GoADatePicker({
       error={error}
       min={min?.toISOString()}
       max={max?.toISOString()}
-      data-testid={testId}
+      testid={testId}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/details/details.spec.tsx
+++ b/libs/react-components/src/lib/details/details.spec.tsx
@@ -20,7 +20,7 @@ describe("Detail", () => {
     expect(baseElement.innerHTML).toContain("The content");
     expect(el?.getAttribute("open")).toBe("true");
     expect(el?.getAttribute("maxwidth")).toBe("480px");
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 
 });

--- a/libs/react-components/src/lib/details/details.tsx
+++ b/libs/react-components/src/lib/details/details.tsx
@@ -5,6 +5,7 @@ interface WCProps extends Margins {
   heading: string;
   open?: boolean;
   maxwidth?: string;
+  testid?: string;
 }
 
 declare global {
@@ -34,7 +35,7 @@ export function GoADetails(props: GoADetailsProps) {
       heading={props.heading}
       open={props.open}
       maxwidth={props.maxWidth}
-      data-testid={props.testId}
+      testid={props.testId}
       mt={props.mt}
       mr={props.mr}
       mb={props.mb}

--- a/libs/react-components/src/lib/divider/divider.tsx
+++ b/libs/react-components/src/lib/divider/divider.tsx
@@ -1,11 +1,14 @@
 import { Margins } from "../../common/styling";
 
+interface WCProps extends Margins {
+  testid?: string;
+}
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface IntrinsicElements {
-      "goa-divider": Margins & React.HTMLAttributes<HTMLElement>;
+      "goa-divider": WCProps & React.HTMLAttributes<HTMLElement>;
     }
   }
 }
@@ -21,7 +24,7 @@ export function GoADivider(props: GoADividerProps) {
       mr={props.mr}
       mb={props.mb}
       ml={props.ml}
-      data-testid={props.testId}
+      testid={props.testId}
     />
   );
 }

--- a/libs/react-components/src/lib/dropdown/dropdown.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown.tsx
@@ -19,6 +19,7 @@ interface WCProps extends Margins {
   width?: string;
   relative?: boolean;
   id?: string;
+  testid?: string;
 }
 
 declare global {
@@ -100,7 +101,7 @@ export function GoADropdown(props: GoADropdownProps): JSX.Element {
       multiselect={props.multiselect}
       native={props.native}
       placeholder={props.placeholder}
-      data-testid={props.testId}
+      testid={props.testId}
       width={props.width}
       relative={props.relative}
       id={props.id}

--- a/libs/react-components/src/lib/file-upload-card/file-upload-card.spec.tsx
+++ b/libs/react-components/src/lib/file-upload-card/file-upload-card.spec.tsx
@@ -32,7 +32,7 @@ describe("FileUploadCard", () => {
     expect(el?.getAttribute("type")).toBe("image/png");
     expect(el?.getAttribute("progress")).toBe("23");
     expect(el?.getAttribute("error")).toBe("true");
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 
   it("dispatches and event when cancel is clicked while uploading", () => {

--- a/libs/react-components/src/lib/file-upload-card/file-upload-card.tsx
+++ b/libs/react-components/src/lib/file-upload-card/file-upload-card.tsx
@@ -7,6 +7,7 @@ interface WCProps {
   type?: string;
   progress?: number;
   error?: string;
+  testid?: string;
 }
 
 declare global {
@@ -65,7 +66,7 @@ export function GoAFileUploadCard({
       type={type}
       progress={progress}
       error={error}
-      data-testid={testId}
+      testid={testId}
     />
   );
 }

--- a/libs/react-components/src/lib/file-upload-input/file-upload-input.spec.tsx
+++ b/libs/react-components/src/lib/file-upload-input/file-upload-input.spec.tsx
@@ -21,7 +21,7 @@ describe("FileUploadInput", () => {
     expect(el?.getAttribute("maxfilesize")).toBe("10MB");
     expect(el?.getAttribute("accept")).toBe("image/*");
     expect(el?.getAttribute("variant")).toBe("dragdrop");
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 
   it("handles the onSelectFile event", () => {

--- a/libs/react-components/src/lib/file-upload-input/file-upload-input.tsx
+++ b/libs/react-components/src/lib/file-upload-input/file-upload-input.tsx
@@ -7,6 +7,7 @@ interface WCProps {
   variant?: GoAFileUploadInputVariant;
   accept?: string;
   maxfilesize?: string;
+  testid?: string;
 }
 
 declare global {
@@ -56,7 +57,7 @@ export function GoAFileUploadInput({
       variant={variant}
       accept={accept}
       maxfilesize={maxFileSize}
-      data-testid={testId}
+      testid={testId}
     />
   );
 }

--- a/libs/react-components/src/lib/footer-meta-section/footer-meta-section.spec.tsx
+++ b/libs/react-components/src/lib/footer-meta-section/footer-meta-section.spec.tsx
@@ -7,6 +7,6 @@ describe("FooterMetaSection", () => {
     const { baseElement } = render(<FooterMetaSection testId="foo" />);
     const el = baseElement.querySelector("goa-app-footer-meta-section");
     expect(baseElement).toBeTruthy();
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/footer-meta-section/footer-meta-section.tsx
+++ b/libs/react-components/src/lib/footer-meta-section/footer-meta-section.tsx
@@ -1,10 +1,14 @@
 import { ReactNode } from "react";
 
+interface WCProps {
+  testid?: string;
+}
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-app-footer-meta-section": React.HTMLAttributes<HTMLElement>;
+      "goa-app-footer-meta-section": WCProps & React.HTMLAttributes<HTMLElement>;
     }
   }
 }
@@ -21,7 +25,7 @@ export type FooterMetaSectionProps = GoAAppFooterMetaSectionProps;
 export function GoAAppFooterMetaSection({ testId, children }: GoAAppFooterMetaSectionProps) {
   return (
     <goa-app-footer-meta-section
-      data-testid= {testId}
+      testid= {testId}
       slot="meta"
     >
       {children}

--- a/libs/react-components/src/lib/footer-nav-section/footer-nav-section.tsx
+++ b/libs/react-components/src/lib/footer-nav-section/footer-nav-section.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from "react";
 interface WCProps {
   maxcolumncount?: number;
   heading?: string;
+  testid?: string;
 }
 
 declare global {
@@ -33,7 +34,7 @@ export function GoAAppFooterNavSection({
       slot="nav"
       heading={heading}
       maxcolumncount={maxColumnCount}
-      data-testid={testId}
+      testid={testId}
     >
       {children}
     </goa-app-footer-nav-section>

--- a/libs/react-components/src/lib/footer/footer.tsx
+++ b/libs/react-components/src/lib/footer/footer.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 
 interface WCProps {
   maxcontentwidth?: string;
+  testid?: string;
 }
 
 declare global {
@@ -29,7 +30,7 @@ export function GoAAppFooter({
   testId,
 }: GoAAppFooterProps): JSX.Element {
   return (
-    <goa-app-footer maxcontentwidth={maxContentWidth} data-testid={testId}>
+    <goa-app-footer maxcontentwidth={maxContentWidth} testid={testId}>
       {children}
     </goa-app-footer>
   );

--- a/libs/react-components/src/lib/form-item/form-item.tsx
+++ b/libs/react-components/src/lib/form-item/form-item.tsx
@@ -11,6 +11,7 @@ interface WCProps extends Margins {
   helptext?: string;
   maxwidth?: string;
   id?: string;
+  testid?: string;
 }
 
 declare global {
@@ -61,7 +62,7 @@ export function GoAFormItem({
       mr={mr}
       mb={mb}
       ml={ml}
-      data-testid={testId}
+      testid={testId}
       id={id}
     >
       {error && typeof error !== "string" && <div slot="error">{error}</div>}

--- a/libs/react-components/src/lib/form-stepper/form-stepper.spec.tsx
+++ b/libs/react-components/src/lib/form-stepper/form-stepper.spec.tsx
@@ -17,7 +17,7 @@ describe("FormStepper", () => {
 
     const el = container.querySelector("goa-form-stepper");
 
-    expect(el?.getAttribute("data-testid")).toBe("form-test-id");
+    expect(el?.getAttribute("testid")).toBe("form-test-id");
     expect(el?.getAttribute("step")).toBe("2");
     expect(el?.getAttribute("mt")).toBe("s");
     expect(el?.getAttribute("mr")).toBe("m");

--- a/libs/react-components/src/lib/form-stepper/form-stepper.tsx
+++ b/libs/react-components/src/lib/form-stepper/form-stepper.tsx
@@ -4,6 +4,7 @@ import { Margins } from "../../common/styling";
 interface WCProps extends Margins {
   ref?: React.MutableRefObject<HTMLElement | null>;
   step?: number;
+  testid?: string;
 }
 
 declare global {
@@ -56,7 +57,7 @@ export function GoAFormStepper({
   return (
     <goa-form-stepper
       ref={ref}
-      data-testid={testId}
+      testid={testId}
       step={step}
       mt={mt}
       mr={mr}

--- a/libs/react-components/src/lib/grid/grid.tsx
+++ b/libs/react-components/src/lib/grid/grid.tsx
@@ -3,6 +3,7 @@ import { Margins, Spacing } from "../../common/styling";
 interface WCProps extends Margins {
   gap?: Spacing;
   minchildwidth: string;
+  testid?: string;
 }
 
 declare global {
@@ -39,7 +40,7 @@ export function GoAGrid({
       mr={mr}
       mb={mb}
       ml={ml}
-      data-testid={testId}
+      testid={testId}
     >
       {children}
     </goa-grid>

--- a/libs/react-components/src/lib/hero-banner/hero-banner.tsx
+++ b/libs/react-components/src/lib/hero-banner/hero-banner.tsx
@@ -5,6 +5,7 @@ interface WCProps {
   maxcontentwidth?: string;
   backgroundcolor?: string;
   textcolor?: string;
+  testid?: string;
 }
 
 declare global {
@@ -45,7 +46,7 @@ export function GoAHeroBanner({
       maxcontentwidth={maxContentWidth}
       backgroundcolor={backgroundColor}
       textcolor={textColor}
-      data-testid={testId}
+      testid={testId}
     >
       {children}
     </goa-hero-banner>

--- a/libs/react-components/src/lib/icon-button/icon-button.tsx
+++ b/libs/react-components/src/lib/icon-button/icon-button.tsx
@@ -15,6 +15,7 @@ interface WCProps extends Margins {
   title?: string;
   disabled?: boolean;
   arialabel?: string;
+  testid?: string;
 }
 
 declare global {
@@ -85,7 +86,7 @@ export function GoAIconButton({
       mr={mr}
       mb={mb}
       ml={ml}
-      data-testid={testId}
+      testid={testId}
     >
       {children}
     </goa-icon-button>

--- a/libs/react-components/src/lib/icon/icon.spec.tsx
+++ b/libs/react-components/src/lib/icon/icon.spec.tsx
@@ -29,7 +29,7 @@ describe("GoA Icon", () => {
     expect(el?.getAttribute("opacity")).toBe("0.5");
     expect(el?.getAttribute("title")).toBe("foo");
     expect(el?.getAttribute("arialabel")).toBe("bar");
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
     expect(el?.getAttribute("mt")).toBe("s");
     expect(el?.getAttribute("mr")).toBe("m");
     expect(el?.getAttribute("mb")).toBe("l");

--- a/libs/react-components/src/lib/icon/icon.tsx
+++ b/libs/react-components/src/lib/icon/icon.tsx
@@ -598,7 +598,7 @@ export function GoAIcon({
       mr={mr}
       mb={mb}
       ml={ml}
-      data-testid={testId}
+      testid={testId}
     />
   );
 }

--- a/libs/react-components/src/lib/input/input.spec.tsx
+++ b/libs/react-components/src/lib/input/input.spec.tsx
@@ -60,7 +60,7 @@ describe("Input", () => {
     expect(input?.getAttribute("placeholder")).toBe("placeholder");
     expect(input?.getAttribute("prefix")).toBe("foo");
     expect(input?.getAttribute("suffix")).toBe("bar");
-    expect(input?.getAttribute("data-testid")).toBe(testId);
+    expect(input?.getAttribute("testid")).toBe(testId);
     expect(input?.getAttribute("debounce")).toBe("1000");
     expect(input?.getAttribute("mt")).toBe("s");
     expect(input?.getAttribute("mr")).toBe("m");

--- a/libs/react-components/src/lib/input/input.tsx
+++ b/libs/react-components/src/lib/input/input.tsx
@@ -49,6 +49,7 @@ interface WCProps extends Margins {
   prefix?: string;
   suffix?: string;
   arialabel?: string;
+  testid?: string;
 
   // type=number
   min?: string | number;
@@ -226,7 +227,7 @@ export function GoAInput({
       readonly={readonly}
       placeholder={placeholder}
       error={error}
-      data-testid={testId}
+      testid={testId}
       value={value}
       width={width}
       min={min}

--- a/libs/react-components/src/lib/microsite-header/microsite-header.tsx
+++ b/libs/react-components/src/lib/microsite-header/microsite-header.tsx
@@ -21,6 +21,7 @@ interface WCProps {
   maxcontentwidth?: string;
   feedbackurltarget?: GoALinkTarget
   headerurltarget?: GoALinkTarget;
+  testid?: string;
 }
 
 export interface GoAHeaderProps {
@@ -50,7 +51,7 @@ export function GoAMicrositeHeader({
       type={type}
       version={version}
       feedbackurl={feedbackUrl}
-      data-testid={testId}
+      testid={testId}
       maxcontentwidth={maxContentWidth}
       feedbackurltarget={feedbackUrlTarget}
       headerurltarget={headerUrlTarget}

--- a/libs/react-components/src/lib/modal/modal.tsx
+++ b/libs/react-components/src/lib/modal/modal.tsx
@@ -22,6 +22,7 @@ interface WCProps {
   transition?: GoAModalTransition;
   calloutvariant?: GoAModalCalloutVariant;
   role?: GoAModalRole;
+  testid?: string;
 }
 
 declare global {
@@ -102,7 +103,7 @@ export function GoAModal({
       maxwidth={maxWidth}
       transition={transition}
       calloutvariant={calloutVariant}
-      data-testid={testId}
+      testid={testId}
       role={role}
     >
       {heading && <div slot="heading">{heading}</div>}

--- a/libs/react-components/src/lib/notification/notification.tsx
+++ b/libs/react-components/src/lib/notification/notification.tsx
@@ -16,6 +16,7 @@ interface WCProps {
   type: GoANotificationType;
   maxcontentwidth?: string;
   arialive?: GoAAriaLiveType;
+  testid?: string;
 }
 
 declare global {
@@ -65,7 +66,7 @@ export const GoANotification = ({
     <goa-notification
       ref={el}
       type={type}
-      data-testid={testId}
+      testid={testId}
       maxcontentwidth={maxContentWidth}
       arialive={ariaLive}
     >

--- a/libs/react-components/src/lib/page-block/page-block.tsx
+++ b/libs/react-components/src/lib/page-block/page-block.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 
 interface WCProps {
   width: "full" | string;
+  testid?: string;
 }
 
 declare global {
@@ -24,7 +25,7 @@ export type PageBlockProps = GoAPageBlockProps;
 
 export function GoAPageBlock(props: PageBlockProps): JSX.Element {
   return (
-    <goa-page-block width={props.width} data-testid={props.testId}>
+    <goa-page-block width={props.width} testid={props.testId}>
       {props.children}
     </goa-page-block>
   );

--- a/libs/react-components/src/lib/pagination/pagination.tsx
+++ b/libs/react-components/src/lib/pagination/pagination.tsx
@@ -7,6 +7,7 @@ interface WCProps extends Margins {
   perpagecount?: number;
   pagenumber: number;
   variant?: "all" | "links-only";
+  testid?: string;
 }
 
 declare global {
@@ -61,7 +62,7 @@ export function GoAPagination({onChange, ...props}: GoAPaginationProps) {
       mb={props.mb}
       ml={props.ml}
       mr={props.mr}
-      data-testid={props.testId}
+      testid={props.testId}
     />
   );
 }

--- a/libs/react-components/src/lib/popover/popover.tsx
+++ b/libs/react-components/src/lib/popover/popover.tsx
@@ -9,6 +9,7 @@ interface WCProps extends Margins {
   padded?: boolean;
   position?: GoAPosition;
   relative?: boolean;
+  testid?: string;
 }
 
 declare global {
@@ -47,7 +48,7 @@ export function GoAPopover({
 }: GoAPopoverProps): JSX.Element {
   return (
     <goa-popover
-      data-testid={testId}
+      testid={testId}
       maxwidth={maxWidth}
       minwidth={minWidth}
       padded={padded}

--- a/libs/react-components/src/lib/radio-group/radio-group.tsx
+++ b/libs/react-components/src/lib/radio-group/radio-group.tsx
@@ -13,6 +13,7 @@ interface WCProps extends Margins {
   disabled?: boolean;
   error?: boolean;
   arialabel?: string;
+  testid?: string;
 }
 
 declare global {
@@ -74,7 +75,7 @@ export function GoARadioGroup({
 
   return (
     <goa-radio-group
-      data-testid={testId}
+      testid={testId}
       ref={el}
       name={name}
       value={value}

--- a/libs/react-components/src/lib/side-menu-group/side-menu-group.spec.tsx
+++ b/libs/react-components/src/lib/side-menu-group/side-menu-group.spec.tsx
@@ -8,6 +8,6 @@ describe("SideMenuGroup", () => {
 
     const el = baseElement.querySelector("goa-side-menu-group");
     expect(el?.getAttribute("heading")).toBe("some header");
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/side-menu-group/side-menu-group.tsx
+++ b/libs/react-components/src/lib/side-menu-group/side-menu-group.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 
 interface WCProps {
   heading: string;
+  testid?: string;
 }
 
 declare global {
@@ -25,7 +26,7 @@ export function GoASideMenuGroup(props: GoASideMenuGroupProps): JSX.Element {
   return (
     <goa-side-menu-group
       heading={props.heading}
-      data-testid={props.testId}
+      testid={props.testId}
     >
       {props.children}
     </goa-side-menu-group>

--- a/libs/react-components/src/lib/side-menu-heading/side-menu-heading.spec.tsx
+++ b/libs/react-components/src/lib/side-menu-heading/side-menu-heading.spec.tsx
@@ -9,6 +9,6 @@ describe("SideMenuHeading", () => {
     const el = baseElement.querySelector("goa-side-menu-heading");
     expect(el).toBeTruthy();
     expect(el?.getAttribute("icon")).toBe("home");
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/side-menu-heading/side-menu-heading.tsx
+++ b/libs/react-components/src/lib/side-menu-heading/side-menu-heading.tsx
@@ -4,6 +4,7 @@ import { GoAIconType } from "../icon/icon";
 
 interface WCProps {
   icon?: GoAIconType;
+  testid?: string;
 }
 
 declare global {
@@ -28,7 +29,7 @@ export function GoASideMenuHeading(props: GoASideMenuHeadingProps) {
   return (
     <goa-side-menu-heading
       icon={props.icon}
-      data-testid={props.testId}
+      testid={props.testId}
     >
       {props.children}
       {props.meta && <span slot="meta">{props.meta}</span>}

--- a/libs/react-components/src/lib/side-menu/side-menu.spec.tsx
+++ b/libs/react-components/src/lib/side-menu/side-menu.spec.tsx
@@ -11,6 +11,6 @@ describe("SideMenu", () => {
     );
     const el = baseElement.querySelector("goa-side-menu");
     expect(baseElement).toBeTruthy();
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/side-menu/side-menu.tsx
+++ b/libs/react-components/src/lib/side-menu/side-menu.tsx
@@ -1,11 +1,15 @@
 import { ReactNode } from "react";
 
+interface WCProps {
+  testid?: string;
+}
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface IntrinsicElements {
-      "goa-side-menu": React.HTMLAttributes<HTMLElement>;
+      "goa-side-menu": WCProps & React.HTMLAttributes<HTMLElement>;
     }
   }
 }
@@ -20,7 +24,7 @@ export interface GoASideMenuProps {
 export type SideMenuProps = GoASideMenuProps;
 
 export function GoASideMenu(props: GoASideMenuProps): JSX.Element {
-  return <goa-side-menu data-testid={props.testId}>{props.children}</goa-side-menu>;
+  return <goa-side-menu testid={props.testId}>{props.children}</goa-side-menu>;
 }
 
 export default GoASideMenu;

--- a/libs/react-components/src/lib/skeleton/skeleton.tsx
+++ b/libs/react-components/src/lib/skeleton/skeleton.tsx
@@ -23,6 +23,7 @@ interface WCProps extends Margins {
   size?: GoASkeletonSize;
   linecount?: number;
   type: GoASkeletonType;
+  testid?: string;
 }
 
 declare global {
@@ -66,7 +67,7 @@ export const GoASkeleton = ({
       mr={mr}
       mb={mb}
       ml={ml}
-      data-testid={testId}
+      testid={testId}
     />
   );
 };

--- a/libs/react-components/src/lib/spacer/spacer.tsx
+++ b/libs/react-components/src/lib/spacer/spacer.tsx
@@ -4,6 +4,7 @@ import { Spacing } from "../../common/styling";
 interface WCProps {
   hspacing?: Spacing | "fill";
   vspacing?: Spacing;
+  testid?: string;
 }
 
 declare global {
@@ -29,7 +30,7 @@ export function GoASpacer(props: GoASpacerProps) {
     <goa-spacer
       hspacing={props.hSpacing}
       vspacing={props.vSpacing}
-      data-testid={props.testId}
+      testid={props.testId}
     />
   );
 }

--- a/libs/react-components/src/lib/spinner/spinner.spec.tsx
+++ b/libs/react-components/src/lib/spinner/spinner.spec.tsx
@@ -16,7 +16,7 @@ describe("Spinner", () => {
       const el = document.querySelector("goa-spinner");
       expect(el?.getAttribute("size")).toBe(size);
       expect(el?.getAttribute("type")).toBe("progress");
-      expect(el?.getAttribute("data-testid")).toBe("spinner-testid");
+      expect(el?.getAttribute("testid")).toBe("spinner-testid");
       expect(el?.getAttribute("progress")).toBe("20");
       expect(el?.getAttribute("invert")).not.toBeNull();
     });

--- a/libs/react-components/src/lib/spinner/spinner.tsx
+++ b/libs/react-components/src/lib/spinner/spinner.tsx
@@ -6,6 +6,7 @@ interface WCProps {
   type: SpinnerType;
   invert?: boolean;
   progress?: number;
+  testid?: string;
 }
 
 declare global {
@@ -40,7 +41,7 @@ export function GoASpinner({
       size={size}
       progress={progress}
       invert={invert}
-      data-testid={testId}
+      testid={testId}
     />
   );
 }

--- a/libs/react-components/src/lib/table/table.spec.tsx
+++ b/libs/react-components/src/lib/table/table.spec.tsx
@@ -11,10 +11,12 @@ describe("Table", () => {
 
   it("should call onSort when _sort event is triggered", () => {
     const onSort = vi.fn();
-    const { getByTestId } = render(<Table onSort={onSort} testId="test-table" />);
+    const { baseElement } = render(<Table onSort={onSort} />);
+    const table = baseElement.querySelector("goa-table");
 
-    fireEvent(
-      getByTestId("test-table"),
+    expect(table).toBeTruthy();
+    table && fireEvent(
+      table,
       new CustomEvent("_sort", {
         detail: { sortBy: "name", sortDir: 1 }
       })
@@ -24,11 +26,13 @@ describe("Table", () => {
   });
 
   it("should handle _sort event gracefully when no onSort prop is passed", () => {
-    const { getByTestId } = render(<Table testId="test-table-without-sort" />);
+    const { baseElement } = render(<Table testId="test-table-without-sort" />);
+    const table = baseElement.querySelector("goa-table");
 
+    expect(table).toBeTruthy();
     expect(() =>
-      fireEvent(
-        getByTestId("test-table-without-sort"),
+      table && fireEvent(
+        table,
         new CustomEvent("_sort", {
           detail: { sortBy: "age", sortDir: -1 }
         })

--- a/libs/react-components/src/lib/table/table.tsx
+++ b/libs/react-components/src/lib/table/table.tsx
@@ -11,6 +11,7 @@ interface WCProps extends Margins {
   width?: string;
   stickyheader?: boolean;
   variant?: GoATableVariant;
+  testid?: string;
 }
 
 declare global {
@@ -60,7 +61,7 @@ export function GoATable({onSort, ...props}: GoATableProps) {
       width={props.width}
       stickyheader={false}
       variant={props.variant}
-      data-testid={props.testId}
+      testid={props.testId}
       mt={props.mt}
       mb={props.mb}
       ml={props.ml}

--- a/libs/react-components/src/lib/tabs/tabs.spec.tsx
+++ b/libs/react-components/src/lib/tabs/tabs.spec.tsx
@@ -18,7 +18,7 @@ describe("Tabs", () => {
     const el = baseElement.querySelector("goa-tabs");
     expect(el).toBeTruthy();
     expect(el?.getAttribute("initialTab")).toBe("1");
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
 
     const tabElements = baseElement.querySelectorAll("goa-tab");
     expect(tabElements.length).toBe(1);

--- a/libs/react-components/src/lib/tabs/tabs.tsx
+++ b/libs/react-components/src/lib/tabs/tabs.tsx
@@ -4,6 +4,7 @@ interface WCProps {
   initialtab?: number;
   ref: React.RefObject<HTMLElement>;
   onChange?: (tab: number) => void;
+  testid?: string;
 }
 
 declare global {
@@ -45,7 +46,7 @@ export function GoATabs({
   }, [onChange]);
 
   return (
-    <goa-tabs ref={ref} initialtab={initialTab} data-testid={testId}>
+    <goa-tabs ref={ref} initialtab={initialTab} testid={testId}>
       {children}
     </goa-tabs>
   );

--- a/libs/react-components/src/lib/textarea/textarea.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.tsx
@@ -17,6 +17,7 @@ interface WCProps extends Margins {
   arialabel?: string;
   countby?: CountBy;
   maxcount?: number;
+  testid?: string;
 }
 
 declare global {
@@ -115,7 +116,7 @@ export function GoATextarea({
       width={width}
       maxwidth={maxWidth}
       error={error}
-      data-testid={testId}
+      testid={testId}
       arialabel={ariaLabel}
       mt={mt}
       mr={mr}

--- a/libs/react-components/src/lib/tooltip/tooltip.spec.tsx
+++ b/libs/react-components/src/lib/tooltip/tooltip.spec.tsx
@@ -29,6 +29,6 @@ describe("Tooltip", () => {
 
     expect(el?.getAttribute("position")).toBe("top");
     expect(el?.getAttribute("halign")).toBe("right");
-    expect(el?.getAttribute("data-testid")).toBe("foo");
+    expect(el?.getAttribute("testid")).toBe("foo");
   });
 });

--- a/libs/react-components/src/lib/tooltip/tooltip.tsx
+++ b/libs/react-components/src/lib/tooltip/tooltip.tsx
@@ -9,6 +9,7 @@ interface WCProps extends Margins {
   position?: GoATooltipPosition;
   content?: string;
   halign?: GoATooltipHorizontalAlignment;
+  testid?: string;
 }
 
 declare global {
@@ -35,7 +36,7 @@ export function GoATooltip(props: GoATooltipProps): JSX.Element {
       position={props.position}
       content={props.content}
       halign={props.hAlign}
-      data-testid={props.testId}
+      testid={props.testId}
       mt={props.mt}
       mr={props.mr}
       mb={props.mb}

--- a/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
+++ b/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
@@ -5,6 +5,7 @@
     el: HTMLElement;
     links: Element[];
     currentHref?: string;
+    testid?: string;
   };
 </script>
 
@@ -20,6 +21,7 @@
   // Optional
   export let leadingicon: GoAIconType;
   export let type: "primary" | "secondary" = "primary";
+  export let testid: string = "rootEl";
 
   // Private
 
@@ -151,7 +153,7 @@
 
 <svelte:window bind:innerWidth={_innerWidth} />
 
-<div bind:this={_rootEl} data-testid="rootEl">
+<div bind:this={_rootEl} data-testid={testid}>
   {#if _desktop}
     <goa-popover
       bind:this={_popoverEl}

--- a/libs/web-components/src/components/block/Block.svelte
+++ b/libs/web-components/src/components/block/Block.svelte
@@ -7,6 +7,7 @@
   export let gap: Spacing = "m";
   export let direction: "row" | "column" = "row";
   export let alignment: "center" | "start" | "end" | "normal" = "normal";
+  export let testid: string = "";
 
   $: _alignment =
     alignment === "start"
@@ -32,6 +33,7 @@
     --alignment: ${_alignment};
     --direction: ${direction};
   `}
+  data-testid={testid}
 >
   <slot />
 </div>

--- a/libs/web-components/src/components/calendar/Calendar.svelte
+++ b/libs/web-components/src/components/calendar/Calendar.svelte
@@ -28,6 +28,7 @@
   export let value: string = "";
   export let min: string = "";
   export let max: string = "";
+  export let testid: string = "";
 
   // margin
   export let mt: Spacing = null;
@@ -290,6 +291,7 @@
 <div
   style={calculateMargin(mt, mr, mb, ml)}
   class:bordered={bordered === "true"}
+  data-testid={testid}
 >
   <goa-block mb="m">
     <goa-form-item label="Month" mt="0">

--- a/libs/web-components/src/components/circular-progress/CircularProgress.svelte
+++ b/libs/web-components/src/components/circular-progress/CircularProgress.svelte
@@ -27,6 +27,7 @@
   export let message: string = "";
   export let progress: number = -1;
   export let visible: string = "false";
+  export let testid: string = "";
 
   $: isVisible = toBoolean(visible);
 
@@ -50,6 +51,7 @@
       transition:fade={{ duration: 300 }}
       use:noScroll={{ enable: true }}
       class:fullscreen
+      data-testid={testid}
     >
       <goa-spinner size={spinnerSize} {progress} />
       {#if message}
@@ -57,7 +59,11 @@
       {/if}
     </div>
   {:else if inline}
-    <div class:inline class={"spinner-" + spinnerSize}>
+    <div
+      class:inline
+      class={"spinner-" + spinnerSize}
+      data-testid={testid}
+    >
       <goa-spinner size={spinnerSize} {progress} />
       {#if message}
         <div class="message">{message}</div>

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -22,6 +22,7 @@
   export let min: string = "";
   export let max: string = "";
   export let relative: string = "false";
+  export let testid: string = "";
 
   // margin
   export let mt: Spacing = null;
@@ -161,6 +162,7 @@
   {mr}
   open={_showPopover}
   on:_close={() => dispatchValue(_date)}
+  testid={testid}
 >
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <goa-input

--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -17,6 +17,7 @@
   export let mb: Spacing = null;
   export let ml: Spacing = null;
   export let open: string = "false";
+  export let testid: string = "";
 
   let _isMouseOver: boolean = false;
   let _summaryEl: HTMLElement;
@@ -45,6 +46,7 @@
     ${calculateMargin(mt, mr, mb, ml)}
     max-width: ${maxwidth};
   `}
+  data-testid={testid}
 >
   <summary
     bind:this={_summaryEl}

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -34,6 +34,7 @@
   export let mr: Spacing = null;
   export let mb: Spacing = null;
   export let ml: Spacing = null;
+  export let testid: string = "";
 
   //
   // Private
@@ -273,7 +274,7 @@
       : { name, value: newValue };
 
     if (!_isDirty) {
-      return;  
+      return;
     }
 
     setTimeout(() => {
@@ -293,7 +294,7 @@
 
     _isDirty = option.value !== _selectedOption?.value;
     _selectedOption = option;
-  
+
     if (!_native) {
       hideMenu();
       syncFilteredOptions();
@@ -322,7 +323,7 @@
       _selectedOption = undefined;
       setDisplayedValue();
       dispatchValue("");
-    }  
+    }
   }
 
   function onInputKeyUp(e: KeyboardEvent) {
@@ -531,7 +532,7 @@
 
 <!-- Template -->
 <div
-  data-testid={`${name}-dropdown`}
+  data-testid={testid || `${name}-dropdown`}
   class="dropdown"
   class:dropdown-native={_native}
   style={`

--- a/libs/web-components/src/components/file-upload-card/FileUploadCard.svelte
+++ b/libs/web-components/src/components/file-upload-card/FileUploadCard.svelte
@@ -10,6 +10,7 @@
   export let type: string = "";
   export let progress: number = -1;
   export let error: string = "";
+  export let testid: string = "";
 
   // Private
 
@@ -83,7 +84,7 @@
   }
 </script>
 
-<div id="container">
+<div id="container" data-testid={testid}>
   <div
     data-testid="root"
     bind:this={_rootEl}
@@ -194,7 +195,7 @@
       margin-left: 0.5rem;
     }
   }
- 
+
   @container self (--mobile) {
     .root {
       grid-template-columns: 38px auto;

--- a/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
+++ b/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
@@ -15,6 +15,7 @@
   export let variant: Variant = "dragdrop";
   export let accept: string = "*";
   export let maxfilesize: string = "5MB";
+  export let testid: string = "";
 
   // Private
 
@@ -181,7 +182,7 @@
 {#if variant === "dragdrop"}
   <div
     bind:this={_el}
-    data-testid="dragdrop"
+    data-testid={testid || "dragdrop"}
     class={`dragdrop state-${_state}`}
     on:click={openFilePicker}
     on:drop={onDrop}
@@ -230,7 +231,7 @@
 
   <input
     bind:this={_fileInput}
-    data-testid="input"
+    data-testid={testid || "input"}
     tabindex="-1"
     type="file"
     {accept}

--- a/libs/web-components/src/components/footer-meta-section/FooterMetaSection.svelte
+++ b/libs/web-components/src/components/footer-meta-section/FooterMetaSection.svelte
@@ -3,6 +3,8 @@
 <script lang="ts">
   import { onMount, tick } from "svelte";
 
+  export let testid: string =  "";
+
   let rootEl: HTMLElement;
   let children: HTMLLinkElement[] = [];
 
@@ -27,7 +29,7 @@
 </script>
 
 <!-- Template -->
-<section bind:this={rootEl}>
+<section bind:this={rootEl} data-testid={testid}>
   <div class="hidden">
     <slot />
   </div>

--- a/libs/web-components/src/components/footer-nav-section/FooterNavSection.svelte
+++ b/libs/web-components/src/components/footer-nav-section/FooterNavSection.svelte
@@ -5,6 +5,7 @@
 
   export let heading: string = "";
   export let maxcolumncount: number = 1;
+  export let testid: string = "";
 
   let rootEl: HTMLElement;
   let children: HTMLLinkElement[] = [];
@@ -32,7 +33,7 @@
 </script>
 
 <!-- Template -->
-<section bind:this={rootEl}>
+<section bind:this={rootEl} data-testid={testid}>
   {#if heading}
     <div class="title">{heading}</div>
     <goa-divider spacing="small" />

--- a/libs/web-components/src/components/footer/Footer.svelte
+++ b/libs/web-components/src/components/footer/Footer.svelte
@@ -4,6 +4,7 @@
   import { onMount, tick } from "svelte";
 
   export let maxcontentwidth: string = "";
+  export let testid: string = "";
 
   let rootEl: HTMLElement;
   let navLinks: Element[];
@@ -24,6 +25,7 @@
   class="app-footer"
   bind:this={rootEl}
   style={`--max-content-width: ${maxcontentwidth || "100%"}`}
+  data-testid={testid}
 >
   <div class="content">
     <div class="nav-links">

--- a/libs/web-components/src/components/grid/Grid.svelte
+++ b/libs/web-components/src/components/grid/Grid.svelte
@@ -9,6 +9,7 @@
 
   export let gap: Spacing = "m";
   export let minchildwidth: string = "";
+  export let testid: string = "";
 
   // margin
   export let mt: Spacing = null;
@@ -29,6 +30,7 @@
     --min-child-width: ${minchildwidth || 0};
     gap: var(--goa-space-${gap})
   `}
+    data-testid={testid}
   >
     <slot />
   </div>

--- a/libs/web-components/src/components/hero-banner/HeroBanner.svelte
+++ b/libs/web-components/src/components/hero-banner/HeroBanner.svelte
@@ -8,6 +8,7 @@
   export let maxcontentwidth = "100%";
   export let backgroundcolor: string = "#f8f8f8";
   export let textcolor: string = "";
+  export let testid: string = "background";
 
   /* Set minheight to support old default value of 600px */
   $: if (!minheight && backgroundurl) minheight = "600px";
@@ -17,7 +18,7 @@
 <div
   class="goa-hero"
   class:with-image={backgroundurl}
-  data-testid="background"
+  data-testid={testid}
   style="
     min-height: {minheight};
     --hero-banner-background-color: {backgroundcolor};

--- a/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
+++ b/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
@@ -20,6 +20,7 @@
   export let maxcontentwidth = "100%";
   export let headerurltarget: UrlTargetType = "blank";
   export let feedbackurltarget: UrlTargetType = "blank";
+  export let testid: string = "";
 
   // Validator
   const [UrlTarget, validateUrlTargetType] = typeValidator(
@@ -43,7 +44,7 @@
 </script>
 
 <!-- HTML -->
-<div id="container">
+<div id="container" data-testid={testid}>
   <div
     class="content-container"
     style={`--max-content-width: ${maxcontentwidth}`}

--- a/libs/web-components/src/components/modal/Modal.svelte
+++ b/libs/web-components/src/components/modal/Modal.svelte
@@ -24,6 +24,7 @@
   export let transition: Transition = "none";
   export let calloutvariant: CalloutVariant | null = null;
   export let maxwidth: string = "60ch";
+  export let testid: string = "modal";
 
   // @deprecated: use maxwidth
   export let width: string = "";
@@ -177,7 +178,7 @@
       use:noscroll={{ enable: _isOpen }}
       in:fade={{ duration: _transitionTime }}
       out:fade={{ delay: _transitionTime, duration: _transitionTime }}
-      data-testid="modal"
+      data-testid={testid}
       class={`modal ${_scrollPos}`}
       style={`--maxwidth: ${maxwidth};`}
       role="presentation"

--- a/libs/web-components/src/components/notification/Notification.svelte
+++ b/libs/web-components/src/components/notification/Notification.svelte
@@ -5,6 +5,7 @@
   import { fade } from "svelte/transition";
   import { onMount } from "svelte";
   import { typeValidator } from "../../common/utils";
+  import test from "node:test";
 
   // Validator
   const [Types, validateType] = typeValidator(
@@ -25,6 +26,7 @@
   export let type: NotificationType = "";
   export let maxcontentwidth = "100%";
   export let arialive: AriaLiveType = "polite";
+  export let testid: string = "";
 
   let show = true;
   $: iconType =
@@ -52,7 +54,7 @@
 
 <!-- HTML -->
 {#if show}
-  <div id="container">
+  <div id="container" data-testid={testid}>
     <div
       transition:fade
       class="notification {type}"
@@ -97,7 +99,7 @@
   #container {
     container: self / inline-size;
   }
-  
+
   .notification {
     padding: var(--goa-space-l) var(--goa-space-m);
     display: flex;

--- a/libs/web-components/src/components/page-block/PageBlock.svelte
+++ b/libs/web-components/src/components/page-block/PageBlock.svelte
@@ -4,6 +4,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { isValidDimension } from "../../common/validators";
+  import test from "node:test";
 
   type Size = "full" | string;
   const Sizes = {
@@ -12,6 +13,9 @@
 
   // Required
   export let width: Size;
+
+  // Optional
+  export let testid: string = "";
 
   // Private
   export let _width: string;
@@ -33,7 +37,7 @@
 </script>
 
 <!-- HTML -->
-<div class="page-content" style={`--max-width: ${_width}`}>
+<div class="page-content" style={`--max-width: ${_width}`} data-testid={testid}>
   <slot />
 </div>
 

--- a/libs/web-components/src/components/pagination/Pagination.svelte
+++ b/libs/web-components/src/components/pagination/Pagination.svelte
@@ -19,6 +19,7 @@
   export let itemcount: number;
   export let perpagecount: number = 10;
   export let variant: Variant = "all";
+  export let testid: string = "";
   export let mt: Spacing = "none";
   export let mr: Spacing = "none";
   export let mb: Spacing = "m";
@@ -85,7 +86,7 @@
 </script>
 
 <goa-block id="root" {ml} {mr} {mb} {mt}>
-  <div class="controls">
+  <div class="controls" data-testid={testid}>
     {#if variant === "all"}
       <goa-block data-testid="page-selector" alignment="center" gap="s">
         <span>Page</span>

--- a/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
+++ b/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
@@ -13,6 +13,7 @@
   import { getSlottedChildren } from "../../common/utils";
 
   export let heading: string;
+  export let testid: string = "";
 
   let _open = false;
   let _current = false;
@@ -111,7 +112,7 @@
   }
 </script>
 
-<div bind:this={_rootEl} class="side-menu-group" class:current={_current}>
+<div bind:this={_rootEl} class="side-menu-group" class:current={_current} data-testid={testid}>
   <a href={`#${_slug}`} class="heading" on:click={handleClick}>
     {heading}
     {#if _open}

--- a/libs/web-components/src/components/side-menu-heading/SideMenuHeading.svelte
+++ b/libs/web-components/src/components/side-menu-heading/SideMenuHeading.svelte
@@ -4,9 +4,10 @@
   import type { GoAIconType } from "../icon/Icon.svelte";
 
   export let icon: GoAIconType = null;
+  export let testid: string = "section-heading";
 </script>
 
-<h2 data-testid="section-heading" class:icon>
+<h2 data-testid={testid} class:icon>
   {#if icon}
     <goa-icon id="heading-icon" type={icon} theme="filled" />
   {/if}

--- a/libs/web-components/src/components/side-menu/SideMenu.svelte
+++ b/libs/web-components/src/components/side-menu/SideMenu.svelte
@@ -6,6 +6,8 @@
   import { isUrlMatch, getMatchedLink } from "../../common/urls";
   import { SideMenuGroupProps } from "../side-menu-group/SideMenuGroup.svelte";
 
+  export let testid: string = "";
+
   let _rootEl: HTMLElement;
   let _sideMenuLinks: Element[] = [];
   let _sideMenuGroupItems: SideMenuGroupProps[] = [];
@@ -103,7 +105,7 @@
   }
 </script>
 
-<div bind:this={_rootEl} class="side-menu">
+<div bind:this={_rootEl} class="side-menu" data-testid={testid}>
   <slot />
 </div>
 

--- a/libs/web-components/src/components/spacer/Spacer.svelte
+++ b/libs/web-components/src/components/spacer/Spacer.svelte
@@ -6,21 +6,23 @@
 
   export let hspacing: Spacing | "fill" = "none";
   export let vspacing: Spacing = "none";
+  export let testid: string = "";
 
   let rootEl: HTMLElement;
   onMount(() => {
     const height = `var(--goa-space-${vspacing})`;
-    const width = hspacing === "fill" 
-      ? "100%" 
+    const width = hspacing === "fill"
+      ? "100%"
       : `var(--goa-space-${hspacing})`;
     injectCss(rootEl, ":host", { width, height });
   });
 </script>
 
-<div 
+<div
   bind:this={rootEl}
   style={`
     height: var(--goa-space-${vspacing});
     width: var(--goa-space-${hspacing});
   `}
+  data-testid={testid}
 />

--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -25,6 +25,7 @@
   export let width: string = "";
   export let stickyheader: string = "false";
   export let variant: Variant = "normal";
+  export let testid: string = "";
 
   export let mt: Spacing = null;
   export let mr: Spacing = null;
@@ -129,6 +130,7 @@
     ${`width: ${width || "100%"};`}
     ${calculateMargin(mt, mr, mb, ml)}
   `}
+  data-testid={testid}
 >
   {#if _isTableRoot}
     <slot />

--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -6,6 +6,7 @@
   import { GoATabProps } from "../tab/Tab.svelte";
 
   export let initialtab: number = 1; // 1-based
+  export let testid: string = "";
 
   // Private
 
@@ -212,7 +213,7 @@
 
 <!--HTML-->
 
-<div role="tablist" bind:this={_rootEl}>
+<div role="tablist" bind:this={_rootEl} data-testid={testid}>
   <div class="tabs" bind:this={_tabsEl}></div>
   <div class="tabpanel" tabindex="0" bind:this={_panelEl} role="tabpanel">
     <slot />


### PR DESCRIPTION
This PR makes the following changes:
1. Adds `testid` property to the below web components:
    - `app-header-menu`
    - `block`
    - `calendar`
    - `circular-progress`
    - `date-picker`
    - `details`
    - `file-upload-card`
    - `file-upload-input`
    - `footer-meta-section`
    - `footer-nav-section`
    - `footer`
    - `grid`
    - `hero-banner`
    - `microsite-header`
    - `modal`
    - `notification`
    - `page-block`
    - `pagination`
    - `side-menu-group`
    - `side-menu-heading`
    - `side-menu`
    - `spacer`
    - `table`
    - `tabs`
3. Updates all React components to use the `testid` web component property instead of `data-testid`.

### Outstanding questions
- I've added a `testid` property to the web components that are missing one. Is this the best approach? Or should I just keep the `data-testid` on the react components for these ones?
- This PR touches a ton of files. 😬 Should I move the web component changes into a separate PR?

## Checklist
- [x] I have updated the relevant unit tests
- [x] My local unit tests pass
- [x] I've manually tested all components
