### PR TITLE
fix(#2075): Changed Pagination block ID

### DIFF
--- a/libs/angular-components/src/lib/angular-components.module.ts
+++ b/libs/angular-components/src/lib/angular-components.module.ts
@@ -1,3 +1,4 @@
+// Remove this comment the next time you work on this file
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from "@angular/core";
 import { ValueDirective, ValueListDirective } from "./value-directive";
 import { CheckedDirective } from "./checked-directive";

--- a/libs/react-components/src/lib/accordion/accordion.tsx
+++ b/libs/react-components/src/lib/accordion/accordion.tsx
@@ -1,3 +1,4 @@
+// Remove this comment the next time you work on this file
 import { ReactNode } from "react";
 import { Margins } from "../../common/styling";
 

--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -1,3 +1,4 @@
+<!--Remove this comment next time you work on this file-->
 <svelte:options customElement="goa-accordion" />
 
 <!-- Script -->

--- a/libs/web-components/src/components/pagination/Pagination.svelte
+++ b/libs/web-components/src/components/pagination/Pagination.svelte
@@ -85,7 +85,7 @@
   }
 </script>
 
-<goa-block id="root" {ml} {mr} {mb} {mt}>
+<goa-block id="goa-pagination" {ml} {mr} {mb} {mt}>
   <div class="controls" data-testid={testid}>
     {#if variant === "all"}
       <goa-block data-testid="page-selector" alignment="center" gap="s">


### PR DESCRIPTION
# Before

`id` property of `goa-block` element was "root"

# After

`id` property of `goa-block` element is "goa-pagination"

## Additional

Made a separate commit to add a comment to each package, so that they release on next push to main
