### PR TITLE
fix(#2088): Updated Tooltip font size and padding

### DIFF
--- a/libs/angular-components/src/lib/checked-directive.ts
+++ b/libs/angular-components/src/lib/checked-directive.ts
@@ -14,8 +14,8 @@ import {
   selector: "[goaChecked]",
   providers: [
     {
-      provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => CheckedDirective),
+      provide: NG_VALUE_ACCESSOR,
       multi: true,
     },
   ],

--- a/libs/react-components/src/experimental/resizable-panel/ResizablePanel.tsx
+++ b/libs/react-components/src/experimental/resizable-panel/ResizablePanel.tsx
@@ -5,27 +5,27 @@ import { GoAIcon } from "../../lib/icon/icon";
 export type ResizableProps = {
   minWidth?: number;
   children: ReactNode;
-}
+};
 
 type MouseState = "static" | "active";
 
 export function ResizablePanel(props: ResizableProps): JSX.Element {
+  // value refs
+  const maxWidth = useRef<number>(0);
+  const resizeBarState = useRef<MouseState>("static");
+
   // element refs
   const bgRef = useRef<HTMLDivElement | null>(null);
   const sectionRef = useRef<HTMLElement | null>(null);
   const widthRef = useRef<HTMLDivElement | null>(null);
   const handleRef = useRef<HTMLDivElement | null>(null);
 
-  // value refs
-  const maxWidth = useRef<number>(0);
-  const resizeBarState = useRef<MouseState>("static")
-
   // state
   const [width, setWidth] = useState<string>();
 
   useEffect(() => {
     maxWidth.current = bgRef.current?.getBoundingClientRect().width ?? 0;
-  }, [])
+  }, []);
 
   function resetMouseState() {
     resizeBarState.current = "static";
@@ -59,7 +59,10 @@ export function ResizablePanel(props: ResizableProps): JSX.Element {
     const newXPos = handleRef.current?.getBoundingClientRect().x ?? 0;
 
     // set width of preview area
-    const calcWidth = Math.max(newXPos - xOffset, Math.min(mouseX - xOffset, maxWidth.current));
+    const calcWidth = Math.max(
+      newXPos - xOffset,
+      Math.min(mouseX - xOffset, maxWidth.current),
+    );
     const elementWidth = Math.max(minWidth, calcWidth - 64); // 4rem padding
 
     // prevent dragging bar more than allowed
@@ -70,29 +73,32 @@ export function ResizablePanel(props: ResizableProps): JSX.Element {
     // set resizable area width
     sectionEl?.setAttribute("style", `width: ${calcWidth}px;`);
     // set displayed px width
-    widthRef.current?.setAttribute("style", `right: ${maxWidth.current - calcWidth + 32}px`);
-    setWidth(`${Math.round(elementWidth)}px`)
+    widthRef.current?.setAttribute(
+      "style",
+      `right: ${maxWidth.current - calcWidth + 32}px`,
+    );
+    setWidth(`${Math.round(elementWidth)}px`);
   }
 
   return (
-    <div 
-      ref={bgRef} 
+    <div
+      ref={bgRef}
       className={Css.panelBackground}
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
       onMouseUp={onMouseUp}
     >
       <section ref={sectionRef} className={Css.panel}>
-        <div className={Css.children}>
-          {props.children}
-        </div>
+        <div className={Css.children}>{props.children}</div>
         <div ref={handleRef} className={Css.handle}>
           <GoAIcon type="reorder-two" />
         </div>
       </section>
-      <div ref={widthRef} className={Css.width}>{width}</div>
+      <div ref={widthRef} className={Css.width}>
+        {width}
+      </div>
     </div>
-  )
+  );
 }
 
 export default ResizablePanel;

--- a/libs/web-components/src/common/no-scroll.ts
+++ b/libs/web-components/src/common/no-scroll.ts
@@ -1,16 +1,6 @@
 export default function (_node: HTMLElement, opts: { enable: boolean }) {
   let toggledScrolling = false;
 
-  function hideScrollbars() {
-    if (!isScrollable()) {
-      return;
-    }
-    const scrollbarWidth = calculateScrollbarWidth();
-    toggledScrolling = true;
-    document.body.style.overflow = "hidden";
-    document.body.style.borderRight = `${scrollbarWidth}px solid #eee`;
-  }
-
   function isScrollable() {
     return document.body.style.overflow !== "hidden";
   }
@@ -26,6 +16,16 @@ export default function (_node: HTMLElement, opts: { enable: boolean }) {
       document.body.style.overflow = "";
       document.body.style.borderRight = "";
     }, 200);
+  }
+
+  function hideScrollbars() {
+    if (!isScrollable()) {
+      return;
+    }
+    const scrollbarWidth = calculateScrollbarWidth();
+    toggledScrolling = true;
+    document.body.style.overflow = "hidden";
+    document.body.style.borderRight = `${scrollbarWidth}px solid #eee`;
   }
 
   function calculateScrollbarWidth() {

--- a/libs/web-components/src/components/tooltip/Tooltip.svelte
+++ b/libs/web-components/src/components/tooltip/Tooltip.svelte
@@ -236,7 +236,7 @@
 
   .tooltip-text {
     visibility: hidden;
-    font: var(--goa-typography-body-s);
+    font: var(--goa-typography-body-m);
     background-color: var(--goa-color-greyscale-700);
     color: var(--goa-color-text-light);
     text-align: center;
@@ -245,7 +245,7 @@
     z-index: 2;
     opacity: 0;
     transition: opacity 0.3s;
-    padding: var(--goa-space-xs) var(--goa-space-m);
+    padding: var(--goa-space-m);
     text-align: left;
     white-space: nowrap;
     display: flex;


### PR DESCRIPTION
# Before

Padding around the Tooltip component was defined as `--goa-space-xs` on top and bottom and `--goa-space-m` on the sides. Font typography was defined as `--goa-typography-body-s`

# After

Padding around the Tooltip component is now defined as `--goa-space-m` on all sides. Font typography is `--goa-typography-body-m`
