### PR TITLE
Feature/2162 & 2177 app header - privacy portal components + app header to trigger fly out menu

### DIFF
--- a/libs/react-components/src/lib/accordion/accordion.tsx
+++ b/libs/react-components/src/lib/accordion/accordion.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import { Margins } from "../../common/styling";
 
 export type GoAHeadingSize = "small" | "medium";
+export type GoAIconPosition = "left" | "right";
 
 interface WCProps extends Margins {
   open?: boolean;
@@ -11,6 +12,7 @@ interface WCProps extends Margins {
   headingContent?: ReactNode;
   maxwidth?: string;
   testid?: string;
+  iconposition?: GoAIconPosition;
 }
 
 declare global {
@@ -30,6 +32,7 @@ export interface GoAAccordionProps extends Margins {
   headingContent?: ReactNode;
   maxWidth?: string;
   testid?: string;
+  iconPosition?: GoAIconPosition;
   children: ReactNode;
 }
 
@@ -39,6 +42,7 @@ export function GoAAccordion({
   headingSize,
   secondaryText,
   headingContent,
+  iconPosition,
   maxWidth,
   testid,
   children,
@@ -53,6 +57,7 @@ export function GoAAccordion({
       headingSize={headingSize}
       heading={heading}
       secondaryText={secondaryText}
+      iconposition={iconPosition}
       maxwidth={maxWidth}
       testid={testid}
       mt={mt}

--- a/libs/react-components/src/lib/app-header/app-header.spec.tsx
+++ b/libs/react-components/src/lib/app-header/app-header.spec.tsx
@@ -10,4 +10,15 @@ describe("GoAAppHeader", () => {
     const header = baseElement.querySelector("goa-app-header");
     expect(header).toBeTruthy();
   });
+  it("should dispatch onMobileMenuClick if provided", () => {
+    const onMobileMenuClick = vi.fn();
+    const { baseElement } = render(
+      <GoAAppHeader heading="Test heading" url="test" onMenuClick={onMobileMenuClick} />
+    );
+
+    const header = baseElement.querySelector("goa-app-header");
+    expect(header).toBeTruthy();
+    header?.dispatchEvent(new Event("_menuClick"));
+    expect(onMobileMenuClick).toHaveBeenCalled();
+  })
 });

--- a/libs/react-components/src/lib/app-header/app-header.tsx
+++ b/libs/react-components/src/lib/app-header/app-header.tsx
@@ -1,8 +1,12 @@
+import { useEffect, useRef } from "react";
+
 interface WCProps {
   heading?: string;
   url?: string;
   maxcontentwidth?: string;
   fullmenubreakpoint?: number;
+  hasmenuclickhandler?: boolean;
+  ref: React.RefObject<HTMLElement>;
   testid?: string;
 }
 
@@ -21,6 +25,7 @@ export interface GoAAppHeaderProps {
   maxContentWidth?: string;
   fullMenuBreakpoint?: number;
   children?: React.ReactNode;
+  onMenuClick?: () => void;
   testId?: string;
 }
 
@@ -31,14 +36,36 @@ export function GoAAppHeader({
   fullMenuBreakpoint,
   testId,
   children,
+  onMenuClick,
 }: GoAAppHeaderProps): JSX.Element {
+  const el = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!el.current) {
+      return;
+    }
+    if (!onMenuClick) {
+      return;
+    }
+    const current = el.current;
+    const listener = () => {
+      onMenuClick();
+    }
+    current.addEventListener("_menuClick", listener);
+    return () => {
+      current.removeEventListener("_menuClick", listener);
+    }
+  }, [el, onMenuClick]);
+
   return (
     <goa-app-header
+      ref={el}
       heading={heading}
       url={url}
       fullmenubreakpoint={fullMenuBreakpoint}
       maxcontentwidth={maxContentWidth}
       testid={testId}
+      hasmenuclickhandler={!!onMenuClick}
     >
       {children}
     </goa-app-header>

--- a/libs/react-components/src/lib/callout/callout.tsx
+++ b/libs/react-components/src/lib/callout/callout.tsx
@@ -9,6 +9,7 @@ export type GoACalloutType =
 
 export type GoACalloutSize = "medium" | "large";
 export type GoACalloutAriaLive = "off" | "polite" | "assertive";
+export type GoACalloutIconTheme = "outline" | "filled";
 
 interface WCProps extends Margins {
   heading?: string;
@@ -16,6 +17,7 @@ interface WCProps extends Margins {
   size?: GoACalloutSize;
   maxwidth?: string;
   arialive?: GoACalloutAriaLive;
+  icontheme?: GoACalloutIconTheme;
   testid?: string;
 }
 
@@ -32,6 +34,7 @@ export interface GoACalloutProps extends Margins {
   heading?: string;
   type?: GoACalloutType;
   size?: GoACalloutSize;
+  iconTheme?: GoACalloutIconTheme;
   maxWidth?: string;
   testId?: string;
   ariaLive?: GoACalloutAriaLive;
@@ -43,6 +46,7 @@ export type CalloutProps = GoACalloutProps;
 export const GoACallout = ({
   heading,
   type = "information",
+  iconTheme = "outline",
   size = "large",
   maxWidth,
   testId,
@@ -60,6 +64,7 @@ export const GoACallout = ({
       size={size}
       maxwidth={maxWidth}
       arialive={ariaLive}
+      icontheme={iconTheme}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/react-components/src/lib/side-menu-group/side-menu-group.spec.tsx
+++ b/libs/react-components/src/lib/side-menu-group/side-menu-group.spec.tsx
@@ -10,4 +10,12 @@ describe("SideMenuGroup", () => {
     expect(el?.getAttribute("heading")).toBe("some header");
     expect(el?.getAttribute("testid")).toBe("foo");
   });
+  it("should render icon if provided", () => {
+    const { baseElement } = render(
+      <SideMenuGroup heading={"Some header"} testId={"foo"} icon={"accessibility"} />,
+    );
+
+    const el = baseElement.querySelector("goa-side-menu-group");
+    expect(el?.getAttribute("icon")).toBe("accessibility");
+  })
 });

--- a/libs/react-components/src/lib/side-menu-group/side-menu-group.tsx
+++ b/libs/react-components/src/lib/side-menu-group/side-menu-group.tsx
@@ -1,8 +1,12 @@
 import { ReactNode } from "react";
+import { GoAIconType } from "../icon/icon";
+import { Margins } from "../../common/styling";
 
-interface WCProps {
+interface WCProps extends Margins {
   heading: string;
+  icon?: GoAIconType;
   testid?: string;
+
 }
 
 declare global {
@@ -16,8 +20,9 @@ declare global {
 }
 
 /* eslint-disable-next-line */
-export interface GoASideMenuGroupProps {
+export interface GoASideMenuGroupProps extends Margins {
   heading: string;
+  icon?: GoAIconType;
   testId?: string;
   children?: ReactNode;
 }
@@ -26,7 +31,12 @@ export function GoASideMenuGroup(props: GoASideMenuGroupProps): JSX.Element {
   return (
     <goa-side-menu-group
       heading={props.heading}
+      icon={props.icon}
       testid={props.testId}
+      mt={props.mt}
+      mr={props.mr}
+      mb={props.mb}
+      ml={props.ml}
     >
       {props.children}
     </goa-side-menu-group>

--- a/libs/react-components/src/lib/three-column-layout/three-column-layout.spec.tsx
+++ b/libs/react-components/src/lib/three-column-layout/three-column-layout.spec.tsx
@@ -39,7 +39,7 @@ describe("ThreeColumnLayout", () => {
     expect(baseElement.innerHTML).toContain(
       "Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat."
     );
-    expect(baseElement.innerHTML).toContain("<goa-app-header>");
+    expect(baseElement.querySelector("goa-app-header")).toBeTruthy();
     expect(baseElement.innerHTML).toContain("<goa-app-footer>");
     expect(baseElement.querySelectorAll("[slot=nav] a").length).toEqual(5);
 

--- a/libs/react-components/src/lib/two-column-layout/two-column-layout.spec.tsx
+++ b/libs/react-components/src/lib/two-column-layout/two-column-layout.spec.tsx
@@ -34,7 +34,7 @@ describe("TwoColumnLayout", () => {
     expect(baseElement.innerHTML).toContain(
       "Lorem ipsum dolor sit amet, qui minim labore adipisicing minim sint cillum sint consectetur cupidatat."
     );
-    expect(baseElement.innerHTML).toContain("<goa-app-header>");
+    expect(baseElement.querySelector("goa-app-header")).toBeTruthy();
     expect(baseElement.innerHTML).toContain("<goa-app-footer>");
     expect(baseElement.querySelectorAll("[slot=nav] a").length).toEqual(5);
   });

--- a/libs/web-components/src/assets/css/components.css
+++ b/libs/web-components/src/assets/css/components.css
@@ -56,10 +56,10 @@ goa-table[variant="relaxed"] td {
 
 goa-table thead th {
   background-color: var(--goa-color-greyscale-white);
-  color: var(--goa-color-text-secondary);
+  color: var(--goa-table-color-heading);
   padding: var(--goa-space-s) var(--goa-table-header-padding, var(--goa-space-m)) var(--goa-space-xs) var(--goa-table-header-padding, var(--goa-space-m));
   text-align: left;
-  border-bottom: 2px solid var(--goa-color-greyscale-600);
+  border-bottom: 2px solid var(--goa-table-color-border-heading);
   vertical-align: bottom;
   }
 

--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -32,7 +32,7 @@
   export let mr: Spacing = null;
   export let mb: Spacing = "xs";
   export let ml: Spacing = null;
-
+  export let iconposition: "left" | "right" = "left";
   // Private
 
   let _hovering: boolean = false;
@@ -86,12 +86,16 @@
       aria-controls={`${_accordionId}-content`}
       aria-expanded={open === "true"}
     >
-      <goa-icon
-        type="chevron-forward"
-        fillcolor={_hovering
-          ? "var(--goa-color-interactive-hover)"
-          : "var(--goa-color-interactive-default)"}
-      ></goa-icon>
+
+      {#if iconposition === "left"}
+        <goa-icon
+          type="chevron-forward"
+          fillcolor={_hovering
+      ? "var(--goa-color-interactive-hover)"
+      : "var(--goa-color-interactive-default)"}
+        ></goa-icon>
+      {/if}
+
       <div class="title" bind:this={_titleEl} id={`${_accordionId}-heading`}>
         <span
           class="heading heading-{headingsize}"
@@ -107,6 +111,15 @@
           <slot name="headingcontent" />
         </div>
       </div>
+
+      {#if iconposition === "right"}
+        <goa-icon
+          type="chevron-forward"
+          fillcolor={_hovering
+      ? "var(--goa-color-interactive-hover)"
+      : "var(--goa-color-interactive-default)"}
+        ></goa-icon>
+      {/if}
     </summary>
     <div
       class="content"
@@ -127,6 +140,11 @@
     font-size: var(--goa-font-size-4);
   }
 
+  .goa-accordion {
+    border-radius: var(--goa-accordion-border-radius);
+    box-shadow: var(--goa-accordion-shadow);
+  }
+
   .goa-accordion,
   .goa-accordion * {
     box-sizing: border-box;
@@ -138,13 +156,11 @@
 
   summary {
     min-height: 3.5rem;
-    padding: var(--goa-space-s) var(--goa-space-m) var(--goa-space-s) 0;
-    border-width: var(--goa-border-width-s);
-    border-style: solid;
-    border-radius: var(--goa-border-radius-m);
-    background-color: var(--goa-color-greyscale-100);
-    border-color: var(--goa-color-greyscale-200);
-    color: var(--goa-color-text-default);
+    padding: var(--goa-accordion-padding-heading);
+    border: var(--goa-accordion-border);
+    border-radius: var(--goa-accordion-border-radius);
+    background-color: var(--goa-accordion-color-bg-heading);
+    color: var(--goa-accordion-color-heading);
     cursor: pointer;
     list-style: none;
     display: flex;
@@ -155,11 +171,12 @@
   }
 
   summary:hover {
-    background-color: var(--goa-color-greyscale-200);
+    background-color: var(--goa-accordion-color-bg-heading-hover);
+    color: var(--goa-accordion-color-heading-hover);
   }
   summary:focus-visible,
   summary:active {
-    background-color: var(--goa-color-greyscale-100);
+    background-color: var(--goa-accordion-color-bg-heading);
     outline: none;
   }
 
@@ -172,7 +189,7 @@
     bottom: -1px;
     left: -1px;
     border: var(--goa-border-width-l) solid var(--goa-color-interactive-focus);
-    border-radius: 4px;
+    border-radius: var(--goa-accordion-border-radius);
   }
 
   summary::marker, /* Latest Chrome, Edge, Firefox */
@@ -194,7 +211,7 @@
   }
 
   .heading {
-    font: var(--goa-typography-heading-s);
+    font: var(--goa-accordion-heading-s);
     padding-right: 1rem;
   }
 
@@ -221,12 +238,12 @@
   }
 
   .content {
-    border-bottom: var(--goa-border-width-s) solid
-      var(--goa-color-greyscale-200);
-    border-left: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
-    border-right: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
-    border-bottom-left-radius: var(--goa-border-radius-m);
-    border-bottom-right-radius: var(--goa-border-radius-m);
+    border-bottom: var(--goa-accordion-border);
+    border-left: var(--goa-accordion-border);
+    border-right: var(--goa-accordion-border);
+    border-bottom-left-radius: var(--goa-accordion-border-radius);
+    border-bottom-right-radius: var(--goa-accordion-border-radius);
+    background-color: var(--goa-accordion-color-bg-content);
   }
 
   .content :global(::slotted(*:last-child)) {
@@ -240,17 +257,18 @@
   details[open] summary {
     border-bottom-left-radius: var(--goa-border-radius-none);
     border-bottom-right-radius: var(--goa-border-radius-none);
+    border-bottom: var(--goa-accordion-divider);
   }
 
   /* Sizes */
   .heading-medium {
     line-height: 2rem;
-    font: var(--goa-typography-heading-m);
+    font: var(--goa-accordion-heading-m);
   }
 
   @container self (--mobile) {
     .content {
-      padding: 1.5rem;
+      padding: var(--goa-accordion-padding-content-narrow);
     }
     .title {
       display: flex;
@@ -261,7 +279,7 @@
 
   @container self (--not-mobile) {
     .content {
-      padding: 1.5rem 2rem 1.5rem 3.5rem;
+      padding: var(--goa-accordion-padding-content-wide);
     }
     .title {
       align-items: center;

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -100,28 +100,22 @@
 
 <style>
   :host {
-    --button-height: 2.625rem; /* 42px */
-    --button-height-compact: 2rem; /* 32px */
     --button-height-tall: 3.25rem; /* 52px */
-
     box-sizing: border-box;
-    font-family: var(--goa-font-family-sans);
   }
 
   button {
     display: inline-flex;
     box-sizing: border-box;
-    border-radius: 0.25rem;
+    border-radius: var(--goa-button-border-radius);
     border: 2px solid var(--goa-color-interactive-default);
     box-sizing: border-box;
     cursor: pointer;
-    font-family: var(--goa-font-family-sans);
-    font-size: var(--goa-font-size-5);
-    font-weight: 400;
-    height: var(--button-height);
+    font: var(--goa-button-text);
+    height: var(--goa-button-height);
     letter-spacing: var(--goa-letter-spacing-button);
     line-height: 100%;
-    padding: 0 0.75rem;
+    padding:0 var(--goa-button-padding-lr);
     white-space: nowrap;
 
     /* for leading and trailing icon vertical alignment */
@@ -162,10 +156,10 @@
   }
 
   button.compact {
-    height: var(--button-height-compact);
+    height: var(--goa-button-height-compact);
     font-size: var(--goa-font-size-4);
-    padding-left: var(--goa-space-xs);
-    padding-right: var(--goa-space-xs);
+    padding-left: var(--goa-button-padding-lr-compact);
+    padding-right: var(--goa-button-padding-lr-compact);
   }
 
   button.start {

--- a/libs/web-components/src/components/callout/Callout.svelte
+++ b/libs/web-components/src/components/callout/Callout.svelte
@@ -6,6 +6,7 @@
   import { onMount } from "svelte";
   import { typeValidator } from "../../common/utils";
   import { MOBILE_BP } from "../../common/breakpoints";
+  import type { IconTheme } from "../icon/Icon.svelte";
 
   // Validators
 
@@ -41,6 +42,7 @@
   export let maxwidth: string = "none";
   export let testid: string = "";
   export let arialive: AriaLiveType = "off";
+  export let icontheme: IconTheme = "outline";
 
   // Private
 
@@ -83,7 +85,7 @@
     ${calculateMargin(mt, mr, mb, ml)};
     max-width: ${maxwidth};
   `}
-  class="notification"
+  class="notification {type}"
   class:medium={isMediumCallout}
   data-testid={testid}
   aria-live={arialive}
@@ -92,10 +94,10 @@
     <goa-icon
       type={iconType}
       size={iconSize}
-      inverted={type === "important" ? "false" : "true"}
+      theme={icontheme}
     />
   </span>
-  <span class="content">
+  <span class="content {type}">
     {#if heading}
       <h3 class:medium={isMediumCallout}>{heading}</h3>
     {/if}
@@ -113,57 +115,110 @@
     display: flex;
     align-items: stretch;
     overflow: hidden;
-    font: var(--goa-typography-body-m);
+    font: var(--goa-callout-l-text-size);
+    border: var(--goa-callout-l-border-width) solid;
+    border-radius: var(--goa-callout-border-radius);
   }
 
   h3 {
-    font: var(--goa-typography-heading-m);
+    font: var(--goa-callout-l-heading-size);
     margin-top: var(--goa-space-none);
-    margin-bottom: var(--goa-space-m);
+    margin-bottom: var(--goa-callout-l-content-gap);
   }
 
-  .emergency {
+  .icon.information {
+    background-color: var(--goa-callout-info-color-bg-statusbar);
+  }
+
+  .icon.information > * {
+    fill: var(--fill-color, var(--goa-callout-info-icon-color));
+    color: var(--fill-color, var(--goa-callout-info-icon-color));
+  }
+  .icon.important > * {
+    fill: var(--fill-color, var(--goa-callout-warning-icon-color));
+    color: var(--fill-color, var(--goa-callout-warning-icon-color));
+  }
+  .icon.success > * {
+    fill: var(--fill-color, var(--goa-callout-success-icon-color));
+    color: var(--fill-color, var(--goa-callout-success-icon-color));
+  }
+  .icon.emergency > * {
+    fill: var(--fill-color, var(--goa-callout-emergency-icon-color));
+    color: var(--fill-color, var(--goa-callout-emergency-icon-color));
+  }
+  .icon.event > * {
+    fill: var(--fill-color, var(--goa-callout-event-icon-color));
+    color: var(--fill-color, var(--goa-callout-event-icon-color));
+  }
+
+  .icon.emergency {
     background-color: var(--goa-color-emergency-default);
   }
-  .important {
-    background-color: var(--goa-color-warning-default);
+  .icon.important {
+    background-color: var(--goa-callout-warning-color-bg-statusbar);
   }
-  .information {
+  .icon.information {
     background-color: var(--goa-color-info-default);
   }
-  .event {
+  .icon.event {
     background-color: var(--goa-color-info-default);
   }
-  .success {
-    background-color: var(--goa-color-success-default);
+  .icon.success {
+    background-color: var(--goa-callout-success-color-bg-statusbar);
+  }
+  .icon.emergency {
+    background-color: var(--goa-callout-emergency-color-bg-statusbar);
   }
 
   .icon {
     text-align: center;
-    padding-top: var(--goa-space-l);
-    padding-left: var(--goa-space-s);
-    padding-right: var(--goa-space-s);
+    padding: var(--goa-callout-l-statusbar-padding);
+  }
+
+  .content.information {
+    background-color: var(--goa-callout-info-color-bg-content);
+  }
+  .content.important {
+    background-color: var(--goa-callout-warning-color-bg-content);
+  }
+  .content.success {
+    background-color: var(--goa-callout-success-color-bg-content);
+  }
+  .content.emergency {
+    background-color: var(--goa-callout-emergency-color-bg-content);
   }
   .content {
     flex: 1 1 auto;
     background-color: var(--goa-color-greyscale-100);
-    padding: var(--goa-space-l);
+    padding: var(--goa-callout-l-content-padding);
+  }
+
+  .notification.information {
+    border-color: var(--goa-callout-info-border-color);
+  }
+  .notification.important {
+    border-color: var(--goa-callout-warning-border-color);
+  }
+  .notification.success {
+    border-color: var(--goa-callout-success-border-color);
+  }
+  .notification.emergency {
+    border-color: var(--goa-callout-emergency-border-color);
   }
   /*Medium callout style*/
   .notification.medium {
-    font: var(--goa-typography-body-s);
+    font: var(--goa-callout-m-text-size);
+    border-width: var(--goa-callout-m-border-width);
   }
   h3.medium {
-    font: var(--goa-typography-heading-xs);
-    margin-bottom: var(--goa-space-2xs);
+    font: var(--goa-callout-m-heading-size);
+    margin-bottom: var(--goa-callout-m-content-gap);
   }
   .notification.medium .content {
-    padding: var(--goa-space-s);
+    padding: var(--goa-callout-m-content-padding);
     margin-top: calc(-1 * var(--goa-space-3xs));
   }
   .notification.medium .icon {
-    padding-top: var(--goa-space-s);
-    padding-left: var(--goa-space-2xs);
-    padding-right: var(--goa-space-2xs);
+    padding: var(--goa-callout-m-statusbar-padding);
   }
 </style>

--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -118,16 +118,16 @@
     font: var(--goa-typography-heading-s);
     border-width: 1px;
     border-style: solid;
-    border-top-left-radius: var(--goa-border-radius-m);
-    border-top-right-radius: var(--goa-border-radius-m);
+    border-top-left-radius: var(--goa-container-border-radius);
+    border-top-right-radius: var(--goa-container-border-radius);
   }
 
   .content {
-    border-bottom: 1px solid var(--goa-color-greyscale-200);
-    border-left: 1px solid var(--goa-color-greyscale-200);
-    border-right: 1px solid var(--goa-color-greyscale-200);
-    border-bottom-left-radius: var(--goa-border-radius-m);
-    border-bottom-right-radius: var(--goa-border-radius-m);
+    border-bottom: var(--goa-container-border);
+    border-left: var(--goa-container-border);
+    border-right: var(--goa-container-border);
+    border-bottom-left-radius: var(--goa-container-border-radius);
+    border-bottom-right-radius: var(--goa-container-border-radius);
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
@@ -174,11 +174,11 @@
   /* Padding variants */
 
   .padding--relaxed header {
-    padding: 0 1.5rem;
+    padding: 0 var(--goa-container-padding);
   }
 
   .padding--relaxed .content {
-    padding: 1.5rem;
+    padding: var(--goa-container-padding);
   }
 
   .padding--compact header,
@@ -258,9 +258,9 @@
     display: none;
   }
   .heading--filled ~ .content {
-    border-top: 1px solid var(--goa-color-greyscale-200);
-    border-top-left-radius: var(--goa-border-radius-m);
-    border-top-right-radius: var(--goa-border-radius-m);
+    border-top: var(--goa-container-border);
+    border-top-left-radius: var(--goa-container-border-radius);
+    border-top-right-radius: var(--goa-container-border-radius);
   }
 
   .heading--thin .title,

--- a/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
+++ b/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
@@ -11,9 +11,16 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { getSlottedChildren } from "../../common/utils";
+  import type { GoAIconType } from "../icon/Icon.svelte";
+  import { calculateMargin, Spacing } from "../../common/styling";
 
   export let heading: string;
+  export let icon: GoAIconType | null = null;
   export let testid: string = "";
+  export let mt: Spacing = null;
+  export let mr: Spacing = null;
+  export let mb: Spacing = null;
+  export let ml: Spacing = null;
 
   let _open = false;
   let _current = false;
@@ -112,14 +119,29 @@
   }
 </script>
 
-<div bind:this={_rootEl} class="side-menu-group" class:current={_current} data-testid={testid}>
-  <a href={`#${_slug}`} class="heading" on:click={handleClick}>
-    {heading}
-    {#if _open}
-      <goa-icon type="chevron-down" />
-    {:else}
-      <goa-icon type="chevron-forward" />
+<div bind:this={_rootEl}
+     class="side-menu-group"
+     class:current={_current}
+     data-testid={testid}
+     style={`
+    ${calculateMargin(mt, mr, mb, ml)};
+  `}
+>
+  <a href={`#${_slug}`} class="heading" class:open={_open} on:click={handleClick}>
+    {#if icon}
+      <div class="leading-icon">
+        <goa-icon type={icon} />
+      </div>
     {/if}
+    {heading}
+    <div class="trailing-icon">
+      {#if _open}
+        <goa-icon type="chevron-down"/>
+      {:else}
+        <goa-icon type="chevron-forward"/>
+      {/if}
+    </div>
+
   </a>
   <div class:hidden={!_open} class="group" data-testid="group">
     <slot />
@@ -135,23 +157,26 @@
     display: block;
     font: var(--goa-typography-body-m);
     margin-left: 1rem;
+    background-color: var(--goa-side-menu-group-color-bg);
   }
 
   :global(::slotted(a)),
   :global(::slotted(a:visited)) {
     padding: 0.5rem 1rem;
     text-decoration: none;
-    border-left: 4px solid var(--goa-color-greyscale-100);
+    border-left: var(--goa-side-menu-child-border-width) solid var(--goa-color-greyscale-100);
   }
 
   :global(::slotted(a.current)) {
     font: var(--goa-typography-heading-s);
-    border-left: 4px solid var(--goa-color-interactive-disabled);
-    background: var(--goa-color-info-background);
+    border-left: var(--goa-side-menu-child-border-width) solid var(--goa-color-interactive-disabled);
+    background: var(--goa-side-menu-child-color-bg-selected);
+    /* required to override base styles & above :global(::slotted(a) !important */
+    color: var(--goa-side-menu-child-color-text-selected)!important;
   }
 
   :global(::slotted(a:hover:not(.current))) {
-    background: var(--goa-color-info-background);
+    background: var(--goa-side-menu-child-color-bg-hover);
     border-color: var(--goa-color-greyscale-200);
   }
 
@@ -171,13 +196,17 @@
     align-items: center;
     justify-content: space-between;
     line-height: 2rem;
-    padding: 0.5rem 1rem 0.5rem 2rem;
+    padding: var(--goa-side-menu-parent-padding);
     text-decoration: none;
+    font: var(--goa-side-menu-parent-text);
+  }
+  .heading.open {
+    font: var(--goa-side-menu-parent-text-active);
   }
 
   :host([child="true"]) a.heading {
     margin-left: 1rem;
-    border-left: 4px solid var(--goa-color-greyscale-100);
+    border-left: var(--goa-side-menu-child-border-width) solid var(--goa-color-greyscale-100);
     padding: 0.5rem 1rem 0.5rem 1rem;
   }
 
@@ -188,15 +217,21 @@
 
   :host([child="true"]) .side-menu-group.current a.heading {
     background: var(--goa-color-info-background);
-    border-left: 4px solid var(--goa-color-interactive-disabled);
+    border-left: var(--goa-side-menu-child-border-width) solid var(--goa-color-interactive-disabled);
+  }
+
+  .side-menu-group {
+    background-color: var(--goa-side-menu-group-color-bg);
+    border-radius: var(--goa-side-menu-group-border-radius);
+    padding: var(--goa-side-menu-group-padding);
   }
 
   .side-menu-group.current .heading {
-    background: #cedfee;
+    background: var(--goa-side-menu-parent-color-bg-hover);
   }
 
   .heading:hover {
-    background: #cedfee;
+    background: var(--goa-side-menu-parent-color-bg-hover);
   }
 
   .hidden {
@@ -204,6 +239,15 @@
   }
 
   .group {
-    padding-left: 1rem;
+    padding: var(--goa-side-menu-sub-group-padding);
+  }
+
+  .trailing-icon {
+    margin-left: auto;
+    height: var(--goa-icon-size-l); /* to make sure the icon vertical center */
+  }
+  .leading-icon {
+    margin-right: var(--goa-space-xs);
+    height: var(--goa-icon-size-l); /* to make sure the icon vertical center */
   }
 </style>

--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -126,7 +126,6 @@
   class={`goatable ${variant}`}
   class:sticky={_stickyHeader}
   style={`
-    overflow-x: auto;
     ${`width: ${width || "100%"};`}
     ${calculateMargin(mt, mr, mb, ml)}
   `}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "zone.js": "0.14.3"
       },
       "devDependencies": {
-        "@abgov/design-tokens": "^1.4.0",
+        "@abgov/design-tokens": "^1.4.1",
         "@abgov/nx-release": "8.0.0",
         "@angular-devkit/build-angular": "18.2.8",
         "@angular-devkit/core": "18.1.4",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@abgov/design-tokens": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-1.4.0.tgz",
-      "integrity": "sha512-J15RqUvRDvpqQ2zVAUn3Kcky47Rzt+tYO6AFuEu556DzDgGyEQenpquj2KZB7xxexgkZekNMjKqgBPiykgPHpQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-1.4.1.tgz",
+      "integrity": "sha512-GDXvX2+yiYBHJsJOw/eKwehvVXCSYIdWI0RjDlLBaizpEoiMUWRcN1OeS2PVK7fm/WtceB46WKn5qxyQgRT+Qg==",
       "dev": true,
       "dependencies": {
         "style-dictionary": "^3.7.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "private": true,
   "devDependencies": {
-    "@abgov/design-tokens": "^1.4.0",
+    "@abgov/design-tokens": "^1.4.1",
     "@abgov/nx-release": "8.0.0",
     "@angular-devkit/build-angular": "18.2.8",
     "@angular-devkit/core": "18.1.4",


### PR DESCRIPTION
# Before (the change)
If we want to have the look for those below 5 components:
* Accordion
* Button
* Callout
* Container
* Table
* SideMenuGroup
Like this figma design: https://www.figma.com/design/NRFUYjCwVoI9qMbFEG6s7J/Component-tokens?node-id=0-1&node-type=canvas&m=dev

It is impossible to override CSS right now, and if we override `--goa-text-default-color` for example, we will affect other components. 
This pull request is to add more specific design token variable names for those above 5 components, at the same time assigning values for those adding tokens, so it won't affect our components, but at the same time, allow other teams (specifically Privacy Portal Team) to override variable design token CSS (For example: https://github.com/vanessatran-ddi/latest-react-demo/blob/privacy-portal-components/src/override.css) 

# After (the change)
They can change the CSS variable token values on their app, example: https://vanessatran-ddi.github.io/latest-react-demo/



## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
The below is how we can test: @lizhuomeng71 :

Step 1:  Build the project: `npm run build:all`

Step 2: Check The 6 above components to see if their looks are different with existing components. We don't want to have anything different. 
(You can check with `ui-component-docs` by `npm link`)

Accordion: 
![image](https://github.com/user-attachments/assets/0295f303-a86d-466b-9472-59e9782063c1)

New attribute:
* iconPosition
![image](https://github.com/user-attachments/assets/1069c620-055f-4c0c-ad0c-a762c171bdde)

Button: (remain same)
![image](https://github.com/user-attachments/assets/b2165c63-ddd1-4337-8f40-63193e45f0e3)

Callout: (style remains the same but has a new attribute `iconTheme`)
![image](https://github.com/user-attachments/assets/6cb6b08c-a959-4b45-bcb9-124ba67f836c)

Container (remains the same)
![image](https://github.com/user-attachments/assets/2bc9e14c-198d-4a31-9984-da4b05af4a01)

Side Menu Group (remains the same with a new attribute `icon`)
![image](https://github.com/user-attachments/assets/7a8d0cdc-2e46-4dce-ab00-ad4a3d36f5ca)

(notice: for padding issue it has a PR https://github.com/GovAlta/design-tokens/pull/54 to fix)


AppHeader (styles remain the same)
![image](https://github.com/user-attachments/assets/e6c5209b-f0c4-4f10-8cdf-9cd036277916)

If `onMenuClick` function is passed, then when it is on Tablet/Mobile, clicking the burger menu won't show up the AppHeaderMenu, but trigger the function `handleMenuClick`