### PR TITLE
fix(#1207): fix visual design issues on radio item

### DIFF
--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -165,6 +165,8 @@
     --goa-radio-diameter: 1.5rem;
     --goa-radio-border-width: 1px;
     --goa-radio-border-width--checked: 7px;
+    --goa-radio-border-width--hover: 2px;
+    --goa-radio-border-width--error: 2px;
     box-sizing: border-box;
     display: flex;
   }
@@ -202,7 +204,7 @@
     height: var(--goa-radio-diameter);
     width: var(--goa-radio-diameter);
     border-radius: 50%;
-    background-color: #fff;
+    background-color: var(--goa-color-text-light, #fff);
     transition: box-shadow 100ms ease-in-out;
 
     /* prevent squishing of radio button */
@@ -211,7 +213,7 @@
   }
 
   .goa-radio--disabled .goa-radio-label {
-    opacity: 0.4;
+    color: var(--goa-color-greyscale-500);
   }
 
   .goa-radio--disabled:hover {
@@ -220,30 +222,16 @@
 
   /* States */
 
-  /* Default */
+  /* Unchecked */
   input[type="radio"]:not(:checked) ~ .goa-radio-icon {
-    border: var(--goa-radio-border-width) solid var(--goa-color-greyscale-700);
+    border: var(--goa-radio-border-width) solid
+      var(--goa-color-greyscale-700);
   }
 
-  /* Default:hover */
+  /* Hover */
   input[type="radio"]:hover ~ .goa-radio-icon {
-    border: 1px solid var(--goa-color-interactive-hover);
-    box-shadow: 0 0 0 1px var(--goa-color-interactive-hover);
-  }
-
-  /* Checked:hover */
-  input[type="radio"]:checked:hover ~ .goa-radio-icon {
-    border: 7px solid var(--goa-color-interactive-hover);
-    box-shadow: 0 0 0 1px var(--goa-color-interactive-hover);
-  }
-
-  /* Default:focus */
-  input[type="radio"]:focus ~ .goa-radio-icon,
-  input[type="radio"]:hover:active ~ .goa-radio-icon,
-  input[type="radio"]:hover:focus ~ .goa-radio-icon,
-  input[type="radio"]:active ~ .goa-radio-icon {
-    box-shadow: 0 0 0 var(--goa-radio-outline-width)
-      var(--goa-color-interactive-focus);
+    border: var(--goa-radio-border-width--hover) solid
+      var(--goa-color-interactive-hover);
   }
 
   /* Checked */
@@ -252,45 +240,59 @@
       var(--goa-color-interactive-default);
   }
 
-  /* Disabled */
-  input[type="radio"]:disabled ~ .goa-radio-icon,
-  input[type="radio"]:disabled:focus ~ .goa-radio-icon,
-  input[type="radio"]:disabled:active ~ .goa-radio-icon {
-    border: var(--goa-radio-border-width) solid var(--goa-color-greyscale-700);
-    box-shadow: none;
-    opacity: 40%;
+  /* Hover & checked */
+      input[type="radio"]:checked:hover ~ .goa-radio-icon {
+    border-color: var(--goa-color-interactive-hover);
   }
 
-  /* Disabled and checked */
-  input[type="radio"]:disabled:checked ~ .goa-radio-icon,
-  input[type="radio"]:disabled:checked:focus ~ .goa-radio-icon,
-  input[type="radio"]:disabled:checked:active ~ .goa-radio-icon {
-    border: var(--goa-radio-border-width--checked) solid
-      var(--goa-color-interactive-hover);
-    box-shadow: none;
-  }
-
-  /* Error */
-  .goa-radio--error input[type="radio"]:checked ~ .goa-radio-icon,
-  .goa-radio--error input[type="radio"]:disabled:checked ~ .goa-radio-icon {
-    border: 7px solid var(--goa-color-emergency-default);
-  }
-
-  .goa-radio--error input[type="radio"]:hover ~ .goa-radio-icon {
-    box-shadow: 0 0 0 1px var(--goa-color-emergency-default);
-  }
-
-  .goa-radio--error input[type="radio"]:hover:active ~ .goa-radio-icon,
-  .goa-radio--error input[type="radio"]:hover:focus ~ .goa-radio-icon {
+  /* Focus */
+  input[type="radio"]:focus ~ .goa-radio-icon,
+  input[type="radio"]:hover:active ~ .goa-radio-icon,
+  input[type="radio"]:hover:focus ~ .goa-radio-icon,
+  input[type="radio"]:active ~ .goa-radio-icon {
     box-shadow: 0 0 0 var(--goa-radio-outline-width)
       var(--goa-color-interactive-focus);
   }
 
-  .goa-radio--error input[type="radio"]:disabled:hover ~ .goa-radio-icon {
+  /* Disabled */
+  input[type="radio"]:disabled ~ .goa-radio-icon,
+  input[type="radio"]:disabled:focus ~ .goa-radio-icon,
+  input[type="radio"]:disabled:active ~ .goa-radio-icon {
+    border: var(--goa-radio-border-width) solid
+      var(--goa-color-greyscale-400);
     box-shadow: none;
   }
 
+  /* Disabled & checked */
+  input[type="radio"]:disabled:checked ~ .goa-radio-icon,
+  input[type="radio"]:disabled:checked:focus ~ .goa-radio-icon,
+  input[type="radio"]:disabled:checked:active ~ .goa-radio-icon {
+    border: var(--goa-radio-border-width--checked) solid
+      var(--goa-color-interactive-disabled);
+    box-shadow: none;
+  }
+
+  /* Error & unchecked */
   .goa-radio--error input[type="radio"]:not(:checked) ~ .goa-radio-icon {
-    border: 2px solid var(--goa-color-emergency-default);
+    border: var(--goa-radio-border-width--error) solid
+      var(--goa-color-interactive-error);
+  }
+
+  /* Error & checked */
+  .goa-radio--error input[type="radio"]:checked ~ .goa-radio-icon {
+    border-color: var(--goa-color-interactive-error);
+  }
+
+  /* Error & hover */
+  .goa-radio--error input[type="radio"]:hover ~ .goa-radio-icon {
+    border-color: var(--goa-color-interactive-error-hover, #BA0000);
+  }
+
+  /* Error & disabled */
+  .goa-radio--error input[type="radio"]:disabled ~ .goa-radio-icon,
+  .goa-radio--error input[type="radio"]:disabled:focus ~ .goa-radio-icon,
+  .goa-radio--error input[type="radio"]:disabled:active ~ .goa-radio-icon {
+    border-color: var(--goa-color-interactive-error-disabled, #F58185);
+    box-shadow: none;
   }
 </style>


### PR DESCRIPTION
This PR fixes some minor visual issues with the radio component to make it consistent with Figma. Changes include the following:

| Change | Before | After |
|--------|--------|--------|
| Button uses an inner border on hover | ![before - normal - hover](https://github.com/user-attachments/assets/21d992f6-fdf4-4d56-af13-feca1a8766d9) | ![after - normal - hover](https://github.com/user-attachments/assets/e67b8be5-eb6d-4cbb-8b9f-8522c4bfa86b) |
| Disabled label color is `grey-500` | ![image](https://github.com/user-attachments/assets/c6b71138-4700-47e0-a936-5be7c107ae6d) | ![image](https://github.com/user-attachments/assets/da85683e-194e-4543-a415-d6797a3c9fda) |
| Disabled button color is `grey-400`  | | | 
| Button border order width does not increase on focus | ![before - normal - focus](https://github.com/user-attachments/assets/1d145eb2-0f86-4cfc-bfe6-961139d82d99) | ![after - normal - focus](https://github.com/user-attachments/assets/0e8c1515-aac3-4d33-b673-adf36bd8db1b) | 
| Error button color is `interactive-error` | ![image](https://github.com/user-attachments/assets/739b7cf8-07f3-4b6e-837d-89796a04f17d) | ![image](https://github.com/user-attachments/assets/8d3a8278-96a5-47d5-9874-e9d6d57b0295) | 
| Error button color is `interactive-error-hover` on hover | ![before - error - hover](https://github.com/user-attachments/assets/d0a12dac-c277-4ef6-8ad1-913881869c23) | ![after - error - hover](https://github.com/user-attachments/assets/fbfb649f-9cc0-4674-a5ff-fb129843dc97) |
| Error button border width does not change on hover | | |
| Error & disabled label color is `grey-500` | ![image](https://github.com/user-attachments/assets/17a7d292-4a97-4584-a641-daf18aed5edd) | ![image](https://github.com/user-attachments/assets/df7f0078-8ab6-4273-9a26-f4c5fff3e67f) |
| Error & disabled button color is `interactive-error-disabled` | | |
| Error button border order width does not increase on focus | ![before - error - focus](https://github.com/user-attachments/assets/b1412a80-ad79-4dd2-8c67-74c6d9c46ca4) | ![after - error -focus](https://github.com/user-attachments/assets/393c3b3e-17b6-49b2-a6e2-04de6c8da49e) | 

### Note
I didn't implement the following change from https://github.com/GovAlta/ui-components/issues/1207:

>  Circle element should be color.interactive.error.hover

I noticed that the [Figma component](https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?m=auto&node-id=27340-612721&t=HMIrCwKaOtZbCcPB-1) uses the standard `error` colour on focus and not the `error-hover` color. I've kept it consistent with Figma.

![image](https://github.com/user-attachments/assets/4e0540d7-a3c7-44c6-9b37-f782f0e44d74)


## PR checklist
- [x] My local unit tests pass
- [x] I have tested the functionality in both React and Angular.
