### PR TITLE
fix: prevent all the semicolons from being replaced with a space

### DIFF
--- a/libs/web-components/src/common/utils.ts
+++ b/libs/web-components/src/common/utils.ts
@@ -12,12 +12,16 @@
 
 // ```
 export function styles(...css: (string | boolean)[]): string {
-  return css
-    .filter((item: string | boolean) => !!item)
-    .map((item: string | boolean) =>
-      typeof item === "string" ? item.replace(";", "") : item,
-    )
-    .join(";");
+  return (
+    css
+      // remove blank items
+      .filter((item: string | boolean) => !!item)
+      // replace the ending `;` with a blank
+      .map((item: string | boolean) =>
+        typeof item === "string" ? item.replace(/;$/, "") : item,
+      )
+      .join(";")
+  );
 }
 
 // creates a style attribute/value or empty string


### PR DESCRIPTION
# Before (the change)

# After (the change)

## Make sure that you've checked the boxes below before you submit the PR

- [ x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

```
<div>Some Text</div>
<goa-text as="h2" mt="xl" mb="xl">
   There should be padding above this text
</goa-text>
```