### PR TITLE
fix(#2162): accordion padding for right and left icon position

### DIFF
--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -85,6 +85,7 @@
       on:blur={() => (_hovering = false)}
       aria-controls={`${_accordionId}-content`}
       aria-expanded={open === "true"}
+      class:iconRight={iconposition === "right"}
     >
 
       {#if iconposition === "left"}
@@ -156,7 +157,7 @@
 
   summary {
     min-height: 3.5rem;
-    padding: var(--goa-accordion-padding-heading);
+    padding: var(--goa-accordion-padding-heading-icon-left);
     border: var(--goa-accordion-border);
     border-radius: var(--goa-accordion-border-radius);
     background-color: var(--goa-accordion-color-bg-heading);
@@ -168,6 +169,10 @@
 
     /* safari hack (see below) */
     position: relative;
+  }
+
+  summary.iconRight {
+    padding: var(--goa-accordion-padding-heading-icon-right);
   }
 
   summary:hover {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "zone.js": "0.14.3"
       },
       "devDependencies": {
-        "@abgov/design-tokens": "^1.4.1",
+        "@abgov/design-tokens": "^1.4.2",
         "@abgov/nx-release": "8.0.0",
         "@angular-devkit/build-angular": "18.2.8",
         "@angular-devkit/core": "18.1.4",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@abgov/design-tokens": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-1.4.1.tgz",
-      "integrity": "sha512-GDXvX2+yiYBHJsJOw/eKwehvVXCSYIdWI0RjDlLBaizpEoiMUWRcN1OeS2PVK7fm/WtceB46WKn5qxyQgRT+Qg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-1.4.2.tgz",
+      "integrity": "sha512-7ieW6s7XxwDGbaAlU8XAer3CuoJP8mVh0PIq7TjHrFYAbNBM11JZrF6SMJ7dRwbLH3F8LNeKyZIIKDB041Pf2g==",
       "dev": true,
       "dependencies": {
         "style-dictionary": "^3.7.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "private": true,
   "devDependencies": {
-    "@abgov/design-tokens": "^1.4.1",
+    "@abgov/design-tokens": "^1.4.2",
     "@abgov/nx-release": "8.0.0",
     "@angular-devkit/build-angular": "18.2.8",
     "@angular-devkit/core": "18.1.4",


### PR DESCRIPTION
# Before (the change)
Accordion padding is not correct:
![image](https://github.com/user-attachments/assets/bca5418c-c3fa-4a5a-978c-8f1d95769314)

The correct one should be like this: 
![image](https://github.com/user-attachments/assets/43be6203-de52-4cdb-9925-8c8b49a81abb)

# After (the change)

The padding is fixed, the padding when icon position is right, also being fixed. This PR is to upgrade the version of our package `@abgov/design-tokens`


## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
