### PR TITLE
feat(#2109): tabs query string, loading 1st tab issues

### DIFF
--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -16,6 +16,7 @@
   let _currentTab: number = 1;
   let _tabProps: (GoATabProps & { bound: boolean })[] = [];
   let _bindTimeoutId: any;
+  let _initialLoad: boolean = true;
 
   // ========
   // Hooks
@@ -34,6 +35,29 @@
   // Functions
   // =========
 
+  function getTabIndexFromHash() {
+    const hash = window.location.hash;
+    if (!hash) return null;
+
+    // Find the matching tab based on href
+    const tabs = _tabsEl?.querySelectorAll('[role="tab"]');
+
+    for (let i = 0; i < tabs.length; i++) {
+      const tab = tabs[i] as HTMLAnchorElement;
+
+      const tabHref = tab.getAttribute("href");
+      const tabHash = tabHref?.split("#")[1] || "";
+
+      const isFullUrlMatch = tabHref?.endsWith(hash);
+      const isHashOnlyMatch = hash.endsWith(tabHash);
+
+      if (isFullUrlMatch || isHashOnlyMatch) {
+        return i + 1;
+      }
+    }
+    return null;
+  }
+
   function addChildMountListener() {
     _rootEl.addEventListener("tab:mounted", (e: Event) => {
       const detail = (e as CustomEvent<GoATabProps>).detail;
@@ -46,7 +70,13 @@
       }
       _bindTimeoutId = setTimeout(() => {
         bindChildren();
-        setCurrentTab(initialtab || 1);
+
+        // Check URL hash on initial load
+        if (_initialLoad) {
+          const tabIndexFromHash = getTabIndexFromHash();
+          setCurrentTab(tabIndexFromHash ?? (initialtab || 1));
+          _initialLoad = false;
+        }
       }, 1);
       e.stopPropagation();
     });
@@ -54,6 +84,7 @@
 
   function bindChildren() {
     const path = window.location.pathname;
+    const search = window.location.search; // Get current query string
 
     // create buttons (tabs) for each of the tab contents elements
     _tabProps.forEach((tabProps, index) => {
@@ -94,7 +125,7 @@
       link.setAttribute("id", `tab-${index + 1}`);
       link.setAttribute("data-testid", `tab-${index + 1}`);
       link.setAttribute("role", "tab");
-      link.setAttribute("href", path + "#" + tabSlug);
+      link.setAttribute("href", `${path}${search}#${tabSlug}`);
       link.addEventListener("click", () => setCurrentTab(index + 1));
       link.setAttribute("aria-controls", `tabpanel-${index + 1}`);
       link.appendChild(headingEl);
@@ -157,7 +188,8 @@
 
     // update the browswers url with the new hash
     if (currentLocation) {
-      document.location = currentLocation;
+      const url = new URL(currentLocation);
+      history.pushState({}, "", url.pathname + url.search + url.hash);
     }
   }
 

--- a/libs/web-components/src/components/tabs/tabs.spec.ts
+++ b/libs/web-components/src/components/tabs/tabs.spec.ts
@@ -52,40 +52,6 @@ describe("Tabs", () => {
     });
   });
 
-  it("should select specified tab if the tab property is set", async () => {
-    const result = render(Tabs, { initialtab: 2 });
-
-    await waitFor(() => {
-      const tab1Link = result.container.querySelector("a#tab-1");
-      const tab2Link = result.container.querySelector("a#tab-2");
-      const tabPanel = result.container.querySelector("div[role=tabpanel]");
-      const goaTabs = result.container.querySelectorAll("goa-tab");
-
-      expect(tab1Link).toBeTruthy();
-      expect(tab1Link?.getAttribute("aria-selected")).toBe("false");
-
-      expect(tab2Link).toBeTruthy();
-      expect(tab2Link?.getAttribute("aria-selected")).toBe("true");
-
-      expect(tabPanel).toBeTruthy();
-      expect(tabPanel?.getAttribute("id")).toBe("tabpanel-2");
-
-      expect(goaTabs[0].getAttribute("open")).toBe("false");
-      expect(goaTabs[1].getAttribute("open")).toBe("true");
-    });
-  });
-
-  it("should select the last tab if the tab exceeds the number of tabs", async () => {
-    const result = render(Tabs, { initialtab: 3 });
-
-    // last tab
-    await waitFor(() => {
-      const tab = result.container.querySelector("a#tab-2");
-      expect(tab).toBeTruthy();
-      expect(tab?.getAttribute("aria-selected")).toBe("true");
-    });
-  });
-
   it("should select the first tab if the tab is less than 1", async () => {
     const result = render(Tabs, { initialtab: 0 });
 
@@ -129,6 +95,40 @@ describe("Tabs", () => {
       expect(goaTabs?.length).toBe(2);
       expect(goaTabs?.[0].getAttribute("open")).toBe("false");
       expect(goaTabs?.[1].getAttribute("open")).toBe("true");
+    });
+  });
+
+  it("should select the last tab if the tab exceeds the number of tabs", async () => {
+    const result = render(Tabs, { initialtab: 3 });
+
+    // last tab
+    await waitFor(() => {
+      const tab = result.container.querySelector("a#tab-2");
+      expect(tab).toBeTruthy();
+      expect(tab?.getAttribute("aria-selected")).toBe("true");
+    });
+  });
+
+  it("should select specified tab if the tab property is set", async () => {
+    const result = render(Tabs, { initialtab: 2 });
+
+    await waitFor(() => {
+      const tab1Link = result.container.querySelector("a#tab-1");
+      const tab2Link = result.container.querySelector("a#tab-2");
+      const tabPanel = result.container.querySelector("div[role=tabpanel]");
+      const goaTabs = result.container.querySelectorAll("goa-tab");
+
+      expect(tab1Link).toBeTruthy();
+      expect(tab1Link?.getAttribute("aria-selected")).toBe("false");
+
+      expect(tab2Link).toBeTruthy();
+      expect(tab2Link?.getAttribute("aria-selected")).toBe("true");
+
+      expect(tabPanel).toBeTruthy();
+      expect(tabPanel?.getAttribute("id")).toBe("tabpanel-2");
+
+      expect(goaTabs[0].getAttribute("open")).toBe("false");
+      expect(goaTabs[1].getAttribute("open")).toBe("true");
     });
   });
 });


### PR DESCRIPTION
# Before (the change)

# After (the change)
-If query string is present, it should be preserved. 
-Indicated tab should be honoured.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Angular playground code
```
<goa-tabs (_change)="handleTabChange($event)" initialtab="1">
  <goa-tab>
    <div slot="heading">Profile</div>
    <p>
      <b>Profile:</b> Lorem ipsum dolor sit amet, consectetur adipiscing elit,
      sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
    </p>

  </goa-tab>
  <goa-tab>
    <div slot="heading">
      Review pending
      <goa-badge type="important" content="1"></goa-badge>
    </div>
    <p>
      <b>Review pending:</b> Lorem ipsum dolor sit amet, consectetur adipiscing
      elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
    </p>
  </goa-tab>
  <goa-tab>
    <div slot="heading">
      Completed
      <goa-badge type="midtone" content="1"></goa-badge>
    </div>
    <p>
      <b>Completed:</b> Lorem ipsum dolor sit amet, consectetur adipiscing elit,
      sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
    </p>
    <p>New text</p>
  </goa-tab>
  <goa-tab heading="Test 1"> Testing </goa-tab>
</goa-tabs>
```


```
import { Component } from "@angular/core";

@Component({
  selector: "abgov-tabs",
  templateUrl: "./tabs.html",
})
export class TabsComponent {

  handleTabChange(event: Event) {
    const customEvent = event as CustomEvent;
    const tabIndex = customEvent.detail.tab;
    console.log(`Tab changed to ${tabIndex}`);
  }
}
```