### PR TITLE
fix(#2252): allow to override text color of sidemenu slotted::a

### DIFF
--- a/libs/web-components/src/components/side-menu/SideMenu.svelte
+++ b/libs/web-components/src/components/side-menu/SideMenu.svelte
@@ -109,8 +109,7 @@
   :global(::slotted(a)),
   :global(::slotted(a:visited)) {
     /* required to override base styles */
-    color: var(--goa-color-text-default) !important;
-
+    color: var(--goa-side-menu-text-color, var(--goa-color-text-default)) !important;
     display: block;
     font: var(--goa-typography-body-m);
     padding: 0.5rem 1rem 0.5rem 2rem;


### PR DESCRIPTION
# Before (the change)
```

::slotted(a), ::slotted(a:visited) {
    color: var(--goa-color-text-default) !important;
}
```

So privacy portal team wants to override this color, they have no way to do. 

```
goa-side-menu .uiam--side-menu--sub-item.current {
  font: var(--goa-typography-heading-s);
  border-left: var(--goa-side-menu-child-border-width) solid var(--goa-color-interactive-disabled);
  background: var(--goa-side-menu-child-color-bg-selected);
  /* This color is rule that is not taking affect: */
  color: var(--goa-color-interactive-default) !important;
}
```


# After (the change)

We will fallback to the `goa-color-text-default` if the new token (customized color token) isn't defined (so it won't affect our DDI)
This is how they can "tweak" (I also inform Chase personally)

```
goa-side-menu .uiam--side-menu--sub-item.current {
    font: var(--goa-typography-heading-s);
    border-left: var(--goa-side-menu-child-border-width) solid var(--goa-color-interactive-disabled);
    background: var(--goa-side-menu-child-color-bg-selected);
    /** Define the color that we want to have for the current link **/
    --goa-side-menu-text-color: var(--goa-color-interactive-default);
}

goa-side-menu .uiam--side-menu--sub-item {
    /* Make sure we fall back to text color default or any color if a link isn't selected*/
    --goa-side-menu-text-color: initial;
}

```

Screenshots of privacy portal team's side menu that can be ^^
(Not active)

![image](https://github.com/user-attachments/assets/5d333050-9e02-4afd-84ec-1928c4bf750b)

(And Active)
![image](https://github.com/user-attachments/assets/5fab5379-f4f4-4724-8e2f-02317602f294)


(Our DDI Side Menu has no changes --> as expected)
![image](https://github.com/user-attachments/assets/0d1cc153-bcaf-4393-a14e-8d272a9a3af8)


## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
