### PR TITLE
fix(#2253): add border-radius for side-menu-group-heading

### DIFF
--- a/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
+++ b/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
@@ -199,6 +199,7 @@
     padding: var(--goa-side-menu-parent-padding);
     text-decoration: none;
     font: var(--goa-side-menu-parent-text);
+    border-radius: var(--goa-side-menu-group-border-radius);
   }
   .heading.open {
     font: var(--goa-side-menu-parent-text-active);


### PR DESCRIPTION
Allow to have border-radius when we hover the menu, it is for privacy portal. 

For them, they can override the token that's already there. 

```
 --goa-side-menu-group-border-radius: 15px;
```

![image](https://github.com/user-attachments/assets/8de3720a-c084-4b07-aa1e-560df017175f)

For DDI component, there won't be affected:

![image](https://github.com/user-attachments/assets/5f0fc5bb-a7ac-45e7-a75f-74e109288c83)

