### PR TITLE
fix(#2265): add token side-menu-parent-color-bg-selected for side-men…

### DIFF
--- a/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
+++ b/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
@@ -227,7 +227,7 @@
   }
 
   .side-menu-group.current .heading {
-    background: var(--goa-side-menu-parent-color-bg-hover);
+    background: var(--goa-side-menu-parent-color-bg-selected);
   }
 
   .heading:hover {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "zone.js": "0.14.3"
       },
       "devDependencies": {
-        "@abgov/design-tokens": "^1.4.2",
+        "@abgov/design-tokens": "^1.4.3",
         "@abgov/nx-release": "8.0.0",
         "@angular-devkit/build-angular": "18.2.8",
         "@angular-devkit/core": "18.1.4",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@abgov/design-tokens": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-1.4.2.tgz",
-      "integrity": "sha512-7ieW6s7XxwDGbaAlU8XAer3CuoJP8mVh0PIq7TjHrFYAbNBM11JZrF6SMJ7dRwbLH3F8LNeKyZIIKDB041Pf2g==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-1.4.3.tgz",
+      "integrity": "sha512-OCGenyMLdNBqo4wiCS/rWZ0+DWcra+ZnR/C0atS/eLlp4WtGzpvOOFkCF4JX6kuABzXQaTZtr/+4vjd0a8Trfg==",
       "dev": true,
       "dependencies": {
         "style-dictionary": "^3.7.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "private": true,
   "devDependencies": {
-    "@abgov/design-tokens": "^1.4.2",
+    "@abgov/design-tokens": "^1.4.3",
     "@abgov/nx-release": "8.0.0",
     "@angular-devkit/build-angular": "18.2.8",
     "@angular-devkit/core": "18.1.4",


### PR DESCRIPTION
This is how to override the value: 

![image](https://github.com/user-attachments/assets/52072776-cc6d-41b4-aa33-bfe3f2a93163)


Allow pp team to override the `side-menu-group a.heading` when one of its child is selected.