### PR TITLE
feat(#1412): add width property for button

### DIFF
--- a/libs/react-components/src/lib/button/button.tsx
+++ b/libs/react-components/src/lib/button/button.tsx
@@ -24,6 +24,7 @@ interface WCProps extends Margins {
   disabled?: boolean;
   leadingicon?: string;
   trailingicon?: string;
+  width?: string;
   testid?: string;
   ref: React.RefObject<HTMLElement>;
 }
@@ -45,6 +46,7 @@ export interface GoAButtonProps extends Margins {
   disabled?: boolean;
   leadingIcon?: GoAIconType;
   trailingIcon?: GoAIconType;
+  width?: string;
   onClick?: () => void;
   testId?: string;
   children?: ReactNode;
@@ -57,6 +59,7 @@ export function GoAButton({
   variant,
   leadingIcon,
   trailingIcon,
+  width,
   testId,
   children,
   onClick,
@@ -93,6 +96,7 @@ export function GoAButton({
       disabled={disabled}
       leadingicon={leadingIcon}
       trailingicon={trailingIcon}
+      width={width}
       testid={testId}
       mt={mt}
       mr={mr}

--- a/libs/web-components/src/components/button/Button.html-data.json
+++ b/libs/web-components/src/components/button/Button.html-data.json
@@ -56,6 +56,11 @@
       "valueSet": "goaIconType"
     },
     {
+      "name": "width",
+      "description": "Set the width of the button",
+      "type": "string"
+    },
+    {
       "name": "_click",
       "description": "Callback function when button is clicked"
     },

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -38,6 +38,7 @@
   export let leadingicon: GoAIconType | null = null;
   export let trailingicon: GoAIconType | null = null;
   export let testid: string = "";
+  export let width: string = "";
 
   export let mt: Spacing = null;
   export let mr: Spacing = null;
@@ -74,7 +75,10 @@
 
 <button
   class="{type} {size} {variant}"
-  style={calculateMargin(mt, mr, mb, ml)}
+  style={`
+      ${calculateMargin(mt, mr, mb, ml)};
+      --width: ${width};
+    `}
   disabled={isDisabled}
   on:click={clickHandler}
   data-testid={testid}
@@ -126,6 +130,7 @@
       transform 0.1s ease-in-out,
       background-color 0.2s ease-in-out,
       border-color 0.2s ease-in-out;
+    width: var(--width, auto);
   }
   button:disabled {
     pointer-events: none;


### PR DESCRIPTION
# Before (the change)
Request from Privacy portal team member: 

is it possible to adjust the width of the button (Continue as a guest) to full width as in figma?

Expected figma for the button "Continue as a guest" (Desktop)
![image](https://github.com/user-attachments/assets/58bb8d2e-9601-416b-8fa5-0dfe64e32b87)

Current:
![image](https://github.com/user-attachments/assets/4c808f3a-8f5d-4c58-8f97-1dc920068759)

# After (the change)
Should be able to adjust the width:
And on mobile, the width is 100% so we can use a parent <div> to control its width. The first button set `width=100%`, the second button has `width` auto like now. 
![image](https://github.com/user-attachments/assets/e4855ea0-7bf8-4ba9-a237-878b6a961514)


## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

React code snippet:
```
<GoAButton mt="m" type="secondary" leadingIcon="arrow-back" width="100%">
            Back to personal information
        </GoAButton>
        <br/>
        <GoAButton mt="m" type="secondary" leadingIcon="arrow-back">
            Back to personal information
        </GoAButton>
        <br/>
```
