### PR TITLE
fix(#2279): Add support for Angular 19

### DIFF
--- a/libs/angular-components/package.json
+++ b/libs/angular-components/package.json
@@ -17,8 +17,8 @@
     "directory": "libs/angular-components"
   },
   "peerDependencies": {
-    "@angular/core":  "^16.0.0 || ^17.0.0 || ^18.0.0",
-    "@angular/forms": "^16.0.0 || ^17.0.0 || ^18.0.0"
+    "@angular/core":  "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "@angular/forms": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
# Before (the change)

Angular 19 wasn't allowed

# After (the change)

Angular 19 is allowed

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Just need to test that you can install Angular 19 on a separate app outside of the playground