### PR TITLE
Vite config for prod only minification

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-# Nx 18 enables using plugins to infer targets by default
-# This is disabled for existing workspaces to maintain compatibility
-# For more info, see: https://nx.dev/concepts/inferred-tasks
-NX_ADD_PLUGINS=false

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 playground
 NOTES.md
 
+# environment
+.env
+
 # compiled output
 dist
 tmp

--- a/libs/web-components/vite.config.js
+++ b/libs/web-components/vite.config.js
@@ -1,5 +1,5 @@
 /// <reference types='vitest' />
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import dts from "vite-plugin-dts";
 import * as path from "path";
 import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
@@ -7,110 +7,116 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import autoprefixer from "autoprefixer";
 import { postcssReplace } from "./utils/postcss-replace";
 
-export default defineConfig(() => ({
-  root: __dirname,
-  cacheDir: "../../node_modules/.vite/libs/web-components",
+export default defineConfig(({ mode }) => {
 
-  css: {
-    postcss: {
-      plugins: [
-        postcssReplace({
-          pattern: /\(--tablet\)/g,
-          replaceWith: "(min-width: 624px) and (max-width: 1023px)",
-        }),
-        postcssReplace({
-          pattern: /\(--mobile\)/g,
-          replaceWith: "(max-width: 623px)"
-        }),
-        postcssReplace({
-          pattern: /\(--mobile\)/g,
-          replaceWith: "(max-width: 623px)"
-        }),
-        postcssReplace({
-          pattern: /\(--mobile\)/g,
-          replaceWith: "(max-width: 623px)"
-        }),
-        postcssReplace({
-          pattern: /\(--mobile\)/g,
-          replaceWith: "(max-width: 623px)"
-        }),
-        postcssReplace({
-          pattern: /\(--not-mobile\)/g,
-          replaceWith: "(min-width: 624px)",
-        }),
-        postcssReplace({
-          pattern: /\(--not-tablet\)/g,
-          replaceWith: "(max-width: 623px) or (min-width: 1024px)",
-        }),
-        postcssReplace({
-          pattern: /\(--desktop\)/g,
-          replaceWith: "(min-width: 1024px)",
-        }),
-        postcssReplace({
-          pattern: /\(--not-desktop\)/g,
-          replaceWith: "(max-width: 1023px)",
-        }),
-        autoprefixer(),
-      ]
-    }
-  },
+  const env = loadEnv(mode, process.cwd());
+  const isDev = env.VITE_DEV === "true";
 
-  plugins: [
-    nxViteTsPaths(),
-    dts({
-      entryRoot: "src",
-      tsConfigFilePath: path.join(__dirname, "tsconfig.lib.json"),
-      skipDiagnostics: true,
-    }),
-    svelte({
-      include: /\.svelte$/,
-      compilerOptions: {
-        customElement: true,
+  return {
+    root: __dirname,
+    cacheDir: "../../node_modules/.vite/libs/web-components",
+
+    css: {
+      postcss: {
+        plugins: [
+          postcssReplace({
+            pattern: /\(--tablet\)/g,
+            replaceWith: "(min-width: 624px) and (max-width: 1023px)",
+          }),
+          postcssReplace({
+            pattern: /\(--mobile\)/g,
+            replaceWith: "(max-width: 623px)"
+          }),
+          postcssReplace({
+            pattern: /\(--mobile\)/g,
+            replaceWith: "(max-width: 623px)"
+          }),
+          postcssReplace({
+            pattern: /\(--mobile\)/g,
+            replaceWith: "(max-width: 623px)"
+          }),
+          postcssReplace({
+            pattern: /\(--mobile\)/g,
+            replaceWith: "(max-width: 623px)"
+          }),
+          postcssReplace({
+            pattern: /\(--not-mobile\)/g,
+            replaceWith: "(min-width: 624px)",
+          }),
+          postcssReplace({
+            pattern: /\(--not-tablet\)/g,
+            replaceWith: "(max-width: 623px) or (min-width: 1024px)",
+          }),
+          postcssReplace({
+            pattern: /\(--desktop\)/g,
+            replaceWith: "(min-width: 1024px)",
+          }),
+          postcssReplace({
+            pattern: /\(--not-desktop\)/g,
+            replaceWith: "(max-width: 1023px)",
+          }),
+          autoprefixer(),
+        ]
+      }
+    },
+
+    plugins: [
+      nxViteTsPaths(),
+      dts({
+        entryRoot: "src",
+        tsConfigFilePath: path.join(__dirname, "tsconfig.lib.json"),
+        skipDiagnostics: true,
+      }),
+      svelte({
+        include: /\.svelte$/,
+        compilerOptions: {
+          customElement: true,
+        },
+      }),
+    ],
+
+    // Configuration for building your library.
+    // See: https://vitejs.dev/guide/build.html#library-mode
+    build: {
+      outDir: "../../dist/libs/web-components",
+      sourcemap: isDev,
+      minify: !isDev,
+      reportCompressedSize: true,
+      commonjsOptions: {
+        transformMixedEsModules: true,
       },
-    }),
-  ],
-
-  // Configuration for building your library.
-  // See: https://vitejs.dev/guide/build.html#library-mode
-  build: {
-    outDir: "../../dist/libs/web-components",
-    sourcemap: true,
-    minify: false,
-    reportCompressedSize: true,
-    commonjsOptions: {
-      transformMixedEsModules: true,
-    },
-    lib: {
-      entry: "src/index.ts",
-      name: "web-components",
-      fileName: "index",
-      formats: ["es"],
-    },
-    rollupOptions: {
-      output: {
-        assetFileNames: (info) => {
-          if (info.name === "style.css") {
-            return "index.css";
+      lib: {
+        entry: "src/index.ts",
+        name: "web-components",
+        fileName: "index",
+        formats: ["es"],
+      },
+      rollupOptions: {
+        output: {
+          assetFileNames: (info) => {
+            if (info.name === "style.css") {
+              return "index.css";
+            }
+            return info.name;
           }
-          return info.name;
-        }
+        },
+        external: [],
       },
-      external: [],
     },
-  },
 
-  test: {
-    globals: true,
-    cache: {
-      dir: "../../node_modules/.vitest",
-    },
-    environment: "node",
-    include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+    test: {
+      globals: true,
+      cache: {
+        dir: "../../node_modules/.vitest",
+      },
+      environment: "node",
+      include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
 
-    reporters: ["default"],
-    coverage: {
-      reportsDirectory: "../../coverage/libs/web-components",
-      provider: "v8",
+      reporters: ["default"],
+      coverage: {
+        reportsDirectory: "../../coverage/libs/web-components",
+        provider: "v8",
+      },
     },
-  },
-}));
+  }
+});


### PR DESCRIPTION
This change will allow for one to step through the code within the inspector, but still publish a minified file to npm.

## Steps needed to test

1. Compile the web-components lib via `npx nx reset; npm run build` and note the file size (~760KB).
2. Create a `.env` file and add `VITE_DEV=true`
3. Recompile the project `npx nx reset; npm run build`. The new size of the build would be ~1.2MB
