### PR TITLE
#1712 react readonly textarea

### DIFF
--- a/libs/react-components/src/lib/textarea/textarea.spec.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.spec.tsx
@@ -19,8 +19,10 @@ describe("TextArea", () => {
         mr="m"
         mb="l"
         ml="xl"
-        onChange={() => { /* do nothing */ }}
-      />
+        onChange={() => {
+          /* do nothing */
+        }}
+      />,
     );
 
     const el = document.querySelector("goa-textarea");
@@ -56,7 +58,7 @@ describe("TextArea", () => {
           expect(value).toBe(newValue);
           onChange();
         }}
-      />
+      />,
     );
 
     const el = document.querySelector("goa-textarea");
@@ -65,7 +67,7 @@ describe("TextArea", () => {
       el,
       new CustomEvent("_change", {
         detail: { name: "textarea-name", value: newValue },
-      })
+      }),
     );
 
     expect(onChange).toBeCalled();

--- a/libs/react-components/src/lib/textarea/textarea.spec.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.spec.tsx
@@ -11,6 +11,7 @@ describe("TextArea", () => {
         value="textarea-value"
         rows={10}
         placeholder="textarea-placeholder"
+        readOnly={true}
         disabled={true}
         countBy="word"
         maxCount={50}
@@ -30,6 +31,7 @@ describe("TextArea", () => {
     expect(el.getAttribute("value")).toBe("textarea-value");
     expect(el.getAttribute("rows")).toBe("10");
     expect(el.getAttribute("placeholder")).toBe("textarea-placeholder");
+    expect(el.getAttribute("readonly")).toBe("true");
     expect(el.getAttribute("disabled")).toBe("true");
     expect(el.getAttribute("countby")).toBe("word");
     expect(el.getAttribute("maxcount")).toBe("50");
@@ -52,6 +54,7 @@ describe("TextArea", () => {
         countBy="word"
         rows={10}
         placeholder="textarea-placeholder"
+        readOnly={true}
         disabled={true}
         onChange={(name: string, value: string) => {
           expect(name).toBe("textarea-name");

--- a/libs/react-components/src/lib/textarea/textarea.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.tsx
@@ -10,6 +10,7 @@ interface WCProps extends Margins {
   placeholder?: string;
   rows?: number;
   error?: boolean;
+  readOnly?: boolean;
   disabled?: boolean;
   width?: string;
   maxwidth?: string;
@@ -35,6 +36,7 @@ export interface GoATextAreaProps extends Margins {
   placeholder?: string;
   rows?: number;
   error?: boolean;
+  readOnly?: boolean;
   disabled?: boolean;
   width?: string;
   maxWidth?: string;
@@ -52,6 +54,7 @@ export function GoATextarea({
   value,
   placeholder,
   rows,
+  readOnly,
   disabled,
   countBy,
   maxCount,
@@ -108,6 +111,7 @@ export function GoATextarea({
       placeholder={placeholder}
       value={value}
       rows={rows}
+      readOnly={readOnly}
       disabled={disabled}
       countby={countBy}
       maxcount={maxCount}

--- a/libs/react-components/src/lib/textarea/textarea.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from "react";
 import { Margins } from "../../common/styling";
 
-
 type CountBy = "character" | "word";
 
 interface WCProps extends Margins {
@@ -86,7 +85,6 @@ export function GoATextarea({
     };
   }, [el, onChange]);
 
-
   useEffect(() => {
     if (!el.current) {
       return;
@@ -95,7 +93,7 @@ export function GoATextarea({
     const keypressListener = (e: unknown) => {
       const { name, value, key } = (e as CustomEvent).detail;
       onKeyPress?.(name, value, key);
-    }
+    };
 
     current.addEventListener("_keyPress", keypressListener);
     return () => {
@@ -126,6 +124,5 @@ export function GoATextarea({
   );
 }
 
-export {GoATextarea as GoATextArea}
+export { GoATextarea as GoATextArea };
 export default GoATextarea;
-

--- a/libs/web-components/src/components/text-area/TextArea.spec.ts
+++ b/libs/web-components/src/components/text-area/TextArea.spec.ts
@@ -9,6 +9,7 @@ describe("GoATextArea", () => {
       placeholder: "Enter text here",
       value: "foobar",
       rows: 42,
+      readonly: "true",
       disabled: "true",
       testid: "test-id",
     });
@@ -17,6 +18,7 @@ describe("GoATextArea", () => {
     expect(el).toHaveAttribute("name", "name");
     expect(el).toHaveAttribute("placeholder", "Enter text here");
     expect(el.value).toBe("foobar");
+    expect(el).toHaveAttribute("readonly", "");
     expect(el).toHaveAttribute("disabled", "");
     expect(el).toHaveAttribute("data-testid", "test-id");
     expect(el).toHaveAttribute("rows", "42");
@@ -74,6 +76,20 @@ describe("GoATextArea", () => {
     });
   });
 
+  it("can be readonly", async () => {
+    const result = render(GoATextArea, {
+      name: "name",
+      value: "foo",
+      readonly: "true",
+    });
+
+    const el = result.container.querySelector("textarea");
+
+    el?.focus();
+    expect(el).toHaveAttribute("readonly", "");
+    expect(el).toHaveFocus();
+  });
+
   it("can be disabled", async () => {
     const onChange = vi.fn();
     const result = render(GoATextArea, {
@@ -88,6 +104,7 @@ describe("GoATextArea", () => {
     await fireEvent.keyUp(el, { target: { value: "bar" } });
     expect(el).toHaveAttribute("disabled", "");
     expect(onChange).not.toBeCalled();
+    expect(el).not.toHaveFocus();
   });
 
   it("indicates an error state", async () => {


### PR DESCRIPTION
# Before (the change)

textarea react component does not expose readonly prop, like the textarea web component does.

# After (the change)

textarea react component does expose readonly prop

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Add textarea react component with readonly prop to react playground, then as a user try to change its input value. Expected result: Textarea can receive focus but won't accept keyboard input. 