### PR TITLE
fix(#2211): filterable dropdown selected option

### DIFF
--- a/libs/web-components/src/components/dropdown/DropdownWrapper.test.svelte
+++ b/libs/web-components/src/components/dropdown/DropdownWrapper.test.svelte
@@ -19,6 +19,7 @@
   export let native: string = "false";
   export let items: string[];
   export let filterable: string = "false";
+  export let testid: string = "";
 
   export let resetValue = "orange";
 
@@ -46,6 +47,7 @@
   {disabled}
   {width}
   {filterable}
+  {testid}
   on:_change={onChange}
 >
   {#each items as item (item)}


### PR DESCRIPTION
# Before (the change)

Filterable dropdown selected option broken when a) clicking an option to select, b) using arrows keys to highlight an option then pressing Enter to select, and c) when filterable dropdown input loses focus. Also, selected option in the DOM would not have "aria-selected=true".

# After (the change)

Filterable dropdown selected option fixed when a) clicking an option to select, b) using arrows keys to highlight an option then pressing Enter to select, and c) when filterable dropdown input loses focus. Also, selected option in the DOM has "aria-selected=true".

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Testing considerations: Tested in Chrome, Firefox

These Autofill Dropdown examples may be helpful for svelte, react and angular: https://github.com/user-attachments/files/19014103/2025-02-26-playground-examples.zip
