### PR TITLE
fix(#2291): add workflow to release on different version and tag

### DIFF
--- a/.github/workflows/lts-release-ci.yml
+++ b/.github/workflows/lts-release-ci.yml
@@ -1,0 +1,53 @@
+name: LTS Release CI (v5 react, v3 angular)
+
+on:
+  push:
+    branches:
+      - lts
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "20"
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - run: npm ci
+
+      - name: Lint
+        run: npx nx run-many --target=lint --all
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npx nx run-many --target=build --all --prod
+
+      - name: Update VsCode documentation
+        run: npm run build:vscode-doc
+
+      - name: Update Web components documentation
+        run: cp libs/web-components/README.md dist/libs/web-components
+
+      - name: Remove types file for now
+        run: rm dist/libs/web-components/index.d.ts
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx nx run-many --target release --all

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,6 +10,10 @@
     {
       "name": "alpha",
       "prerelease": true
+    },
+    {
+      "name": "lts",
+      "channel": "lts"
     }
   ]
 }

--- a/libs/angular-components/src/lib/value-directive.ts
+++ b/libs/angular-components/src/lib/value-directive.ts
@@ -13,8 +13,8 @@ export class ValueDirective implements ControlValueAccessor {
   private _disabled = false;
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  onChange: any = () => { };
-  onTouched: any = () => { };
+  onChange: any = () => { /* default implementation */ };
+  onTouched: any = () => { /* default implementation */ };
 
   get value(): string {
     return this._value;

--- a/libs/react-components/src/lib/input/input.tsx
+++ b/libs/react-components/src/lib/input/input.tsx
@@ -44,7 +44,7 @@ interface WCProps extends Margins {
   error?: boolean;
   readonly?: boolean;
   focused?: boolean;
-  handletrailingiconclick: boolean;
+  handletrailingiconclick?: boolean;
   width?: string;
   prefix?: string;
   suffix?: string;

--- a/libs/web-components/src/components/app-header/AppHeader.svelte
+++ b/libs/web-components/src/components/app-header/AppHeader.svelte
@@ -108,8 +108,6 @@
   }
 
   function setCurrentLink() {
-    const url = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-
     // Combine all links
     let links = [..._appHeaderLinks];
     _appHeaderMenuItems.forEach((el) => {


### PR DESCRIPTION
This is a spike ticket to understand how we can publish the major version on different branches/tags: 

### 1. What is the effect semantic-release has on our release process?
- Running the command `npx semantic-release --dry-run` helps us understand the next version without actually publishing or tagging.
- semantic-release relies on the most recent Git tag and commit messages to calculate the next version according to Semantic Versioning:
* fix: Patch version bump (e.g., 1.0.1).
* feat: Minor version bump (e.g., 1.1.0).
* BREAKING CHANGE: Major version bump (e.g., 2.0.0).

### 2. Proof of Concept: Testing Repo

As a result, I set up my testing repo (the reason why I cannot check on our `ui-components` is because I don't have enough permission): [example repo](https://github.com/vanessatran-ddi/test-npm-publish):

My testing repo has the below: 

1. main branch: Current tag is react-v5.3.0.
2. alpha branch: Current tag is react-v5.0.0-alpha.
3. react-components-test branch: No tags, contains a commit with BREAKING CHANGE.
When running: 

`npx semantic-release --dry-run --branches react-components-test`

![image](https://github.com/user-attachments/assets/efbb0798-1691-4978-930b-0023261436bf)

Expected version for react-components-test:
6.0.0-beta.1 (because of BREAKING CHANGE and the use of beta prerelease configuration).

### 3. Prediction for angular-components Branch
Based on the above theory, I can predict the following versions if we release the angular-components branch with beta:

Package | Predicted Version
-- | --
@abgov/react-components | 6.0.0-beta.1
@abgov/angular-components | 4.0.0-beta.1
@abgov/ui-components-common | 1.0.0-beta.1
@abgov/web-components | 1.28.0-beta.1

If we do not use the beta pre-release config (e.g., publish as stable, no pre-release), the versions will look like this:
Package | Predicted Version
-- | --
@abgov/react-components | 6.0.0
@abgov/angular-components | 4.0.0
@abgov/ui-components-common | 1.0.0
@abgov/web-components | 1.28.0

### 4. Proposed Scenario: Prove the Concept
To understand more about this theory and how the process could be, I create a realistic example: 

#### 4.1 Angular Wrapper Fixing: [Issue 2154](https://github.com/GovAlta/ui-components/issues/2154 )
* Checkout from `angular-components` branch
* Fix on `DatePicker.svelte` and `date-picker.ts`
* Commit: "fix: reset UI value for date picker"
* Create a PR and merge into angular-components.
#### 4.2 Expected versions after release: 

- @abgov/react-components: 6.0.0 (no changes).
- @abgov/angular-components: 4.0.1 (fix).
- @abgov/ui-components-common: 1.0.0 (no changes).
- @abgov/web-components: 1.28.1 (fix version bump).

In a meantime, If another fix occurs on the <code>main</code> branch for Svelte components only, versions will look like:</p>
Package | Version After Fix
-- | --
@abgov/web-components | 1.28.2 (no overlapped versions with `angular-components` branch)

### 5. Do We Need to Update Our GitHub Actions?

Yes, we need to ensure:

Specific branches like angular-components trigger their own workflows.

### 6. Branching Strategy

I recommend the following branch strategy for version separation:

1. main: For stable releases of the old version.
2. alpha: For alpha releases of the old version.
3. angular-components: latest release of the new version. **(recommend with tag like beta or next)**
4. angular-components-alpha: alpha release of the new version. (Optional)

To avoid conflicts, angular-components should be kept in sync with main or alpha regularly. This ensures:

The latest tags are available for semantic-release to calculate versions correctly.
Compatibility with the most recent fixes and features.

### 7. Can We Test the Release Strategy?
Yes, we can use --dry-run to simulate the release process without actual publishing. I cannot run this on the ui-components repo due to permission issues. However, I validated the process using my testing repo.