### PR TITLE
fix(#2284): radio group tabindex order

### DIFF
--- a/_templates/web/src/pages/RadioPage.svelte
+++ b/_templates/web/src/pages/RadioPage.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <goa-form-item label="Basic">
-  <goa-radio-group name="item" value="1">
+  <goa-radio-group name="item">
     <goa-radio-item value="1" label="Label"></goa-radio-item>
     <goa-radio-item value="2" label="Label"></goa-radio-item>
     <goa-radio-item value="3" label="Label"></goa-radio-item>

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -201,7 +201,6 @@
   role="radiogroup"
   aria-label={arialabel}
   aria-invalid={_error ? "true" : "false"}
-  tabindex="0"
   on:focusin={onFocus}
 >
   <slot />


### PR DESCRIPTION
# Before (the change)

Reproduced tabindex order in react playground:
https://jam.dev/c/46fe0f96-1479-4447-8388-d711c9f0f570

# After (the change)

Result:
https://jam.dev/c/9c45de4b-36f3-4226-9dc9-582e912293aa

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Tested result on chrome in web-components playground and in react playground:
![image](https://github.com/user-attachments/assets/b870d955-2315-4cbd-bc1e-3729b978f95e)