### PR TITLE
fix(#2991): remove "sharp" from GoabChipTheme

### DIFF
--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -53,7 +53,7 @@ export type GoabDatePickerOnChangeDetail = {
 
 export type GoabChipVariant = "filter";
 
-export type GoabChipTheme = "outline" | "filled" | "sharp";
+export type GoabChipTheme = "outline" | "filled";
 export type GoabFilterChipTheme = "outline" | "filled";
 
 export type GoabCheckboxOnChangeDetail = {


### PR DESCRIPTION
This PR is to release `@abgov/ui-components-common` on `alpha`, which failed due to the timeout in previous release.