### PR TITLE
fix(#2991): update ui-components-common package to be public with its…

### DIFF
--- a/libs/common/.releaserc.json
+++ b/libs/common/.releaserc.json
@@ -11,7 +11,8 @@
     [
       "@semantic-release/npm",
       {
-        "pkgRoot": "dist/libs/common"
+        "pkgRoot": "dist/libs/common",
+        "npmPublish": true
       }
     ],
     "@semantic-release/github"

--- a/libs/common/package.json
+++ b/libs/common/package.json
@@ -1,8 +1,25 @@
 {
   "name": "@abgov/ui-components-common",
   "version": "0.0.0",
+  "bugs": {
+    "url": "https://github.com/GovAlta/ui-components/issues"
+  },
+   "keywords": [
+    "Goab",
+    "ui-components",
+    "common"
+  ],
+   "repository": {
+    "type": "git",
+    "url": "https://github.com/GovAlta/ui-components.git",
+    "directory": "libs/common"
+  },
+  "license": "Apache-2.0",
   "description": "Government of Alberta - UI Web components",
   "type": "module",
   "main": "./index.js",
-  "module": "./index.js"
+  "module": "./index.js",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -132,8 +132,6 @@ export type GoabButtonGroupGap = "relaxed" | "compact";
 export type GoabAccordionHeadingSize = "small" | "medium";
 export type GoabAccordionIconPosition = "left" | "right";
 
-// Formstepper
-
 // Tooltip
 
 export type GoabTooltipPosition = "top" | "bottom" | "left" | "right";


### PR DESCRIPTION
release semantic failed to release `ui-components-common` library to `npm` with the error that this package is private.
This PR is to make sure the package is public. 