### PR TITLE
fix: build error roperty 'mt' does not exist on type 'IntrinsicAttrib…

### DIFF
--- a/libs/react-components/vite.config.ts
+++ b/libs/react-components/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     dts({
       entryRoot: "src",
       tsconfigPath: path.join(__dirname, "tsconfig.lib.json"),
+      aliasesExclude: [/^@abgov\/ui-components-common$/],
     }),
   ],
 


### PR DESCRIPTION
…utes & component props' on react

# Before (the change)

We have a build issue with React app when using `alpha` version. Example build error is: 
5:17:57 PM: src/components/component-properties/ComponentProperties.tsx(66,62): error TS2322: Type '{ children: Element; heading: string; mt: string; mb: string; }' is not assignable to type 'IntrinsicAttributes & GoabAccordionProps'.
5:17:57 PM:   Property 'mt' does not exist on type 'IntrinsicAttributes & GoabAccordionProps'.
5:17:57 PM: src/components/sandbox/SandboxProperties.tsx(126,13): error TS2322: Type '{ name: string; checked: boolean; onChange: (event: GoabCheckboxOnChangeDetail) => void; mt: string; text: string; }' is not assignable to type 'IntrinsicAttributes & GoabCheckboxProps'.
5:17:57 PM:   Property 'mt' does not exist on type 'IntrinsicAttributes & GoabCheckboxProps'.
5:17:57 PM: src/examples/accordion/AccordionExamples.tsx(333,37): error TS2322: Type '{ children: string; type: string; mb: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & GoabButtonProps'.

....




# After (the change)

Combine with this update on React app: 
https://github.com/GovAlta/ui-components-docs/pull/277/commits/dc0dad977e3645db7a58d3ec0f43a8190d2fc88f#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0R26

![image](https://github.com/user-attachments/assets/a0c31639-d1f1-4bd0-9199-f7aa0ce5a4da)

It works now. 
![image](https://github.com/user-attachments/assets/a443c4c5-bb1a-4189-927b-0524b92d2655)

This is the investigation: 

IntrinsicAttributes: Provided by React, it contains:
* key: for React element keys.
* ref: for React ref forwarding.

When TypeScript resolves component props, it combines
```
IntrinsicAttributes & GoabAccordionProps
```

If mt and mb aren’t part of GoabAccordionProps, TypeScript defaults to assuming IntrinsicAttributes is the problem.

Build tools like Vite might strip or mishandle the mt and mb props in the build step.

Fixing the build vite config. 


## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
