### PR TITLE
fix(#1511) fix click outside popover

### DIFF
--- a/_templates/web/src/pages/PopoverPage.svelte
+++ b/_templates/web/src/pages/PopoverPage.svelte
@@ -9,6 +9,3 @@
     <goa-button type="secondary" size="compact">Click me</goa-button>
   </div>
 </goa-popover>
-
-
-

--- a/libs/web-components/src/components/calendar/Calendar.svelte
+++ b/libs/web-components/src/components/calendar/Calendar.svelte
@@ -304,6 +304,7 @@
   style={calculateMargin(mt, mr, mb, ml)}
   class:bordered={bordered === "true"}
   data-testid={testid}
+  tabindex="-1"
 >
   <goa-block mb="m">
     <goa-form-item label="Month" mt="0">

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -368,7 +368,7 @@
     setTimeout(async () => {
       syncFilteredOptions();
       _isMenuVisible = true;
-      // _inputEl?.focus();
+      _inputEl?.focus();
       setTimeout(() => {
         if (_inputEl?.value === "" && _selectedOption) {
           reset();
@@ -458,12 +458,13 @@
 
     syncFilteredOptions();
 
-    const matchedOption =
-      _inputEl?.value &&
-      _inputEl?.value !== "" &&
-      _filteredOptions.find((option) =>
-        isFilterMatch(option, _inputEl?.value || "", false),
-      );
+    const inputValue = _inputEl?.value || "";
+    const hasInputValue = inputValue !== "";
+    const matchedOption = hasInputValue
+      ? _filteredOptions.find((option) =>
+          isFilterMatch(option, inputValue, false),
+        )
+      : null;
 
     if (!_selectedOption) {
       if (matchedOption) {
@@ -492,9 +493,9 @@
 
   function onClearIconKeyDown(e: KeyboardEvent) {
     if (e.key === "Enter" || e.key === " ") {
-      e.stopPropagation();
       reset();
       showMenu();
+      e.stopPropagation();
     }
   }
 
@@ -524,8 +525,15 @@
     setDisplayedValue();
   }
 
-  async function onChevronClick(e: Event) {
-    showMenu();
+  function onChevronClick(e: Event) {
+    if (_isMenuVisible) {
+      _inputEl?.focus();
+      hideMenu();
+    } else {
+      showMenu();
+    }
+    e.preventDefault();
+    e.stopPropagation();
   }
 
   function onFocus(e: Event) {
@@ -775,6 +783,7 @@
           on:keyup={onInputKeyUp}
           on:change={onInputChange}
           on:focus={onFocus}
+          on:click={!_filterable && onChevronClick}
         />
 
         {#if _inputEl?.value && _filterable}
@@ -821,11 +830,12 @@
         aria-label={arialabel || name}
         aria-labelledby={arialabelledby}
         on:focus={onFocus}
+        on:mousedown={(e) => e.preventDefault()}
         style={`
-            outline: none;
-            overflow-y: auto;
-            max-height: ${maxheight};
-          `}
+          outline: none;
+          overflow-y: auto;
+          max-height: ${maxheight};
+        `}
       >
         {#each _filteredOptions as option, index (index)}
           <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -840,7 +850,11 @@
             data-value={option.value}
             role="option"
             style="display: block"
-            on:click={() => onFilteredOptionClick(option)}
+            on:click={(e) => {
+              onFilteredOptionClick(option);
+              _inputEl?.focus();
+              e.stopPropagation();
+            }}
           >
             {option.label || option.value}
           </li>
@@ -903,7 +917,7 @@
 
   .dropdown-icon--arrow,
   .dropdown-icon--clear {
-    margin-right: var(--goa-dropdown-space-icon-text);
+    padding-right: var(--goa-dropdown-space-icon-text);
   }
 
   /* TODO: add indicator to when the reset button has focus state */

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -93,7 +93,6 @@
   let _prevError = false;
   let _containerWidth = "";
 
-
   // ========
   // Reactive
   // ========
@@ -307,6 +306,7 @@
         class="leading-icon"
         data-testid="leading-icon"
         type={leadingicon}
+        tabindex="-1"
       />
     {/if}
 
@@ -347,6 +347,7 @@
         size="medium"
         type={trailingicon}
         arialabel={trailingiconarialabel}
+        tabindex="-1"
       />
     {/if}
 
@@ -377,7 +378,6 @@
 
 <!-- Styles -->
 <style>
-
   :host {
     box-sizing: border-box; /* border box: the element's specified width and height include the content, padding, and border. The margin is still added */
   }
@@ -388,7 +388,6 @@
     display: inline-block;
     max-width: 100%;
   }
-
 
   @media not (--mobile) {
     .container {
@@ -424,9 +423,7 @@
   }
   .goa-input:not(.error):has(input:focus-visible) {
     /* focus border(s) */
-    box-shadow:
-      var(--goa-text-input-border),
-      var(--goa-text-input-border-focus);
+    box-shadow: var(--goa-text-input-border), var(--goa-text-input-border-focus);
   }
 
   /* Error state */
@@ -446,9 +443,7 @@
 
   /* Focus state (including when in error state) */
   .goa-input:has(input:focus-visible) {
-    box-shadow:
-      var(--goa-text-input-border),
-      var(--goa-text-input-border-focus);
+    box-shadow: var(--goa-text-input-border), var(--goa-text-input-border-focus);
   }
 
   /* type=range does not have an outline/box-shadow */
@@ -581,16 +576,12 @@
   .input-leading-content:active,
   .input-leading-content:focus-visible,
   .input-leading-content:focus-within {
-    box-shadow:
-      var(--goa-text-input-border),
-      var(--goa-text-input-border-focus);
+    box-shadow: var(--goa-text-input-border), var(--goa-text-input-border-focus);
   }
   .input-trailing-content:active,
   .input-trailing-content:focus-visible,
   .input-trailing-content:focus-within {
-    box-shadow:
-      var(--goa-text-input-border),
-      var(--goa-text-input-border-focus);
+    box-shadow: var(--goa-text-input-border), var(--goa-text-input-border-focus);
   }
 
   /* Hide main focus border for inputs with leading and trailing content */

--- a/libs/web-components/src/components/popover/PopoverWrapper.test.svelte
+++ b/libs/web-components/src/components/popover/PopoverWrapper.test.svelte
@@ -2,16 +2,14 @@
 
 <!-- Script -->
 <script lang="ts">
+  import Popover from "./Popover.svelte";
+
   export let content: string = "";
   export let targetTrigger: string = "";
 </script>
 
 <!-- HTML -->
-<goa-popover>
-  {#if content}
-    <div slot="content">{content}</div>
-  {/if}
-  {#if targetTrigger}
-    <div slot="target">{targetTrigger}</div>
-  {/if}
-</goa-popover>
+<Popover>
+  <div slot="target">{@html targetTrigger}</div>
+  {@html content}
+</Popover>


### PR DESCRIPTION
# Before (the change)

Dropdown uses Popover to show the list of options. Popovers had an invisible background behind them that user could click to close the popover. This prevented a user from clicking on anything behind the invisible background, like a hyperlink for example, until they clicked once to close the popover. This does not happen with a regular select. This problem affected Popover, Dropdown, AppHeader, AppHeaderMenu, and DatePicker.

# After (the change)

Popover no longer has an invisible background and the component now handles a `focusout` event to decide if popover should be closed. Now it is possible to click outside of a popover to immediately interact with other elements, which is how a native select behaves:

<video src="https://github.com/user-attachments/assets/f19299f1-11da-452c-b1af-edf3655b9e28" width="300"></video>

## Technical info

Popover no longer has an invisible background and the component now handles a `focusout` event for the same behavior. If the popover container or any element within that container loses focus, then `focusout` event bubbles up. It bubbles up from slotted children. When handling `focusout` it checks if the now active element is contained within the popover container by recursively looking down within nested slots. Whenever a popover open it also checks in the default slot used for content to see if any immediate children do not have tabindex set and if not then it adds tabindex="-1" which allows the `focusout` event to bubble up from these non-focusable elements. Another key change that was made is to always render popover contents to the DOM that are hidden when popover is closed.. previously it would not render those contents to the DOM, which was fine most of the time but causes edge case problems. This change makes the page more accessible, making it an additional fix. Take dropdown for example: the contents of a dropdown's options are now always part of the DOM just like how a native select options are always part of the DOM, so I think this is a positive change, and fwiw this change was needed to make Datepicker work well. Previously in [DatePicker](https://design.alberta.ca/components/date-picker) when you had one of its Month or Year dropdowns expanded, then if you click outside the calendar to collapse the entire Calendar popover, that dropdown will remain expanded next time the Calendar popover opens. This no longer happens.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.
  - [x] tested in React
  - [ ] tested in Angular

## Steps needed to test

Try this out with Dropdown, DatePicker, or the dropdown navigation within the App Header Menu. While any dropdown, datepicker, or sub-navigation is expanded, try clicking anywhere inside of the expanded content and it should not collapse. Then try clicking outside of the expanded content and it should collapse. This is all demonstrated in the video.