### PR TITLE
fix(#2003): popover remove relative prop

### DIFF
--- a/apps/angular-tests/src/app/dropdown/dropdown.component.html
+++ b/apps/angular-tests/src/app/dropdown/dropdown.component.html
@@ -32,8 +32,12 @@ value: {{reactiveFormCtrl.value | json}}
   </goab-form-item>
 
   <goab-form-item label="Country">
-    <goab-dropdown [filterable]="true" [relative]="true" name="country" width="30ch">
-      <goab-dropdown-item *ngFor="let opt of countries" [value]="opt.code" [label]="opt.name"></goab-dropdown-item>
+    <goab-dropdown [filterable]="true" name="country" width="30ch">
+      <goab-dropdown-item
+        *ngFor="let opt of countries"
+        [value]="opt.code"
+        [label]="opt.name"
+      ></goab-dropdown-item>
     </goab-dropdown>
   </goab-form-item>
 </form>
@@ -57,8 +61,12 @@ value: {{reactiveFormCtrl.value | json}}
 <goab-container accent="thin">
   <form [formGroup]="form">
     <goab-form-item label="Select Option">
-      <goab-dropdown [relative]="true" name="option" formControlName="option" width="100%">
-        <goab-dropdown-item *ngFor="let option of options" [value]="option.value" [label]="option.displayValue" />
+      <goab-dropdown name="option" formControlName="option" width="100%">
+        <goab-dropdown-item
+          *ngFor="let option of options"
+          [value]="option.value"
+          [label]="option.displayValue"
+        />
       </goab-dropdown>
     </goab-form-item>
   </form>

--- a/libs/angular-components/src/lib/components/date-picker/date-picker.ts
+++ b/libs/angular-components/src/lib/components/date-picker/date-picker.ts
@@ -46,6 +46,9 @@ export class GoabDatePicker implements ControlValueAccessor {
   @Input() max?: Date | string;
   @Input() error?: boolean;
   @Input() disabled?: boolean;
+  /***
+   * @deprecated This property has no effect and will be removed in a future version
+   */
   @Input() relative?: boolean;
   @Input() testId?: string;
   @Input() mt?: Spacing;

--- a/libs/angular-components/src/lib/components/dropdown/dropdown.spec.ts
+++ b/libs/angular-components/src/lib/components/dropdown/dropdown.spec.ts
@@ -55,7 +55,6 @@ class TestDropdownComponent {
   placeholder?: string;
   testId?: string;
   width?: string;
-  relative?: boolean;
   mt?: Spacing;
   mb?: Spacing;
   ml?: Spacing;

--- a/libs/angular-components/src/lib/components/dropdown/dropdown.ts
+++ b/libs/angular-components/src/lib/components/dropdown/dropdown.ts
@@ -59,6 +59,9 @@ export class GoabDropdown implements ControlValueAccessor{
   @Input() placeholder?: string;
   @Input() testId?: string;
   @Input() width?: string;
+  /***
+   * @deprecated This property has no effect and will be removed in a future version
+   */
   @Input() relative?: boolean;
   @Input() mt?: Spacing;
   @Input() mb?: Spacing;

--- a/libs/angular-components/src/lib/components/popover/popover.spec.ts
+++ b/libs/angular-components/src/lib/components/popover/popover.spec.ts
@@ -11,7 +11,6 @@ import { GoabButton } from "../button/button";
       [maxWidth]="maxWidth"
       [padded]="padded"
       [position]="position"
-      [relative]="relative"
       [mt]="mt"
       [mb]="mb"
       [ml]="ml"
@@ -29,7 +28,6 @@ class TestPopoverComponent {
   maxWidth = "320px";
   padded = true;
   position?: GoabPopoverPosition;
-  relative?: boolean;
   testId?: string;
   mt?: Spacing;
   mb?: Spacing;
@@ -55,7 +53,6 @@ describe("GoABPopover", () => {
     component.maxWidth = "500px";
     component.padded = false;
     component.position = "above" as GoabPopoverPosition;
-    component.relative = true;
     component.mt = "l" as Spacing;
     component.mb = "s" as Spacing;
     component.ml = "xs" as Spacing;
@@ -75,7 +72,6 @@ describe("GoABPopover", () => {
     expect(el.getAttribute("maxwidth")).toBe(component.maxWidth);
     expect(el.getAttribute("padded")).toBe(`${component.padded}`);
     expect(el.getAttribute("position")).toBe(component.position);
-    expect(el.getAttribute("relative")).toBe(`${component.relative}`);
 
     expect(el.getAttribute("mt")).toBe("l");
     expect(el.getAttribute("mb")).toBe("s");

--- a/libs/angular-components/src/lib/components/popover/popover.ts
+++ b/libs/angular-components/src/lib/components/popover/popover.ts
@@ -32,6 +32,9 @@ export class GoabPopover {
   @Input() minWidth?: string;
   @Input() padded = true;
   @Input() position?: GoabPopoverPosition;
+  /***
+   * @deprecated This property has no effect and will be removed in a future version
+   */
   @Input() relative?: boolean;
   @Input() testId?: string;
   @Input() mt?: Spacing;

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -255,6 +255,9 @@ export interface GoabPopoverProps extends Margins {
   maxWidth?: string;
   padded?: boolean;
   position?: GoabPopoverPosition;
+  /***
+   * @deprecated This property has no effect and will be removed in a future version
+   */
   relative?: boolean;
 }
 

--- a/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
@@ -15,7 +15,6 @@ describe("DatePicker", () => {
     const min = addMonths(value, -1);
     const max = addMonths(value, 1);
     const disabled = true;
-    const relative = true;
 
     const { baseElement } = render(
       <DatePicker
@@ -26,7 +25,6 @@ describe("DatePicker", () => {
         testId="foo"
         error={error}
         disabled={disabled}
-        relative={relative}
         onChange={noop}
       />,
     );
@@ -41,7 +39,6 @@ describe("DatePicker", () => {
     expect(el?.getAttribute("disabled")).toBe("true");
     expect(el?.getAttribute("min")).toBe(min.toISOString());
     expect(el?.getAttribute("max")).toBe(max.toISOString());
-    expect(el?.getAttribute("relative")).toBe("true");
     expect(el?.getAttribute("testid")).toBe("foo");
   });
 
@@ -70,16 +67,5 @@ describe("DatePicker", () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toBeCalledWith({ name, value, type: "date" });
-  });
-
-  it("should render without relative property", () => {
-    const value = new Date();
-    const { baseElement } = render(
-      <DatePicker name="foo" value={value} onChange={noop} />,
-    );
-
-    const el = baseElement.querySelector("goa-date-picker");
-    expect(el).toBeTruthy();
-    expect(el?.getAttribute("relative")).toBeNull();
   });
 });

--- a/libs/react-components/src/lib/date-picker/date-picker.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.tsx
@@ -30,6 +30,9 @@ export interface GoabDatePickerProps extends Margins {
   min?: Date;
   max?: Date;
   testId?: string;
+  /***
+   * @deprecated This property has no effect and will be removed in a future version
+   */
   relative?: boolean;
   disabled?: boolean;
   onChange: (detail: GoabDatePickerOnChangeDetail) => void;

--- a/libs/react-components/src/lib/dropdown/dropdown.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown.tsx
@@ -55,6 +55,9 @@ export interface GoabDropdownProps extends Margins {
   placeholder?: string;
   testId?: string;
   width?: string;
+  /***
+   * @deprecated This property has no effect and will be removed in a future version
+   */
   relative?: boolean;
 }
 

--- a/libs/react-components/src/lib/popover/popover.tsx
+++ b/libs/react-components/src/lib/popover/popover.tsx
@@ -27,6 +27,9 @@ export interface GoabPopoverProps extends Margins {
   padded?: boolean;
   position?: GoabPopoverPosition;
   children: ReactNode;
+  /***
+   * @deprecated This property has no effect and will be removed in a future version
+   */
   relative?: boolean;
 }
 

--- a/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
+++ b/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
@@ -157,7 +157,8 @@
   {#if _desktop}
     <goa-popover
       bind:this={_popoverEl}
-      context="app-header-menu"
+      class="app-header-menu-popover"
+      context="menu"
       focusborderwidth="0"
       borderradius="0"
       padded="false"
@@ -204,6 +205,10 @@
 <style>
   * {
     font: var(--goa-typography-body-m);
+  }
+
+  goa-popover.app-header-menu-popover {
+    position: inherit;
   }
 
   /* Menu item with children */

--- a/libs/web-components/src/components/app-header/AppHeader.svelte
+++ b/libs/web-components/src/components/app-header/AppHeader.svelte
@@ -230,10 +230,10 @@
     <!-- Menu and menu button for tablet -->
     {#if _showToggleMenu && _tablet}
       <goa-popover
-        class="menu"
+        class="app-header-popover"
+        context="menu-toggle-area"
         open={_showMenu}
         minwidth="16rem"
-        context="menu-toggle-area"
         focusborderwidth="0"
         borderradius="4"
         padded="false"
@@ -297,6 +297,10 @@
   *,
   :global(::slotted(*)) {
     font: var(--goa-app-header-typography-service-name);
+  }
+
+  goa-popover.app-header-popover {
+    position: inherit;
   }
 
   /* Spans the full page width */

--- a/libs/web-components/src/components/calendar/Calendar.svelte
+++ b/libs/web-components/src/components/calendar/Calendar.svelte
@@ -331,7 +331,6 @@
         data-testid="months"
         width="160px"
         maxheight="240px"
-        relative="true"
         value={_calendarDate?.getMonth()}
         on:_change={setMonth}
       >
@@ -348,7 +347,6 @@
         data-testid="years"
         width="104px"
         maxheight="240px"
-        relative="true"
         value={_calendarDate?.getFullYear()}
         on:_change={setYear}
       >

--- a/libs/web-components/src/components/date-picker/DatePicker.html-data.json
+++ b/libs/web-components/src/components/date-picker/DatePicker.html-data.json
@@ -22,13 +22,6 @@
       "description": "Max allowed date value"
     },
     {
-      "name": "relative",
-      "type": "boolean",
-      "valueSet": "boolean",
-      "defaultValue": "false",
-      "description": "Set to true when datepicker is nested in a position=relative element"
-    },
-    {
       "name": "disabled",
       "type": "boolean",
       "valueSet": "boolean",

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -2,13 +2,7 @@
 
 <script lang="ts">
   import { onMount, tick } from "svelte";
-  import {
-    addDays,
-    addMonths,
-    addYears,
-    format,
-    startOfDay,
-  } from "date-fns";
+  import { addDays, addMonths, addYears, format, startOfDay } from "date-fns";
   import type { Spacing } from "../../common/styling";
   import { padLeft, toBoolean } from "../../common/utils";
   import { receive, dispatch, relay } from "../../common/utils";
@@ -19,7 +13,9 @@
     FieldsetResetErrorsMsg,
     FormFieldMountMsg,
     FormFieldMountRelayDetail,
-    FieldsetErrorRelayDetail, FieldsetResetFieldsMsg, FormItemMountMsg,
+    FieldsetErrorRelayDetail,
+    FieldsetResetFieldsMsg,
+    FormItemMountMsg,
   } from "../../types/relay-types";
 
   type DateValue = {
@@ -40,7 +36,10 @@
   export let error: string = "false";
   export let min: string = "";
   export let max: string = "";
-  export let relative: string = "false";
+  /***
+   * @deprecated This property has no effect and will be removed in a future version
+   */
+  export let relative: string = "";
   export let disabled: string = "false";
   export let testid: string = "";
 
@@ -70,7 +69,16 @@
     setDate(value);
     addRelayListener();
     sendMountedMessage();
+    showDeprecationWarnings();
   });
+
+  function showDeprecationWarnings() {
+    if (relative != "") {
+      console.warn(
+        "Date Picker `relative` property is deprecated. It should be removed from your code because it is no longer needed to help with positioning.",
+      );
+    }
+  }
 
   // Listen for relayed messages
   function addRelayListener() {
@@ -86,7 +94,7 @@
           error = "false";
           break;
         case FieldsetResetFieldsMsg:
-          onSetValue({name, value: ""})
+          onSetValue({ name, value: "" });
           break;
 
         // prevent child fields from mounting/registering themselves with parent components
@@ -125,7 +133,7 @@
 
   function setDate(value: string) {
     // invalid date
-    if (!value || !(new Date(value).getDate())) {
+    if (!value || !new Date(value).getDate()) {
       _date = null;
       _inputDate = { day: "", month: "", year: "" };
       return;
@@ -133,7 +141,7 @@
 
     if (type === "input") {
       const [year, month, day] = value.split("-");
-      _inputDate = { year: year, month: `${+month-1}`, day: day };
+      _inputDate = { year: year, month: `${+month - 1}`, day: day };
     } else if (type === "calendar") {
       _date = startOfDay(new Date(value));
     }
@@ -252,7 +260,7 @@
       e as CustomEvent<{ name: string; value: string }>
     ).detail;
 
-    _inputDate = {..._inputDate, [elName]: +value};
+    _inputDate = { ..._inputDate, [elName]: +value };
 
     if (!new Date(+_inputDate.year, +_inputDate.month, +_inputDate.day)) {
       return;
@@ -275,7 +283,6 @@
     bind:this={_rootEl}
     tabindex="-1"
     {testid}
-    {relative}
     {mt}
     {mb}
     {ml}
@@ -309,7 +316,12 @@
   <goa-form-item error={_error && error} bind:this={_rootEl}>
     <goa-block direction="row">
       <goa-form-item label="Month" helptext="Month">
-        <goa-dropdown name="month" on:_change={onInputChange} {error} value={_inputDate.month+""}>
+        <goa-dropdown
+          name="month"
+          on:_change={onInputChange}
+          {error}
+          value={_inputDate.month + ""}
+        >
           <goa-dropdown-item value="0" label="January" />
           <goa-dropdown-item value="1" label="February" />
           <goa-dropdown-item value="2" label="March" />

--- a/libs/web-components/src/components/date-picker/date-picker.spec.ts
+++ b/libs/web-components/src/components/date-picker/date-picker.spec.ts
@@ -21,14 +21,11 @@ it("it renders", async () => {
 
 it("renders with props", async () => {
   const value = addDays(new Date(), -10);
-  const relative = "true";
 
-  const { container } = render(DatePicker, { value, relative });
+  const { container } = render(DatePicker, { value });
 
-  const popover = container.querySelector("goa-popover");
   const input = container.querySelector("goa-input");
 
-  expect(popover?.getAttribute("relative")).toBe("true");
   expect(input?.getAttribute("value")).toBe(format(value, "PPP"));
 });
 

--- a/libs/web-components/src/components/date-picker/doc.md
+++ b/libs/web-components/src/components/date-picker/doc.md
@@ -1,11 +1,9 @@
 # DatePicker Library
 
-
 Use it like this:
 
 ```
 	<goa-date-picker></goa-date-picker>
-	<goa-date-picker relative="true"></goa-date-picker>
 	<goa-date-picker [value]="date"></goa-date-picker>
 	<goa-date-picker [min]="min" [max]="max"></goa-date-picker>
 ```

--- a/libs/web-components/src/components/dropdown/Dropdown.html-data.json
+++ b/libs/web-components/src/components/dropdown/Dropdown.html-data.json
@@ -69,12 +69,6 @@
       "default": "false"
     },
     {
-      "name": "relative",
-      "description": "Set to true if a parent element has a css position of `relative`",
-      "type": "boolean",
-      "default": "false"
-    },
-    {
       "name": "mt",
       "description": "Top margin",
       "valueSet": "spacing"

--- a/libs/web-components/src/components/dropdown/Dropdown.spec.ts
+++ b/libs/web-components/src/components/dropdown/Dropdown.spec.ts
@@ -32,7 +32,6 @@ describe("GoADropdown", () => {
       expect(popover?.getAttribute("disabled")).toBe("false");
       expect(popover?.getAttribute("open")).toBe("false");
       expect(popover?.getAttribute("padded")).toBe("false");
-      expect(popover?.getAttribute("relative")).toBe("false");
 
       const dropdown = result.queryByTestId("favcolor-dropdown");
       const inputField = dropdown?.querySelector("input");
@@ -114,7 +113,6 @@ describe("GoADropdown", () => {
         expect(popover?.getAttribute("disabled")).toBe("false");
         expect(popover?.getAttribute("open")).toBe("false");
         expect(popover?.getAttribute("padded")).toBe("false");
-        expect(popover?.getAttribute("relative")).toBe("false");
 
         expect(inputField?.getAttribute("id")).toBe("favcolor");
         expect(inputField?.getAttribute("aria-autocomplete")).toBe("list");

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -53,7 +53,10 @@
   export let error: string = "false";
   export let multiselect: string = "false";
   export let native: string = "false";
-  export let relative: string = "false";
+  /***
+   * @deprecated This property has no effect and will be removed in a future version
+   */
+  export let relative: string = "";
   export let mt: Spacing = null;
   export let mr: Spacing = null;
   export let mb: Spacing = null;
@@ -156,11 +159,20 @@
     _eventHandler = _filterable
       ? new ComboboxKeyUpHandler(_inputEl)
       : new DropdownKeyUpHandler(_inputEl);
+    showDeprecationWarnings();
   });
 
   //
   // Functions
   //
+
+  function showDeprecationWarnings() {
+    if (relative != "") {
+      console.warn(
+        "Dropdown `relative` property is deprecated. It should be removed from your code because it is no longer needed to help with positioning.",
+      );
+    }
+  }
 
   function addRelayListener() {
     receive(_rootEl, (action, data, event) => {
@@ -733,7 +745,6 @@
     <!-- list and filter -->
     <goa-popover
       {disabled}
-      {relative}
       data-testid="option-list"
       width={`${_popoverMaxWidth || 0}`}
       minwidth={_dropdownWidth}

--- a/libs/web-components/src/components/popover/Popover.html-data.json
+++ b/libs/web-components/src/components/popover/Popover.html-data.json
@@ -20,12 +20,6 @@
       "default": "false"
     },
     {
-      "name": "relative",
-      "description": "Set to true if a parent element has a css position of `relative`",
-      "type": "boolean",
-      "default": "false"
-    },
-    {
       "name": "mt",
       "description": "Top margin",
       "valueSet": "spacing"

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -31,8 +31,10 @@
   // allows to override the default padding when content needs to be flush with boundries
   export let padded: string = "true";
 
-  // ajust positioning when popover component is contained within a relative positioned parent
-  export let relative: string = "false";
+  /***
+   * @deprecated This property has no effect and will be removed in a future version
+   */
+  export let relative: string = "";
 
   // margins
   export let mt: Spacing = null;
@@ -79,7 +81,6 @@
   $: _padded = toBoolean(padded);
   $: _open = toBoolean(open);
   $: _disabled = toBoolean(disabled);
-  $: _relative = toBoolean(relative);
 
   $: (async () => _open && (await setPopoverPosition()))();
   $: (async () => _sectionHeight && (await setPopoverPosition()))();
@@ -103,9 +104,19 @@
       (children.find(
         (el) => (el as HTMLElement).tabIndex >= 0,
       ) as HTMLElement) || _targetEl;
+
+    showDeprecationWarnings();
   });
 
   // Functions
+
+  function showDeprecationWarnings() {
+    if (relative != "") {
+      console.warn(
+        "Popover `relative` property is deprecated. It should be removed from your code because it is no longer needed to help with positioning.",
+      );
+    }
+  }
 
   // Called on window popstate changes. This allows for clicking links within
   // the popover to close the popover
@@ -260,11 +271,9 @@
         : position === "above";
 
     if (displayOnTop) {
-      _popoverEl.style.top = _relative
-        ? `${-popoverRect.height}px`
-        : `${targetRect.y - popoverRect.height + window.scrollY}px`;
+      _popoverEl.style.bottom = `${targetRect.height}px`;
     } else {
-      _popoverEl.style.top = ""; // In case this is triggered by _sectionHeight is changed
+      _popoverEl.style.bottom = "auto"; // In case this is triggered by _sectionHeight is changed
     }
 
     // Move the popover to the left if it is too far to the right and only if there is space to the left
@@ -285,7 +294,6 @@
   data-testid={testid}
   on:focusout={handleFocusOut}
   style={styles(
-    _relative && "position: relative",
     height === "full" && "height: 100%;",
     calculateMargin(mt, mr, mb, ml),
     style("--offset-top", voffset),
@@ -346,6 +354,7 @@
     display: flex;
     align-items: center;
     height: 100%;
+    position: relative;
   }
 
   .popover-target {
@@ -361,13 +370,13 @@
   .popover-content {
     color: var(--goa-color-text-default);
     position: absolute;
+    z-index: 99;
     width: fit-content;
     list-style-type: none;
     background: var(--goa-popover-color-bg);
     border-radius: var(--goa-popover-border-radius);
     outline: none;
     filter: var(--goa-popover-shadow);
-    z-index: 99;
     margin-top: var(--offset-top, 3px);
     margin-bottom: var(--offset-bottom, 3px);
     margin-left: var(--offset-left, 0);


### PR DESCRIPTION
Also see related ui-components-docs PR: https://github.com/GovAlta/ui-components-docs/pull/305

# Before (the change)

Popover had prop: "relative" that when enabled would add style, "position: relative;" to the popover container to help with positioning flow. Dropdown and DatePicker had "relative" prop that would be passed down to child popover component. Code was adjusted to always set style, "position: relative;" and to calculate the position of popover when displaying upwards.

# After (the change)

Popover always has "position: relative" (related to #2003):
<video src="https://github.com/user-attachments/assets/bdc9255a-c743-4e1f-8180-c2f78d77539e" width="200"></video>

Popover positioning is still okay when scrolling within a modal (related to #2466):
<video src="https://github.com/user-attachments/assets/cafca2ec-8c13-45e8-a652-52ba847d4249" width="200"></video>

Note: a popover cannot appear over top of modal because of z-index layer hierarchy
  - E.g. basic or filterable Dropdown (E.g. `<goa-dropdown filterable="true">`) cannot have its contents "drop down" outside of modal like a native Dropdown can, because native html select is not affected by z-index layering and will always show over top
  - this was already the behavior of popover when relative property was used before these changes (E.g. `<goa-dropdown relative="true">`)

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Try dropdown and datepicker, some with a wrapper that has "position: relative" and some inside a modal -- try resizing the viewport to see how it calculates space below to determine if it dropdown or datepicker should expand upwards -- and try this in the different playgrounds:
- [angular-modal.component.html.txt](https://github.com/user-attachments/files/18482932/angular-modal.component.html.txt)
- [react-modal.tsx.txt](https://github.com/user-attachments/files/18482933/react-modal.tsx.txt)
- [ModalPage.svelte.txt](https://github.com/user-attachments/files/18482934/ModalPage.svelte.txt)
  - Alternative [ModalPage.svelte.txt](https://github.com/user-attachments/files/19212549/2025-03-12-web-components-playground-ModalPage.svelte.txt) related to #2466 