### PR TITLE
fix(#2299): input value of 0 not getting displayed

### DIFF
--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -313,7 +313,7 @@
       {autocapitalize}
       {name}
       {type}
-      value={value || ""}
+      value={value ?? ""}
       {placeholder}
       {min}
       {max}


### PR DESCRIPTION
# Before (the change)

https://github.com/user-attachments/assets/b6ffc9b0-16ec-44a5-b5b8-1f6ca54da537


# After (the change)

https://github.com/user-attachments/assets/ccd64874-b4dd-493d-b4a2-c87ba8ab4e57


## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

**-switch to LTS branch**
to test with<goa- 

Angular playground test code
```
<goa-form-item label="Example 2">
  <goa-input
    name="inputControl"
    formControlName="inputControl"
    [value]="inputControl.value"
    placeholder="Enter text"
  />
</goa-form-item>
```

```
import { Component } from "@angular/core";
import { FormControl } from "@angular/forms";

@Component({
  selector: "abgov-input-component",
  templateUrl: "./input-component.component.html",
})
export class InputComponent {
  inputControl = new FormControl(0);
}
```

**switch to alpha**
to test with<goab- 

```
<form [formGroup]="example2Form">
  <goab-form-item label="Example 2">
    <goab-input name="inputControl" formControlName="inputControl" placeholder="Enter text"></goab-input>
    <goab-form-item-slot slot="helptext">Entered value: {{example2Form.get('inputControl')?.value }}</goab-form-item-slot>
  </goab-form-item>
</form>
```


```
@Component({
  standalone: true,
  selector: "abgov-input-component",
  templateUrl: "./input-component.component.html",
  imports: [
    GoabInput,
    GoabDatePicker,
    GoabBadge,
    GoabFormItem,
    JsonPipe,
    ReactiveFormsModule,
    FormsModule,
    GoabFormItemSlot,
    NgTemplateOutlet
  ],
})
export class InputComponentComponent implements OnInit {
  example2Form: FormGroup;
  zeroVal = 0;
  constructor() {
    this.example2Form = new FormGroup({
      //inputControl: new FormControl("")
      inputControl: new FormControl(this.zeroVal)
    })
  }
```
