### PR TITLE
fix(#2381): react getByTestId

### DIFF
--- a/libs/react-components/src/lib/badge/badge.spec.tsx
+++ b/libs/react-components/src/lib/badge/badge.spec.tsx
@@ -1,12 +1,16 @@
-import { render } from "@testing-library/react";
+import { configure, render } from "@testing-library/react";
 import { GoabBadge } from "./badge";
 import { screen } from "@testing-library/dom";
+
+configure({
+  testIdAttribute: "testId",
+});
 
 describe("GoabBadge", () => {
   it("should render", () => {
     render(<GoabBadge type="information" testId="badge-test" content="Text Content" />);
 
-    const badge = screen.findByTestId("badge-test");
+    const badge = screen.getByTestId("badge-test");
     expect(badge).toBeTruthy();
   });
 


### PR DESCRIPTION
# Before (the change)

Test was passing with a false-positive

# After (the change)

Test is now finding element by `testId` attribute instead of the default, `data-testid` attribute.

Reason: While using react testing library with jsdom the shadow DOM is not visible the same as in a browser or when testing svelte components.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Run `libs\react-components\src\lib\badge\badge.spec.tsx`