### PR TITLE
fix(#2375): add "final" attribute to form-step

### DIFF
--- a/libs/web-components/src/components/form-step/FormStep.svelte
+++ b/libs/web-components/src/components/form-step/FormStep.svelte
@@ -15,6 +15,7 @@
 
 <script lang="ts">
   import { onMount } from "svelte";
+  import { toBoolean } from "../../common/utils";
 
   // ======
   // Public
@@ -22,6 +23,7 @@
 
   export let text: string;
   export let status: FormStepStatus | undefined = undefined;
+  export let last: string = "false";
 
   // Set by FormStepper parent component
   let current: boolean = false;
@@ -42,6 +44,7 @@
   // ========
 
   $: _isEnabled = enabled || status === "complete";
+  $: _isLast = toBoolean(last);
 
   onMount(() => {
     // receive notification from parent of resize
@@ -111,6 +114,7 @@
   bind:this={_rootEl}
   class:mobile={_isMobile}
   class:desktop={!_isMobile}
+  class:last={_isLast}
   role="listitem"
   tabindex="-1"
   for={text}
@@ -131,11 +135,15 @@
   />
   <div data-testid="status" class="status">
     {#if current}
-      <goa-icon type="pencil" theme="filled" />
+      {#if _isLast && status === "complete"}
+        <goa-icon type="checkmark" inverted />
+      {:else}
+        <goa-icon type="pencil"  theme="filled" />
+      {/if}
     {:else if status === "complete"}
       <goa-icon type="checkmark" inverted />
     {:else if status === "incomplete"}
-      <goa-icon type="remove" theme="filled"/>
+      <goa-icon type="remove" theme="filled" />
     {:else}
       <div data-testid="step-number" class="step-number">
         {childindex || ""}
@@ -216,7 +224,7 @@
     background: var(--goa-step-color-bg-complete);
   }
 
-  [aria-current="step"][data-status="complete"] .status {
+  [aria-current="step"][data-status="complete"]:not(.last) .status {
     background: var(--goa-step-color-bg-active);
   }
 

--- a/libs/web-components/src/components/form-stepper/FormStepper.svelte
+++ b/libs/web-components/src/components/form-stepper/FormStepper.svelte
@@ -199,7 +199,7 @@
 
   // change current step state and update children
   function changeStep(nextStep: number) {
-    if (_steps.length === 0) return;
+    if (_steps.length === 0 || nextStep > _steps.length) return;
 
     // deactivate current step (currentStep is initially undefined)
     if (_currentStep > 0) {


### PR DESCRIPTION
# Before (the change)
At version 1.20.0 (published 7 months ago), a developer can set icon “complete” for step 6 (final step) programmatically, by set Step 6 status Complete, and make [step]=7, something different from 1-> 6)

Using the below code: 
```
<goa-form-stepper
  (_change)="updateCurrentStep($event)"
  ml="s"
  mr="s"
  [step]="paymentBatchStatusStep"
  class="non-clickable-stepper"
  data-automation-id="payment-stepper"
>
  <goa-form-step text="New" status="" [status]="paymentBatchStatusArray[0].status"></goa-form-step>
  <goa-form-step text="Under Review" status="" [status]="paymentBatchStatusArray[1].status"></goa-form-step>
  <goa-form-step
    class="text-nowrap"
    text="EO Recommendation"
    [status]="paymentBatchStatusArray[2].status"
  ></goa-form-step>
  <goa-form-step text="AO Approval" status="" [status]="paymentBatchStatusArray[3].status"></goa-form-step>
  <goa-form-step
    text="step 5"
    status=""
    [status]="paymentBatchStatusArray[4].status"
  ></goa-form-step>
  <goa-form-step
    text="step 6"
    [status]="paymentBatchStatusArray[5].status"
  ></goa-form-step>
</goa-form-stepper>

<goa-container>
  <p>Current step: {{paymentBatchStatusStep}}</p>
  <p>Final page: {{isFinal}}</p>
  <ul>
    <li *ngFor="let item of paymentBatchStatusArray">
      {{item.stageSequence}} : {{item.status}}
    </li>
  </ul>
</goa-container>

<div style="display: flex; justify-content: space-between">
  <goa-button (_click)="setPage(paymentBatchStatusStep - 1)" type="secondary"
  >Previous</goa-button
  >

  <goa-button (_click)="setPage(paymentBatchStatusStep + 1)" type="primary">
    Next
  </goa-button>
</div>

```

```
import { Component, OnInit } from "@angular/core";

const PaymentBatchStageSequence = {
  New: 1,
  UnderReview: 2,
  EORecommendation: 3,
  AOApproval: 4,
  PaymentInProgress: 5,
  PaidReconciled: 6
};
const PaymentStageType = {
  NewInBatch: "new",
  UnderReview: "reviewing",
  EORecommendation: "eo",
  AOApproval: "ao",
  PaymentInProgress: "inprogress",
  PaidReconciled: "paid"
}
const PaymentStageStatus = {
  NotStarted: "",
  Complete: "complete",
}

@Component({
  selector: "abgov-form-stepper-issue-2375",
  templateUrl: "./form-stepper-issue-2375.component.html",
})
export class FormStepperIssue2375Component implements OnInit {
  paymentBatchStatusStep = -1;
  paymentBatchStatusArray = [
    {
      stageSequence: PaymentBatchStageSequence.New,
      stageType: PaymentStageType.NewInBatch,
      status: PaymentStageStatus.NotStarted,
    },
    {
      stageSequence: PaymentBatchStageSequence.UnderReview,
      stageType: PaymentStageType.UnderReview,
      status: PaymentStageStatus.NotStarted,
    },
    {
      stageSequence: PaymentBatchStageSequence.EORecommendation,
      stageType: PaymentStageType.EORecommendation,
      status: PaymentStageStatus.NotStarted,
    },
    {
      stageSequence: PaymentBatchStageSequence.AOApproval,
      stageType: PaymentStageType.AOApproval,
      status: PaymentStageStatus.NotStarted,
    },
    {
      stageSequence: PaymentBatchStageSequence.PaymentInProgress,
      stageType: PaymentStageType.PaymentInProgress,
      status: PaymentStageStatus.NotStarted,
    },
    {
      stageSequence: PaymentBatchStageSequence.PaidReconciled,
      stageType: PaymentStageType.PaidReconciled,
      status: PaymentStageStatus.NotStarted,
    },
  ];

  markCompletedStages = (step: number, status: string) => {
    this.paymentBatchStatusArray.forEach((stage) => {
      if (status === PaymentStageStatus.Complete) {
        if (stage.stageSequence < step) {
          stage.status = status;
        }
      } else {
        if (stage.stageSequence > step) {
          stage.status = status;
        }
      }

    });
    this.paymentBatchStatusStep = step;
  }

  ngOnInit() {
    this.markCompletedStages(4, PaymentStageStatus.Complete);
    if (this.paymentBatchStatusStep === this.paymentBatchStatusArray.length) {
      this.markCompletedStages(++this.paymentBatchStatusStep, PaymentStageStatus.Complete);
    } else {
      this.markCompletedStages(this.paymentBatchStatusStep, PaymentStageStatus.Complete);
    }
  }


  setPage(page: number) {
    console.log("setPage is called ", page);
    if (page < this.paymentBatchStatusStep) {
      // This goes back
      this.markCompletedStages(page, PaymentStageStatus.NotStarted);
    } else {
      this.markCompletedStages(page, PaymentStageStatus.Complete);
    }
  }

  updateCurrentStep(event: Event) {
    this.paymentBatchStatusStep = (event as CustomEvent).detail.step as number;
  }
  confirm () {
    this.isFinal = true;
  }
}

```

To make the step 6 (final step) showing a `checkmark` icon, they must set `this.paymentBatchStatusStep > 6`, which caused an error if using the latest `abgov/web-components` (this works for version 1.20.0)

The fix is to try to help the team, showing `checkmark` for the step 6. 

# After (the change)

Using the below code: 
https://gist.github.com/vanessatran-ddi/08da77c4be987ead602f64ddb38fc390#file-form-stepper-issue-2375-component-html-L33
(Add `final` for step 6)
https://gist.github.com/vanessatran-ddi/5de77742d07753437a65cefe7f7bcf56#file-form-stepper-issue-2375-component-ts-L83

The demo below works: 
https://vanessatran-ddi.github.io/angular-16-demo/

* This is only to support the team. I don't think we need to add `final` to new angular & react components. 

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
