### PR TITLE
fix(#2416): new angular - dropdown item label not render, filterable …

### DIFF
--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -1,7 +1,7 @@
 <svelte:options customElement="goa-dropdown" />
 
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
 
   import type { GoAIconType } from "../icon/Icon.svelte";
   import type { Spacing } from "../../common/styling";
@@ -148,11 +148,11 @@
   // Hooks
   //
 
-  onMount(() => {
+  onMount(async() => {
     ensureSlotExists(_rootEl);
     addRelayListener();
     sendMountedMessage();
-
+    await tick();
     _eventHandler = _filterable
       ? new ComboboxKeyUpHandler(_inputEl)
       : new DropdownKeyUpHandler(_inputEl);

--- a/libs/web-components/src/components/dropdown/DropdownItem.svelte
+++ b/libs/web-components/src/components/dropdown/DropdownItem.svelte
@@ -11,7 +11,7 @@
     filter: string;
     value: string;
     label: string;
-    mountType: DropdownItemMountType;  
+    mountType: DropdownItemMountType;
   }
   export type DropdownItemDestroyRelayDetail = {
     value: string;
@@ -28,7 +28,7 @@
 </script>
 
 <script lang="ts">
-  import { onDestroy, onMount } from "svelte";
+  import { onDestroy, onMount, tick } from "svelte";
   import { receive, relay } from "../../common/utils";
 
   // Props
@@ -41,7 +41,8 @@
   let _rootEl: HTMLElement;
   let _parentEl: HTMLElement;
 
-  onMount(() => {
+  onMount(async() => {
+    await tick();
     relay<DropdownItemMountedRelayDetail>(
       _rootEl,
       DropdownItemMountedMsg,
@@ -59,7 +60,7 @@
           _parentEl = (data as { el: HTMLElement}).el;
           break;
       }
-    })  
+    })
   }
 
   onDestroy(async () => {


### PR DESCRIPTION
# Before (the change)
1. Using the code snippet defined under https://deploy-preview-277--abgov-ui-component-docs.netlify.app/components/v4.0.0+-angular/button#component-example-ask-address for angular. Any event based, or reactive form or template driven, the options render as empty like this image: 
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/1a23257c-34ad-4486-9fe2-d9c0b746a6f8" />

2. Fixing the code by render the dropdown after a small delay, and set `filterable=true`, it doesn't search the options based on the user's input, until move the mouse away and click somewhere:

https://github.com/user-attachments/assets/08e5e0c7-c9fb-4a3e-a3b1-8d58c5dca60e



# After (the change)

* Options are render
* Filterable is more reactive

https://github.com/user-attachments/assets/a3af8a30-c385-46f4-80c7-1b83122ea9c6



## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
