### PR TITLE
fix: text styling for hover on current page in app header menu

### DIFF
--- a/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
+++ b/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
@@ -281,6 +281,7 @@
   /* Secondary Menu items (in popover on menu item) --Current--Hover */
   :global(::slotted(a.current:hover)) {
     background: var(--goa-app-header-color-bg-nav-item-in-menu-current-hover);
+    color: var(--goa-app-header-color-text-nav-item-in-menu-current-hover) !important;
   }
 
   /* Menu items in collapsed menu --Interactive */

--- a/libs/web-components/src/components/app-header/AppHeader.svelte
+++ b/libs/web-components/src/components/app-header/AppHeader.svelte
@@ -428,13 +428,13 @@
 
   /* Menu items in collapsed menu -- Current */
   :global(::slotted(a.inside-collapse-menu.current)) {
-    color: var(app-header-color-text-nav-item-in-menu-current);
+    color: var(--goa-app-header-color-text-nav-item-in-menu-current);
     background-color: var(--goa-app-header-color-bg-nav-item-in-menu-current) !important;
   }
 
   /* Menu items in collapsed menu -- Current -- Hover */
   :global(::slotted(a.inside-collapse-menu.current:hover)) {
-    color: var(app-header-color-text-nav-item-in-menu-current-hover) !important;
+    color: var(--goa-app-header-color-text-nav-item-in-menu-current-hover) !important;
     background-color: var(--goa-app-header-color-bg-nav-item-in-menu-current-hover) !important;
   }
 


### PR DESCRIPTION
### This is fixing this bug: 
App Header: Hovering over active AppHeaderMenu link makes font disappear #2434

# Before (the change)
Text colour was the same colour as the background on current page + hover, which made the text visually dissapear.

<img width="517" alt="image" src="https://github.com/user-attachments/assets/af38b1f8-79eb-437e-a2b0-f7d2188bb63b" />
<img width="304" alt="image" src="https://github.com/user-attachments/assets/b5d63ebf-5cd7-47d9-9a45-a9451002c264" />
<img width="309" alt="image" src="https://github.com/user-attachments/assets/936215f4-64cf-47a2-8686-bb703c425c2b" />



# After (the change)
Text colour is now styled with correct token, and shows up as white with a dark blue (hover) background.

<img width="282" alt="image" src="https://github.com/user-attachments/assets/509196f3-28f6-4bb3-abe9-7a812ed26e4c" />
<img width="325" alt="image" src="https://github.com/user-attachments/assets/8ff05738-473a-42ee-8145-89cbffd24410" />
<img width="517" alt="image" src="https://github.com/user-attachments/assets/7f910545-049c-4362-8f65-eabaaebf687c" />


