### PR TITLE
fix(#2474): Changing token used for radio description font

### DIFF
--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -250,7 +250,7 @@
   }
 
   .description {
-    font: var(--description);
+    font: var(--goa-radio-description);
     margin-left: var(--goa-space-xl);
     margin-top: var(--goa-space-2xs);
     color: var(--goa-color-text-default);


### PR DESCRIPTION
# Before (the change)

![image](https://github.com/user-attachments/assets/7ed66721-3dea-4ffb-ba17-48af81851010)

# After (the change)

![image](https://github.com/user-attachments/assets/2838df80-a3ac-4670-ac9a-8ffc8e168c77)

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

```html
<goab-form-item label="Select one option">
  <goab-radio-group name="selectOne" value="1">
    <goab-radio-item value="1" label="Option one" [description]="description">
      <ng-template #description> Help text with a <a href="#">link</a>. </ng-template>
    </goab-radio-item>
    <goab-radio-item value="2" label="Option two" />
    <goab-radio-item value="3" label="Option three" />
  </goab-radio-group>
</goab-form-item>
```
Make sure the `description` slot `font` property is styled using the correct design token