### PR TITLE
chore: ensure all the `dist` builds exist on each PR

### DIFF
--- a/.github/workflows/alpha-release-ci.yml
+++ b/.github/workflows/alpha-release-ci.yml
@@ -40,11 +40,12 @@ jobs:
       - name: Build
         run: npm run build:prod
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-
       - name: Test
-        run: npm run test:headless
+        run: |
+          if [ -d "./dist" ]; then
+            npx playwright install --with-deps
+            npm run test:headless
+          fi
 
       - name: Update Web components documentation
         run: cp libs/web-components/README.md dist/libs/web-components

--- a/.github/workflows/lts-release-ci.yml
+++ b/.github/workflows/lts-release-ci.yml
@@ -34,11 +34,12 @@ jobs:
       - name: Build
         run: npm run build:prod
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-
       - name: Test
-        run: npm run test:headless
+        run: |
+          if [ -d "./dist" ]; then
+            npx playwright install --with-deps
+            npm run test:headless
+          fi
 
       - name: Update VsCode documentation
         run: npm run build:vscode-doc

--- a/.github/workflows/prod-release-ci.yml
+++ b/.github/workflows/prod-release-ci.yml
@@ -35,11 +35,12 @@ jobs:
       - name: Build
         run: npm run build:prod
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-
       - name: Test
-        run: npm run test:headless
+        run: |
+          if [ -d "./dist" ]; then
+            npx playwright install --with-deps
+            npm run test:headless
+          fi
 
       - name: Update Web components documentation
         run: cp libs/web-components/README.md dist/libs/web-components

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,15 +24,18 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-
       # Run with the target branch as the base.
       - name: Lint
         run: npm run lint
+
       - name: Build
         run: |
           npx nx affected --target=build --base=origin/${{ github.base_ref }}
           npx nx affected --target=post --base=origin/${{ github.base_ref }}
+
       - name: Test
-        run: npm run test:headless
+        run: |
+          if [ -d "./dist" ]; then
+            npx playwright install --with-deps
+            npm run test:headless
+          fi


### PR DESCRIPTION
This should allow all the required `dist` sub-folders to exist and prevent the failed tests