### PR TITLE
feat(#2365): allow screen reader to announce description slot content

### DIFF
--- a/libs/web-components/src/components/checkbox/Checkbox.spec.ts
+++ b/libs/web-components/src/components/checkbox/Checkbox.spec.ts
@@ -73,6 +73,20 @@ describe('GoACheckbox Component', () => {
       const root = el.container.querySelector('.error');
       expect(root).toBeTruthy();
     });
+
+    describe("aria-describedby", () => {
+      it("should not have aria-describedby when description is empty", async () => {
+        const el = await createElement({ description: "" });
+        const checkbox = el.container.querySelector("input");
+        expect(checkbox?.getAttribute("aria-describedby")).toBeNull();
+      });
+
+      it("should have aria-describedby when description has content", async () => {
+        const el = await createElement({ description: "test description" });
+        const checkbox = el.container.querySelector("input");
+        expect(checkbox?.getAttribute("aria-describedby")).toBe("description_checkbox-test-name");
+      });
+    });
   });
 
   describe("events", () => {

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -206,7 +206,7 @@
         type="checkbox"
         value={`${value}`}
         aria-label={arialabel || text || name}
-        aria-describedby={description ? _descriptionId : null}
+        aria-describedby={$$slots.description || description !== "" ? _descriptionId : null}
         aria-invalid={_error ? "true" : "false"}
         on:change={onChange}
         on:focus={onFocus}


### PR DESCRIPTION
# Before (the change)
When focusing or even using the mouse hovering the description slot, the screen reader doesn't recognize this `div` is a region that needs to be spoken out loud because it is under the shadow DOM. 

```
<goab-checkbox name="description" text="description slot" [description]="descriptionTemplate">
  <ng-template #descriptionTemplate>
   <p style="color: blue;">Example description inside a slot by Vanessa should be read aloud.</p>
  </ng-template>
</goab-checkbox>
```

# After (the change)

Developers can control what should be spoken out loud and what shouldn't. For example:

```
<goab-checkbox name="description" text="description slot" [description]="descriptionTemplate">
  <ng-template #descriptionTemplate>
    <div aria-hidden="true">
      <p style="color: grey"> This text is hidden from screen readers </p>
    </div>
   <p style="color: blue;">Example description inside a slot by Vanessa should be read aloud.</p>
  </ng-template>
</goab-checkbox>
```

Voice Over:

https://github.com/user-attachments/assets/c00b37d4-1975-42b7-a347-95a9d077f28c

NVDA:


https://github.com/user-attachments/assets/5b6a4221-6f5c-4afe-bd98-86d4541c7ba4




## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
