### PR TITLE
fix(#2439): text react component color prop

### DIFF
--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -953,6 +953,7 @@ export type GoabTextHeadingSize =
   | "heading-xs";
 export type GoabTextBodySize = "body-l" | "body-m" | "body-s" | "body-xs";
 export type GoabTextSize = GoabTextHeadingSize | GoabTextBodySize;
+export type GoabTextColor = "primary" | "secondary";
 
 export type GoabFielsetOnContinueDetail = {
   el: HTMLElement;

--- a/libs/react-components/src/index.ts
+++ b/libs/react-components/src/index.ts
@@ -164,6 +164,7 @@ export type {
   GoabTextHeadingSize,
   GoabTextBodySize,
   GoabTextSize,
+  GoabTextColor,
   GoabFielsetOnContinueDetail,
   GoabFormField,
   GoabFormState,

--- a/libs/react-components/src/lib/text/text.spec.tsx
+++ b/libs/react-components/src/lib/text/text.spec.tsx
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/react";
+import GoabText from "./text";
+import { describe, it, expect } from "vitest";
+
+describe("Text", () => {
+  it("should render successfully", () => {
+    const { baseElement } = render(<GoabText>test</GoabText>);
+
+    expect(baseElement.innerHTML).toContain("test");
+  });
+
+  it("should render with properties", async () => {
+    render(
+      <GoabText
+        as="h1"
+        maxWidth="100px"
+        size="heading-xl"
+        color="secondary"
+        mt="s"
+        mr="m"
+        mb="l"
+        ml="xl"
+      >
+        Test
+      </GoabText>,
+    );
+
+    const el = document.querySelector("goa-text");
+    expect(el?.innerHTML).toContain("Test");
+    expect(el?.getAttribute("maxwidth")).toBe("100px");
+    expect(el?.getAttribute("size")).toBe("heading-xl");
+    expect(el?.getAttribute("color")).toBe("secondary");
+    expect(el?.getAttribute("mt")).toBe("s");
+    expect(el?.getAttribute("mr")).toBe("m");
+    expect(el?.getAttribute("mb")).toBe("l");
+    expect(el?.getAttribute("ml")).toBe("xl");
+  });
+});

--- a/libs/react-components/src/lib/text/text.tsx
+++ b/libs/react-components/src/lib/text/text.tsx
@@ -1,10 +1,18 @@
 import { ReactNode } from "react";
-import {GoabTextMaxWidth, GoabTextHeadingElement, GoabTextTextElement, GoabTextSize, Margins } from "@abgov/ui-components-common";
+import {
+  GoabTextMaxWidth,
+  GoabTextHeadingElement,
+  GoabTextTextElement,
+  GoabTextSize,
+  GoabTextColor,
+  Margins,
+} from "@abgov/ui-components-common";
 
 interface WCProps extends Margins {
   as?: GoabTextTextElement | GoabTextHeadingElement;
   size?: GoabTextSize;
   maxwidth?: GoabTextMaxWidth;
+  color?: GoabTextColor;
 }
 
 declare global {
@@ -20,15 +28,17 @@ interface GoATextProps extends Margins {
   as?: GoabTextTextElement | GoabTextHeadingElement;
   size?: GoabTextSize;
   maxWidth?: GoabTextMaxWidth;
+  color?: GoabTextColor;
   children: ReactNode;
 }
 
 export function GoabText(props: GoATextProps): JSX.Element {
   return (
     <goa-text
-      as={props.as || "div"}
+      as={props.as}
       size={props.size}
-      maxwidth={props.maxWidth || "65ch"}
+      maxwidth={props.maxWidth}
+      color={props.color}
       mt={props.mt}
       mb={props.mb}
       ml={props.ml}


### PR DESCRIPTION
_For LTS refer to #2528_

# Before (the change)

Could not change color of Text react component

# After (the change)

Can change color to "secondary"
![image](https://github.com/user-attachments/assets/da16cd5d-1638-41be-9093-abdf65a383e5)

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in ~both React and Angular~ React.

## Steps needed to test

```tsx
import { GoabBlock, GoabText } from "@abgov/react-components";

export function TextRoute() {
  return (
    <main>
      <GoabBlock direction="column">
        <GoabText>Text with primary color</GoabText>
      </GoabBlock>

      <GoabBlock direction="column">
        <GoabText color="secondary">Text with secondary color</GoabText>
      </GoabBlock>
    </main>
  );
}
```