### PR TITLE
fix(#2551): reposition the order of inputs to M d y

### DIFF
--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -300,18 +300,6 @@
 {:else if type === "input"}
   <goa-form-item error={_error && error} bind:this={_rootEl}>
     <goa-block direction="row">
-      <goa-form-item label="Day" helptext="Day (DD)">
-        <goa-input
-          name="day"
-          type="number"
-          on:_change={onInputChange}
-          width="7ch"
-          value={_inputDate.day}
-          min="1"
-          max="31"
-          {_error}
-        />
-      </goa-form-item>
       <goa-form-item label="Month" helptext="Month">
         <goa-dropdown name="month" on:_change={onInputChange} {error} value={_inputDate.month+""}>
           <goa-dropdown-item value="0" label="January" />
@@ -327,6 +315,18 @@
           <goa-dropdown-item value="10" label="November" />
           <goa-dropdown-item value="11" label="December" />
         </goa-dropdown>
+      </goa-form-item>
+      <goa-form-item label="Day" helptext="Day (DD)">
+        <goa-input
+          name="day"
+          type="number"
+          on:_change={onInputChange}
+          width="7ch"
+          value={_inputDate.day}
+          min="1"
+          max="31"
+          {_error}
+        />
       </goa-form-item>
       <goa-form-item label="Year" helptext="Year (YYYY)">
         <goa-input


### PR DESCRIPTION
This better aligns with the common output format of MMMM d, yyyy

# Before (the change)

# After (the change)

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] ~~I have created necessary unit tests~~
- [x] I have tested the functionality in both React and Angular.

## Before
![image](https://github.com/user-attachments/assets/d9d280a5-5f7a-4d3f-ae98-fabe8408bdcb)

## After
![image](https://github.com/user-attachments/assets/041dede0-f726-45d6-870c-25775bb2220b)

# To test
```
<goa-datepicker type="input" />
```

