### PR TITLE
fix (#2575): Tab label not centered when the tab reaches the min width

### DIFF
--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -267,7 +267,7 @@
   }
 
   :global([role="tab"]) {
-    display: block;
+    display: flex;
     background: none;
     overflow: hidden;
     white-space: nowrap;
@@ -311,7 +311,7 @@
       border-bottom: var(--goa-tab-border-not-selected);
       text-overflow: ellipsis;
       min-width: var(--goa-space-2xl);
-      text-align: center;
+      justify-content: center; /* Horizontally center content */
     }
     :global([role="tab"][aria-selected="true"]) {
       border-bottom: var(--goa-tab-border-selected);


### PR DESCRIPTION
Related issue: https://github.com/GovAlta/ui-components/issues/2575

# Before (the change)
<img width="294" alt="image" src="https://github.com/user-attachments/assets/ced766ec-ed79-4c93-9e93-a53cf216a06a" />

# After (the change)
<img width="161" alt="image" src="https://github.com/user-attachments/assets/ad6aab61-ce84-4110-8336-01db0d1bab9a" />