### PR TITLE
fix(#2491): wrong color of meta links

### DIFF
--- a/libs/web-components/src/components/footer-meta-section/FooterMetaSection.spec.ts
+++ b/libs/web-components/src/components/footer-meta-section/FooterMetaSection.spec.ts
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/svelte';
+import FooterMetaSectionWrapper from './FooterMetaSectionWrapper.test.svelte';
+import { fireEvent } from '@testing-library/svelte';
+import '@testing-library/jest-dom';
+describe('FooterMetaSection', () => {
+  it('should display and handle link clicks correctly', async () => {
+    const { getByTestId, getByText } = render(FooterMetaSectionWrapper);
+
+    const link1 = getByText('Link 1');
+    const link2 = getByTestId('specialClick');
+    expect(link1).toBeTruthy();
+    expect(link2).toBeTruthy();
+    await fireEvent.click(link2);
+    await fireEvent.click(link2);
+    const clickedText = getByTestId('link-is-clicked');
+    expect(clickedText).toHaveTextContent('Link 2 clicked');
+  });
+});

--- a/libs/web-components/src/components/footer-meta-section/FooterMetaSection.svelte
+++ b/libs/web-components/src/components/footer-meta-section/FooterMetaSection.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import { onMount, tick } from "svelte";
+  import { getSlottedChildren } from "../../common/utils";
 
   export let testid: string = "";
 
@@ -16,10 +17,7 @@
 
   onMount(async () => {
     await tick();
-    children = rootEl
-      .querySelector("slot")
-      .assignedElements() as HTMLLinkElement[];
-
+    children = getSlottedChildren(rootEl) as HTMLLinkElement[];
     const isValid = children
       .map((child) => child.hasAttribute("href"))
       .reduce((sum: boolean, valid: boolean) => {

--- a/libs/web-components/src/components/footer-meta-section/FooterMetaSectionWrapper.test.svelte
+++ b/libs/web-components/src/components/footer-meta-section/FooterMetaSectionWrapper.test.svelte
@@ -1,0 +1,24 @@
+<svelte:options customElement="test-footer-meta-section-wrapper"></svelte:options>
+
+<script lang="ts">
+  import GoAAppFooterMetaSection from "./FooterMetaSection.svelte";
+
+  function onClick(e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
+    // To test if function is delegated and client app can do whatever they want without navigating to /contact
+    const target = document.querySelector("span[data-testid='link-is-clicked']");
+    if (target) {
+      target.innerHTML = "Link 2 clicked";
+    }
+  }
+
+</script>
+
+<GoAAppFooterMetaSection
+  testid="test-footer-meta-section-wrapper">
+  <a href="https://example.com">Link 1</a>
+  <a href="/contact" data-testid="specialClick" on:click={onClick}>Link 2</a>
+</GoAAppFooterMetaSection>
+
+<span data-testid="link-is-clicked"></span>


### PR DESCRIPTION
# Before (the change)

Color is not correct 


# After (the change)

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
(Since this PR changed/refactored for the bug https://github.com/GovAlta/ui-components/issues/2013 so I included the code snippet to cover the qa too)

```
<goab-app-footer id="meta-only">
  <goab-app-footer-meta-section slot="meta">
    <a href="privacy.html" (click)="handleClickLink($event)">Privacy with handle click</a>
    <a href="disclaimer.html">Disclaimer</a>
    <a href="accessibility.html">Accessibility</a>
    <a href="using-alberta.html">Using Alberta.ca</a>
  </goab-app-footer-meta-section>
</goab-app-footer>
```
```
export class AppFooterComponent {
  constructor() { }
  handleClickLink(e: Event) {
    e.preventDefault();
    e.stopPropagation();
    alert("Link clicked");
  }
}
```
