### PR TITLE
fix(#2586): Changed keypress event for Input for Angular

### DIFF
--- a/libs/angular-components/src/lib/components/input/input.spec.ts
+++ b/libs/angular-components/src/lib/components/input/input.spec.ts
@@ -186,7 +186,7 @@ describe("GoABInput", () => {
     expect(validateOnChange).toBeCalledWith({ name: "foo", value: "new value" });
   });
 
-it("should handle onFocus event", () => {
+  it("should handle onFocus event", () => {
     const validateOnFocus = jest.spyOn(component, "onFocus");
 
     const input = fixture.debugElement.query(By.css("goa-input")).nativeElement;
@@ -211,7 +211,7 @@ it("should handle onFocus event", () => {
 
     const input = fixture.debugElement.query(By.css("goa-input")).nativeElement;
 
-    fireEvent(input, new CustomEvent("_keypress"));
+    fireEvent(input, new CustomEvent("_keyPress"));
 
     expect(validateOnKeyPress).toBeCalled();
   });

--- a/libs/angular-components/src/lib/components/input/input.spec.ts
+++ b/libs/angular-components/src/lib/components/input/input.spec.ts
@@ -3,7 +3,8 @@ import { GoabInput } from "./input";
 import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import {
   GoabIconType,
-  GoabInputAutoCapitalize, GoabInputOnChangeDetail,
+  GoabInputAutoCapitalize,
+  GoabInputOnChangeDetail,
   GoabInputType,
   Spacing,
 } from "@abgov/ui-components-common";
@@ -177,9 +178,12 @@ describe("GoABInput", () => {
 
     const input = fixture.debugElement.query(By.css("goa-input")).nativeElement;
 
-    fireEvent(input, new CustomEvent("_change", {detail: {name: "foo", value: "new value"}}));
+    fireEvent(
+      input,
+      new CustomEvent("_change", { detail: { name: "foo", value: "new value" } }),
+    );
 
-    expect(validateOnChange).toBeCalledWith({name: "foo", value: "new value"});
+    expect(validateOnChange).toBeCalledWith({ name: "foo", value: "new value" });
   });
 
 it("should handle onFocus event", () => {

--- a/libs/angular-components/src/lib/components/input/input.ts
+++ b/libs/angular-components/src/lib/components/input/input.ts
@@ -61,7 +61,7 @@ export interface IgnoreMe {
       (_change)="_onChange($event)"
       (_focus)="_onFocus($event)"
       (_blur)="_onBlur($event)"
-      (_keypress)="_onKeyPress($event)"
+      (_keyPress)="_onKeyPress($event)"
       [attr.trailingiconarialabel]="trailingIconAriaLabel"
     >
       <ng-content />

--- a/libs/angular-components/src/lib/components/input/input.ts
+++ b/libs/angular-components/src/lib/components/input/input.ts
@@ -1,5 +1,22 @@
-import { GoabIconType, GoabInputAutoCapitalize, GoaInputOnBlurDetail, GoabInputOnChangeDetail, GoabInputOnFocusDetail, GoabInputOnKeyPressDetail, GoabInputType, Spacing } from "@abgov/ui-components-common";
-import { CUSTOM_ELEMENTS_SCHEMA, Component, EventEmitter, Input, Output, forwardRef, OnInit } from "@angular/core";
+import {
+  GoabIconType,
+  GoabInputAutoCapitalize,
+  GoaInputOnBlurDetail,
+  GoabInputOnChangeDetail,
+  GoabInputOnFocusDetail,
+  GoabInputOnKeyPressDetail,
+  GoabInputType,
+  Spacing,
+} from "@abgov/ui-components-common";
+import {
+  CUSTOM_ELEMENTS_SCHEMA,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  forwardRef,
+  OnInit,
+} from "@angular/core";
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 
 export interface IgnoreMe {
@@ -47,7 +64,7 @@ export interface IgnoreMe {
       (_keypress)="_onKeyPress($event)"
       [attr.trailingiconarialabel]="trailingIconAriaLabel"
     >
-      <ng-content/>
+      <ng-content />
     </goa-input>
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -56,8 +73,8 @@ export interface IgnoreMe {
       provide: NG_VALUE_ACCESSOR,
       multi: true,
       useExisting: forwardRef(() => GoabInput),
-    }
-  ]
+    },
+  ],
 })
 export class GoabInput implements ControlValueAccessor, OnInit {
   @Input() type?: GoabInputType = "text";
@@ -118,7 +135,7 @@ export class GoabInput implements ControlValueAccessor, OnInit {
 
   _onKeyPress(e: Event) {
     this.markAsTouched();
-    const detail = (e as CustomEvent<GoabInputOnKeyPressDetail>).detail
+    const detail = (e as CustomEvent<GoabInputOnKeyPressDetail>).detail;
     this.onKeyPress.emit(detail);
 
     this.fcTouched?.();
@@ -126,15 +143,14 @@ export class GoabInput implements ControlValueAccessor, OnInit {
 
   _onFocus(e: Event) {
     this.markAsTouched();
-    const detail = (e as CustomEvent<GoabInputOnFocusDetail>).detail
+    const detail = (e as CustomEvent<GoabInputOnFocusDetail>).detail;
     this.onFocus.emit(detail);
   }
 
   _onBlur(e: Event) {
-    const detail = (e as CustomEvent<GoaInputOnBlurDetail>).detail
+    const detail = (e as CustomEvent<GoaInputOnBlurDetail>).detail;
     this.onBlur.emit(detail);
   }
-
 
   // ControlValueAccessor
 
@@ -155,7 +171,7 @@ export class GoabInput implements ControlValueAccessor, OnInit {
     this.fcChange = fn;
   }
   registerOnTouched(fn: any): void {
-    this.fcTouched = fn
+    this.fcTouched = fn;
   }
 
   setDisabledState?(isDisabled: boolean): void {


### PR DESCRIPTION
# Before (the change)

`(onKeyPress)` wouldn't fire on the Input component for Angular

# After (the change)

`(onKeyPress)` will fire on the Input component for Angular

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

```html
<goab-input (onKeyPress)="handleInputKeyDown()"> </goab-input>
```

```typescript
handleInputKeyDown() {
  console.log("key pressed");
}
```
