### PR TITLE
chore: Removing the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @chrisolsen @vanessatran-ddi @syedszeeshan @BumbleB2na


### PR DESCRIPTION
Nothing to be tested, just removing the CODEOWNERS file so that reviewers aren't auto assigned to every PR
