### PR TITLE
fix(#2557): Updating SideMenu typography tokens

### DIFF
--- a/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
+++ b/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
@@ -168,7 +168,7 @@
   }
 
   :global(::slotted(a.current)) {
-    font: var(--goa-side-menu-typography-item-selected);
+    font: var(--goa-side-menu-typography-item-current);
     border-left: var(--goa-side-menu-child-border-left-selected);
     background: var(--goa-side-menu-child-color-bg-selected);
     /* required to override base styles & above :global(::slotted(a) !important */
@@ -210,11 +210,11 @@
     font: var(--goa-side-menu-typography-item);
     padding: var(--goa-side-menu-parent-padding);
     text-decoration: none;
-    font: var(--goa-side-menu-parent-text);
+    font: var(--goa-side-menu-typography-item);
     border-radius: var(--goa-side-menu-group-border-radius);
   }
   .heading.open {
-    font: var(--goa-side-menu-parent-text-active);
+    font: var(--goa-side-menu-typography-item-current);
   }
 
   :host([child="true"]) a.heading {

--- a/libs/web-components/src/components/side-menu/SideMenu.svelte
+++ b/libs/web-components/src/components/side-menu/SideMenu.svelte
@@ -117,7 +117,7 @@
   }
 
   :global(::slotted(a.current)) {
-    font: var(--goa-side-menu-typography-item-active);
+    font: var(--goa-side-menu-typography-item-current);
     background: var(--goa-side-menu-color-bg-menu-item-hover);
   }
 


### PR DESCRIPTION
# Before (the change)

![image](https://github.com/user-attachments/assets/7cbc12d4-fc01-4978-9296-f9b2baf41281)
![image](https://github.com/user-attachments/assets/14118806-6d41-4764-8d9f-6977eff2f246)
![image](https://github.com/user-attachments/assets/31a3e496-7e34-4cbb-86c4-f0477ef81275)

# After (the change)

![image](https://github.com/user-attachments/assets/7d53036c-e77e-477a-a088-54942330369f)
![image](https://github.com/user-attachments/assets/92a8b718-8cdf-49b9-a718-baee67fb4dc6)
![image](https://github.com/user-attachments/assets/7f0a8e4a-4407-41bf-b1ce-373d120c9359)

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

In your overall CSS file (that hits everything), `styles.css`. Add:
```css
body {
  font-size: 10px;
}
```
This should override the font properties in the SideMenu because the tokens being used don't exist. Once you build this branch, the font tokens should exist and should take precedence.
