### PR TITLE
chore: fix headless test

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "nx affected --base=alpha -t build --exclude=apps/* --exclude=playground/*",
     "build:prod": "nx run-many -t build --all --prod --exclude=apps/* --exclude=playground/*",
     "build:vscode-doc": "node libs/web-components/custom-element-manifest-analyze.js",
-    "pretest": "npx nx run common:build",
+    "pretest:headless": "npx nx run common:build && npx nx run web-components:build && npx nx run react-components:build",
     "test:watch": "vitest --project=*-unit --project=*-browser",
     "test:watch:headless": "vitest --project=*-unit --project=*-headless",
     "test:angular": "nx test angular-components",


### PR DESCRIPTION
 I need to change the scrip name pretest to pretest:headless because we don't have test anymore. Also I need to build web-components:build first because I have this error: (You only have the below error if you clean `dist` folder

FAIL |firefox-react-headless| libs/react-components/specs/accordion.browser.spec.tsx [ libs/react-components/specs/accordion.browser.spec.tsx ]
TypeError: error loading dynamically imported module: http://localhost:63315/Users/thytran142/WebstormProjects/ui-components/vitest.browser.setup.ts?import&browserv=1744324303359
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯

FAIL |react-headless| libs/react-components/specs/accordion.browser.spec.tsx [ libs/react-components/specs/accordion.browser.spec.tsx ]
FAIL |react-headless| libs/react-components/specs/dropdown.browser.spec.tsx [ libs/react-components/specs/dropdown.browser.spec.tsx ]
TypeError: Failed to fetch dynamically imported module: http://localhost:63316/Users/thytran142/WebstormProjects/ui-components/vitest.browser.setup.ts?import&browserv=1744324304791
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/4]⎯

FAIL |firefox-react-headless| libs/react-components/specs/dropdown.browser.spec.tsx [ libs/react-components/specs/dropdown.browser.spec.tsx ]....

I debug and understand that it failed because because those browser tests can't find the built web-components library that's referenced in the vitest.browser.setup.ts file.

![image](https://github.com/user-attachments/assets/4da2c779-09b6-48e0-8d7d-ef1b9207f50e)
That is why my PR build took long time.

