### PR TITLE
fix(#2643): fix design token references

### DIFF
--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -124,7 +124,7 @@
     cursor: pointer;
     font: var(--goa-button-text);
     height: var(--goa-button-height);
-    letter-spacing: var(--goa-letter-spacing-button);
+    letter-spacing: var(--goa-button-letter-spacing);
     padding: 0 var(--goa-button-padding-lr);
     white-space: nowrap;
     gap: var(--goa-button-gap);
@@ -192,10 +192,10 @@
   }
 
   button.start {
-    height: var(--goa-button-start-height);
+    height: var(--goa-button-height-start);
     font: var(--goa-button-text-start);
     padding: var(--goa-button-padding-lr-start);
-    letter-spacing: var(--goa-letter-spacing-button);
+    letter-spacing: var(--goa-button-letter-spacing);
   }
 
   /* Primary */

--- a/libs/web-components/src/components/circular-progress/CircularProgress.svelte
+++ b/libs/web-components/src/components/circular-progress/CircularProgress.svelte
@@ -100,7 +100,7 @@
 
   .spinner-large .message {
     margin-top: var(--goa-circular-progress-small-margin-top);
-    font: var(--goa-circular-progress-medium-text);
+    font: var(--goa-circular-progress-small-text);
   }
   .spinner-xlarge .message {
     margin-top: var(--goa-circular-progress-large-margin-top);

--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -75,7 +75,7 @@
 
 <style>
   :host {
-    font-family: var(--goa-font-family-serif);
+    font-family: var(--goa-font-family-sans);
   }
 
   details {
@@ -108,7 +108,6 @@
   summary:focus-visible {
     outline: var(--goa-details-focus-border);
     color: var(--goa-color-interactive-hover);
-
   }
   summary:focus,
   summary:active {
@@ -124,7 +123,7 @@
     margin-left: var(--goa-space-xl);
     text-decoration: var(--goa-details-text-decoration);
     color: var(--goa-details-color-text);
-    font: var(--goa-details-typeface);
+    font: var(--goa-details-typography);
   }
   summary:hover span {
     color: var(--goa-details-color-text-hover);

--- a/libs/web-components/src/components/spinner/Spinner.spec.ts
+++ b/libs/web-components/src/components/spinner/Spinner.spec.ts
@@ -35,7 +35,7 @@ describe('GoASpinner', () => {
         expect(circle.getAttribute("stroke")).toBe("var(--goa-color-brand-light)");
         expect(path.getAttribute("stroke")).toBe("var(--goa-color-info-default)");
       } else {
-        expect(circle.getAttribute("stroke")).toBe("var(--goa-color-info-hover)");
+        expect(circle.getAttribute("stroke")).toBe("var(--goa-color-info-default)");
         expect(path.getAttribute("stroke")).toBe("var(--goa-color-brand-light)");
       }
     })

--- a/libs/web-components/src/components/spinner/Spinner.svelte
+++ b/libs/web-components/src/components/spinner/Spinner.svelte
@@ -103,7 +103,7 @@
       cx={radius}
       cy={radius}
       stroke={invert
-        ? "var(--goa-color-info-hover)"
+        ? "var(--goa-color-info-default)"
         : "var(--goa-color-brand-light)"}
       stroke-width={strokewidth}
       r={radius - strokewidth / 2}


### PR DESCRIPTION
This PR fixes some design token references on the following web components:
- Button
- Circular Progress
- Details
- Spinner

These are only CSS changes. There shouldn't be any impact on React, Angular, or unit tests.

### Before
The CSS custom parameters reference non-existent design tokens and are undefined.
<img width="469" alt="image" src="https://github.com/user-attachments/assets/78455b39-ac5a-4d49-ae9d-d0097754cddf" />
 

### After
The CSS custom parameters reference existing design token values.

<img width="387" alt="image" src="https://github.com/user-attachments/assets/2b60d668-625f-466e-9362-2aac9424903b" />
