### PR TITLE
fix(#2455): spacer hspacing fill doesnt work in Angular

### DIFF
--- a/libs/web-components/src/components/spacer/Spacer.svelte
+++ b/libs/web-components/src/components/spacer/Spacer.svelte
@@ -11,9 +11,7 @@
   let rootEl: HTMLElement;
   onMount(() => {
     const height = `var(--goa-space-${vspacing})`;
-    const width = hspacing === "fill"
-      ? "100%"
-      : `var(--goa-space-${hspacing})`;
+    const width = hspacing === "fill" ? "100%" : `var(--goa-space-${hspacing})`;
     injectCss(rootEl, ":host", { width, height });
   });
 </script>
@@ -21,6 +19,7 @@
 <div
   bind:this={rootEl}
   style={`
+    display: ${hspacing ? "inline-block" : "block"};
     height: var(--goa-space-${vspacing});
     width: var(--goa-space-${hspacing});
   `}


### PR DESCRIPTION
# Before (the change)

# After (the change)

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

**Angular Playground Code**
```
<goab-block gap="none">
  <div>FILL</div>
  <goab-spacer hSpacing="fill"></goab-spacer>
  <div>FILL</div>
  <goab-spacer hSpacing="fill"></goab-spacer>
  <div>FILL</div>
</goab-block>
```

```
import { GoabBadge, GoabBlock, GoabButton, GoabIcon, GoabInput, GoabSpacer, GoabTextArea } from "@abgov/angular-components";
import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";

@Component({
  standalone: true,
  selector: "abgov-spacing",
  templateUrl: "./spacing.html",
  imports: [
    GoabInput,
    GoabButton,
    GoabIcon,
    GoabSpacer,
    GoabBlock,
    GoabTextArea,
    GoabBadge,
  ],
  schemas: [CUSTOM_ELEMENTS_SCHEMA]
})
export class SpacingComponent {
  constructor() { }
}
```


