### PR TITLE
fix(1219): fixed height of input type date

### DIFF
--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -410,6 +410,7 @@
     display: inline-flex;
     align-items: stretch;
     width: 100%;
+    height: 42px;
     z-index: 1;
     background-color: var(--goa-text-input-color-bg);
     /* default border */
@@ -465,7 +466,6 @@
   }
 
   input {
-    display: inline-block;
     color: var(--goa-text-input-color-text);
     font: var(--goa-text-input-typography);
     padding: var(--goa-text-input-padding);
@@ -527,6 +527,7 @@
     display: flex;
     align-items: center;
     white-space: normal;
+    height: 42px;
   }
 
   .leading-content-slot :global(::slotted(div)),


### PR DESCRIPTION
This is a fix for issue https://github.com/GovAlta/ui-components/issues/1219

This also fixes an additional bug where input type=date, datetime-local, and time, is 44px tall (should be 42px)

# Before (the change)
<img width="402" alt="image" src="https://github.com/user-attachments/assets/49eed406-8d07-4357-904e-b96d3e595d08" />

# After (the change)
<img width="368" alt="image" src="https://github.com/user-attachments/assets/5f6eea06-0d3f-4606-af94-cebce10111a5" />
