### PR TITLE
fix(#2415): modal empty header and heading accessibility (angular)

### DIFF
--- a/libs/angular-components/src/lib/components/modal/modal.ts
+++ b/libs/angular-components/src/lib/components/modal/modal.ts
@@ -18,12 +18,14 @@ import { NgIf, NgTemplateOutlet } from "@angular/common";
       [attr.heading]="getHeadingAsString()"
       (_close)="_onClose()"
     >
-      <ng-content></ng-content>
-      <div slot="heading" *ngIf="this.heading !== '' || this.closable">
-        <ng-container [ngTemplateOutlet]="getHeadingAsTemplate()"></ng-container>
+      <div slot="heading">
+        <ng-container *ngIf="this.heading !== '' && getHeadingAsTemplate() !== null" [ngTemplateOutlet]="getHeadingAsTemplate()"></ng-container>
       </div>
-      <div slot="actions" *ngIf="this.actions">
-        <ng-container [ngTemplateOutlet]="actions"></ng-container>
+
+      <ng-content></ng-content>
+
+      <div slot="actions">
+        <ng-container *ngIf="this.actions" [ngTemplateOutlet]="actions"></ng-container>
       </div>
     </goa-modal>
   `,
@@ -50,6 +52,7 @@ export class GoabModal {
     if (!this.heading) return null;
     return this.heading instanceof TemplateRef ? this.heading : null;
   }
+
   _onClose() {
     this.onClose.emit();
   }

--- a/libs/web-components/src/components/modal/Modal.spec.ts
+++ b/libs/web-components/src/components/modal/Modal.spec.ts
@@ -53,17 +53,15 @@ describe("Modal Component", () => {
 
   it("should show slotted heading content and have accessibility attributes", async () => {
     const heading = "Test heading";
-    const el = render(GoAModalWrapper, { heading });
+    const el =  render(GoAModal, { open: "true", heading });
     await waitFor(() => {
-      expect(el.container.querySelector("[slot=heading]")?.innerHTML).toContain(
-        heading,
-      );
       const modal = el.queryByRole("dialog");
       expect(modal?.getAttribute("tabindex")).toBe("-1");
       expect(modal?.getAttribute("aria-modal")).toBe("true");
       expect(modal?.getAttribute("aria-labelledby")).toBe("goa-modal-heading");
-      expect(modal?.querySelector(".has-content")).toBeTruthy();
+      expect(modal?.querySelector(".has-content")).not.toBeNull(); // make sure the slot is rendered
       const modalHeading = el.queryByTestId("modal-title");
+      expect(modalHeading?.textContent).toContain(heading);
       expect(modalHeading?.getAttribute("aria-label")).toBeNull();
     });
   });


### PR DESCRIPTION
# Before (the change)

In alpha version, angular templates used in modal did not work with modal the same as slots worked in LTS.

# After (the change)

In alpha version, angular templates used in modal work with modal the same as slots worked in LTS.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in ~both React and~ Angular.

## Steps needed to test

```ts
  isOpenModalUsingNgTemplate = false;
  openModalUsingNgTemplate() {
    this.isOpenModalUsingNgTemplate  = true;
  }
  closeModalUsingNgTemplate() {
    this.isOpenModalUsingNgTemplate = false;
  }
```
```html
<goab-button id="button2" (onClick)="openModalUsingNgTemplate()" ml="xs">Open Modal with actions and heading templates</goab-button>
<goab-modal id="modalUsingNgTemplate" [open]="isOpenModalUsingNgTemplate" [heading]="headingTemplate" [actions]="actionsTemplate">
  <ng-template #headingTemplate><h1><i>Do you agree?</i></h1></ng-template>
  <p>
    Lorem ipsum dolor sit amet consectetur adipisicing elit. Mollitia obcaecati
    id molestiae, natus dicta, eaque qui iusto similique, libero explicabo
    eligendi eius laboriosam! Repellendus ducimus officia asperiores. Eos, eius
    numquam.
  </p>
  <ng-template #actionsTemplate>
    <goab-button-group alignment="end">
      <goab-button type="secondary" (onClick)="closeModalUsingNgTemplate()">Secondary</goab-button>
      <goab-button type="primary" (onClick)="closeModalUsingNgTemplate()">Primary</goab-button>
    </goab-button-group>
  </ng-template>
</goab-modal>
```

## Other info
- This pattern used in modal.ts can be repeated in other angular components
- Related to #2647