### PR TITLE
2690 - public form fixes

### DIFF
--- a/libs/web-components/src/components/form-item/FormItem.svelte
+++ b/libs/web-components/src/components/form-item/FormItem.svelte
@@ -1,4 +1,9 @@
-<svelte:options customElement="goa-form-item" />
+<svelte:options customElement={{
+  tag: "goa-form-item",
+  props: {
+    publicFormSummaryOrder: { type: "Number", attribute: "public-form-summary-order" },
+  }
+}} />
 
 <!-- Script -->
 <script lang="ts" context="module">
@@ -63,6 +68,7 @@
   // **For the public-form only**
   // Overrides the label value within the form-summary to provide a shorter description of the value
   export let name: string = "blank";
+  export let publicFormSummaryOrder: number = 0;
 
   let _rootEl: HTMLElement;
   let _inputEl: HTMLElement;
@@ -190,7 +196,7 @@
     relay<FormItemMountRelayDetail>(
       _rootEl,
       FormItemMountMsg,
-      { id: _name, label: name !== "blank" ? name : label, el: _rootEl },
+      { id: _name, label: name !== "blank" ? name : label, el: _rootEl, order: publicFormSummaryOrder },
       { bubbles: true, timeout: 10 },
     );
   }

--- a/libs/web-components/src/components/form/FormSummary.svelte
+++ b/libs/web-components/src/components/form/FormSummary.svelte
@@ -228,6 +228,10 @@
       width: 100%;
     }
 
+    td {
+      vertical-align: top;
+    }
+
     .label {
       width: 50%;
       font: var(--goa-typography-heading-s);

--- a/libs/web-components/src/types/relay-types.ts
+++ b/libs/web-components/src/types/relay-types.ts
@@ -167,6 +167,7 @@ export type FormItemMountRelayDetail = {
   id: string;
   label: string;
   el: HTMLElement;
+  order: number;
 };
 
 // ========


### PR DESCRIPTION
https://github.com/GovAlta/ui-components/issues/2690

- allows one to override the default sort order of fields within the form summary
- vertically aligns data within the form-summary table

Previously the birthdate (Datepicker) would always be displayed as the first item in the last section and the Address label would be vertically centred.

# Before
![image](https://github.com/user-attachments/assets/4d915435-7c06-4fa1-8b0f-aad57a7ff9c3)



# After

The below code will result in 
```html
    <goa-fieldset>
      <goa-form-item name="Your City" label="Foo City" helptext="Where you live">
        <goa-input name="city"></goa-input>
      </goa-form-item>
      <goa-form-item name="Address" label="Address">
        <goa-textarea name="address"></goa-textarea>
      </goa-form-item>
      <goa-form-item name="Postal Code" label="Postal Code">
        <goa-input name="postal-code"></goa-input>
      </goa-form-item>
      <goa-form-item name="Date of birth" label="Date of birth" public-form-summary-order="99">
        <goa-date-picker name="dob" type="input"></goa-date-picker>
      </goa-form-item>
    </goa-fieldset>
```
![image](https://github.com/user-attachments/assets/e6f9ae24-1671-43f0-8d3b-b4487ed4fcb2)


