### PR TITLE
fix: input width missing 1ch, date picker too small

### DIFF
--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -294,7 +294,7 @@
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <goa-input
       slot="target"
-      width="10rem"
+      width="16ch"
       readonly="true"
       trailingicon="calendar"
       value={formatDate(_date)}

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -147,7 +147,7 @@
       _inputWidth = "";
     } else if (width.includes("ch") || width.trim() === "") {
       _containerStyle = "";
-      _inputWidth = width;
+      _inputWidth =`${parseInt(width) + 1}ch`;
     } else {
       _containerStyle = `--width: ${width};`;
       _inputWidth = "";
@@ -483,7 +483,6 @@
     z-index: 1;
     border-radius: var(--goa-text-input-border-radius);
     min-width: 0;
-    text-overflow: ellipsis;
   }
   input,
   input:focus-visible,


### PR DESCRIPTION
# Before (the change)
<img width="129" alt="image" src="https://github.com/user-attachments/assets/31f5e163-cf18-4756-be15-092664ab7385" />

<img width="286" alt="image" src="https://github.com/user-attachments/assets/d9ac310e-2fdf-45dd-bb44-1681b79cea88" />

# After (the change)
<img width="126" alt="image" src="https://github.com/user-attachments/assets/36777bd1-3b38-43a5-8fd7-3a7e4acde7b3" />
<img width="286" alt="image" src="https://github.com/user-attachments/assets/26e6946f-6c46-42ce-9b59-d56a52a243c1" />
