### PR TITLE
fix(#2526): date value mismatch seconds issue

### DIFF
--- a/libs/react-components/src/lib/input/input.tsx
+++ b/libs/react-components/src/lib/input/input.tsx
@@ -195,7 +195,7 @@ export function GoAInput({
     const keypressListener = (e: unknown) => {
       const { name, value, key } = (e as CustomEvent).detail;
       onKeyPress?.(name, value, key);
-    }
+    };
 
     current.addEventListener("_change", changeListener);
     current.addEventListener("_trailingIconClick", clickListener);
@@ -334,13 +334,17 @@ export function GoAInputDateTime({
   value,
   min = "",
   max = "",
+  step,
   ...props
 }: GoADateInputProps): JSX.Element {
+  const formatString = step === 1 ? "yyyy-MM-dd'T'HH:mm:ss" : "yyyy-MM-dd'T'HH:mm";
+
   return (
     <GoAInput
       {...props}
+      step={step}
       onChange={onDateChangeHandler(props.onChange)}
-      value={toString(value, "yyyy-MM-dd'T'HH:mm")}
+      value={toString(value, formatString)}
       type="datetime-local"
     />
   );


### PR DESCRIPTION
# Before (the change)

# After (the change)

https://github.com/user-attachments/assets/5f383afc-2624-4ceb-83b9-ee61c1270d1f


## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
```
import { GoAInputDateTime } from "@abgov/react-components";
import { useState } from "react";

export default function Input() {
  function noop() {
    // noop
  }

  const [date, setDate] = useState<Date | string>("");

  return (
    <GoAInputDateTime
      name={"ADSP test"}
      value={date}
      step={1}
      onChange={(name, value: Date | string) => {
        setDate(value);
        console.log(value);
      }}
    />
  );
}
```
