### PR TITLE
fix(#2410): modal scrolling should be on the top when open

### DIFF
--- a/libs/web-components/src/components/drawer/Drawer.svelte
+++ b/libs/web-components/src/components/drawer/Drawer.svelte
@@ -192,6 +192,7 @@
       class:drawer-open-right={position === "right" && open}
       class:drawer-open-left={position === "left" && open}
       bind:this={_contentEl}
+      data-first-focus="true"
     >
       <!-- Header -->
       <div class="header" bind:clientHeight={_headerHeight}>

--- a/libs/web-components/src/components/focus-trap/FocusTrapTestComponent.svelte
+++ b/libs/web-components/src/components/focus-trap/FocusTrapTestComponent.svelte
@@ -7,7 +7,6 @@
 <div>
   <input type="text" class="description" name="description" />
   <GoAFocusTrap>
-    <button data-ignore-focus="true">Ignore Focus</button>
     <input type="text" data-testid="username" name="username" />
     <input type="text" data-testid="email" name="email" />
     <input type="text" data-testid="address" name="address" />

--- a/libs/web-components/src/components/modal/Modal.spec.ts
+++ b/libs/web-components/src/components/modal/Modal.spec.ts
@@ -98,15 +98,6 @@ describe("Modal Component", () => {
     });
   });
 
-  it("should set role to alertdialog when alert is set", async () => {
-    const el = render(GoAModal, { open: "true", role: "alertdialog"});
-
-    await waitFor(() => {
-      const modal = el.queryByRole("alertdialog");
-      expect(modal?.getAttribute("aria-modal")).toBe("true");
-    });
-  });
-
   it("should open when the `open` attribute is set to true", async () => {
     const el = render(GoAModal, { open: "true" });
 
@@ -221,6 +212,25 @@ describe("Modal Component", () => {
       await waitFor(() => {
         closeIcon && expect(closeIcon).not.toHaveFocus();
       });
+    });
+  });
+
+  it("should set role to dialog by default and set initial focus to it on open", async() => {
+    const el = render(GoAModal, { open: "true" });
+
+    await waitFor(() => {
+      const modal = el.queryByRole("dialog");
+      expect(modal?.getAttribute("data-first-focus")).toBe("true");
+    });
+  });
+
+  it("should set role to alertdialog and not set focus to it by default", async () => {
+    const el = render(GoAModal, { open: "true", role: "alertdialog"});
+
+    await waitFor(() => {
+      const modal = el.queryByRole("alertdialog");
+      expect(modal?.getAttribute("aria-modal")).toBe("true");
+      expect(modal?.getAttribute("data-first-focus")).toBeNull();
     });
   });
 });

--- a/libs/web-components/src/components/modal/Modal.svelte
+++ b/libs/web-components/src/components/modal/Modal.svelte
@@ -215,6 +215,7 @@
         {role}
         aria-modal="true"
         aria-labelledby="goa-modal-heading"
+        data-first-focus={role === "dialog" ? "true" : undefined}
       >
         {#if calloutvariant !== null}
           <div class="callout-bar {calloutvariant}">


### PR DESCRIPTION
# Before (the change)
With a long content, when opening a modal, it scrolls into the middle 

https://github.com/user-attachments/assets/d3f562d6-222d-4ccf-8d50-b9ba8d7c5c25


# After (the change)

https://github.com/user-attachments/assets/922d3165-9b0f-4798-b7d4-2d436f7af3c8

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

You can use the below angular code to test (similar vs React)
```
<goab-button (onClick)="openModal()">Show Modal</goab-button>
<goab-modal heading="Industry Description" [open]="open" [closable]="true" (onClose)="closeModal()">
  <h4>Business, building, and other support services</h4>
  <p>This industry is made up of two major sub industries:</p>
  <ol>
    <li>Management of companies and enterprises</li>
    <li>Administrative and support, waste management and remediation services</li>
  </ol>
  <h4>Management of companies and enterprises</h4>
  <p>This industry compprises:</p>
  <ol>
    <li>
      Legal entities engaged only in holding the securities of subsidiaries and
      affiliates for the purpose of owning a controlling interest or influencing the
      management decisions of these businesses, or
    </li>
    <li>
      Businesses primarily engaged in adminstering, overseeing, and managing other
      establishments of the company or enterprise and which may also hold the
      securities of their subsidiaries and affiliates.
    </li>
  </ol>
  <h4>Administrative and support, waste management and remediation services</h4>
  <p>This industry comprises of:</p>
  <ol>
    <li>
      Administrative and support services, estabilishments primarily engaged in
      activities such as administration, hiring, and placing personnel
    </li>
  </ol>
  <goab-button-group alignment="end" mt="l">
    <goab-button type="primary" (onClick)="closeModal()">
      I understand
    </goab-button>
  </goab-button-group>
</goab-modal>
```

and ts: 
```
import { Component } from "@angular/core";
import { GoabButton, GoabButtonGroup, GoabModal } from "@abgov/angular-components";

@Component({
  selector: "abgov-issue-2410",
  standalone: true,
  templateUrl: "./issue-2410.component.html",
  imports: [GoabButtonGroup, GoabButton, GoabModal],
})
export class Issue2410Component {
  open = false;

  openModal() {
    this.open = true;
  }
  closeModal() {
    this.open = false;
  }
}

```

The below video is what I have tested with Windows NVDA screen reader. As expected, when open a modal, the title of the modal will be announced, when open an alertdialog modal, the full content will be announced, when `Tab` to move to the first focusable element, the first focusable element inside a modal is focused. When tab until the end of the modal and tab one more time, it goes back to the X (close button) and go to the next focusable element instead of exit the modal and focusing on somewhere else. 

https://github.com/user-attachments/assets/85e5b72c-c35a-40a8-9f81-51da31d3f826

