### PR TITLE
fix: remove text-overflow ellipsis from input styles

### DIFF
--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -488,7 +488,6 @@
     z-index: 1;
     border-radius: var(--goa-text-input-border-radius);
     min-width: 0;
-    text-overflow: ellipsis;
   }
 
   input,


### PR DESCRIPTION
The ellipsis will be removed until a property that controls the ellipsis' visibility is added

# Before (the change)

# After (the change)

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
