### PR TITLE
feat(#1216): add reveal slot to angular/react radio/checkbox

### DIFF
--- a/libs/angular-components/src/lib/components/checkbox/checkbox.spec.ts
+++ b/libs/angular-components/src/lib/components/checkbox/checkbox.spec.ts
@@ -154,6 +154,7 @@ describe("Checkbox with description slot", () => {
       [checked]="true"
       text="check box text"
       [reveal]="revealTemplate"
+      revealArialLabel="Screen reader announcement for reveal content"
     >
       <ng-template #revealTemplate>
         <strong>A reveal slot</strong>
@@ -166,7 +167,7 @@ class TestCheckboxWithRevealSlotComponent {}
 describe("Checkbox with reveal slot", () => {
   let fixture: ComponentFixture<TestCheckboxWithRevealSlotComponent>;
 
-  it("should render with slot reveal", async () => {
+  beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [GoabCheckbox, ReactiveFormsModule],
       declarations: [TestCheckboxWithRevealSlotComponent],
@@ -175,11 +176,20 @@ describe("Checkbox with reveal slot", () => {
 
     fixture = TestBed.createComponent(TestCheckboxWithRevealSlotComponent);
     fixture.detectChanges();
-    
+  });
+
+  it("should render with slot reveal", () => {
     const checkboxElement = fixture.debugElement.query(
       By.css("goa-checkbox"),
     ).nativeElement;
     const slotReveal = checkboxElement.querySelector("[slot='reveal']");
     expect(slotReveal.textContent).toContain("A reveal slot");
+  });
+
+  it("should pass the revealAriaLabel property to the web component", () => {
+    const checkboxElement = fixture.debugElement.query(
+      By.css("goa-checkbox"),
+    ).nativeElement;
+    expect(checkboxElement.getAttribute("revealarialabel")).toBe("Screen reader announcement for reveal content");
   });
 });

--- a/libs/angular-components/src/lib/components/checkbox/checkbox.spec.ts
+++ b/libs/angular-components/src/lib/components/checkbox/checkbox.spec.ts
@@ -47,7 +47,7 @@ class TestCheckboxComponent {
   }
 }
 
-describe("GoABCheckbox", () => {
+describe("GoabCheckbox", () => {
   let fixture: ComponentFixture<TestCheckboxComponent>;
   let component: TestCheckboxComponent;
 
@@ -144,5 +144,42 @@ describe("Checkbox with description slot", () => {
     ).nativeElement;
     const slotDescription = checkboxElement.querySelector("[slot='description']");
     expect(slotDescription.textContent).toContain("A description slot");
+  });
+});
+
+@Component({
+  template: `
+    <goab-checkbox
+      name="test"
+      [checked]="true"
+      text="check box text"
+      [reveal]="revealTemplate"
+    >
+      <ng-template #revealTemplate>
+        <strong>A reveal slot</strong>
+      </ng-template>
+    </goab-checkbox>
+  `,
+})
+class TestCheckboxWithRevealSlotComponent {}
+
+describe("Checkbox with reveal slot", () => {
+  let fixture: ComponentFixture<TestCheckboxWithRevealSlotComponent>;
+
+  it("should render with slot reveal", async () => {
+    await TestBed.configureTestingModule({
+      imports: [GoabCheckbox, ReactiveFormsModule],
+      declarations: [TestCheckboxWithRevealSlotComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestCheckboxWithRevealSlotComponent);
+    fixture.detectChanges();
+    
+    const checkboxElement = fixture.debugElement.query(
+      By.css("goa-checkbox"),
+    ).nativeElement;
+    const slotReveal = checkboxElement.querySelector("[slot='reveal']");
+    expect(slotReveal.textContent).toContain("A reveal slot");
   });
 });

--- a/libs/angular-components/src/lib/components/checkbox/checkbox.ts
+++ b/libs/angular-components/src/lib/components/checkbox/checkbox.ts
@@ -26,6 +26,7 @@ import { GoabControlValueAccessor } from "../base.component";
     [attr.testid]="testId"
     [attr.arialabel]="ariaLabel"
     [attr.description]="getDescriptionAsString()"
+    [attr.revealarialabel]="revealArialLabel"
     [id]="id"
     [attr.maxwidth]="maxWidth"
     [attr.mt]="mt"
@@ -39,7 +40,7 @@ import { GoabControlValueAccessor } from "../base.component";
       <ng-container [ngTemplateOutlet]="getDescriptionAsTemplate()"></ng-container>
     </div>
     <div slot="reveal">
-      <ng-container *ngIf="reveal !== null && reveal !== undefined" [ngTemplateOutlet]="reveal"></ng-container>
+      <ng-container *ngIf="reveal" [ngTemplateOutlet]="reveal"></ng-container>
     </div>
   </goa-checkbox>`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -60,7 +61,8 @@ export class GoabCheckbox extends GoabControlValueAccessor {
   @Input() override value?: string | number | boolean;
   @Input() ariaLabel?: string;
   @Input() description!: string | TemplateRef<any>;
-  @Input() reveal!: TemplateRef<any>;
+  @Input() reveal?: TemplateRef<any>;
+  @Input() revealArialLabel?: string;
   @Input() maxWidth?: string;
 
   @Output() onChange = new EventEmitter<GoabCheckboxOnChangeDetail>();

--- a/libs/angular-components/src/lib/components/checkbox/checkbox.ts
+++ b/libs/angular-components/src/lib/components/checkbox/checkbox.ts
@@ -1,4 +1,4 @@
-import { GoabCheckboxOnChangeDetail, Spacing } from "@abgov/ui-components-common";
+import { GoabCheckboxOnChangeDetail } from "@abgov/ui-components-common";
 import {
   CUSTOM_ELEMENTS_SCHEMA,
   Component,
@@ -10,7 +10,7 @@ import {
   booleanAttribute,
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
-import { NgTemplateOutlet } from "@angular/common";
+import { NgIf, NgTemplateOutlet } from "@angular/common";
 import { GoabControlValueAccessor } from "../base.component";
 
 @Component({
@@ -38,6 +38,9 @@ import { GoabControlValueAccessor } from "../base.component";
     <div slot="description">
       <ng-container [ngTemplateOutlet]="getDescriptionAsTemplate()"></ng-container>
     </div>
+    <div slot="reveal">
+      <ng-container *ngIf="reveal !== null && reveal !== undefined" [ngTemplateOutlet]="reveal"></ng-container>
+    </div>
   </goa-checkbox>`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   providers: [
@@ -47,7 +50,7 @@ import { GoabControlValueAccessor } from "../base.component";
       useExisting: forwardRef(() => GoabCheckbox),
     },
   ],
-  imports: [NgTemplateOutlet],
+  imports: [NgTemplateOutlet, NgIf],
 })
 export class GoabCheckbox extends GoabControlValueAccessor {
   @Input() name?: string;
@@ -57,6 +60,7 @@ export class GoabCheckbox extends GoabControlValueAccessor {
   @Input() override value?: string | number | boolean;
   @Input() ariaLabel?: string;
   @Input() description!: string | TemplateRef<any>;
+  @Input() reveal!: TemplateRef<any>;
   @Input() maxWidth?: string;
 
   @Output() onChange = new EventEmitter<GoabCheckboxOnChangeDetail>();

--- a/libs/angular-components/src/lib/components/radio-item/radio-item.spec.ts
+++ b/libs/angular-components/src/lib/components/radio-item/radio-item.spec.ts
@@ -1,18 +1,42 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { GoabRadioItem } from "./radio-item";
 
-let component: GoabRadioItem;
-let fixture: ComponentFixture<GoabRadioItem>;
+@Component({
+  template: `
+    <goab-radio-item
+      name="test"
+      [checked]="true"
+      label="radio item text"
+      [reveal]="revealTemplate"
+    >
+      <ng-template #revealTemplate>
+        <strong>A reveal slot</strong>
+      </ng-template>
+    </goab-radio-item>
+  `,
+})
+class TestRadioItemWithRevealSlotComponent {}
 
-beforeEach(() => {
-  TestBed.configureTestingModule({
-    imports: [GoabRadioItem],
+describe("Radio item with reveal slot", () => {
+  let fixture: ComponentFixture<TestRadioItemWithRevealSlotComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GoabRadioItem],
+      declarations: [TestRadioItemWithRevealSlotComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
   });
-  fixture = TestBed.createComponent(GoabRadioItem);
-  component = fixture.componentInstance;
-});
 
-it("should render", () => {
-  expect(component).toBeTruthy();
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestRadioItemWithRevealSlotComponent);
+    fixture.detectChanges();
+  });
+
+  it("should render with slot reveal", () => {
+    const radioItemElement = fixture.debugElement.nativeElement.querySelector("goa-radio-item");
+    const slotReveal = radioItemElement.querySelector("[slot='reveal']");
+    expect(slotReveal.textContent).toContain("A reveal slot");
+  });
 });

--- a/libs/angular-components/src/lib/components/radio-item/radio-item.spec.ts
+++ b/libs/angular-components/src/lib/components/radio-item/radio-item.spec.ts
@@ -9,6 +9,7 @@ import { GoabRadioItem } from "./radio-item";
       [checked]="true"
       label="radio item text"
       [reveal]="revealTemplate"
+      revealAriaLabel="Screen reader announcement for radio reveal content"
     >
       <ng-template #revealTemplate>
         <strong>A reveal slot</strong>
@@ -38,5 +39,10 @@ describe("Radio item with reveal slot", () => {
     const radioItemElement = fixture.debugElement.nativeElement.querySelector("goa-radio-item");
     const slotReveal = radioItemElement.querySelector("[slot='reveal']");
     expect(slotReveal.textContent).toContain("A reveal slot");
+  });
+
+  it("should pass the revealAriaLabel property to the web component", () => {
+    const radioItemElement = fixture.debugElement.nativeElement.querySelector("goa-radio-item");
+    expect(radioItemElement.getAttribute("revealarialabel")).toBe("Screen reader announcement for radio reveal content");
   });
 });

--- a/libs/angular-components/src/lib/components/radio-item/radio-item.ts
+++ b/libs/angular-components/src/lib/components/radio-item/radio-item.ts
@@ -1,11 +1,5 @@
-import {
-  CUSTOM_ELEMENTS_SCHEMA,
-  Component,
-  Input,
-  TemplateRef,
-  booleanAttribute,
-} from "@angular/core";
-import { NgTemplateOutlet } from "@angular/common";
+import { CUSTOM_ELEMENTS_SCHEMA, Component, Input, TemplateRef, booleanAttribute, } from "@angular/core";
+import { NgIf, NgTemplateOutlet } from "@angular/common";
 import { GoabBaseComponent } from "../base.component";
 
 @Component({
@@ -31,9 +25,15 @@ import { GoabBaseComponent } from "../base.component";
       <div slot="description">
         <ng-container [ngTemplateOutlet]="getDescriptionAsTemplate()"></ng-container>
       </div>
+      <div slot="reveal">
+        <ng-container
+          *ngIf="this.reveal !== null && this.reveal !== undefined"
+          [ngTemplateOutlet]="reveal"
+        ></ng-container>
+      </div>
     </goa-radio-item>
   `,
-  imports: [NgTemplateOutlet],
+  imports: [NgTemplateOutlet, NgIf],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class GoabRadioItem extends GoabBaseComponent {
@@ -41,6 +41,7 @@ export class GoabRadioItem extends GoabBaseComponent {
   @Input() label?: string;
   @Input() name?: string;
   @Input() description!: string | TemplateRef<any>;
+  @Input() reveal!: TemplateRef<any>;
   @Input() ariaLabel?: string;
   @Input({ transform: booleanAttribute }) disabled?: boolean;
   @Input({ transform: booleanAttribute }) checked?: boolean;

--- a/libs/angular-components/src/lib/components/radio-item/radio-item.ts
+++ b/libs/angular-components/src/lib/components/radio-item/radio-item.ts
@@ -12,6 +12,7 @@ import { GoabBaseComponent } from "../base.component";
       [attr.label]="label"
       [attr.description]="getDescriptionAsString()"
       [attr.arialabel]="ariaLabel"
+      [attr.revealarialabel]="revealAriaLabel"
       [disabled]="disabled"
       [attr.maxwidth]="maxWidth"
       [attr.checked]="checked"
@@ -27,7 +28,7 @@ import { GoabBaseComponent } from "../base.component";
       </div>
       <div slot="reveal">
         <ng-container
-          *ngIf="this.reveal !== null && this.reveal !== undefined"
+          *ngIf="this.reveal"
           [ngTemplateOutlet]="reveal"
         ></ng-container>
       </div>
@@ -41,8 +42,9 @@ export class GoabRadioItem extends GoabBaseComponent {
   @Input() label?: string;
   @Input() name?: string;
   @Input() description!: string | TemplateRef<any>;
-  @Input() reveal!: TemplateRef<any>;
+  @Input() reveal?: TemplateRef<any>;
   @Input() ariaLabel?: string;
+  @Input() revealAriaLabel?: string;
   @Input({ transform: booleanAttribute }) disabled?: boolean;
   @Input({ transform: booleanAttribute }) checked?: boolean;
   @Input({ transform: booleanAttribute }) error?: boolean;

--- a/libs/react-components/src/lib/checkbox/checkbox.spec.tsx
+++ b/libs/react-components/src/lib/checkbox/checkbox.spec.tsx
@@ -96,6 +96,19 @@ describe("GoabCheckbox", () => {
     ).toContain("reveal slot");
   });
 
+  it("should pass the revealAriaLabel property to the web component", () => {
+    render(
+      <GoabCheckbox 
+        name={"foo"} 
+        reveal={<div>reveal slot</div>} 
+        revealAriaLabel="Screen reader announcement for checkbox reveal content" 
+      />,
+    );
+
+    const checkbox = document.querySelector("goa-checkbox");
+    expect(checkbox?.getAttribute("revealarialabel")).toBe("Screen reader announcement for checkbox reveal content");
+  });
+
   it("should handle the onChange event", async function () {
     const onChangeStub = vi.fn();
 

--- a/libs/react-components/src/lib/checkbox/checkbox.spec.tsx
+++ b/libs/react-components/src/lib/checkbox/checkbox.spec.tsx
@@ -84,6 +84,18 @@ describe("GoabCheckbox", () => {
     ).toContain("description slot");
   });
 
+  it("should render with slot reveal", () => {
+    const result = render(
+      <GoabCheckbox name={"foo"} reveal={<div>reveal slot</div>} />,
+    );
+
+    const checkbox = document.querySelector("goa-checkbox");
+    expect(checkbox?.getAttribute("reveal")).toBe(null);
+    expect(
+      result.container.querySelector('div[slot="reveal"]')?.innerHTML,
+    ).toContain("reveal slot");
+  });
+
   it("should handle the onChange event", async function () {
     const onChangeStub = vi.fn();
 

--- a/libs/react-components/src/lib/checkbox/checkbox.tsx
+++ b/libs/react-components/src/lib/checkbox/checkbox.tsx
@@ -21,6 +21,7 @@ interface WCProps extends Margins {
   value?: string | number;
   arialabel?: string;
   description?: string | React.ReactNode;
+  reveal?: React.ReactNode;
   maxwidth?: string;
   testid?: string;
 }
@@ -38,6 +39,7 @@ export interface GoabCheckboxProps extends Margins {
   testId?: string;
   ariaLabel?: string;
   description?: string | React.ReactNode;
+  reveal?: React.ReactNode;
   maxWidth?: string;
   onChange?: (detail: GoabCheckboxOnChangeDetail) => void;
 }
@@ -55,6 +57,7 @@ export function GoabCheckbox({
   value,
   text,
   description,
+  reveal,
   maxWidth,
   children,
   onChange,
@@ -104,6 +107,7 @@ export function GoabCheckbox({
       {description && typeof description !== "string" && (
         <div slot="description">{description}</div>
       )}
+      {reveal && <div slot="reveal">{reveal}</div>}
       {children}
     </goa-checkbox>
   );

--- a/libs/react-components/src/lib/checkbox/checkbox.tsx
+++ b/libs/react-components/src/lib/checkbox/checkbox.tsx
@@ -22,6 +22,7 @@ interface WCProps extends Margins {
   arialabel?: string;
   description?: string | React.ReactNode;
   reveal?: React.ReactNode;
+  revealarialabel?: string;
   maxwidth?: string;
   testid?: string;
 }
@@ -40,6 +41,7 @@ export interface GoabCheckboxProps extends Margins {
   ariaLabel?: string;
   description?: string | React.ReactNode;
   reveal?: React.ReactNode;
+  revealAriaLabel?: string;
   maxWidth?: string;
   onChange?: (detail: GoabCheckboxOnChangeDetail) => void;
 }
@@ -58,6 +60,7 @@ export function GoabCheckbox({
   text,
   description,
   reveal,
+  revealAriaLabel,
   maxWidth,
   children,
   onChange,
@@ -97,6 +100,7 @@ export function GoabCheckbox({
       text={text}
       value={typeof value === "boolean" ? (value ? "true" : undefined) : value}
       arialabel={ariaLabel}
+      revealarialabel={revealAriaLabel}
       description={typeof description === "string" ? description : undefined}
       maxwidth={maxWidth}
       mt={mt}
@@ -104,11 +108,11 @@ export function GoabCheckbox({
       mb={mb}
       ml={ml}
     >
-      {description && typeof description !== "string" && (
+      {children}
+      {typeof description !== "string" && description && (
         <div slot="description">{description}</div>
       )}
       {reveal && <div slot="reveal">{reveal}</div>}
-      {children}
     </goa-checkbox>
   );
 }

--- a/libs/react-components/src/lib/radio-group/radio-group.spec.tsx
+++ b/libs/react-components/src/lib/radio-group/radio-group.spec.tsx
@@ -177,6 +177,26 @@ describe("RadioGroup", () => {
         result.container.querySelector("div[slot='description']")?.innerHTML,
       ).toContain("Bananas are banana");
     });
+
+    it("should pass the revealAriaLabel property to the web component", () => {
+      const result = render(
+        <GoabRadioGroup name="fruits" onChange={noop}>
+          <GoabRadioItem
+            label="Apples with reveal"
+            name="fruits"
+            value="apples"
+            reveal={<div>Additional apple options</div>}
+            revealAriaLabel="Screen reader announcement for radio reveal content"
+          />
+        </GoabRadioGroup>,
+      );
+
+      const radioItem = document.querySelector("goa-radio-item");
+      expect(radioItem?.getAttribute("revealarialabel")).toBe("Screen reader announcement for radio reveal content");
+      expect(
+        result.container.querySelector("div[slot='reveal']")?.innerHTML,
+      ).toContain("Additional apple options");
+    });
   });
 
   describe("Selection Change Tests", () => {

--- a/libs/react-components/src/lib/radio-group/radio.tsx
+++ b/libs/react-components/src/lib/radio-group/radio.tsx
@@ -6,6 +6,7 @@ interface WCProps extends Margins {
   name?: string;
   value?: string;
   description?: string | React.ReactNode;
+  reveal?: React.ReactNode;
   label?: string;
   maxwidth?: string;
   disabled?: string;
@@ -28,6 +29,7 @@ export interface GoabRadioItemProps extends Margins {
   label?: string;
   name?: string;
   description?: string | React.ReactNode;
+  reveal?: React.ReactNode;
   maxWidth?: string;
   disabled?: boolean;
   checked?: boolean;
@@ -41,6 +43,7 @@ export function GoabRadioItem({
   label,
   value,
   description,
+  reveal,
   maxWidth,
   disabled,
   checked,
@@ -71,6 +74,7 @@ export function GoabRadioItem({
       {description && typeof description !== "string" && (
         <div slot="description">{description}</div>
       )}
+      {reveal && <div slot="reveal">{reveal}</div>}
       {children}
     </goa-radio-item>
   );

--- a/libs/react-components/src/lib/radio-group/radio.tsx
+++ b/libs/react-components/src/lib/radio-group/radio.tsx
@@ -7,6 +7,7 @@ interface WCProps extends Margins {
   value?: string;
   description?: string | React.ReactNode;
   reveal?: React.ReactNode;
+  revealarialabel?: string;
   label?: string;
   maxwidth?: string;
   disabled?: string;
@@ -30,6 +31,7 @@ export interface GoabRadioItemProps extends Margins {
   name?: string;
   description?: string | React.ReactNode;
   reveal?: React.ReactNode;
+  revealAriaLabel?: string;
   maxWidth?: string;
   disabled?: boolean;
   checked?: boolean;
@@ -44,6 +46,7 @@ export function GoabRadioItem({
   value,
   description,
   reveal,
+  revealAriaLabel,
   maxWidth,
   disabled,
   checked,
@@ -66,6 +69,7 @@ export function GoabRadioItem({
       disabled={disabled ? "true" : undefined}
       checked={checked ? "true" : undefined}
       arialabel={ariaLabel}
+      revealarialabel={revealAriaLabel}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/web-components/src/common/utils.spec.ts
+++ b/libs/web-components/src/common/utils.spec.ts
@@ -1,6 +1,6 @@
 import { waitFor } from "@testing-library/svelte";
-import { getTimestamp, performOnce } from "./utils";
-import { it, describe } from "vitest";
+import { getTimestamp, performOnce, announceToScreenReader } from "./utils";
+import { it, describe, expect, vi, beforeEach, afterEach } from "vitest";
 
 describe("getTimestamp", () => {
   it("sets the correct postfix", () => {
@@ -64,3 +64,72 @@ describe("performOnce", () => {
     });
   })
 })
+
+describe("announceToScreenReader", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    if (!document.body) {
+      const body = document.createElement('body');
+      document.documentElement.appendChild(body);
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+
+    // Clean up any announcer elements
+    const announcers = document.querySelectorAll('[aria-live="polite"]');
+    announcers.forEach(el => el.parentNode?.removeChild(el));
+  });
+
+  it("creates an accessible announcer element with the correct attributes", () => {
+    announceToScreenReader("Test announcement");
+
+    const announcer = document.querySelector('[aria-live="polite"]');
+    expect(announcer).not.toBeNull();
+    expect(announcer?.getAttribute("aria-atomic")).toBe("true");
+    expect(announcer?.textContent).toBe("");
+
+    vi.advanceTimersByTime(100);
+    expect(announcer?.textContent).toBe("Test announcement");
+  });
+
+  it("sets up timers to remove the announcer element", () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+    const customDuration = 1500;
+    announceToScreenReader("Test announcement", customDuration);
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+
+    expect(setTimeoutSpy.mock.calls[1][1]).toBe(customDuration);
+  });
+
+  it("uses default duration when not specified", () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+    announceToScreenReader("Test announcement");
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+
+    expect(setTimeoutSpy.mock.calls[1][1]).toBe(3000);
+  });
+
+  it("applies visually hidden styles to the announcer element", () => {
+    announceToScreenReader("Test announcement");
+
+    const announcer = document.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(announcer).not.toBeNull();
+
+    // Check that the element has visually hidden styles
+    expect(announcer.style.position).toBe("absolute");
+    expect(announcer.style.width).toBe("1px");
+    expect(announcer.style.height).toBe("1px");
+    expect(announcer.style.padding).toBe("0px");
+    expect(announcer.style.margin).toBe("-1px");
+    expect(announcer.style.overflow).toBe("hidden");
+    expect(announcer.style.clipPath).toBe("inset(50%)");
+    expect(announcer.style.opacity).toBe("0");
+  });
+});

--- a/libs/web-components/src/common/utils.ts
+++ b/libs/web-components/src/common/utils.ts
@@ -278,5 +278,38 @@ export function getQueryParam(
   url: string | URL,
   key: string,
 ): string | undefined {
-  return getQueryParams(url)[key];
+  const params = getQueryParams(url);
+  return params[key];
+}
+
+/**
+ * Creates a temporary screen reader announcement using aria-live
+ * @param text The text to announce to screen readers
+ * @param duration How long to keep the announcer element in the DOM (in milliseconds)
+ */
+export function announceToScreenReader(text: string, duration = 3000): void {
+  const announcer = document.createElement("div");
+
+  announcer.style.position = "absolute";
+  announcer.style.width = "1px";
+  announcer.style.height = "1px";
+  announcer.style.padding = "0";
+  announcer.style.margin = "-1px";
+  announcer.style.overflow = "hidden";
+  announcer.style.clipPath = "inset(50%)";
+  announcer.style.whiteSpace = "nowrap";
+  announcer.style.borderWidth = "0";
+  announcer.style.opacity = "0";
+
+  announcer.setAttribute("aria-live", "polite");
+  announcer.setAttribute("aria-atomic", "true");
+  document.body.appendChild(announcer);
+
+  setTimeout(() => {
+    announcer.textContent = text;
+  }, 100);
+
+  setTimeout(() => {
+    document.body.removeChild(announcer);
+  }, duration);
 }

--- a/libs/web-components/src/components/checkbox/Checkbox.spec.ts
+++ b/libs/web-components/src/components/checkbox/Checkbox.spec.ts
@@ -142,6 +142,35 @@ describe('GoACheckbox Component', () => {
     });
   });
 
+  describe("Reveal slot", () => {
+    it("should stop propagation of _click and _change events from reveal slot", async () => {
+      const el = await createElement();
+      const revealSlot = document.createElement('div');
+      revealSlot.setAttribute('slot', 'reveal');
+      revealSlot.textContent = 'Reveal content';
+
+      const checkbox = el.container.querySelector('goa-checkbox');
+      checkbox?.appendChild(revealSlot);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Test _click event propagation
+      const clickSpy = vi.fn();
+      checkbox?.addEventListener('_click', clickSpy);
+
+      const clickEvent = new CustomEvent('_click', { bubbles: true });
+      revealSlot.dispatchEvent(clickEvent);
+      expect(clickSpy).not.toHaveBeenCalled();
+
+      // Test _change event propagation
+      const changeSpy = vi.fn();
+      checkbox?.addEventListener('_change', changeSpy);
+
+      const changeEvent = new CustomEvent('_change', { bubbles: true });
+      revealSlot.dispatchEvent(changeEvent);
+      expect(changeSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Margins", () => {
     it(`should add the margin`, async () => {
       const baseElement = render(GoACheckbox, {

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -5,7 +5,7 @@
   import type { Spacing } from "../../common/styling";
   import { calculateMargin } from "../../common/styling";
 
-  import { dispatch, fromBoolean, receive, relay, toBoolean } from "../../common/utils";
+  import { dispatch, fromBoolean, receive, relay, toBoolean, announceToScreenReader } from "../../common/utils";
   import {
     FieldsetSetValueMsg,
     FieldsetSetValueRelayDetail,
@@ -29,6 +29,7 @@
   export let testid: string = "";
   export let arialabel: string = "";
   export let description: string = "";
+  export let revealarialabel: string = ""; // screen reader will announce this when reveal slot is displayed
   export let maxwidth: string = "none";
 
   // margin
@@ -112,7 +113,7 @@
       }
     });
     if (_revealSlotEl) {
-      onRevealSlotCustomEventListener();
+      addRevealSlotEventListeners();
     }
   }
 
@@ -178,6 +179,11 @@
     if (!!$$slots.reveal && !newCheckStatus) {
       resetChildFormFields();
     }
+
+    // Announce the reveal content change to screen readers if checkbox is checked and reveal content exists
+    if ($$slots.reveal && newCheckStatus && _revealSlotEl && revealarialabel !== "") {
+      announceToScreenReader(revealarialabel);
+    }
   }
 
   function onFocus() {
@@ -187,7 +193,7 @@
   /**
    * Stop propagate the _click,_change to checkbox (so it won't toggle the value)
    */
-  function onRevealSlotCustomEventListener() {
+  function addRevealSlotEventListeners() {
     _revealSlotEl.addEventListener("_click", (e: Event) => {
       // Stop custom event propagation
       e.stopPropagation();

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -46,6 +46,7 @@
   let _descriptionId: string;
   let _error: boolean;
   let _prevError: boolean;
+  let _revealSlotHeight: number = 0;
 
   // Binding
   $: isDisabled = toBoolean(disabled);
@@ -63,6 +64,7 @@
   }
   $: isChecked = toBoolean(checked);
   $: isIndeterminate = false; // Design review. To be built with TreeView Later
+  $: revealSlotHasContent = _revealSlotHeight > 0;
 
   onMount(() => {
     // hold on to the initial value to prevent losing it on check changes
@@ -109,6 +111,9 @@
           break;
       }
     });
+    if (_revealSlotEl) {
+      onRevealSlotCustomEventListener();
+    }
   }
 
   function setCheckStatusByChildState(detail: FormFieldMountRelayDetail) {
@@ -177,6 +182,21 @@
 
   function onFocus() {
     dispatch(_rootEl, "help-text::announce", undefined, { bubbles: true });
+  }
+
+  /**
+   * Stop propagate the _click,_change to checkbox (so it won't toggle the value)
+   */
+  function onRevealSlotCustomEventListener() {
+    _revealSlotEl.addEventListener("_click", (e: Event) => {
+      // Stop custom event propagation
+      e.stopPropagation();
+    });
+
+    _revealSlotEl.addEventListener("_change", (e: Event) => {
+      // Stop custom event propagation
+      e.stopPropagation();
+    });
   }
 </script>
 
@@ -248,6 +268,8 @@
     bind:this={_revealSlotEl}
     class="reveal"
     class:visible={$$slots.reveal && isChecked}
+    class:has-content={revealSlotHasContent}
+    bind:clientHeight={_revealSlotHeight}
   >
     <slot name="reveal" />
   </div>
@@ -315,11 +337,13 @@
     height: 0;
   }
   .reveal.visible {
+    display: block;
+    height: fit-content;
+  }
+  .reveal.visible.has-content {
     border-left: 4px solid var(--goa-color-greyscale-200);
     padding: var(--goa-space-m);
     margin: var(--goa-space-2xs) 0 0 calc(var(--goa-space-s) - 2px);
-    display: block;
-    height: fit-content;
   }
 
   /* Container */

--- a/libs/web-components/src/components/form-item/FormItem.svelte
+++ b/libs/web-components/src/components/form-item/FormItem.svelte
@@ -21,6 +21,7 @@
     relay,
     generateRandomId,
     typeValidator,
+    announceToScreenReader,
   } from "../../common/utils";
   import {
     FieldsetResetErrorsMsg,
@@ -129,35 +130,8 @@
   function handleAnnounceHelperText() {
     const message = _hasError ? error || helptext : helptext;
     if (message) {
-      announceOnFocus(message);
+      announceToScreenReader(message);
     }
-  }
-
-  function announceOnFocus(text: string) {
-    const announcer = document.createElement("div");
-
-    announcer.style.position = "absolute";
-    announcer.style.width = "1px";
-    announcer.style.height = "1px";
-    announcer.style.padding = "0";
-    announcer.style.margin = "-1px";
-    announcer.style.overflow = "hidden";
-    announcer.style.clipPath = "inset(50%)";
-    announcer.style.whiteSpace = "nowrap";
-    announcer.style.borderWidth = "0";
-    announcer.style.opacity = "0";
-
-    announcer.setAttribute("aria-live", "polite");
-    announcer.setAttribute("aria-atomic", "true");
-    document.body.appendChild(announcer);
-
-    setTimeout(() => {
-      announcer.textContent = text;
-    }, 100);
-
-    setTimeout(() => {
-      document.body.removeChild(announcer);
-    }, 3000);
   }
 
   function updateAriaDescribedBy() {

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -159,6 +159,7 @@
             description: props.description,
             name,
             checked: props.value === value,
+            revealAriaLabel: props.revealAriaLabel,
           },
         }),
       );

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -229,9 +229,10 @@
   }
 
   .goa-radio-group--vertical {
-    display: inline-flex;
-    flex-direction: column; /* Vertical stacking */
-    gap: var(--goa-radio-group-gap-vertical); /* Adds spacing */
+    display: flex;
+    flex-direction: column;  /* Vertical stacking */
+    gap: var(--goa-radio-group-gap-vertical);  /* Adds spacing */
+    width: 100%;
   }
 
   /* Focus styles */

--- a/libs/web-components/src/components/radio-item/RadioItem.spec.ts
+++ b/libs/web-components/src/components/radio-item/RadioItem.spec.ts
@@ -134,4 +134,38 @@ describe("RadioItem", () => {
 
     expect(mockOnChange).toBeCalledTimes(0);
   });
+
+  describe("Reveal slot", () => {
+    it("should stop propagation of _click, _change, and _radioItemChange events from reveal slot", async () => {
+      const result = render(GoARadioItem, { value: "test-radio" });
+      const revealSlot = document.createElement('div');
+      revealSlot.setAttribute('slot', 'reveal');
+      revealSlot.textContent = 'Reveal content';
+      
+      const radioItem = result.container.querySelector('goa-radio-item');
+      radioItem?.appendChild(revealSlot);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Test _click event propagation
+      const clickSpy = vi.fn();
+      radioItem?.addEventListener('_click', clickSpy);
+      const clickEvent = new CustomEvent('_click', { bubbles: true });
+      revealSlot.dispatchEvent(clickEvent);
+      expect(clickSpy).not.toHaveBeenCalled();
+
+      // Test _change event propagation
+      const changeSpy = vi.fn();
+      radioItem?.addEventListener('_change', changeSpy);
+      const changeEvent = new CustomEvent('_change', { bubbles: true });
+      revealSlot.dispatchEvent(changeEvent);
+      expect(changeSpy).not.toHaveBeenCalled();
+
+      // Test _radioItemChange event propagation
+      const radioChangeSpy = vi.fn();
+      radioItem?.addEventListener('_radioItemChange', radioChangeSpy);
+      const radioChangeEvent = new CustomEvent('_radioItemChange', { bubbles: true });
+      revealSlot.dispatchEvent(radioChangeEvent);
+      expect(radioChangeSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -6,6 +6,7 @@
     checked: { reflect: true },
     arialabel: { reflect: true },
     error: { reflect: true },
+    revealarialabel: { reflect: true },
   }
 }}/>
 
@@ -21,6 +22,7 @@
     checked: boolean;
     ariaLabel: string;
     maxWidth: string;
+    revealAriaLabel?: string;
   };
 
   export type RadioItemSelectProps = {
@@ -30,7 +32,7 @@
 
 <script lang="ts">
   import { onMount } from "svelte";
-  import { dispatch, fromBoolean, receive, relay, toBoolean } from "../../common/utils";
+  import { dispatch, fromBoolean, receive, relay, toBoolean, announceToScreenReader } from "../../common/utils";
   import { calculateMargin } from "../../common/styling";
   import type { Spacing } from "../../common/styling";
   import { FieldsetResetFieldsMsg, FormFieldMountMsg, FormFieldMountRelayDetail } from "../../types/relay-types";
@@ -43,6 +45,7 @@
   export let error: string = "false";
   export let checked: string = "false";
   export let arialabel: string = "";
+  export let revealarialabel: string = ""; // screen reader will announce this when reveal slot is displayed
   export let maxwidth: string = "none";
 
   // margin
@@ -149,6 +152,7 @@
             checked: isChecked,
             ariaLabel: arialabel,
             maxWidth: maxwidth,
+            revealAriaLabel: revealarialabel
           },
         }),
       );
@@ -163,6 +167,7 @@
       checked = fromBoolean(data.checked);
       description = data.description;
       name = data.name;
+      revealarialabel = data.revealAriaLabel;
     });
   }
 
@@ -177,6 +182,11 @@
     // if (isChecked) return;  FIXME: does having this uncommented break something?
 
     dispatch(_radioItemEl, "_radioItemChange", value, { bubbles: true })
+
+    // Announce the reveal content change to screen readers if radio is checked and reveal content exists
+    if ($$slots.reveal && isChecked && revealarialabel && revealarialabel !== "") {
+      announceToScreenReader(revealarialabel);
+    }
 
     if (!isChecked && !!$$slots.reveal) {
       resetChildFormFields();

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -56,12 +56,14 @@
   let _radioItemEl: HTMLElement;
   let _revealSlotEl: HTMLElement;
   let _formFields: HTMLElement[] = [];
+  let _revealSlotHeight: number = 0;
 
   // Reactive
 
   $: isDisabled = toBoolean(disabled);
   $: isError = toBoolean(error);
   $: isChecked = toBoolean(checked);
+  $: revealSlotHasContent = _revealSlotHeight > 0;
 
   // Hooks
 
@@ -94,6 +96,27 @@
           break;
       }
     });
+    if (_revealSlotEl) {
+      onRevealSlotCustomEventListener();
+    }
+  }
+
+  /**
+   * Stop propagate the _click,_change to checkbox (so it won't toggle the value)
+   */
+  function onRevealSlotCustomEventListener() {
+    _revealSlotEl.addEventListener("_click", (e: Event) => {
+      e.stopPropagation();
+    });
+
+    _revealSlotEl.addEventListener("_change", (e: Event) => {
+      // Stop custom event propagation
+      e.stopPropagation();
+    });
+
+    _revealSlotEl.addEventListener("_radioItemChange", (e: Event) => {
+      e.stopPropagation();
+    })
   }
 
   function onFormFieldMount(detail: FormFieldMountRelayDetail) {
@@ -207,7 +230,11 @@
       {description}
     </div>
   {/if}
-  <div class="reveal" class:visible={$$slots.reveal && isChecked}>
+  <div class="reveal"
+       class:visible={$$slots.reveal && isChecked}
+       class:has-content={revealSlotHasContent}
+       bind:this={_revealSlotEl}
+       bind:clientHeight={_revealSlotHeight}>
     <slot name="reveal" />
   </div>
 </div>
@@ -261,11 +288,13 @@
     height: 0;
   }
   .reveal.visible {
-    border-left: 4px solid var(--goa-color-greyscale-200);
+    height: fit-content;
+    display: block;
+  }
+  .reveal.visible.has-content {
     padding: var(--goa-space-m);
     margin: var(--goa-space-2xs) 0 0 calc(var(--goa-space-s) - 2px);
-    display: block;
-    height: fit-content;
+    border-left: 4px solid var(--goa-color-greyscale-200);
   }
 
   .icon {
@@ -362,5 +391,3 @@
     border: var(--goa-radio-border-checked-error-disabled);
   }
 </style>
-
-


### PR DESCRIPTION
# Before (the change)

# After (the change)
**Accordion:** 
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/194707ed-22ae-437e-87ad-9d13771bbe5c" />

and other components: 

<img width="1177" alt="image" src="https://github.com/user-attachments/assets/afdf2114-d46d-40dc-a7bc-b588211d93c7" />

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
You can use this code snippet to test:
HTML: https://gist.github.com/vanessatran-ddi/2901d56221c85c9580363896f7b130d1
TS: https://gist.github.com/vanessatran-ddi/0558044b4e010863e7f54d7cf9e45bd3 