### PR TITLE
feat(#2664): add valueStr to calendar _change event

### DIFF
--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -55,6 +55,7 @@ export type GoabDropdownOnChangeDetail = {
 export type GoabDatePickerOnChangeDetail = {
   name?: string;
   value: string | Date | undefined;
+  valueStr?: string;
 };
 export type GoabDatePickerInputType = "calendar" | "input";
 
@@ -72,7 +73,8 @@ export type GoabCheckboxOnChangeDetail = {
 
 export type GoabCalendarOnChangeDetail = {
   name?: string;
-  value: string;
+  value?: string;
+  valueStr?: string;
 };
 
 export type GoabBadgeType =

--- a/libs/web-components/src/components/calendar/Calendar.svelte
+++ b/libs/web-components/src/components/calendar/Calendar.svelte
@@ -47,6 +47,7 @@
   // ********
 
   let _selectedDate: Date | null; // date set by the user
+  let _selectedDateRaw: number | null; // raw date string in UTC format (T)
   let _calendarDate: Date; // date that the calendar is synced to (days of month, month/year dropdowns)
   let _min: Date;
   let _max: Date;
@@ -77,7 +78,7 @@
 
       if (isValidDate(newDate)) {
         renderCalendar({ type: "date", value: _selectedDate || newDate });
-        _selectedDate = newDate;
+        _selectedDateRaw = newDate.getTime();
         _calendarDate = newDate;
       }
     }
@@ -114,6 +115,7 @@
       ? startOfDay(new Date(value))
       : startOfDay(new Date());
 
+    _selectedDateRaw = _selectedDate.getTime();
     initKeybindings();
     await tick();
     renderCalendar({ type: "date", value: _selectedDate });
@@ -221,7 +223,7 @@
           break;
         case "Delete":
         case "Backspace":
-          _selectedDate = null;
+          _selectedDate = _selectedDateRaw = null;
           break;
         case "Home": {
           let homeDate = new Date(_calendarDate);
@@ -248,6 +250,7 @@
           break;
         case "Enter":
           _selectedDate = _calendarDate;
+          _selectedDateRaw = _calendarDate.getTime();
           dispatchValue();
           e.stopPropagation();
           e.preventDefault();
@@ -265,6 +268,8 @@
     if (!isValidDate(_selectedDate)) return;
 
     value = _selectedDate.toISOString();
+    const valueStr = format(_selectedDateRaw, "yyyy-MM-dd");
+
     _calendarEl.dispatchEvent(
       new CustomEvent("_change", {
         composed: true,
@@ -272,6 +277,7 @@
           type: "date",
           name: name,
           value: _selectedDate,
+          valueStr: valueStr,
         },
       }),
     );
@@ -313,6 +319,8 @@
     }
 
     _selectedDate = _calendarDate = newDate;
+    _selectedDateRaw = raw;
+
     dispatchValue();
   }
 </script>

--- a/libs/web-components/src/components/calendar/calendar.spec.ts
+++ b/libs/web-components/src/components/calendar/calendar.spec.ts
@@ -5,7 +5,7 @@ import {
   render,
   waitFor,
 } from "@testing-library/svelte";
-import { addDays, lastDayOfMonth, startOfDay } from "date-fns";
+import { addDays, lastDayOfMonth, startOfDay, format } from "date-fns";
 import { tick } from "svelte";
 import { it, expect, vi } from "vitest";
 
@@ -130,6 +130,7 @@ it("emits an event when a date is selected", async () => {
   await tick()
 
   const today = toDayStart(new Date());
+  const todayStr = format(today, "yyyy-MM-dd");
   const todayEl = container.querySelector(
     `button.today[data-date="${today.getTime()}"]`,
   );
@@ -141,10 +142,11 @@ it("emits an event when a date is selected", async () => {
     onChange((e as CustomEvent).detail);
   });
 
+
   await fireEvent.click(todayEl);
   await waitFor(() => {
     expect(onChange).toBeCalled();
-    expect(onChange).toBeCalledWith({ type: "date", value: today, name });
+    expect(onChange).toBeCalledWith({ type: "date", value: today, valueStr: todayStr, name });
   });
 });
 

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -149,11 +149,7 @@
 
   function onCalendarChange(e: CustomEvent) {
     _date = e.detail.value;
-    if (_date) {
-      value = _date.toISOString();
-    } else {
-      value = "";
-    }
+    value = e.detail.valueStr || "";
 
     hideCalendar();
     dispatchValue(_date);


### PR DESCRIPTION
This PR adds a `valueStr` property to the Calendar's `_change` event. It uses the new property to set the Date Picker date when the Calendar changes. It retains the current `value` property to prevent breaking changes.

The [issue description](https://github.com/GovAlta/ui-components/issues/2664) also mentions the following:

> All the logic within the calendar component dealing with dates can be removed

I was thinking of doing that in a second PR so its easier to test. But I could add it to this PR if that's simpler.

### Before
- The calendar `_change` event has a `value` property with a date ISO string
- The date picker uses the `value` from the calendar

### After 
- The calendar `_change` event has two date properties: `value` and `valueStr`
- The `value` property with a date ISO string
- The `valueStr` property with a `yyyy-MM-dd` date string
- The `valueStr` uses the "raw" UTC milliseconds from the calendar buttons
- The date picker sets its value with calendar's `valueStr`