### PR TITLE
feat(#2248): add id and type to react & angular date-picker

### DIFF
--- a/libs/angular-components/src/lib/components/date-picker/date-picker.spec.ts
+++ b/libs/angular-components/src/lib/components/date-picker/date-picker.spec.ts
@@ -14,6 +14,7 @@ import { fireEvent } from "@testing-library/dom";
       [value]="value"
       [min]="min"
       [max]="max"
+      type="input"
       [error]="error"
       [mt]="mt"
       [mb]="mb"
@@ -79,6 +80,7 @@ describe("GoABDatePicker", () => {
     expect(el?.getAttribute("mb")).toBe(component.mb);
     expect(el?.getAttribute("ml")).toBe(component.ml);
     expect(el?.getAttribute("mr")).toBe(component.mr);
+    expect(el?.getAttribute("type")).toBe("input");
   });
 
   it("should handle event", async () => {

--- a/libs/angular-components/src/lib/components/date-picker/date-picker.ts
+++ b/libs/angular-components/src/lib/components/date-picker/date-picker.ts
@@ -1,4 +1,4 @@
-import { GoabDatePickerOnChangeDetail, Spacing } from "@abgov/ui-components-common";
+import { GoabDatePickerInputType, GoabDatePickerOnChangeDetail } from "@abgov/ui-components-common";
 import {
   CUSTOM_ELEMENTS_SCHEMA,
   Component,
@@ -23,6 +23,7 @@ import { GoabControlValueAccessor } from "../base.component";
     [attr.error]="error"
     [attr.disabled]="disabled"
     [attr.relative]="relative"
+    [attr.type]="type"
     [attr.testid]="testId"
     [attr.mt]="mt"
     [attr.mb]="mb"
@@ -46,6 +47,7 @@ export class GoabDatePicker extends GoabControlValueAccessor {
   @Input() override value?: Date | string | null | undefined;
   @Input() min?: Date | string;
   @Input() max?: Date | string;
+  @Input() type?: GoabDatePickerInputType;
   /***
    * @deprecated This property has no effect and will be removed in a future version
    */

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -56,6 +56,7 @@ export type GoabDatePickerOnChangeDetail = {
   name?: string;
   value: string | Date | undefined;
 };
+export type GoabDatePickerInputType = "calendar" | "input";
 
 export type GoabChipVariant = "filter";
 

--- a/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
@@ -33,6 +33,7 @@ describe("DatePicker", () => {
         testId="foo"
         error
         disabled
+        type="input"
         onChange={noop}
       />,
     );
@@ -48,6 +49,7 @@ describe("DatePicker", () => {
     expect(el?.getAttribute("min")).toBe(min.toISOString());
     expect(el?.getAttribute("max")).toBe(max.toISOString());
     expect(el?.getAttribute("testid")).toBe("foo");
+    expect(el?.getAttribute("type")).toBe("input");
   });
 
   it("should handle event", async () => {

--- a/libs/react-components/src/lib/date-picker/date-picker.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, type JSX } from "react";
-import { GoabDatePickerOnChangeDetail, Margins } from "@abgov/ui-components-common";
+import { GoabDatePickerInputType, GoabDatePickerOnChangeDetail, Margins } from "@abgov/ui-components-common";
 
 interface WCProps extends Margins {
   ref: React.RefObject<HTMLElement | null>;
@@ -8,6 +8,7 @@ interface WCProps extends Margins {
   error?: string;
   min?: string;
   max?: string;
+  type?: string;
   relative?: string;
   disabled?: string;
   testid?: string;
@@ -28,13 +29,14 @@ export interface GoabDatePickerProps extends Margins {
   error?: boolean;
   min?: Date;
   max?: Date;
+  type?: GoabDatePickerInputType;
   testId?: string;
   /***
    * @deprecated This property has no effect and will be removed in a future version
    */
   relative?: boolean;
   disabled?: boolean;
-  onChange: (detail: GoabDatePickerOnChangeDetail) => void;
+  onChange?: (detail: GoabDatePickerOnChangeDetail) => void;
 }
 
 export function GoabDatePicker({
@@ -45,6 +47,7 @@ export function GoabDatePicker({
   max,
   testId,
   disabled,
+  type,
   mt,
   mr,
   mb,
@@ -62,13 +65,17 @@ export function GoabDatePicker({
 
     const handleChange = (e: Event) => {
       const detail = (e as CustomEvent<GoabDatePickerOnChangeDetail>).detail;
-      onChange(detail);
+      onChange?.(detail);
     };
 
-    current.addEventListener("_change", handleChange);
+    if (onChange) {
+      current.addEventListener("_change", handleChange);
+    }
 
     return () => {
-      current.removeEventListener("_change", handleChange);
+      if (onChange) {
+        current.removeEventListener("_change", handleChange);
+      }
     };
   }, [onChange]);
 
@@ -77,6 +84,7 @@ export function GoabDatePicker({
       ref={ref}
       name={name}
       value={value?.toISOString() || ""}
+      type={type}
       error={error ? "true" : undefined}
       disabled={disabled ? "true" : undefined}
       min={min?.toISOString()}


### PR DESCRIPTION
# Before (the change)
The `id` and `type` for a date-picker isn't exposed so this step on public form example cannot be implemented. 
<img width="361" alt="image" src="https://github.com/user-attachments/assets/dc259eba-f02d-42fb-9c94-b82a232e082d" />

# After (the change)
<img width="458" alt="image" src="https://github.com/user-attachments/assets/63d51d2a-86be-4d34-a955-a4817a38ab27" />


## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

```
 <GoabPublicFormPage
          id="birthdate"
          onContinue={(e) => onPageChange(e, 'birthdate')}
        >
          <GoabFieldset>
            <GoabFormItem
              id="birthdate-item"
              label="What is your date of birth?"
              helpText="Your date of birth is required to ensure you meet the minimum age criteria"
              labelSize="large"
            >
              <GoabFormItem id="birth-date-item" label="Birth Date">
                <GoabDatePicker id="birth-date" name="birth-date" type="input"/>
              </GoabFormItem>
            </GoabFormItem>
          </GoabFieldset>
        </GoabPublicFormPage>
```