### PR TITLE
fix(#2766): Added export for GoabInputOnBlurDetail

### DIFF
--- a/libs/angular-components/src/lib/components/input-number/input-number.ts
+++ b/libs/angular-components/src/lib/components/input-number/input-number.ts
@@ -1,7 +1,7 @@
 import {
   GoabIconType,
   GoabInputAutoCapitalize,
-  GoaInputOnBlurDetail,
+  GoabInputOnBlurDetail,
   GoabInputOnChangeDetail,
   GoabInputOnFocusDetail,
   GoabInputOnKeyPressDetail,
@@ -111,7 +111,7 @@ export class GoabInputNumber implements ControlValueAccessor, OnInit {
 
   @Output() onTrailingIconClick = new EventEmitter<void>(); // Keep void type
   @Output() onFocus = new EventEmitter<GoabInputOnFocusDetail>();
-  @Output() onBlur = new EventEmitter<GoaInputOnBlurDetail>();
+  @Output() onBlur = new EventEmitter<GoabInputOnBlurDetail>();
   @Output() onKeyPress = new EventEmitter<GoabInputOnKeyPressDetail>();
   @Output() onChange = new EventEmitter<GoabInputOnChangeDetail>();
 
@@ -162,7 +162,7 @@ export class GoabInputNumber implements ControlValueAccessor, OnInit {
 
   _onBlur(e: Event) {
     this.markAsTouched();
-    const detail = (e as CustomEvent<GoaInputOnBlurDetail>).detail;
+    const detail = (e as CustomEvent<GoabInputOnBlurDetail>).detail;
     this.onBlur.emit(detail);
   }
 

--- a/libs/angular-components/src/lib/components/input/input.ts
+++ b/libs/angular-components/src/lib/components/input/input.ts
@@ -1,12 +1,11 @@
 import {
   GoabIconType,
   GoabInputAutoCapitalize,
-  GoaInputOnBlurDetail,
+  GoabInputOnBlurDetail,
   GoabInputOnChangeDetail,
   GoabInputOnFocusDetail,
   GoabInputOnKeyPressDetail,
   GoabInputType,
-  Spacing,
 } from "@abgov/ui-components-common";
 import {
   CUSTOM_ELEMENTS_SCHEMA,
@@ -105,7 +104,7 @@ export class GoabInput extends GoabControlValueAccessor implements OnInit {
 
   @Output() onTrailingIconClick = new EventEmitter();
   @Output() onFocus = new EventEmitter<GoabInputOnFocusDetail>();
-  @Output() onBlur = new EventEmitter<GoaInputOnBlurDetail>();
+  @Output() onBlur = new EventEmitter<GoabInputOnBlurDetail>();
   @Output() onKeyPress = new EventEmitter<GoabInputOnKeyPressDetail>();
   @Output() onChange = new EventEmitter<GoabInputOnChangeDetail>();
 
@@ -147,7 +146,7 @@ export class GoabInput extends GoabControlValueAccessor implements OnInit {
   }
 
   _onBlur(e: Event) {
-    const detail = (e as CustomEvent<GoaInputOnBlurDetail>).detail;
+    const detail = (e as CustomEvent<GoabInputOnBlurDetail>).detail;
     this.onBlur.emit(detail);
   }
 }

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -11,12 +11,15 @@ export type GoabInputOnChangeDetail<T = string> = {
   name: string;
   value: T;
 };
+
+// @deprecated GoaInputOnBlurDetail has been deprecated. Use GoabInputOnBlurDetail instead.
+export type GoaInputOnBlurDetail = GoabInputOnBlurDetail;
+export type GoabInputOnBlurDetail<T = string> = {
+  name: string;
+  value: T;
+};
+
 export type GoabInputOnFocusDetail<T = string> = GoabInputOnChangeDetail<T>;
-/***
- * @deprecated GoaInputOnBlurDetail has been deprecated. Use GoabInputOnBlurDetail instead.
- */
-export type GoaInputOnBlurDetail<T = string> = GoabInputOnBlurDetail<T>;
-export type GoabInputOnBlurDetail<T = string> = GoabInputOnChangeDetail<T>;
 
 export type GoabInputAutoCapitalize =
   | "on"
@@ -166,6 +169,7 @@ export type GoabTextAreaOnKeyPressDetail = {
 export interface GoabTabsProps {
   initialTab?: number;
 }
+
 export type GoabTabsOnChangeDetail = {
   tab: number;
 };
@@ -173,6 +177,7 @@ export type GoabTabsOnChangeDetail = {
 
 export type GoabTableVariant = "normal" | "relaxed";
 export type GoabTableSortDirection = "asc" | "desc" | "none";
+
 export interface GoabTableProps extends Margins {
   width?: string;
   onSort?: (sortBy: string, sortDir: number) => void;
@@ -1020,6 +1025,7 @@ export interface GoabFieldsetOnChangeDetail {
   };
   dispatchOn: GoabFormDispatchOn;
 }
+
 export interface GoabFieldsetOnContinueDetail {
   el: HTMLElement;
   state: Record<string, GoabFieldsetItemState>;

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -12,7 +12,11 @@ export type GoabInputOnChangeDetail<T = string> = {
   value: T;
 };
 export type GoabInputOnFocusDetail<T = string> = GoabInputOnChangeDetail<T>;
-export type GoaInputOnBlurDetail<T = string> = GoabInputOnChangeDetail<T>;
+/***
+ * @deprecated GoaInputOnBlurDetail has been deprecated. Use GoabInputOnBlurDetail instead.
+ */
+export type GoaInputOnBlurDetail<T = string> = GoabInputOnBlurDetail<T>;
+export type GoabInputOnBlurDetail<T = string> = GoabInputOnChangeDetail<T>;
 
 export type GoabInputAutoCapitalize =
   | "on"
@@ -975,7 +979,13 @@ export type GoabFormOnStateChange = {
 };
 
 // Common types to use between public form components
-export type GoabFormStatus = "not-started" | "cannot-start-yet" | "in-progress" | "submitted" | "update-needed" | "complete";
+export type GoabFormStatus =
+  | "not-started"
+  | "cannot-start-yet"
+  | "in-progress"
+  | "submitted"
+  | "update-needed"
+  | "complete";
 export type GoabFormState = {
   uuid: string;
   form: Record<string, GoabFieldsetSchema>;
@@ -1030,16 +1040,14 @@ export type GoabPublicFormPageOnFieldsetChangeDetail = {
     data: Record<string, GoabFieldsetItemState>;
   };
   dispatchOn: GoabFormDispatchOn;
-}
+};
 export type GoabPublicFormPageOnCompleteDetail = {
   el: HTMLElement;
   state: Record<string, GoabFieldsetItemState>;
   cancelled: boolean;
-}
+};
 
 // Drawer
 export type GoabDrawerPosition = "bottom" | "left" | "right" | undefined;
 export type GoabDrawerSizeUnit = "px" | "rem" | "ch" | "vh" | "vw";
 export type GoabDrawerSize = `${number}${GoabDrawerSizeUnit}` | undefined;
-
-

--- a/libs/react-components/src/lib/input/input.tsx
+++ b/libs/react-components/src/lib/input/input.tsx
@@ -4,7 +4,7 @@ import {
   GoabAutoCapitalize,
   GoabDate,
   GoabIconType,
-  GoaInputOnBlurDetail,
+  GoabInputOnBlurDetail,
   GoabInputOnChangeDetail,
   GoabInputOnFocusDetail,
   GoabInputOnKeyPressDetail,
@@ -89,7 +89,7 @@ interface BaseProps extends Margins {
 
 type OnChange<T = string> = (detail: GoabInputOnChangeDetail<T>) => void;
 type OnFocus<T = string> = (detail: GoabInputOnFocusDetail<T>) => void;
-type OnBlur<T = string> = (detail: GoaInputOnBlurDetail<T>) => void;
+type OnBlur<T = string> = (detail: GoabInputOnBlurDetail<T>) => void;
 type OnKeyPress<T = string> = (detail: GoabInputOnKeyPressDetail<T>) => void;
 
 export interface GoabInputProps extends BaseProps {
@@ -183,7 +183,7 @@ export function GoabInput({
     };
 
     const blurListener = (e: Event) => {
-      const detail = (e as CustomEvent<GoaInputOnBlurDetail>).detail;
+      const detail = (e as CustomEvent<GoabInputOnBlurDetail>).detail;
       onBlur?.(detail);
     };
 
@@ -392,7 +392,7 @@ export function GoabInputNumber({
   const onFocus = ({ name, value }: GoabInputOnFocusDetail) => {
     props.onFocus?.({ name, value: parseFloat(value) });
   };
-  const onBlur = ({ name, value }: GoaInputOnBlurDetail) => {
+  const onBlur = ({ name, value }: GoabInputOnBlurDetail) => {
     props.onBlur?.({ name, value: parseFloat(value) });
   };
   const onKeyPress = ({ name, value, key }: GoabInputOnKeyPressDetail) => {


### PR DESCRIPTION
# Before (the change)

You would have to use `GoaInputOnBlurDetail` for the `blur` event on the Input component

# After (the change)

Now you can use `GoabInputOnBlurDetail` instead, `GoaInputOnBlurDetail` also still exists so existing use cases aren't wrecked.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
