### PR TITLE
fix(#2765): Undid the addition of goab-text to Hero Banner

### DIFF
--- a/libs/web-components/src/components/hero-banner/HeroBanner.spec.ts
+++ b/libs/web-components/src/components/hero-banner/HeroBanner.spec.ts
@@ -1,21 +1,23 @@
 import { render, waitFor } from "@testing-library/svelte";
-import GoAHeroBanner from "./HeroBanner.svelte"
-import GoAHeroBannerWrapper from "./HeroBannerWrapper.test.svelte"
+import GoAHeroBanner from "./HeroBanner.svelte";
+import GoAHeroBannerWrapper from "./HeroBannerWrapper.test.svelte";
 import { it, describe } from "vitest";
 
 describe("GoAHeroBanner", () => {
-
   it("renders all properties", async () => {
     const title = "Test Title";
-    const el = render(GoAHeroBanner, { heading: title, backgroundurl: "somepic.png" });
+    const el = render(GoAHeroBanner, {
+      heading: title,
+      backgroundurl: "somepic.png",
+    });
 
-    const heading = await el.container.querySelector("goa-text");
+    const heading = await el.findByRole("heading");
     const background = await el.findByTestId("background");
 
     waitFor(() => {
-      expect(heading?.innerHTML).toEqual(title);
+      expect(heading.innerHTML).toEqual(title);
       expect(background.style.backgroundImage).toContain("somepic.png");
-    })
+    });
   });
 
   it("renders actions", async () => {
@@ -28,26 +30,34 @@ describe("GoAHeroBanner", () => {
 
     waitFor(() => {
       expect(el.container.innerHTML).toContain("The content");
-      expect(el.container.innerHTML).toContain("<goa-button>Action</goa-button>");
-    })
-  })
+      expect(el.container.innerHTML).toContain(
+        "<goa-button>Action</goa-button>",
+      );
+    });
+  });
 
   describe("Min Height", () => {
     it("uses the default min height", async () => {
-      const result = render(GoAHeroBanner, { heading: "Jeading", backgroundurl: "somepic.png" });
+      const result = render(GoAHeroBanner, {
+        heading: "Jeading",
+        backgroundurl: "somepic.png",
+      });
       const heroBanner = result.queryByTestId("background");
       await waitFor(() => {
-        expect(heroBanner).toHaveStyle("min-height: 600px");  // 600px is default value
-      })
+        expect(heroBanner).toHaveStyle("min-height: 600px"); // 600px is default value
+      });
     });
 
     it("uses the min height when supplied", async () => {
-      const result = render(GoAHeroBanner, { heading: "Jeading", backgroundurl: "somepic.png", minheight: "700px" });
+      const result = render(GoAHeroBanner, {
+        heading: "Jeading",
+        backgroundurl: "somepic.png",
+        minheight: "700px",
+      });
       const heroBanner = result.queryByTestId("background");
       await waitFor(() => {
         expect(heroBanner).toHaveStyle("min-height: 700px");
-      })
+      });
     });
-  })
-
+  });
 });

--- a/libs/web-components/src/components/hero-banner/HeroBanner.svelte
+++ b/libs/web-components/src/components/hero-banner/HeroBanner.svelte
@@ -27,7 +27,7 @@
   "
 >
   <goa-page-block width={maxcontentwidth || "full"}>
-    <goa-text as="h1" mb="none" mt="none">{heading}</goa-text>
+    <h1>{heading}</h1>
     <div class="goa-hero-banner-content" role="note">
       <slot />
     </div>
@@ -65,7 +65,8 @@
     border-bottom: 8px solid var(--goa-color-brand-default);
     justify-content: flex-end;
     background: unset;
-    background-image: linear-gradient(
+    background-image:
+      linear-gradient(
         rgba(0, 0, 0, 0) 0%,
         rgba(0, 0, 0, 0.42) 42%,
         rgba(0, 0, 0, 0.6) 100%


### PR DESCRIPTION
# Before (the change)

Hero Banner was changed to use the GoabText component.

# After (the change)

This change has been undone and reverted back to using a standard `h1` tag instead

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
