### PR TITLE
fix(#2721): Updating Text component to give margins to size instead of tag

### DIFF
--- a/libs/web-components/src/components/text/Text.svelte
+++ b/libs/web-components/src/components/text/Text.svelte
@@ -33,6 +33,7 @@
   export let ml: Spacing = null;
 
   let _marginBottom: Spacing = null;
+  let _marginTop: Spacing = null;
 
   /**
    * Returns a bottom margin value based on the `size` prop
@@ -43,33 +44,57 @@
       return mb;
     }
 
-    // div and spans should not have any bottom margin
     switch (size) {
       case "heading-xl":
-        return "3xl";
-      case "heading-l":
-        return "2xl";
-      case "heading-m":
-        return "xl";
-      case "heading-s":
         return "l";
+      case "heading-l":
+        return "l";
+      case "heading-m":
+        return "m";
+      case "heading-s":
+        return "s";
       case "heading-xs":
+        return "xs";
       case "body-l":
       case "body-m":
-        return "m";
       case "body-s":
       case "body-xs":
-        return "3xs";
+        return "l";
       default:
-        return "3xs";
+        return "l";
     }
   }
 
-  onMount(async() => {
+  function getTopMargin(): Spacing {
+    // override takes precedence
+    if (mt) {
+      return mt;
+    }
+
+    switch (size) {
+      case "heading-xl":
+      case "heading-l":
+      case "heading-m":
+        return "2xl";
+      case "heading-s":
+      case "heading-xs":
+        return "xl";
+      case "body-l":
+        return "2xl";
+      case "body-m":
+      case "body-s":
+        return "l";
+      case "body-xs":
+        return "s";
+      default:
+        return "s";
+    }
+  }
+
+  onMount(async () => {
     await tick(); // needed to ensure Angular's delay, when rendering within a route, doesn't break things
-    console.log("onMount size ", size);
-    console.log("after onMount size ", size);
     _marginBottom = getBottomMargin();
+    _marginTop = getTopMargin();
   });
 </script>
 
@@ -84,7 +109,7 @@
         : "var(--goa-color-text-secondary)",
     ),
     maxWidth === "none" ? "" : `max-width: ${maxWidth}`,
-    calculateMargin(mt, mr, _marginBottom, ml),
+    calculateMargin(_marginTop, mr, _marginBottom, ml),
   )}
 >
   <slot />

--- a/libs/web-components/src/components/text/Text.svelte
+++ b/libs/web-components/src/components/text/Text.svelte
@@ -32,20 +32,10 @@
   export let mb: Spacing = null;
   export let ml: Spacing = null;
 
-  const sizeMap: Record<HeadingElement | TextElement, HeadingSize | BodySize> =
-    {
-      h1: "heading-xl",
-      h2: "heading-l",
-      h3: "heading-m",
-      h4: "heading-s",
-      h5: "heading-xs",
-      div: "body-m",
-      p: "body-m",
-      span: "body-m",
-    };
+  let _marginBottom: Spacing = null;
 
   /**
-   * Returns a bottom margin value based on the `as` prop
+   * Returns a bottom margin value based on the `size` prop
    */
   function getBottomMargin(): Spacing {
     // override takes precedence
@@ -54,28 +44,32 @@
     }
 
     // div and spans should not have any bottom margin
-    switch (as) {
-      case "h1":
+    switch (size) {
+      case "heading-xl":
         return "3xl";
-      case "h2":
+      case "heading-l":
         return "2xl";
-      case "h3":
+      case "heading-m":
         return "xl";
-      case "h4":
+      case "heading-s":
         return "l";
-      case "h5":
-      case "h6":
-      case "p":
+      case "heading-xs":
+      case "body-l":
+      case "body-m":
         return "m";
+      case "body-s":
+      case "body-xs":
+        return "3xs";
+      default:
+        return "3xs";
     }
-
-    // fix for the GoA font's unwanted top padding
-    return "3xs";
   }
 
   onMount(async() => {
     await tick(); // needed to ensure Angular's delay, when rendering within a route, doesn't break things
-    size ||= sizeMap[as];
+    console.log("onMount size ", size);
+    console.log("after onMount size ", size);
+    _marginBottom = getBottomMargin();
   });
 </script>
 
@@ -90,7 +84,7 @@
         : "var(--goa-color-text-secondary)",
     ),
     maxWidth === "none" ? "" : `max-width: ${maxWidth}`,
-    calculateMargin(mt, mr, getBottomMargin(), ml),
+    calculateMargin(mt, mr, _marginBottom, ml),
   )}
 >
   <slot />


### PR DESCRIPTION
# Before (the change)

Margins were associated with the `tag` property that was used

# After (the change)

Margins should instead be associated with the `size` property, the `tag` property should only be used to determine what element to output. Tag will determine size by using our default CSS provided for some of these tags (`h1`, `h2`, `p`, etc....), but will be overwritten if `size` is given.

Also, all margin bottoms have been changed. And a top margin calculation has been added.

`tag` span won't have any bottom or top margin no matter the `size` property, because it's an inline element, not a block element

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

### React

```typescript
<GoabBlock gap="l" direction="column">
  <GoabBlock gap="m" direction="column">
    <h3>Margin Reference Test</h3>
    <p>Compare margins across different sizes with the same tag:</p>
    <div className="test-container">
      <GoabText tag="p" size="heading-xl">
        Heading XL (should have L bottom margin, 2XL top margin)
      </GoabText>
      <GoabText tag="p" size="heading-l">
        Heading L (should have L bottom margin, 2XL top margin)
      </GoabText>
      <GoabText tag="p" size="heading-m">
        Heading M (should have M bottom margin, 2XL top margin)
      </GoabText>
      <GoabText tag="p" size="heading-s">
        Heading S (should have S bottom margin, XL top margin)
      </GoabText>
      <GoabText tag="p" size="heading-xs">
        Heading XS (should have XS bottom margin, XL top margin)
      </GoabText>
      <GoabText tag="p" size="body-l">
        Body L (should have L bottom margin, 2XL top margin)
      </GoabText>
      <GoabText tag="p" size="body-m">
        Body M (should have L bottom margin, L top margin)
      </GoabText>
      <GoabText tag="p" size="body-s">
        Body S (should have L bottom margin, L top margin)
      </GoabText>
      <GoabText tag="p" size="body-xs">
        Body XS (should have L bottom margin, S top margin)
      </GoabText>
    </div>
  </GoabBlock>

  <GoabBlock gap="m" direction="column">
    <h3>Tag Consistency Test</h3>
    <p>All of these should have identical margins (body-m size):</p>
    <div className="test-container">
      <GoabText tag="h1" size="body-m">
        H1 tag with body-m size
      </GoabText>
      <GoabText tag="h2" size="body-m">
        H2 tag with body-m size
      </GoabText>
      <GoabText tag="h3" size="body-m">
        H3 tag with body-m size
      </GoabText>
      <GoabText tag="p" size="body-m">
        P tag with body-m size
      </GoabText>
      <GoabText tag="span" size="body-m">
        Span tag with body-m size
      </GoabText>
      <GoabText tag="div" size="body-m">
        Div tag with body-m size
      </GoabText>
    </div>
  </GoabBlock>

  <GoabBlock gap="m" direction="column">
    <h3>Expected vs Actual Behavior</h3>
    <p>If the bug is fixed, changing the tag should not affect margins:</p>
    <div className="test-container">
      <h4>Expected: Same margins regardless of tag</h4>
      <GoabText tag="h1" size="heading-m">
        H1 with heading-m (should match below)
      </GoabText>
      <GoabText tag="p" size="heading-m">
        P with heading-m (should match above)
      </GoabText>
      <GoabText tag="span" size="heading-m">
        Span with heading-m (should match above)
      </GoabText>
    </div>
  </GoabBlock>
</GoabBlock>
```

### Angular

```html
<goab-block gap="m" direction="column">
  <goab-block gap="m" direction="column">
    <h3>Margin Reference Test</h3>
    <p>Compare margins across different variants with the same tag:</p>

    <div class="test-container">
      <goab-text tag="p" size="heading-xl"
        >Heading XL (should have L bottom margin, 2XL top margin)</goab-text
      >
      <goab-text tag="p" size="heading-l"
        >Heading L (should have L bottom margin, 2XL top margin)</goab-text
      >
      <goab-text tag="p" size="heading-m"
        >Heading M (should have M bottom margin, 2XL top margin)</goab-text
      >
      <goab-text tag="p" size="heading-s"
        >Heading S (should have S bottom margin, XL top margin)</goab-text
      >
      <goab-text tag="p" size="heading-xs"
        >Heading XS (should have XS bottom margin, XL top margin)</goab-text
      >
      <goab-text tag="p" size="body-l"
        >Body L (should have L bottom margin, 2XL top margin)</goab-text
      >
      <goab-text tag="p" size="body-m"
        >Body M (should have L bottom margin, L top margin)</goab-text
      >
      <goab-text tag="p" size="body-s"
        >Body S (should have L bottom margin, L top margin)</goab-text
      >
      <goab-text tag="p" size="body-xs"
        >Body XS (should have L bottom margin, S top margin)</goab-text
      >
    </div>
  </goab-block>

  <goab-block gap="m" direction="column">
    <h3>Tag Consistency Test</h3>
    <p>All of these should have identical margins (body-m variant):</p>

    <div class="test-container">
      <goab-text tag="h1" size="body-m">H1 tag with body-m size</goab-text>
      <goab-text tag="h2" size="body-m">H2 tag with body-m size</goab-text>
      <goab-text tag="h3" size="body-m">H3 tag with body-m size</goab-text>
      <goab-text tag="p" size="body-m">P tag with body-m size</goab-text>
      <goab-text tag="span" size="body-m">Span tag with body-m size</goab-text>
      <goab-text tag="div" size="body-m">Div tag with body-m size</goab-text>
    </div>
  </goab-block>

  <goab-block gap="m" direction="column">
    <h3>Expected vs Actual Behavior</h3>
    <p>If the bug is fixed, changing the tag should not affect margins:</p>

    <div class="test-container">
      <h4>Expected: Same margins regardless of tag</h4>
      <goab-text tag="h1" size="heading-m"
        >H1 with heading-m (should match below)</goab-text
      >
      <goab-text tag="p" size="heading-m"
        >P with heading-m (should match above)</goab-text
      >
      <goab-text tag="span" size="heading-m"
        >Span with heading-m (should match above)</goab-text
      >
    </div>
  </goab-block>
</goab-block>
```