### PR TITLE
fix(#2858): re register state for 2nd or more subform item

### DIFF
--- a/libs/web-components/src/components/form/Fieldset.svelte
+++ b/libs/web-components/src/components/form/Fieldset.svelte
@@ -38,6 +38,8 @@
     FormToggleActiveRelayDetail,
     FormPageContinueMsg,
     FormPageContinueRelayDetail,
+    SubFormNewItemMsg,
+    SubFormNewItemRelayDetail,
   } from "../../types/relay-types";
 
   // ======
@@ -117,6 +119,10 @@
           resetFields(event);
           event.stopPropagation();
           break;
+        case SubFormNewItemMsg:
+          onReRegisterSubFormNewItem(data as SubFormNewItemRelayDetail);
+          event.stopPropagation();
+          break;
       }
     });
   }
@@ -150,6 +156,34 @@
 
     for (const { el } of Object.values(_formFields)) {
       relay(el, FieldsetResetFieldsMsg);
+    }
+  }
+
+  function onReRegisterSubFormNewItem(detail: SubFormNewItemRelayDetail) {
+    _state = {};
+    _errors = {};
+
+    // Re-trigger onFormItemMount for all form items to rebuild state and visually clear fields
+    for (const [id, { label, el }] of Object.entries(_formItems)) {
+      const defaultOrderIndex = Object.keys(_formItems).length;
+      onFormItemMount({
+        id,
+        label,
+        el,
+        order: defaultOrderIndex
+      });
+
+      // visually clear the corresponding form field
+      if (_formFields[id]) {
+        relay<FieldsetSetValueRelayDetail>(
+          _formFields[id],
+          FieldsetSetValueMsg,
+          {
+            name: id,
+            value: "",
+          },
+        );
+      }
     }
   }
 

--- a/libs/web-components/src/components/form/Form.svelte
+++ b/libs/web-components/src/components/form/Form.svelte
@@ -40,6 +40,8 @@
     FieldsetBindRelayDetail,
     FieldsetBindMsg,
     FormPageBackMsg, FormStatus,
+    SubFormNewItemMsg,
+    SubFormNewItemRelayDetail,
   } from "../../types/relay-types";
 
   // ========
@@ -173,6 +175,9 @@
           break;
         case FormResetFormMsg:
           resetState();
+          break;
+        case SubFormNewItemMsg:
+          onReRegisterSubFormItem(data as SubFormNewItemRelayDetail);
           break;
       }
     });
@@ -399,6 +404,13 @@
     // reset the active fieldset
     const [id] = Object.entries(_formPages)[0];
     sendToggleActiveStateMsg(id);
+  }
+
+  function onReRegisterSubFormItem(detail: SubFormNewItemRelayDetail) {
+    // Relay to all fieldsets to re-initialize for new subform item
+    for (const { el } of Object.values(_fieldsets)) {
+      relay<SubFormNewItemRelayDetail>(el, SubFormNewItemMsg, detail);
+    }
   }
 
   // *********

--- a/libs/web-components/src/components/form/SubForm.svelte
+++ b/libs/web-components/src/components/form/SubForm.svelte
@@ -26,6 +26,8 @@
     StateChangeEvent, StateChangeRelayDetail, SubFormBindMsg, SubFormBindRelayDetail,
     SubFormIndexContinueToParentMsg,
     SubFormIndexContinueToSubFormMsg,
+    SubFormNewItemMsg,
+    SubFormNewItemRelayDetail,
   } from "../../types/relay-types";
 
   // Subform props
@@ -181,6 +183,19 @@
 
   function onSubFormIndexContinueToSubForm() {
     _mode = "form";
+
+    // Check if this is a mounted form item but not registered on state (2+ sub-form item)
+    const currentItem = _state[_itemIndex];
+    const notOnStateItem = !currentItem || !currentItem.form || Object.keys(currentItem.form).length === 0;
+
+    if (notOnStateItem) {
+      // Send SubFormNewItemMsg for Form -> Fieldset to re-register
+      if (_formEl) {
+        relay<SubFormNewItemRelayDetail>(_formEl, SubFormNewItemMsg, {
+          itemIndex: _itemIndex
+        });
+      }
+    }
   }
 
   function onSubFormIndexContinueToParent() {

--- a/libs/web-components/src/types/relay-types.ts
+++ b/libs/web-components/src/types/relay-types.ts
@@ -84,6 +84,12 @@ export const SubFormIndexContinueToParentMsg = "subform::indexContinueToParent";
 export const SubFormIndexContinueToSubFormMsg =
   "subform::indexContinueToSubForm";
 
+// New message for initializing new subform items
+export const SubFormNewItemMsg = "subform::newItem";
+export type SubFormNewItemRelayDetail = {
+  itemIndex: number;
+};
+
 // ========
 // Fieldset
 // ========


### PR DESCRIPTION
# Before (the change)
When we add a 2nd sub item, and no matter what we fill in the value, it returns as null for the below error message:

<img width="1624" height="1512" alt="image" src="https://github.com/user-attachments/assets/b5e2333c-3e82-454b-8bbe-5655e0b68f9c" />


Also when we add the second item, the text field always has the value from the first sub item.

# After (the change)

- [ ] When we add the 2nd item of the sub-form, the text field isn't being filled with the previous value
- [ ] No error and we can see 2nd item in the summary and table/state

https://github.com/user-attachments/assets/2dec0d15-5e00-4e80-b957-7dfe4d2066fb

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
https://stackblitz.com/~/github.com/vanessatran-ddi/ui-components-angular-sandbox/tree/lts-public-form-sub-form-bug?file=src/app/public-form/SupportOrderDetails.html

We can re-use the above code to test.



### So what is the problem:

When we first load the page, this is how the state being initialized:

1
1. `Input.svelte` sends `FormFieldMountMsg` (`relay`)
2. `FormItem.svelte` sends `FormItemMountMsg`
3. `Fieldset.svelte` listens to `FormItemMountMsg` and triggers `onFormFieldMount(data as FormFieldMountRelayDetail)` which init the state 

```
function onFormFieldMount(detail: FormFieldMountRelayDetail) {
    const { name, el } = detail;
    if (!name) return;

    _formFields[name] = el;
  }
```

### Why isn't the `FormItemMountMsg` being sent for the second sub form item?
1. The `FormItem` isn't remounted again.
2. The SubForm just changes the `mode` in order to show the fieldset. 
3. The state becomes null and it throws an error at function https://github.com/GovAlta/ui-components/blob/alpha/libs/web-components/src/components/form/Fieldset.svelte#L293 



### What I fixed:

Because there is a miss-communication between `Fieldset.svelte` to create/init state and `FormItem.svelte` when 2nd onward subform item added, so I fill the gap by:  SubForm when adding a 2nd sub item -> Form -> Fieldset(s) -> remount itself and reset the input value (so no more auto-fill value from the previous sub-form item)

1. I created a new message `SubFormNewItemMsg`
2. SubForm.svelte I relay this message when I add a 2nd sub form item
3. Form.svelte I listen to this message and I will relay this `SubFormNewItemMsg`
4. Fieldset.svelte, I listen to this new message `SubFormNewItemMsg` and then I remount myself and clear the value (`FieldsetSetValueMsg`) so `Input.svelte` or `Dropdown.svelte`... will reset its value.

