### PR TITLE
fix(#2922): properly size Form Steps on mobile

### DIFF
--- a/libs/web-components/src/components/form-step/FormStep.svelte
+++ b/libs/web-components/src/components/form-step/FormStep.svelte
@@ -37,6 +37,7 @@
 
   let _rootEl: HTMLElement;
   let _isMobile: boolean;
+  let _isLoading: boolean = true;
   let _userInitiatedChange = false;
 
   // ========
@@ -51,6 +52,7 @@
     _rootEl.addEventListener("form-stepper:resized", (e: Event) => {
       const { mobile } = (e as CustomEvent).detail;
       _isMobile = mobile;
+      _isLoading = false; // Mark as loaded after receiving resize info
     });
 
     // receive parent el information
@@ -174,6 +176,7 @@
   class="step-container"
   class:mobile={_isMobile}
   class:desktop={!_isMobile}
+  class:loading={_isLoading}
   class:last={_isLast}
   role="listitem"
   data-status={status}
@@ -234,6 +237,10 @@
     height: 100%;
     width: 100%;
     padding: var(--goa-step-padding);
+  }
+
+  .step-container.loading {
+    display: none;
   }
 
   .step-container:focus-within:not([aria-current="step"]) {

--- a/libs/web-components/src/components/form-stepper/FormStepper.svelte
+++ b/libs/web-components/src/components/form-stepper/FormStepper.svelte
@@ -125,6 +125,8 @@
       }
 
       _bindTimeoutId = setTimeout(() => {
+        const width = _gridEl?.offsetWidth ?? 0;
+        dispatchStepResize(width);
         bindChildren();
         calcStepDimensions();
         addClickListener();
@@ -181,19 +183,7 @@
       calcStepDimensions();
 
       const width = entries[0].contentRect.width;
-
-      for (const step of _steps) {
-        step.el.dispatchEvent(
-          new CustomEvent("form-stepper:resized", {
-            bubbles: true,
-            composed: true,
-            detail: {
-              testid,
-              mobile: width < MOBILE_BP,
-            },
-          }),
-        );
-      }
+      dispatchStepResize(width);
     });
   }
 
@@ -251,6 +241,23 @@
       }),
     );
   }
+
+  function dispatchStepResize(width: number) {
+    if (!_steps.length) return;
+
+    for (const step of _steps) {
+      step.el.dispatchEvent(
+        new CustomEvent("form-stepper:resized", {
+          bubbles: true,
+          composed: true,
+          detail: {
+            testid,
+            mobile: width < MOBILE_BP,
+          },
+        }),
+      );
+    }
+  }
 </script>
 
 <div id="container">
@@ -272,9 +279,7 @@
       <progress class="vertical" value={_progress} max="100"></progress>
     {/if}
     <div class="slots" bind:this={_gridEl}>
-      <goa-grid minchildwidth="10ch">
         <slot />
-      </goa-grid>
     </div>
   </div>
 </div>
@@ -321,8 +326,13 @@
     .form-stepper {
       position: relative;
     }
-  }
 
+    .slots {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(10ch, 1fr));
+      gap: var(--goa-space-m);
+    }
+  }
 
   /* 1.25rem = 20px = 40px / 2, half the height of the 40px stepper */
   progress.vertical {
@@ -343,6 +353,12 @@
     }
     .form-stepper {
       display: block;
+    }
+
+    .slots {
+      display: flex;
+      flex-direction: column;
+      gap: var(--goa-space-m);
     }
   }
 


### PR DESCRIPTION
This PR addresses https://github.com/GovAlta/ui-components/issues/2922.

I noticed two issues:
1. The Form Stepper uses the Grid component to size the steps. But the grid uses the viewport, not the container, to decide if the columns should be stacked. A Stepper in a mobile-sized container but a desktop-sized viewport will appear broken.
2. The Form Step has an `_isMobile` variable which is only defined when the Form Stepper is resized. The variable is `undefined` on mount so the Form Step defaults to Desktop.

I decided to fix the issues with two changes:
1. Replace the Grid component with a custom CSS grid which uses the container query.
2. Fire the `form-stepper:resized` event on mount so that the `_isMobile` variable is defined on every Step.

### Before

1. The Stepper layout appears broken on mobile on load for mobile.
3. The layout also appears broken when the container is mobile sized but the viewport is desktop sized.

![stepper-broken-boo](https://github.com/user-attachments/assets/242dd2e8-190d-402a-a5db-83349a10110a)

### After

1. The Stepper layout appears correct on load for mobile.
2. The layout also appears correct when the container is mobile sized but the viewport is desktop sized.

![stepper-fixed-with-gap-better-yeah](https://github.com/user-attachments/assets/a7688da5-d3c9-4eb3-961f-df0c3bb3c0f8)

### Test code

```html
<div style="margin: 12px; padding: 24px;width:360px;border:1px solid #ccc;">
    <goa-form-stepper step="step">
    <goa-form-step text="Crisis response and safety planning" status="complete"></goa-form-step>
    <goa-form-step text="Basic needs and accomodation" status="incomplete"></goa-form-step>
    <goa-form-step text="Case management and system needs"></goa-form-step>
    <goa-form-step text="Child, youth, and family support"></goa-form-step>
    <goa-form-step text="Review and submit"></goa-form-step>
    </goa-form-stepper>
    <goa-pages current="step" mb="3xl">
        <div>Page 1 content</div>
        <div>Page 2 content</div>
        <div>Page 3 content</div>
        <div>Page 4 content</div>
    </goa-pages>
</div>

``` 
