### PR TITLE
chore: correct vite config to allow devcontainer to work

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:24",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/_templates/react/vite.config.ts
+++ b/_templates/react/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 
   server: {
     port: 4200,
-    host: "localhost",
+    host: "0.0.0.0",
   },
 
   preview: {

--- a/_templates/web/vite.config.mts
+++ b/_templates/web/vite.config.mts
@@ -9,7 +9,7 @@ export default defineConfig({
 
   server: {
     port: 4200,
-    host: "localhost",
+    host: "0.0.0.0",
   },
 
   preview: {


### PR DESCRIPTION
Previous commit had incorrect server settings for Vite config files,
which prevented the devcontainer from being accessible via the browser.# Before (the change)

# After (the change)

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
