### PR TITLE
Chore(#2959): Add instructions for GitHub Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,29 @@
+# Project Overview
+This project contains the Government of Alberta UI components.
+
+## Libraries and Frameworks
+- Components are built with Svelte.
+- Angular and React wrappers are provided for each component.
+
+## Folder Structure
+- `libs/web-components/src/components/`: Contains Svelte components.
+- `libs/angular-components/src/lib/components/`: Contains Angular components.
+- `libs/react-components/src/lib/`: Contains React components.
+
+## Commits & Pull Requests
+- Use Conventional Commits format for commit messages.
+- Use the present tense.
+- Use the imperative mood.
+- Limit the first line to 72 characters or less.
+- Start the commit message with a reference to the GitHub Issue number, such as `feat(#1234):`
+- If the commit relates to an issue, include "Closes #ISSUE_NUMBER" in the commit message.
+- If the commit relates to a breaking change, include "BREAKING CHANGE:" in the commit message.
+
+## Pull Requests
+- Only add a single commit to a Pull Request.
+- Start the Pull Request title with a reference to the GitHub Issue number, such as `feat(#1234):`
+
+## CSS and Design Tokens
+- Use CSS custom properties that are defined by our design tokens.
+- Name custom properties for global styles in this format: `--goa-[category]-[name]`, such as `--goa-color-primary`.
+- Name custom properties for component-specific styles in this format: `--goa-[component]-[category]-[name]`.


### PR DESCRIPTION
This PR adds initial instruction files for GitHub Copilot to use. Topics include...

- How our components are structured
- How we use design tokens and CSS custom properties
- How we write commits and pull requests
- General coding guidelines

I've created a test PR using these instruction files: https://github.com/GovAlta/ui-components/pull/2965

These instruction files will guide Copilot in the `ui-components` repo both locally and online. We can continue to update them as we learn.

I've kept the instructions brief to align with the guidelines:

> The instructions you add to your custom instruction file(s) should be short, self-contained statements that provide Copilot with relevant information to help it work in this repository. Because the instructions are sent with every chat message, they should be broadly applicable to most requests you will make in the context of the repository.

### Questions

- Am I missing any key instructions?
- Could I improve the clarity of any of my instructions?
- Are any of my instructions incorrect or anti-patterns?

### How to test

1. Set up GitHub Copilot with your IDE of choice
2. Check that `Copilot > Use Instructions Files` is enabled in your IDE settings
3. Open Copilot chat
4. Switch to Agent mode
5. Prompt Copilot to work on a GitHub Issue. For example: "Fix this issue in GitHub: https://github.com/GovAlta/ui-components/issues/1547"

If it works, you should see the instruction files in the list of references:
<img width="620" height="210" alt="image" src="https://github.com/user-attachments/assets/a77ad06a-10a0-4f3a-9b88-663117ae5dab" />

### Additional reading
- https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions#using-one-or-more-instructionsmd-files