### PR TITLE
remove unwanted saving of state on fieldset change handling

### DIFF
--- a/libs/web-components/src/components/form/Fieldset.svelte
+++ b/libs/web-components/src/components/form/Fieldset.svelte
@@ -292,9 +292,6 @@
     if (!_formItems[name]) {
       return;
     }
-    if (!_formFields[name]) {
-      return;
-    }
 
     _state[name].value = value;
 

--- a/libs/web-components/src/components/form/Form.svelte
+++ b/libs/web-components/src/components/form/Form.svelte
@@ -260,8 +260,6 @@
 
     // updating form state with the fieldset specific data
     _state.form[id] = { heading: state.heading, data: { type: "details", fieldsets: state.data } };
-
-    dispatchStateChange();
   }
 
   /**


### PR DESCRIPTION
# Before (the change)

Any entered invalid data would be immediately saved to the main form's state, which, through reloading the page after the invalid data was entered, allowed the user to be shown the form summary page with the data in an invalid state, thereby skipping the validation

# After (the change)

Invalid state it no longer being saved, so if the user refreshes the browser after entering invalid data after clicking the "Change" link, the summary page will be shown, but with the data in the state that it was in prior to when the invalid data was entered.

## Steps needed to test

Have a form with at least one "input" like item in it that has some validation attached to it. Enter data into the form field and then proceed to the summary page. Click the "Change" link on the page then enter some invalid data into the form field and click "Continue". Once the error messages are shown on the page reload the page. You should then see the form summary with the original (valid) data.
