### PR TITLE
fix(#2682): DatePicker input type can be disabled

### DIFF
--- a/libs/react-components/src/lib/date-picker/date-picker.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef, type JSX } from "react";
-import { GoabDatePickerInputType, GoabDatePickerOnChangeDetail, Margins } from "@abgov/ui-components-common";
+import {
+  GoabDatePickerInputType,
+  GoabDatePickerOnChangeDetail,
+  Margins,
+} from "@abgov/ui-components-common";
 
 interface WCProps extends Margins {
   ref: React.RefObject<HTMLElement | null>;
@@ -25,7 +29,7 @@ declare module "react" {
 
 export interface GoabDatePickerProps extends Margins {
   name?: string;
-  value?: Date;
+  value?: Date | string | undefined;
   error?: boolean;
   min?: Date;
   max?: Date;

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -353,6 +353,7 @@
           on:_change={onInputChange}
           {error}
           value={_inputDate.month + ""}
+          disabled={isDisabled}
         >
           <goa-dropdown-item value="0" label="January" />
           <goa-dropdown-item value="1" label="February" />
@@ -379,6 +380,7 @@
           max="31"
           {error}
           testid="day-input"
+          disabled={isDisabled}
         />
       </goa-form-item>
       <goa-form-item helptext="Year (YYYY)">
@@ -392,6 +394,7 @@
           max="2200"
           {error}
           testid="year-input"
+          disabled={isDisabled}
         />
       </goa-form-item>
     </goa-block>


### PR DESCRIPTION
# Before (the change)

When the DatePicker was disabled, if you had the `type` property set to `input`, it wouldn't appear or behave as disabled.

Also, for React, the only valid value type was `Date`, this conflicted with the allowed values in `GoabDatePickerOnChangeDetail`.

# After (the change)

If you set Date Picker to disabled and `type` to `input`, the 3 separate inputs will now be disabled correctly.

Also, you can now supply `Date`, `string`, or undefined to the `value` property in React. This doesn't actually have any affect at the moment, because the DatePicker component doesn't actually convert strings into actual Dates, but at least it doesn't error like it would have in the past.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

### Angular

```html
<goab-form-item label="Date Picker w/ Input Style" mb="l">
  <goab-date-picker type="input" (onChange)="onChange($event)" [disabled]="true" />
</goab-form-item>
```

### React

```typescript
const [datePickerValue, setDatePickerValue] = useState<Date | string | undefined>(
    "2025-01-01",
  );

<GoabFormItem label="Date Picker w/ Input Style" mb="l">
  <GoabDatePicker type="input" onChange={onChange} value={datePickerValue} />
</GoabFormItem>
```

