### PR TITLE
spike(#3040): web component with version property

### DIFF
--- a/libs/web-components/src/components/callout/Callout.svelte
+++ b/libs/web-components/src/components/callout/Callout.svelte
@@ -19,20 +19,16 @@
     "medium",
     "large",
   ]);
-  const [CalloutEmphasis, validateCalloutEmphasis] = typeValidator("Callout emphasis", [
-    "high",
-    "medium",
-    "low",
-  ]);
+  const [CalloutEmphasis, validateCalloutEmphasis] = typeValidator(
+    "Callout emphasis",
+    ["high", "medium", "low"],
+  );
   const [AriaLive, validateAriaLive] = typeValidator("Aria live", [
     "off",
     "assertive",
     "polite",
   ]);
-  const [Version, validateVersion] = typeValidator("Version", [
-    "1",
-    "2",
-  ]);
+  const [Version, validateVersion] = typeValidator("Version", ["1", "2"]);
 
   // Types
   type CalloutType = (typeof Types)[number];
@@ -108,11 +104,7 @@
 >
   {#if version === "1"}
     <span class="icon {type}">
-      <goa-icon
-        type={iconType}
-        size={iconSize}
-        theme={icontheme}
-      />
+      <goa-icon type={iconType} size={iconSize} theme={icontheme} />
     </span>
   {/if}
   <span class="content {type}">
@@ -251,9 +243,6 @@
     padding: var(--goa-callout-m-statusbar-padding);
   }
 
-
-
-
   /* Version two */
 
   .v2 .heading {
@@ -296,11 +285,10 @@
 
   .v2.information.emphasis-high .heading {
     background-color: var(--goa-callout-info-color-bg-heading-h);
-    color: var(--goa-color-text-light)
+    color: var(--goa-color-text-light);
   }
 
   .v2.information.emphasis-high .body {
     background-color: var(--goa-callout-info-color-bg-content-h);
   }
-
 </style>


### PR DESCRIPTION
[Watch a video overview](https://abgov-my.sharepoint.com/:v:/g/personal/benjamin_franck_gov_ab_ca/EdnHEVkEZVJOm0ts0qN8YoABw24M9mXwpYNeWZzNH_bCSw?e=MQ0Uz0&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D
)

This PR demonstrates a way to have both versions of our web components in our existing Svelte components. It uses the callout component because it has a new property and a different layout.

The PR demonstrates the following changes to the web component:

- Adds a `version` property with two values: `1` and `2`
- Defaults to `1`
- Adds `emphasis` property for version 2
- Adds styling for new layouts and states scoped to a `.v2` class
- Uses `version` property for layout changes

### Assumptions

- There is an updated version of design tokens with the new values
- The new experimental React & Angular wrappers would have `version=2`
- Current React & Angular wrappers default to version 1

## Trade-offs

- You cannot mix v1 and v2 components

## Design tokens

- The new tokens are available in this branch: https://github.com/bdfranck/design-tokens/tree/version-two
- The new CSS variables are in this Gist: https://gist.github.com/bdfranck/dc9806910ebfa22e7a3b9550c79ab510

## Web component test code
```html
<div style="margin: 1rem;">
  <goa-callout version="1" type="information">Version 1 Content</goa-callout>
  <goa-callout version="2" type="information" heading="This is the heading">Version 2 Content</goa-callout>
</div>
```

To test the the version 2 paste the following into the index.html file at the top of the body tag
```html
  <style>
    :root {
      --goa-callout-important-icon-color-l: #CC9300;
      --goa-callout-important-icon-color-m: #cc9300;
      --goa-callout-important-icon-color-h: #333333;
      --goa-callout-info-icon-color-l: #0077ad;
      --goa-callout-info-icon-color-m: #0077ad;
      --goa-callout-success-color-bg-content-l: #edfcf0;
      --goa-callout-success-color-bg-content-h: #edfcf0;
      --goa-callout-success-color-bg-heading-l: #edfcf0;
      --goa-callout-important-color-bg-heading: #fff1cc;
      --goa-callout-important-color-bg-heading-h: #ffb800;
      --goa-callout-info-color-bg-heading-h: #0077ad;
      --goa-callout-emergency-border-color-l: #f4c8c5;
      --goa-callout-emergency-border-color-m: #e1dedd;
      --goa-callout-emergency-border-color-h: #f4c8c5;
      --goa-callout-success-border-color-l: #cceae1;
      --goa-callout-success-border-color-m: #e1dedd;
      --goa-callout-success-border-color-h: #cceae1;
      --goa-callout-important-border-color-l: #fde3a1;
      --goa-callout-important-border-color-m: #e1dedd;
      --goa-callout-important-border-color-h: #fde3a1;
      --goa-callout-info-border-color-l: #98d4ee;
      --goa-callout-info-border-color-h: #98d4ee;
      --goa-callout-emergency-border-color: none;
      --goa-callout-emergency-color-bg-heading: #fdded9;
      --goa-callout-success-border-color: none;
      --goa-callout-success-color-bg-heading: #d8f7e6;
      --goa-callout-warning-border-color: none;
      --goa-callout-info-border-color: #e1dedd;
      --goa-callout-info-color-bg-heading: #cbeaf7;
      --goa-callout-emergency-icon-color-l: var(--goa-color-emergency-default);
      --goa-callout-emergency-icon-color-m: var(--goa-color-emergency-default);
      --goa-callout-emergency-icon-color-h: var(--goa-color-greyscale-white);
      --goa-callout-success-icon-color-l: var(--goa-color-success-default);
      --goa-callout-success-icon-color-m: var(--goa-color-success-default);
      --goa-callout-success-icon-color-h: var(--goa-color-greyscale-white);
      --goa-callout-info-icon-color-h: var(--goa-color-greyscale-white);
      --goa-callout-emergency-color-bg-content-l: var(--goa-color-emergency-background);
      --goa-callout-emergency-color-bg-content-m: var(--goa-color-greyscale-white);
      --goa-callout-emergency-color-bg-content-h: var(--goa-color-emergency-background);
      --goa-callout-success-color-bg-content-m: var(--goa-color-greyscale-white);
      --goa-callout-important-color-bg-content-l: var(--goa-color-warning-background);
      --goa-callout-important-color-bg-content-m: var(--goa-color-greyscale-white);
      --goa-callout-important-color-bg-content-h: var(--goa-color-warning-background);
      --goa-callout-info-color-bg-content-l: var(--goa-color-info-light);
      --goa-callout-info-color-bg-content-h: var(--goa-color-info-light);
      --goa-callout-emergency-color-bg-heading-l: var(--goa-color-emergency-background);
      --goa-callout-emergency-color-bg-heading-h: var(--goa-color-emergency-default);
      --goa-callout-success-color-bg-heading-h: var(--goa-color-success-default);
      --goa-callout-important-color-bg-heading-l: var(--goa-color-warning-background);
      --goa-callout-info-color-bg-heading-l: var(--goa-color-info-light);
      --goa-callout-event-icon-color: var(--goa-color-greyscale-white);
      --goa-callout-emergency-icon-color: var(--goa-color-greyscale-white);
      --goa-callout-emergency-color-bg-content: var(--goa-color-greyscale-100);
      --goa-callout-success-icon-color: var(--goa-color-greyscale-white);
      --goa-callout-success-color-bg-content: var(--goa-color-greyscale-100);
      --goa-callout-warning-icon-color: var(--goa-color-greyscale-black);
      --goa-callout-warning-color-bg-heading: var(--goa-color-warning-default);
      --goa-callout-warning-color-bg-content: var(--goa-color-greyscale-100);
      --goa-callout-info-icon-color: var(--goa-color-greyscale-white);
      --goa-callout-info-color-bg-content: var(--goa-color-greyscale-white);
      --goa-callout-m-heading-padding: var(--goa-space-s) var(--goa-space-2xs);
      --goa-callout-m-content-gap: var(--goa-space-2xs);
      --goa-callout-m-content-padding: var(--goa-space-none);
      --goa-callout-m-icon-size: var(--goa-icon-size-s);
      --goa-callout-l-heading-padding: var(--goa-space-l) var(--goa-space-s);
      --goa-callout-l-content-gap: var(--goa-space-m);
      --goa-callout-l-content-padding: var(--goa-space-none);
      --goa-callout-l-icon-size: var(--goa-icon-size-m);
      --goa-callout-l-border-width: var(--goa-border-width-s);
      --goa-callout-m-border-width: var(--goa-border-width-s);
      --goa-callout-border-radius: var(--goa-border-radius-xl);
      --goa-callout-m-text-size: var(--goa-typography-body-s);
      --goa-callout-l-heading-size: var(--goa-typography-heading-s);
      --goa-callout-m-heading-size: var(--goa-typography-heading-xs);
      --goa-callout-l-text-size: var(--goa-typography-body-m);
      --goa-callout-l-heading: var(--goa-typography-heading-m);
    }
  </style>

```