### PR TITLE
chore: remove tabindex prop from React popover

### DIFF
--- a/libs/react-components/specs/dropdown.browser.spec.tsx
+++ b/libs/react-components/specs/dropdown.browser.spec.tsx
@@ -12,6 +12,7 @@ describe("Dropdown Component", () => {
   describe("Dropdown", () => {
 
     it("should render with the default props", async () => {
+
       // Setup
 
       const Component = () => {
@@ -294,7 +295,6 @@ describe("Dropdown Component", () => {
 
       const result = render(<Component />);
       const filter = result.getByTestId("input");
-      const itemLocator = result.getByTestId(/^dropdown-item/);
 
       // Actions
 
@@ -469,7 +469,8 @@ describe("Dropdown Component", () => {
       };
 
       const result = render(<Component />);
-      const filter = result.getByRole("combobox");
+      const filter = result.getByTestId("input");
+      const filteredOptions = result.getByRole("option");
 
       // Actions
       await filter.fill("2");
@@ -477,11 +478,11 @@ describe("Dropdown Component", () => {
 
       // Result
       await vi.waitFor(() => {
-        const visibleOptions = result.getByRole("option");
-        expect(visibleOptions.elements().length).toBe(1);
-        const el = visibleOptions.elements()[0] as HTMLElement;
+        expect(filteredOptions.elements().length).toBe(1);
+
+        const el = filteredOptions.elements()[0] as HTMLElement;
         expect(el.getAttribute("data-value")).toBe("2");
-      });
+      }, 2000);
     });
   });
 });

--- a/libs/react-components/src/lib/popover/popover.tsx
+++ b/libs/react-components/src/lib/popover/popover.tsx
@@ -8,7 +8,6 @@ interface WCProps extends Margins {
   position?: GoabPopoverPosition;
   relative?: string;
   testid?: string;
-  tabindex?: number;
 }
 
 declare module "react" {
@@ -28,7 +27,6 @@ export interface GoabPopoverProps extends Margins {
   padded?: boolean;
   position?: GoabPopoverPosition;
   children: ReactNode;
-  tabIndex?: number;
   /***
    * @deprecated This property has no effect and will be removed in a future version
    */
@@ -44,7 +42,6 @@ export function GoabPopover({
   position,
   relative,
   children,
-  tabIndex = -1,
   mt,
   mr,
   mb,
@@ -58,7 +55,6 @@ export function GoabPopover({
       padded={typeof padded === "undefined" ? undefined : padded ? "true" : "false"}
       position={position}
       relative={relative ? "true" : undefined}
-      tabindex={tabIndex}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/web-components/src/components/focus-trap/FocusTrap.svelte
+++ b/libs/web-components/src/components/focus-trap/FocusTrap.svelte
@@ -1,4 +1,14 @@
-<svelte:options customElement="goa-focus-trap" />
+<svelte:options
+  customElement={{
+    tag: "goa-focus-trap",
+    props: {
+      preventScrollIntoView: {
+        attribute: "prevent-scroll-into-view",
+        type: "Boolean",
+      },
+    },
+  }}
+/>
 
 <script lang="ts">
   import { onMount, tick } from "svelte";
@@ -6,6 +16,8 @@
   // Public
   // allow for outside control of whether focus trap should re-focus the first element is open/closed (see Drawer)
   export let open: boolean = false;
+
+  export let preventScrollIntoView: boolean = false;
 
   // Private
 
@@ -150,7 +162,11 @@
     // If the focus element is at the bottom, we want to automatically scroll down to the focused element (when user uses keyboard)
     const focusedElement = e?.target;
 
-    if (focusedElement && focusedElement instanceof HTMLElement) {
+    if (
+      !preventScrollIntoView &&
+      focusedElement &&
+      focusedElement instanceof HTMLElement
+    ) {
       focusedElement.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   }

--- a/libs/web-components/src/components/menu-button/MenuButton.svelte
+++ b/libs/web-components/src/components/menu-button/MenuButton.svelte
@@ -131,6 +131,7 @@
   on:_open={open}
   padded="false"
   tabindex="-1"
+  prevent-scroll-into-view={true}
 >
   <goa-button
     bind:this={_targetEl}

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -8,6 +8,10 @@
         type: "Boolean",
         attribute: "disable-global-close-popover",
       },
+      preventScrollIntoView: {
+        attribute: "prevent-scroll-into-view",
+        type: "Boolean",
+      },
     },
   }}
 />
@@ -34,6 +38,9 @@
   export let minwidth: string = "";
   export let width: string = "";
   export let height: "full" | "wrap-content" = "wrap-content";
+
+  // flag passed to the FocusTrap that will prevent unwanted scrolling
+  export let preventScrollIntoView: boolean = false;
 
   // allows to override the default padding when content needs to be flush with boundries
   export let padded: string = "true";
@@ -401,7 +408,7 @@
         style("padding", _padded ? "var(--goa-space-m)" : "0"),
       )}
     >
-      <goa-focus-trap open="true">
+      <goa-focus-trap open="true" prevent-scroll-into-view={preventScrollIntoView || undefined}>
         <div bind:this={_focusTrapEl}>
           <slot />
         </div>


### PR DESCRIPTION
Just removing the exposed `tabIndex` prop from the React popover that was added in the multiaction button PR
