### PR TITLE
fix: use the proper type for the React MenuButton event

### DIFF
--- a/libs/react-components/specs/menu-button.browser.spec.tsx
+++ b/libs/react-components/specs/menu-button.browser.spec.tsx
@@ -46,7 +46,9 @@ describe("MenuButton", () => {
         await menuAction.click();
 
         // Verify the correct action was triggered
-        expect(onAction).toHaveBeenCalledWith(`action${i}`);
+        expect(onAction).toHaveBeenCalledWith({
+          action: `action${i}`
+        });
       });
     }
   });
@@ -99,7 +101,9 @@ describe("MenuButton", () => {
 
       const firstAction = result.getByTestId("first-action");
       await firstAction.click();
-      expect(onAction).toHaveBeenCalledWith("first");
+      expect(onAction).toHaveBeenCalledWith({
+        action: "first"
+      });
     });
 
     // Click second action
@@ -109,12 +113,14 @@ describe("MenuButton", () => {
 
       const secondAction = result.getByTestId("second-action");
       await secondAction.click();
-      expect(onAction).toHaveBeenCalledWith("second");
+      expect(onAction).toHaveBeenCalledWith({
+        action: "second"
+      });
     });
 
     // Verify the correct number of calls and order
     expect(onAction).toHaveBeenCalledTimes(2);
-    expect(onAction.mock.calls[0][0]).toBe("first");
-    expect(onAction.mock.calls[1][0]).toBe("second");
+    expect(onAction.mock.calls[0][0].action).toBe("first");
+    expect(onAction.mock.calls[1][0].action).toBe("second");
   });
 });

--- a/libs/react-components/src/lib/menu-button/menu-button.tsx
+++ b/libs/react-components/src/lib/menu-button/menu-button.tsx
@@ -6,7 +6,7 @@
  * It also includes TypeScript interfaces for improved type checking and development experience.
  */
 
-import { GoabButtonType } from "@abgov/ui-components-common";
+import { GoabButtonType, GoabMenuButtonOnActionDetail } from "@abgov/ui-components-common";
 import { ReactNode, type JSX, useRef, useEffect } from "react";
 
 /**
@@ -53,7 +53,7 @@ export interface GoabMenuButtonProps {
   text: string;
   type?: GoabButtonType;
   testId?: string;
-  onAction?: (action: string) => void;
+  onAction?: (detail: GoabMenuButtonOnActionDetail) => void;
   children?: ReactNode;
 }
 
@@ -100,8 +100,8 @@ export function GoabMenuButton({
 
     // Event listener for the "_action" event emitted by the Web Component.
     const listener = (e: Event) => {
-      const detail = (e as CustomEvent).detail;
-      onAction(detail.action);
+      const detail = (e as CustomEvent).detail as GoabMenuButtonOnActionDetail;
+      onAction(detail);
     };
 
     current.addEventListener("_action", listener);


### PR DESCRIPTION
Updates the React library's MenuButton to use the same type as Angular does in the `onAction` event handler
