### PR TITLE
fix: ensure popover's button is not visible

### DIFF
--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -437,6 +437,7 @@
     outline: none;
     border: none;
     padding: 0;
+    background-color: transparent;
     width: inherit;
   }
 


### PR DESCRIPTION
The background of the popover button was visible when using a tertiary button as the popover target

```tsx
import { GoabBlock, GoabButton, GoabMenuAction, GoabMenuButton } from "@abgov/react-components";
import { GoabMenuButtonOnActionDetail } from "@abgov/ui-components-common";

export function TestContent() {

  function handleAction(detail: GoabMenuButtonOnActionDetail): void {
    console.log(detail.action)
  }

  return (
    <GoabBlock direction="column">
      <GoabMenuButton text={"Click me"} onAction={handleAction}>
        <GoabMenuAction text={"ACtion 1"} action={"action-1"} />
        <GoabMenuAction text={"ACtion 2"} action={"action-2"} />
        <GoabMenuAction text={"ACtion 3"} action={"action-3"} />
      </GoabMenuButton>

      <GoabMenuButton type="secondary" text={"Click me"} onAction={handleAction}>
        <GoabMenuAction text={"ACtion 1"} action={"action-1"} />
        <GoabMenuAction text={"ACtion 2"} action={"action-2"} />
        <GoabMenuAction text={"ACtion 3"} action={"action-3"} />
      </GoabMenuButton>

      <GoabMenuButton type="tertiary" text={"Click me"} onAction={handleAction}>
        <GoabMenuAction text={"ACtion 1"} action={"action-1"} />
        <GoabMenuAction text={"ACtion 2"} action={"action-2"} />
        <GoabMenuAction text={"ACtion 3"} action={"action-3"} />
      </GoabMenuButton>

      <GoabButton type="primary">Primary</GoabButton>
      <GoabButton type="secondary">Secondary</GoabButton>
      <GoabButton type="tertiary">Tertiary</GoabButton>
    </GoabBlock>
  );
}

```