### PR TITLE
feat(#2936): update Radio component for V2

### DIFF
--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -25,14 +25,18 @@
     FieldsetErrorRelayDetail, FieldsetResetFieldsMsg,
   } from "../../types/relay-types";
 
-  // Validator
+  // Validators
   const [Orientations, validateOrientation] = typeValidator("Radio group orientation", [
     "vertical",
     "horizontal",
   ]);
+  const [Version, validateVersion] = typeValidator("Version", ["1", "2"]);
+  const [Size, validateSize] = typeValidator("Size", ["default", "compact"]);
 
-  // Type
+  // Types
   type Orientation = (typeof Orientations)[number];
+  type VersionType = (typeof Version)[number];
+  type SizeType = (typeof Size)[number];
 
   // Public
 
@@ -41,6 +45,8 @@
   export let orientation: Orientation = "vertical";
   export let disabled: string = "false";
   export let error: string = "false";
+  export let version: VersionType = "1";
+  export let size: SizeType = "default";
   export let testid: string = "";
   export let arialabel: string = "";
   export let mt: Spacing = null;
@@ -55,8 +61,11 @@
   // Reactive
 
   $: isDisabled = toBoolean(disabled);
+  $: isCompact = size === "compact";
   $: {
     isDisabled;
+    version;
+    isCompact;
     bindOptions();
   }
 
@@ -86,6 +95,8 @@
   // Hooks
   onMount(() => {
     validateOrientation(orientation);
+    validateVersion(version);
+    validateSize(size);
     addRelayListener();
     sendMountedMessage();
     getChildren();
@@ -163,6 +174,8 @@
             name,
             checked: props.value === value,
             revealAriaLabel: props.revealAriaLabel,
+            version: version,
+            compact: version === "2" && isCompact,
           },
         }),
       );
@@ -212,6 +225,8 @@
   bind:this={_rootEl}
   style={calculateMargin(mt, mr, mb, ml)}
   class={`goa-radio-group--${orientation}`}
+  class:v2={version === "2"}
+  class:compact={isCompact}
   data-testid={testid}
   role="radiogroup"
   aria-label={arialabel}
@@ -233,11 +248,21 @@
     gap: var(--goa-radio-group-gap-horizontal);
   }
 
+  /* V2 compact size variant - V2-only feature */
+  .goa-radio-group--horizontal.v2.compact {
+    gap: var(--goa-radio-group-gap-horizontal-compact);
+  }
+
   .goa-radio-group--vertical {
     display: flex;
     flex-direction: column;  /* Vertical stacking */
     gap: var(--goa-radio-group-gap-vertical);  /* Adds spacing */
     width: 100%;
+  }
+
+  /* V2 compact size variant - V2-only feature */
+  .goa-radio-group--vertical.v2.compact {
+    gap: var(--goa-radio-group-gap-vertical-compact);
   }
 
   /* Focus styles */


### PR DESCRIPTION
  ## Summary

  Updates the Radio component (RadioGroup + RadioItem) to support V2 design
  system styling while maintaining full backward compatibility with V1. This
   is a **Token+CSS+Logic** implementation due to the fundamental visual
  pattern change requiring DOM structure updates.

  ## Changes

  ### RadioGroup Component

  **New Props**:
  - **`version`** (`"1" | "2"`, default `"1"`): Controls V1 vs V2 styling
  - **`size`** (`"default" | "compact"`, default `"default"`): Controls
  spacing between radio items

  **Size Variants**:
  - Default vertical gap: 16px (unchanged from V1)
  - Compact vertical gap: 12px (new)
  - Default horizontal gap: 32px (increased from 24px)
  - Compact horizontal gap: 24px (new)

  **Implementation**:
  - Version and compact state passed to RadioItem children via event
  messaging
  - Reactive block ensures size/version changes propagate immediately
  - CSS scoped with `.v2.compact` for V2-only features

  ### RadioItem Component

  **Visual Pattern Change (V1 → V2)**:

  **V1 Approach** (Border-Based):
  - Uses thick 7px border to create "filled circle" appearance when checked
  - Simple DOM structure: `.icon` div directly in label

  **V2 Approach** (Border + Inner Dot):
  - Uses thin 1.5px border + separate 16px inner dot element when checked
  - Enhanced DOM structure: `.icon-wrapper` > `.icon` + `.icon-inner`
  (conditional)
  - Inner dot absolutely positioned and centered using `transform:
  translate(-50%, -50%)`

   ## New Props:
  - version (received from RadioGroup): Controls V1/V2 rendering
  - compact (received from RadioGroup): Controls typography sizing

   ### State Styling Updates:

  All interaction states properly tokenized across 12+ combinations:
  - Unchecked: default, hover, focus, hover+focus, disabled
  - Checked: default, hover, focus, hover+focus, disabled
  - Error states: unchecked + checked with all interaction combinations

   ## V2-Specific Features:
  - Inner dot colors: Blue (default), dark blue (hover), grey (disabled),
  red (error)
  - Background colors: Light grey (disabled), light red (error), pink (error
   hover)
  - Gap spacing: 12px icon-to-label (default), 8px (compact)
  - Typography: Medium weight (500), 22px line-height

   ### Size Variants:
  - Default: 18px label, medium weight
  - Compact: 16px label, medium weight

##  Related

  - Parent issue: #2998
  - Component issue: #2936
  - [Design tokens PR for Radio](https://github.com/GovAlta/design-tokens/pull/99)
  - [Figma component](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=56970-509527&t=1GgsV1yGYBGtS0lq-4)

## Testing
Playground page: https://github.com/twjeffery/goa-v2-component-playground/blob/main/src/pages/RadioPage.svelte

## V2
<img width="199" height="138" alt="image" src="https://github.com/user-attachments/assets/43c80f7a-318d-40bb-af61-0f11442f1516" />


## V1
<img width="199" height="138" alt="image" src="https://github.com/user-attachments/assets/20122a29-271b-47d5-bea4-3e75544e362f" />

