### PR TITLE
feat(#2947): update Notification Banner component for V2

### DIFF
--- a/libs/web-components/src/components/notification/Notification.svelte
+++ b/libs/web-components/src/components/notification/Notification.svelte
@@ -17,30 +17,44 @@
     ["assertive", "off", "polite"] as const,
     true,
   );
+  const [EmphasisTypes, validateEmphasis] = typeValidator(
+    "Notification emphasis",
+    ["high", "low"] as const,
+    false,
+  );
 
   // Type
   type NotificationType = (typeof Types)[number];
   type AriaLiveType = (typeof AriaLiveTypes)[number];
+  type EmphasisType = (typeof EmphasisTypes)[number];
 
   export let type: NotificationType = "";
   export let maxcontentwidth = "100%";
   export let arialive: AriaLiveType = "polite";
   export let testid: string = "";
+  export let version: "1" | "2" = "1";
+  export let emphasis: EmphasisType = "high";
+  export let compact: boolean = false;
 
   let show = true;
+
   $: iconType =
     type === "emergency"
       ? "warning"
       : type === "important"
         ? "alert-circle"
-        : type === "information"
+        : type === "information" || type === "event"
           ? "information-circle"
-          : type === "event"
-            ? "calendar"
-            : "";
+          : "";
+
+  $: iconInverted =
+    type === "important" ? "false" : emphasis === "high" ? "true" : "false";
+
+  $: iconTheme = emphasis === "low" ? "filled" : "outline";
 
   onMount(() => {
     validateAriaLiveType(arialive);
+    validateEmphasis(emphasis);
     setTimeout(() => validateType(type), 1);
   });
 
@@ -53,10 +67,15 @@
 
 <!-- HTML -->
 {#if show}
-  <div id="container" data-testid={testid}>
+  <div
+    id="container"
+    data-testid={testid}
+    class:v2={version === "2"}
+    class:compact={version === "2" && compact}
+  >
     <div
       transition:fade
-      class="notification {type}"
+      class="notification {type} {emphasis}"
       style={`--max-content-width: ${maxcontentwidth}`}
     >
       <div
@@ -68,7 +87,8 @@
         <div class="icon">
           <goa-icon
             type={iconType}
-            inverted={type === "important" ? "false" : "true"}
+            inverted={iconInverted}
+            theme={iconTheme}
           />
         </div>
         <div class="content">
@@ -79,7 +99,7 @@
           <button class={type} on:click={close}>
             <goa-icon
               type="close"
-              inverted={type === "important" ? "false" : "true"}
+              inverted={iconInverted}
               theme="filled"
             />
           </button>
@@ -160,18 +180,23 @@
     font: var(--goa-notification-banner-text-size);
   }
 
+  /* V2: Improved vertical alignment with icon */
+  .v2 .content {
+    margin-top: 4px;
+  }
+
   :global(::slotted(a)) {
     color: unset !important;
     outline: unset !important;
   }
   :global(::slotted(a:focus)) {
     outline: auto !important;
-    border-radius: var(--goa-border-radius-m);
+    border-radius: var(--goa-border-radius-xs);
   }
   .notification.important :global(::slotted(a:focus)) {
     outline: unset !important;
     box-shadow: 0 0 0 3px var(--goa-color-greyscale-black);
-    border-radius: var(--goa-border-radius-m);
+    border-radius: var(--goa-border-radius-xs);
   }
 
   /*Close Buttons*/
@@ -185,7 +210,7 @@
     padding: var(--goa-space-2xs);
     margin: 0;
     outline: none;
-    border-radius: var(--goa-border-radius-m);
+    border-radius: var(--goa-border-radius-xs);
     display: inline-flex;
     transition: transform 100ms ease-in-out;
   }
@@ -227,5 +252,173 @@
   }
   .close button.emergency:focus-visible {
     box-shadow: 0 0 0 3px var(--goa-color-greyscale-white);
+  }
+
+  /* V2 Styling */
+
+  /* Compact mode spacing */
+  .v2.compact .notification {
+    padding-top: var(--goa-notification-banner-padding-tb-compact);
+    padding-bottom: var(--goa-notification-banner-padding-tb-compact);
+  }
+
+  .v2.compact .content-container {
+    gap: var(--goa-notification-banner-gap-compact);
+  }
+
+  @container self (--not-mobile) {
+    .v2.compact .notification {
+      padding-left: var(--goa-notification-banner-padding-lr-medium-screen-compact);
+      padding-right: var(--goa-notification-banner-padding-lr-medium-screen-compact);
+    }
+  }
+
+  @container self (--desktop) {
+    .v2.compact .notification {
+      padding-left: var(--goa-notification-banner-padding-lr-large-screen-compact);
+      padding-right: var(--goa-notification-banner-padding-lr-large-screen-compact);
+    }
+  }
+
+  /* V2 emphasis-based colors - Information */
+  .v2 .notification.information.high {
+    background-color: var(--goa-notification-banner-information-high-color-bg);
+    color: var(--goa-notification-banner-information-high-color-text);
+  }
+
+  .v2 .notification.information.low {
+    background-color: var(--goa-notification-banner-information-low-color-bg);
+    color: var(--goa-notification-banner-information-low-color-text);
+    border: var(--goa-border-width-s) solid var(--goa-notification-banner-information-low-color-border);
+  }
+
+  /* V2 emphasis-based colors - Important */
+  .v2 .notification.important.high {
+    background-color: var(--goa-notification-banner-important-high-color-bg);
+    color: var(--goa-notification-banner-important-high-color-text);
+  }
+
+  .v2 .notification.important.low {
+    background-color: var(--goa-notification-banner-important-low-color-bg);
+    color: var(--goa-notification-banner-important-low-color-text);
+    border: var(--goa-border-width-s) solid var(--goa-notification-banner-important-low-color-border);
+  }
+
+  /* V2 emphasis-based colors - Emergency */
+  .v2 .notification.emergency.high {
+    background-color: var(--goa-notification-banner-emergency-high-color-bg);
+    color: var(--goa-notification-banner-emergency-high-color-text);
+  }
+
+  .v2 .notification.emergency.low {
+    background-color: var(--goa-notification-banner-emergency-low-color-bg);
+    color: var(--goa-notification-banner-emergency-low-color-text);
+    border: var(--goa-border-width-s) solid var(--goa-notification-banner-emergency-low-color-border);
+  }
+
+  /* V2 close button icon colors */
+  .v2 .notification.information.high .close button goa-icon {
+    color: var(--goa-notification-banner-information-high-color-text);
+  }
+
+  .v2 .notification.information.low .close button goa-icon {
+    color: var(--goa-color-info-dark);
+  }
+
+  .v2 .notification.important.high .close button goa-icon {
+    color: var(--goa-notification-banner-important-high-color-text);
+  }
+
+  .v2 .notification.important.low .close button goa-icon {
+    color: var(--goa-color-important-text-dark);
+  }
+
+  .v2 .notification.emergency.high .close button goa-icon {
+    color: var(--goa-notification-banner-emergency-high-color-text);
+  }
+
+  .v2 .notification.emergency.low .close button goa-icon {
+    color: var(--goa-color-emergency-dark);
+  }
+
+  /* V2 close button hover and focus background colors */
+  .v2 .notification.information.high .close button:hover,
+  .v2 .notification.information.high .close button:focus-visible {
+    background-color: var(--goa-notification-banner-information-high-close-bg-hover);
+  }
+
+  .v2 .notification.information.low .close button:hover,
+  .v2 .notification.information.low .close button:focus-visible {
+    background-color: var(--goa-notification-banner-information-low-close-bg-hover);
+  }
+
+  .v2 .notification.important.high .close button:hover,
+  .v2 .notification.important.high .close button:focus-visible {
+    background-color: var(--goa-notification-banner-important-high-close-bg-hover);
+  }
+
+  .v2 .notification.important.low .close button:hover,
+  .v2 .notification.important.low .close button:focus-visible {
+    background-color: var(--goa-notification-banner-important-low-close-bg-hover);
+  }
+
+  .v2 .notification.emergency.high .close button:hover,
+  .v2 .notification.emergency.high .close button:focus-visible {
+    background-color: var(--goa-notification-banner-emergency-high-close-bg-hover);
+  }
+
+  .v2 .notification.emergency.low .close button:hover,
+  .v2 .notification.emergency.low .close button:focus-visible {
+    background-color: var(--goa-notification-banner-emergency-low-close-bg-hover);
+  }
+
+  /* V2 contrast-based focus borders */
+  .v2 .notification.information.high .close button:focus-visible {
+    box-shadow: var(--goa-notification-banner-information-high-focus-border);
+  }
+
+  .v2 .notification.information.low .close button:focus-visible {
+    box-shadow: var(--goa-notification-banner-information-low-focus-border);
+  }
+
+  .v2 .notification.important.high .close button:focus-visible {
+    box-shadow: var(--goa-notification-banner-important-high-focus-border);
+  }
+
+  .v2 .notification.important.low .close button:focus-visible {
+    box-shadow: var(--goa-notification-banner-important-low-focus-border);
+  }
+
+  .v2 .notification.emergency.high .close button:focus-visible {
+    box-shadow: var(--goa-notification-banner-emergency-high-focus-border);
+  }
+
+  .v2 .notification.emergency.low .close button:focus-visible {
+    box-shadow: var(--goa-notification-banner-emergency-low-focus-border);
+  }
+
+  /* V2 link focus states */
+  .v2 .notification.important.high :global(::slotted(a:focus)) {
+    box-shadow: var(--goa-notification-banner-important-high-focus-border);
+  }
+
+  .v2 .notification.important.low :global(::slotted(a:focus)) {
+    box-shadow: var(--goa-notification-banner-important-low-focus-border);
+  }
+
+  .v2 .notification.information.high :global(::slotted(a:focus)) {
+    box-shadow: var(--goa-notification-banner-information-high-focus-border);
+  }
+
+  .v2 .notification.information.low :global(::slotted(a:focus)) {
+    box-shadow: var(--goa-notification-banner-information-low-focus-border);
+  }
+
+  .v2 .notification.emergency.high :global(::slotted(a:focus)) {
+    box-shadow: var(--goa-notification-banner-emergency-high-focus-border);
+  }
+
+  .v2 .notification.emergency.low :global(::slotted(a:focus)) {
+    box-shadow: var(--goa-notification-banner-emergency-low-focus-border);
   }
 </style>


### PR DESCRIPTION
## Summary

Updates the Notification Banner component to support V2 design system with emphasis-based variants (High/Low emphasis), compact sizing, and enhanced accessibility while maintaining full backward compatibility with V1.

  ## Changes

  ### New Props

  - **`version`** (`"1" | "2"`, default `"1"`): Controls V1 vs V2 styling
  - **`emphasis`** (`"High" | "Low"`, optional): Controls emphasis level for V2 variants
    - High: Bold colors (dark/colored backgrounds, white or dark text)
    - Low: Subtle styling (light backgrounds, colored text, borders)
    - Defaults to "High" when `version="2"` and emphasis not specified
  - **`compact`** (`boolean`, default `false`): Enables compact spacing (V2 only)
    - Reduces gap: 16px → 8px
    - Reduces padding: 24px → 16px (top/bottom)
    - Responsive padding reductions at all breakpoints

  ### V2 Features

  #### 1. Emphasis-Based Styling (6 Variants)

  **Information:**
  - **High**: Blue background (#0077ad), white text, outline icon (inverted)
  - **Low**: Light blue background (#cbeaf7), blue text, filled icon, border

  **Important:**
  - **High**: Yellow background (#f9ce2d), dark brown text (#4d3700), outline icon
  - **Low**: Light yellow background (#fef2c8), brown text (#8d6500), filled icon, border

  **Emergency:**
  - **High**: Red background (#da291c), white text, outline icon (inverted)
  - **Low**: Light red background (#eeaea5), dark red text (#a91a10), filled icon, border

  #### 2. Icon Behavior

  **Icon Inversion Logic:**
  - **V1**: All icons inverted (white) except important (black)
  - **V2 High emphasis**: All icons inverted except important (uses dark brown)
  - **V2 Low emphasis**: No icons inverted (all use default colors)

  **Icon Theme:**
  - **V1**: All icons outline
  - **V2 High emphasis**: All icons outline
  - **V2 Low emphasis**: All icons filled (new GoA icon `theme` prop)

  #### 3. Smart Defaults (`effectiveEmphasis` Pattern)

  **Problem solved**: When `version="2"` but `emphasis` not specified, CSS selectors fail without a `.high` or `.low` class.

  **Solution**: Default `emphasis` to `"High"` automatically for V2:
```
  $: effectiveEmphasis = version === "2" && !emphasis ? "High" : emphasis;
```

  Benefits:
  - Keeps emphasis prop optional (better API)
  - V2 always has a valid emphasis level
  - V1 remains unchanged (emphasis stays undefined)
  - Prevents CSS selector mismatch

  #### 4. Soft Deprecation: type="event"

  V2 silently maps type="event" to type="information":
  - V1: type="event" displays calendar icon with info colors
  - V2: type="event" automatically becomes information (no breaking change)
  - Non-breaking migration path for existing implementations

  #### 5. Compact Spacing

  Default spacing:
  - Gap: 16px
  - Padding (top/bottom): 24px
  - Padding (responsive): 16px/24px/64px by breakpoint

  Compact spacing (compact={true}):
  - Gap: 8px (50% reduction)
  - Padding (top/bottom): 16px (33% reduction)
  - Padding (responsive): 8px/16px/32px (50% reduction)


 ####  Related
  - Parent issue: #2998
  - Component issue: #2947
  - [Design tokens PR for Notification Banner](https://github.com/GovAlta/design-tokens/pull/100)
  - [V2 Figma component](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=56970-485993&t=1GgsV1yGYBGtS0lq-4)

## Testing
Playground page for testing: https://github.com/twjeffery/goa-v2-component-playground/blob/main/src/pages/AccordianPage.svelte

### v2
<img width="792" height="150" alt="image" src="https://github.com/user-attachments/assets/2f178d2b-17f6-4ac6-bbe7-0dc06b5b602e" />
<img width="845" height="596" alt="image" src="https://github.com/user-attachments/assets/61fce687-d60b-4271-a90c-b244434f99fa" />


### v1
<img width="763" height="150" alt="image" src="https://github.com/user-attachments/assets/8a6c07e1-c2b5-4404-9aa7-8974d7d44d3b" />
<img width="845" height="596" alt="image" src="https://github.com/user-attachments/assets/c078bd3a-b062-405a-a57e-a2978e5d347b" />

