### PR TITLE
feat(#2956): update Link component for V2

### DIFF
--- a/libs/web-components/src/components/link/Link.svelte
+++ b/libs/web-components/src/components/link/Link.svelte
@@ -15,7 +15,8 @@
 
   export let leadingicon: GoAIconType | null = null;
   export let trailingicon: GoAIconType | null = null;
-  export let color: "interactive" | "light" = "interactive";
+  export let color: "interactive" | "dark" | "light" = "interactive";
+  export let size: "xsmall" | "small" | "medium" | "large" = "medium";
 
   export let action: string = "";
   export let actionArg: string = "";
@@ -29,6 +30,13 @@
   export let ml: Spacing = null;
 
   let _rootEl: HTMLElement;
+
+  $: _iconSize = {
+    xsmall: "2xsmall", // 12px
+    small: "xsmall", // 16px
+    medium: "small", // 18px
+    large: "medium", // 20px
+  }[size];
 
   onMount(() => {
     if (action) {
@@ -45,21 +53,23 @@
 <div
   class="link"
   class:interactive={color === "interactive"}
+  class:dark={color === "dark"}
   class:light={color === "light"}
+  class:xsmall={size === "xsmall"}
+  class:small={size === "small"}
+  class:medium={size === "medium"}
+  class:large={size === "large"}
   bind:this={_rootEl}
   style={styles(calculateMargin(mt, mr, mb, ml))}
   data-testid={testid}
 >
-  {#if leadingicon}<goa-icon data-testid="leading-icon" type={leadingicon} />{/if}
+  {#if leadingicon}<goa-icon data-testid="leading-icon" type={leadingicon} size={_iconSize} />{/if}
   <slot />
-  {#if trailingicon}<goa-icon data-testid="trailing-icon" type={trailingicon} />{/if}
+  {#if trailingicon}<goa-icon data-testid="trailing-icon" type={trailingicon} size={_iconSize} />{/if}
 </div>
 
 <style>
-  :global(::slotted(a)) {
-    color: var(--goa-color-interactive-default);
-  }
-
+  /* Base link styles */
   .link {
     display: inline-flex;
     align-items: center;
@@ -67,22 +77,104 @@
     border: none;
     background: none;
     cursor: pointer;
-    font: var(--goa-typography-body-m);
     text-decoration: underline;
-    gap: 8px;
+    /* V1: Default gap fallback (4px) */
+    gap: var(--goa-link-gap, 0.25rem);
+    /* V2: Size-specific gaps override below */
   }
 
+  /* Size variants - Typography and Gap */
+  .link.xsmall {
+    font: var(--goa-link-typography-xsmall);
+    gap: var(--goa-link-gap-xsmall, 0.125rem);
+  }
+
+  .link.small {
+    font: var(--goa-link-typography-small);
+    gap: var(--goa-link-gap-small, 0.1875rem);
+  }
+
+  .link.medium {
+    font: var(--goa-link-typography-medium);
+    gap: var(--goa-link-gap-medium, 0.25rem);
+  }
+
+  .link.large {
+    font: var(--goa-link-typography-large);
+    gap: var(--goa-link-gap-large, 0.3125rem);
+  }
+
+  /* Color variant: Interactive (Blue) */
   .link.interactive {
-    color: var(--goa-color-interactive-default);
-  }
-  .link.interactive:hover {
-    color: var(--goa-color-interactive-hover);
+    color: var(--goa-link-color-interactive-default, var(--goa-color-interactive-default));
   }
 
-  .link.light {
-    color: var(--goa-color-text-light);
+  .link.interactive :global(::slotted(a)) {
+    color: var(--goa-link-color-interactive-default, var(--goa-color-interactive-default)) !important;
   }
+
+  .link.interactive:hover {
+    color: var(--goa-link-color-interactive-hover, var(--goa-color-interactive-hover));
+  }
+
+  .link.interactive:hover :global(::slotted(a)) {
+    color: var(--goa-link-color-interactive-hover, var(--goa-color-interactive-hover)) !important;
+  }
+
+  .link.interactive :global(a:visited) {
+    color: var(--goa-link-color-interactive-visited, var(--goa-color-interactive-visited)) !important;
+  }
+
+  /* Color variant: Dark (Black) */
+  .link.dark {
+    color: var(--goa-link-color-dark-default, var(--goa-color-greyscale-black));
+  }
+
+  .link.dark :global(::slotted(a)) {
+    color: var(--goa-link-color-dark-default, var(--goa-color-greyscale-black)) !important;
+  }
+
+  .link.dark:hover {
+    color: var(--goa-link-color-dark-hover, var(--goa-color-greyscale-700));
+  }
+
+  .link.dark:hover :global(::slotted(a)) {
+    color: var(--goa-link-color-dark-hover, var(--goa-color-greyscale-700)) !important;
+  }
+
+  .link.dark :global(a:visited) {
+    color: var(--goa-link-color-dark-visited, var(--goa-color-interactive-visited)) !important;
+  }
+
+  /* Color variant: Light (White) */
+  .link.light {
+    color: var(--goa-link-color-light-default, var(--goa-color-text-light));
+  }
+
+  .link.light :global(::slotted(a)) {
+    color: var(--goa-link-color-light-default, var(--goa-color-text-light)) !important;
+  }
+
   .link.light:hover {
-    color: var(--goa-color-text-light);
+    color: var(--goa-link-color-light-hover, var(--goa-color-greyscale-200));
+  }
+
+  .link.light:hover :global(::slotted(a)) {
+    color: var(--goa-link-color-light-hover, var(--goa-color-greyscale-200)) !important;
+  }
+
+  .link.light :global(a:visited) {
+    color: var(--goa-link-color-light-visited, #9D8EBB) !important;
+  }
+
+  /* Focus */
+  .link:focus-within {
+    border-radius: var(--goa-link-border-radius-focus, var(--goa-border-radius-s));
+    outline: var(--goa-link-border-focus, var(--goa-border-width-l) solid var(--goa-color-interactive-focus));
+    outline-offset: var(--goa-link-focus-offset, var(--goa-space-3xs));
+  }
+
+  .link :global(::slotted(a:focus-visible)) {
+    outline: none;
   }
 </style>


### PR DESCRIPTION
  ## Summary

  Updates the Link component to support V2 design system styling with size variants and an expanded color system, while maintaining full backward compatibility with V1.

  **Note**: This is a Token+CSS update WITHOUT a version prop - the `size` and `color` props handle all variations with sensible defaults.

  ## Changes

  ### New Props

  - **`size`** (`"xsmall" | "small" | "medium" | "large"`, default `"medium"`): Controls link typography and icon sizing
  - **`color`** - Updated to include `"dark"` option: `"interactive" | "dark" | "light"` (default `"interactive"`)

  ### V2 Styling Updates

  **Size Variants**
  - **XSmall**: 14px/20px typography with 12px icons, 2px gap (for captions)
  - **Small**: 16px/22px typography with 16px icons, 3px gap (for small text)
  - **Medium**: 18px/24px typography with 18px icons, 4px gap (standard body text)
  - **Large**: 24px/36px typography with 20px icons, 5px gap (for headings)

  **Color Variants**
  - **Interactive** (blue): Default link color, existing behavior maintained
  - **Dark** (black): NEW - For subtle links on light backgrounds
  - **Light** (white): Updated with proper hover/visited states for dark backgrounds

  **State Styling**
  - **Default**: Size-appropriate typography and color
  - **Hover**: Color changes based on variant (darker blue, grey, or light grey)
  - **Visited**: Purple for interactive/dark variants, light grey for light variant
  - All states maintain underline decoration

  **Icon Integration**
  - Icons automatically size to match link typography
  - Gap spacing scales with link size (2px to 5px)
  - Leading and trailing icons supported
  - Proper vertical alignment with inline text

  ### Technical Implementation

  **No Version Prop Pattern**
  - Size and color props are additive with backward-compatible defaults
  - `size="medium"` matches V1 typography (18px/24px)
  - `color="interactive"` maintains V1 blue link behavior
  - Token fallbacks ensure V1 environment works correctly

  **Gap Spacing with Fallbacks**
  - Base gap: `var(--goa-link-gap, 0.25rem)` provides 4px default
  - Size-specific gaps: `var(--goa-link-gap-medium, 0.25rem)` with fallback values
  - CSS specificity ensures size variants override base gap

  **Dynamic Icon Sizing**
  - Helper function maps link size to icon size prop
  - XSmall → 2xsmall (12px), Small → xsmall (16px), etc.
  - Maintains visual hierarchy across size variants

  ## Related

  - Parent issue: #2998
  - Component issue: #2956
  - [Design tokens PR for Link](https://github.com/GovAlta/design-tokens/pull/101)
  - [V2 Figma component](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=56970-352878&t=Vpgvn2pPxfSoVYLB-4)

## Testing
Playground page: https://github.com/twjeffery/goa-v2-component-playground/blob/main/src/pages/LinkPage.svelte

### V2
<img width="232" height="468" alt="image" src="https://github.com/user-attachments/assets/af9aa7fc-5010-4f65-a288-5176c8ea5024" />


### V1
<img width="135" height="58" alt="image" src="https://github.com/user-attachments/assets/e52534c9-0dc7-43dc-993a-6de0293d3bcc" />

