### PR TITLE
feat(#2949): update checkbox to v2

### DIFF
--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -39,11 +39,13 @@
   export let description: string = "";
   export let revealarialabel: string = ""; // screen reader will announce this when reveal slot is displayed
   export let maxwidth: string = "none";
+  export let size: "default" | "compact" = "default";
+  export let version: "1" | "2" = "1";
 
   // margin
   export let mt: Spacing = null;
   export let mr: Spacing = null;
-  export let mb: Spacing = "m";
+  export let mb: Spacing = null;
   export let ml: Spacing = null;
 
   // Private
@@ -84,6 +86,7 @@
     // hold on to the initial value to prevent losing it on check changes
     _value = value;
     _descriptionId = `description_${name}`;
+    mb ??= size === "compact" ? "s" : "m";
 
     addRelayListener();
     addRevealSlotListener();
@@ -165,12 +168,12 @@
     const checkboxEl = (_rootEl?.getRootNode() as ShadowRoot)?.host as HTMLElement;
     const fromCheckboxList = checkboxEl?.closest("goa-checkbox-list") !== null;
 
-      relay<FormFieldMountRelayDetail>(
-        _rootEl,
-        FormFieldMountMsg,
-        { name, el: _rootEl },
-        { bubbles: !fromCheckboxList, timeout: 10 },
-      );
+    relay<FormFieldMountRelayDetail>(
+      _rootEl,
+      FormFieldMountMsg,
+      { name, el: _rootEl },
+      { bubbles: !fromCheckboxList, timeout: 10 },
+    );
   }
 
   function onChange(e: Event) {
@@ -244,6 +247,8 @@
 <div
   bind:this={_rootEl}
   class="root"
+  class:v2={version === "2"}
+  class:compact={size === "compact"}
   style={`
 ${calculateMargin(mt, mr, mb, ml)}
 max-width: ${maxwidth};
@@ -271,7 +276,25 @@ max-width: ${maxwidth};
         on:change={onChange}
         on:focus={onFocus}
       />
-      {#if isIndeterminate}
+      {#if isIndeterminate && version === "2"}
+        <svg
+          id="dashmark"
+          data-testid="dashmark"
+          width="18"
+          height="12"
+          viewBox="0 0 18 3"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            x="0"
+            y="0"
+            width="18"
+            height="3"
+            rx="1.4"
+          />
+        </svg>
+      {:else if isIndeterminate}
         <svg
           id="dashmark"
           data-testid="dashmark"
@@ -279,6 +302,19 @@ max-width: ${maxwidth};
           viewBox="0 0 15 2"
         >
           <rect width="15" height="2" />
+        </svg>
+      {:else if isChecked && version === "2"}
+        <svg
+          id="checkmark"
+          data-testid="checkmark"
+          width="15"
+          height="12"
+          viewBox="0 0 15 12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.51566 11.2519L1.06114 6.46813C0.812955 6.20493 0.812955 5.77653 1.06114 5.51053L1.96095 4.55433C2.20913 4.29113 2.61258 4.29113 2.86076 4.55433L5.9662 7.90313L12.8885 0.448132C13.1367 0.184932 13.5402 0.184932 13.7884 0.448132L14.6882 1.40573C14.9363 1.66893 14.9363 2.09873 14.6882 2.36053L6.41548 11.2519C6.16729 11.5151 5.76384 11.5151 5.51566 11.2519Z"
+          />
         </svg>
       {:else if isChecked}
         <svg
@@ -518,5 +554,58 @@ max-width: ${maxwidth};
   }
   .disabled.error .container svg {
     fill: #f58185;
+  }
+
+  /* Version 2 */
+
+  .v2 .text {
+    margin-top: var(--goa-space-2xs);
+  }
+
+  .v2 .container svg {
+    margin: 6px 3px;
+  }
+
+  .v2 .container:has(:focus-visible),
+  .v2 .container:has(:focus-visible):hover,
+  .v2 .container.selected:has(:focus-visible):hover,
+  .v2 label:hover .container.selected:has(:focus-visible),
+  .v2 label:hover .container:has(:focus-visible) {
+    outline: var(--goa-checkbox-border-focus);
+    outline-offset: var(--goa-space-3xs);
+    box-shadow: none;
+  }
+  .v2 .disabled:not(.error) .container:not(.selected) {
+    background: var(--goa-input-color-background-disabled);
+    box-shadow: none;
+  }
+
+  .v2 .error .container,
+  .v2 .error .container.selected {
+    background: var(--goa-input-color-background-error);
+  }
+
+  .v2 .error:not(.disabled) .container:hover,
+  .v2 .error:not(.disabled) .container.selected:hover,
+  .v2 label:hover.error:not(.disabled) .container,
+  .v2 label:hover.error:not(.disabled) .container.selected {
+    background: var(--goa-input-color-background-error-hover);
+    border: var(--goa-checkbox-border-error-hover);
+  }
+
+  .v2 .error:not(.disabled) .container:hover svg,
+  .v2 .error:not(.disabled) .container.selected:hover svg,
+  .v2 label:hover.error:not(.disabled) .container svg,
+  .v2 label:hover.error:not(.disabled) .container.selected svg {
+    fill: var(--goa-checkbox-color-bg-checked-error-hover);
+  }
+
+  .v2 .error .container svg {
+    margin-top: 5px;
+  }
+
+  .v2.compact .text {
+    padding-left: var(--goa-checkbox-gap-compact);
+    font: var(--goa-checkbox-label-font-size-compact);
   }
 </style>


### PR DESCRIPTION
This PR updates the checkbox to match the [v2 Figma component](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=56969-469737&t=FCFdhIPcLhRaL1k3-1). Changes include:
- New SVGs for the checkmark and indeterminate dash
- Focus state uses an outline instead of a box shadow
- Compact state
