### PR TITLE
feat(#2953): update Icon button component for V2

### DIFF
--- a/libs/web-components/src/components/icon-button/IconButton.svelte
+++ b/libs/web-components/src/components/icon-button/IconButton.svelte
@@ -104,7 +104,7 @@
   }
 
   .goa-icon-button--small {
-    padding: var(--goa-icon-button-medium-padding);
+    padding: var(--goa-icon-button-small-padding, var(--goa-icon-button-medium-padding));
   }
 
   .goa-icon-button--medium {
@@ -112,10 +112,6 @@
   }
 
   .goa-icon-button--large {
-    padding: var(--goa-icon-button-large-padding);
-  }
-
-  .goa-icon-button--xlarge {
     padding: var(--goa-icon-button-large-padding);
   }
 
@@ -127,9 +123,7 @@
     background: transparent;
     cursor: pointer;
     border: none;
-    border-radius: var(--goa-icon-button-medium-border-radius);
-    padding: var(--padding);
-    cursor: pointer;
+    border-radius: var(--goa-icon-button-border-radius, var(--goa-icon-button-medium-border-radius));
     transition: background-color 0.2s ease-in-out,
     color 0.2s ease-in-out,
     transform 0.1s ease-in-out;
@@ -144,7 +138,7 @@
   }
 
   button:focus-visible {
-    box-shadow: 0 0 0 3px var(--goa-color-interactive-focus);
+    box-shadow: 0 0 0 var(--goa-icon-button-focus-border-width, 3px) var(--goa-icon-button-focus-border-color, var(--goa-color-interactive-focus));
     outline: none;
   }
 
@@ -165,8 +159,7 @@
     fill: var(--goa-icon-button-default-color);
   }
 
-  .color:hover,
-  .color:focus-visible {
+  .color:hover:not(:focus-visible) {
     color: var(--goa-icon-button-default-hover-color);
     fill: var(--goa-icon-button-default-hover-color);
     background-color: var(--goa-icon-button-default-hover-color-bg);
@@ -183,15 +176,14 @@
     fill: var(--goa-icon-button-dark-color);
   }
 
-  .dark:hover,
-  .dark:focus-visible,
+  .dark:hover:not(:focus-visible),
   .dark:active {
     background-color: var(--goa-icon-button-dark-hover-color-bg);
   }
 
   .dark:disabled {
-    color: var(--goa-icon-button-dark-disabled-color-bg);
-    fill: var(--goa-icon-button-dark-disabled-color-bg);
+    color: var(--goa-icon-button-dark-disabled-color, var(--goa-icon-button-dark-disabled-color-bg));
+    fill: var(--goa-icon-button-dark-disabled-color, var(--goa-icon-button-dark-disabled-color-bg));
   }
 
   /*  Type: nocolor (same as dark, not documented) */
@@ -200,8 +192,7 @@
     fill: var(--goa-icon-button-dark-color);
   }
 
-  .nocolor:hover,
-  .nocolor:focus-visible,
+  .nocolor:hover:not(:focus-visible),
   .nocolor:active {
     background-color: var(--goa-icon-button-dark-hover-color-bg);
   }
@@ -212,9 +203,10 @@
     fill: var(--goa-icon-button-destructive-color);
   }
 
-  .destructive:hover,
-  .destructive:focus-visible,
+  .destructive:hover:not(:focus-visible),
   .destructive:active {
+    color: var(--goa-icon-button-destructive-hover-color);
+    fill: var(--goa-icon-button-destructive-hover-color);
     background-color: var(--goa-icon-button-destructive-hover-color-bg);
   }
 
@@ -229,8 +221,7 @@
     fill: var(--goa-icon-button-light-color);
   }
 
-  .light:hover,
-  .light:focus-visible,
+  .light:hover:not(:focus-visible),
   .light:active {
     background-color: var(--goa-icon-button-light-hover-color-bg);
   }
@@ -246,8 +237,7 @@
     fill: var(--goa-icon-button-light-color);
   }
 
-  .inverted:hover,
-  .inverted:focus-visible,
+  .inverted:hover:not(:focus-visible),
   .inverted:active {
     background-color: var(--goa-icon-button-light-hover-color-bg);
   }


### PR DESCRIPTION
  ## Summary

  Updates the Icon Button component to integrate V2 design tokens, achieving V2 styling through token-driven architecture while maintaining full backwards compatibility with V1. This is a Token-Only update with minor code cleanup.

  ## Changes

  ### Token Integration

  **Updated Token References**:
  - Integrated new size-specific padding tokens (`small-padding`, `medium-padding`, `large-padding`)
  - Added fallback chains for V1 compatibility
  - Integrated focus state tokens that reference Input component for system-wide consistency

  **No New Props**:
  - Token-Only classification means no version prop needed
  - V1 and V2 differentiated entirely through token packages

  ### V2 Styling Updates

  **Spacing**:
  - Small buttons: 4px padding (unchanged)
  - Medium buttons: 8px padding (increased from 4px for better clickability)
  - Large buttons: 12px padding (increased from 8px for better hierarchy)

  **Colors**:
  - Light variant hover: Lighter grey background (greyscale.600 vs greyscale.700)
  - Disabled states: Consistent greyscale.500 across all variants

  **Focus State**:
  - Focus tokens now reference Input component (`{input.borderWidth.focus}`, `{input.color.border.focus}`)
  - Maintains box-shadow focus treatment (border-based focus deferred to future update)
  - System-wide consistency: changing Input focus automatically updates Icon Button
  
 ## Related

  - Parent issue: #2998
  - Component issue: #2953
  - [Design tokens PR for Icon Button](https://github.com/GovAlta/design-tokens/pull/104)
  - [v2 Figma component](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=56969-757260&t=er5m2gCNY74C4kvT-4)

## Testing
Playground page: https://github.com/twjeffery/goa-v2-component-playground/blob/main/src/pages/IconButtonPage.svelte

### V2
<img width="209" height="203" alt="image" src="https://github.com/user-attachments/assets/99eae67d-1c76-427f-a981-061441804ebd" />

### V1
<img width="209" height="203" alt="image" src="https://github.com/user-attachments/assets/ff594567-4c2f-47cc-9b1e-acfe5a51c8f6" />
