### PR TITLE
chore: add an ignored dependency when linting

### DIFF
--- a/libs/web-components/.eslintrc.json
+++ b/libs/web-components/.eslintrc.json
@@ -26,7 +26,7 @@
           "error",
           {
             "ignoredFiles": ["{projectRoot}/vite.config.{js,ts,mjs,mts}"],
-            "ignoredDependencies": ["glob", "svelte", "@sveltejs/vite-plugin-svelte"]
+            "ignoredDependencies": ["glob", "date-fns", "svelte", "@sveltejs/vite-plugin-svelte"]
           }
         ]
       }


### PR DESCRIPTION
# Before (the change)

Lint was failing

# After (the change)

Lint is passing

## Steps needed to test

run `npm run lint`
