### PR TITLE
feat(#3143): update Table component for V2

### DIFF
--- a/libs/web-components/src/assets/css/components.css
+++ b/libs/web-components/src/assets/css/components.css
@@ -46,27 +46,39 @@ goa-table.sticky thead {
 
 goa-table td {
   font: var(--goa-typography-body-m);
-  padding: var(--goa-space-xs) var(--goa-space-m) var(--goa-space-xs);
-  border-bottom: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
+  padding: var(--goa-table-padding-data, var(--goa-space-xs) var(--goa-space-m) var(--goa-space-xs));
+  background-color: var(--goa-table-color-bg-data, var(--goa-color-greyscale-white));
+  border-bottom: var(--goa-table-data-border, 1px solid var(--goa-color-greyscale-200));
   vertical-align: top;
   box-sizing: border-box;
-  height: var(--goa-space-2xl);
+  min-height: var(--goa-table-height-data, var(--goa-space-2xl));
 }
 
+/* V2: Remove bottom border from last row to prevent doubling with table border */
+goa-table[version="2"] tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* V2: Zebra striping for readability */
+goa-table[version="2"][striped="true"] tbody tr:nth-child(even) td {
+  background-color: var(--goa-color-greyscale-50);
+}
+
+/* Relaxed variant - larger spacing and height for data cells only */
 goa-table[variant="relaxed"] td {
-  padding: var(--goa-space-m);
+  padding: var(--goa-table-padding-data-relaxed, var(--goa-space-m));
+  min-height: var(--goa-table-height-data-relaxed, 64px);
 }
 
 goa-table thead th {
-  background-color: var(--goa-color-greyscale-white);
-  color: var(--goa-table-color-heading);
-  padding:
-  var(--goa-space-s)
-  var(--goa-table-header-padding, var(--goa-space-m))
-  var(--goa-space-xs) var(--goa-table-header-padding, var(--goa-space-m));
+  background-color: var(--goa-table-color-bg-heading, var(--goa-color-greyscale-white));
+  color: var(--goa-table-color-heading, var(--goa-color-greyscale-600));
+  font: var(--goa-table-typography-heading, var(--goa-typography-heading-s));
+  padding: var(--goa-table-padding-heading, var(--goa-space-s) var(--goa-space-m) var(--goa-space-xs));
   text-align: left;
-  border-bottom: var(--goa-border-width-m) solid var(--goa-table-color-border-heading);
+  border-bottom: var(--goa-table-heading-border, 2px solid var(--goa-color-greyscale-600));
   vertical-align: bottom;
+  min-height: var(--goa-table-height-heading, 56px);
   }
 
 .goa-table-number-column {
@@ -78,22 +90,145 @@ goa-table thead th {
   text-align: right;
 }
 
-.goa-table-number-header:not(:has(goa-table-sort-header)) {
-  padding-bottom: var(--goa-space-xs);
-}
-
 goa-table thead th:has(goa-table-sort-header) {
-	padding-bottom: 1px;
-	padding-top: 0;
+	padding: 0;
 }
 
 goa-table thead th:has(goa-table-sort-header):hover {
-	background-color: var(--goa-color-greyscale-100);
-	color: var(--goa-color-interactive-hover);
+	background-color: var(--goa-table-color-bg-heading-hover, var(--goa-color-greyscale-100));
+	color: var(--goa-table-color-heading-hover, var(--goa-color-interactive-hover));
 }
 
 goa-table tfoot td {
   background-color: var(--goa-color-greyscale-100);
+}
+
+/* V2: Outer edge padding - larger padding on first and last columns */
+
+/* Headers without TableSortHeader - apply padding to th */
+goa-table[version="2"] thead th:first-child:not(:has(goa-table-sort-header)) {
+  padding-left: var(--goa-space-l, 24px);
+}
+
+goa-table[version="2"] thead th:last-child:not(:has(goa-table-sort-header)) {
+  padding-right: var(--goa-space-l, 24px);
+}
+
+/* Headers with TableSortHeader - override token padding for button inside (all variants) */
+goa-table[version="2"] thead th:first-child:has(goa-table-sort-header):not(:last-child) {
+  --goa-table-padding-heading: 18px var(--goa-space-m) var(--goa-space-m) var(--goa-space-l);
+}
+
+goa-table[version="2"] thead th:last-child:has(goa-table-sort-header):not(:first-child) {
+  --goa-table-padding-heading: 18px var(--goa-space-l) var(--goa-space-m) var(--goa-space-m);
+}
+
+goa-table[version="2"] thead th:first-child:last-child:has(goa-table-sort-header) {
+  --goa-table-padding-heading: 18px var(--goa-space-l) var(--goa-space-m) var(--goa-space-l);
+}
+
+/* Data and footer cells */
+goa-table[version="2"] tbody td:first-child,
+goa-table[version="2"] tfoot td:first-child {
+  padding-left: var(--goa-space-l, 24px);
+}
+
+goa-table[version="2"] tbody td:last-child,
+goa-table[version="2"] tfoot td:last-child {
+  padding-right: var(--goa-space-l, 24px);
+}
+
+
+/* Normal Variant Cell Types */
+
+goa-table td.goa-table-cell--text {
+  padding-top: var(--goa-table-padding-cell-text, var(--goa-space-s)) !important;
+  padding-bottom: var(--goa-table-padding-cell-text, var(--goa-space-s)) !important;
+}
+
+goa-table td.goa-table-cell--checkbox {
+  padding-top: var(--goa-table-padding-cell-checkbox, 2px) !important;
+  padding-bottom: var(--goa-table-padding-cell-checkbox, 2px) !important;
+  text-align: center;
+}
+
+goa-table td.goa-table-cell--form-field {
+  padding-top: var(--goa-table-padding-cell-form-field, 3px) !important;
+  padding-bottom: var(--goa-table-padding-cell-form-field, 3px) !important;
+}
+
+goa-table td.goa-table-cell--badge {
+  padding-top: var(--goa-table-padding-cell-badge, var(--goa-space-s)) !important;
+  padding-bottom: var(--goa-table-padding-cell-badge, var(--goa-space-s)) !important;
+}
+
+/* Alignment helper classes */
+
+goa-table td.goa-table-cell--numeric,
+goa-table th.goa-table-cell--numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+goa-table th.goa-table-cell--numeric goa-table-sort-header {
+  text-align: right;
+  justify-content: flex-end;
+}
+
+goa-table td.goa-table-cell--numeric {
+  padding-top: var(--goa-table-padding-cell-text, var(--goa-space-s)) !important;
+  padding-bottom: var(--goa-table-padding-cell-text, var(--goa-space-s)) !important;
+}
+
+goa-table td.goa-table-cell--actions {
+  padding-top: var(--goa-table-padding-cell-actions, 7px) !important;
+  padding-bottom: var(--goa-table-padding-cell-actions, 7px) !important;
+  text-align: right;
+  white-space: nowrap;
+}
+
+goa-table td.goa-table-cell--text-supporting {
+  padding-top: var(--goa-table-padding-cell-text, var(--goa-space-s)) !important;
+  padding-bottom: var(--goa-table-padding-cell-text, var(--goa-space-s)) !important;
+}
+
+/* Relaxed variant overrides for alignment/layout classes */
+
+goa-table[variant="relaxed"] td.goa-table-cell--numeric {
+  padding-top: var(--goa-table-padding-cell-text-relaxed, 20px) !important;
+  padding-bottom: var(--goa-table-padding-cell-text-relaxed, 20px) !important;
+}
+
+goa-table[variant="relaxed"] td.goa-table-cell--actions {
+  padding-top: var(--goa-table-padding-cell-actions-relaxed, 14px) !important;
+  padding-bottom: var(--goa-table-padding-cell-actions-relaxed, 14px) !important;
+}
+
+goa-table[variant="relaxed"] td.goa-table-cell--text-supporting {
+  padding-top: var(--goa-table-padding-cell-text-supporting-relaxed, 8px) !important;
+  padding-bottom: var(--goa-table-padding-cell-text-supporting-relaxed, 8px) !important;
+}
+
+/* Relaxed Variant Cell Types */
+
+goa-table[variant="relaxed"] td.goa-table-cell--text {
+  padding-top: var(--goa-table-padding-cell-text-relaxed, 20px) !important;
+  padding-bottom: var(--goa-table-padding-cell-text-relaxed, 20px) !important;
+}
+
+goa-table[variant="relaxed"] td.goa-table-cell--checkbox {
+  padding-top: var(--goa-table-padding-cell-checkbox-relaxed, 10px) !important;
+  padding-bottom: var(--goa-table-padding-cell-checkbox-relaxed, 10px) !important;
+}
+
+goa-table[variant="relaxed"] td.goa-table-cell--form-field {
+  padding-top: var(--goa-table-padding-cell-form-field-relaxed, 11px) !important;
+  padding-bottom: var(--goa-table-padding-cell-form-field-relaxed, 11px) !important;
+}
+
+goa-table[variant="relaxed"] td.goa-table-cell--badge {
+  padding-top: var(--goa-table-padding-cell-badge-relaxed, 20px) !important;
+  padding-bottom: var(--goa-table-padding-cell-badge-relaxed, 20px) !important;
 }
 
 goa-table tfoot tr:first-child td {

--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -1,7 +1,9 @@
 <svelte:options customElement={{
   tag: "goa-table",
   props: {
-    variant: { reflect: true }
+    variant: { reflect: true },
+    version: { reflect: true },
+    striped: { reflect: true }
   }
 }} />
 
@@ -20,11 +22,16 @@
   );
   type Variant = (typeof Variants)[number];
 
+  const [Version, validateVersion] = typeValidator("Version", ["1", "2"]);
+  type VersionType = (typeof Version)[number];
+
   // Public
 
   export let width: string = "";
   export let stickyheader: string = "false";
+  export let striped: string = "false";
   export let variant: Variant = "normal";
+  export let version: VersionType = "1";
   export let testid: string = "";
 
   export let mt: Spacing = null;
@@ -40,11 +47,13 @@
   // Reactive
 
   $: _stickyHeader = toBoolean(stickyheader);
+  $: _striped = toBoolean(striped);
 
   // Hooks
 
   onMount(() => {
     validateVariant(variant);
+    validateVersion(version);
 
     // without setTimeout it won't properly sort in Safari
     setTimeout(attachSortEventHandling, 0);
@@ -122,7 +131,9 @@
 <div
   bind:this={_rootEl}
   class={`goatable ${variant}`}
+  class:v2={version === "2"}
   class:sticky={_stickyHeader}
+  class:striped={_striped}
   style={`
     ${`width: ${width || "100%"};`}
     ${calculateMargin(mt, mr, mb, ml)}
@@ -146,5 +157,14 @@
 
   table {
     border-collapse: collapse;
+  }
+
+  /* V2 Border and Border-Radius */
+  .v2 table {
+    border-collapse: separate;
+    border-spacing: 0;
+    border: var(--goa-table-container-border, 1px solid #e7e7e7);
+    border-radius: var(--goa-table-border-radius-container, 16px);
+    overflow: hidden;
   }
 </style>

--- a/libs/web-components/src/components/table/TableSortHeader.svelte
+++ b/libs/web-components/src/components/table/TableSortHeader.svelte
@@ -14,10 +14,8 @@
     if (_rootEl) {
       // Add styling if an ancestor has a class to style number columns,
       const hostEl = _rootEl.getRootNode().host;
-      const parentThead = hostEl?.closest("th");
-      parentThead?.style.setProperty("--goa-table-header-padding", "0");
 
-      const ancestor = hostEl?.closest("th.goa-table-number-header");
+      const ancestor = hostEl?.closest("th.goa-table-number-header, th.goa-table-cell--numeric");
       if (ancestor) {
         _rootEl.style.setProperty("--header-text-align", "flex-end");
         _rootEl.style.setProperty("--header-align", "right");
@@ -57,18 +55,18 @@
 		line-height: inherit;
 		height: inherit;
     width: 100%;
-    padding: var(--goa-space-s) var(--goa-space-m) var(--goa-space-xs);
+    padding: var(--goa-table-padding-heading, var(--goa-space-s) var(--goa-space-m) var(--goa-space-xs));
     justify-content: var(--header-text-align, flex-start);
-    gap: var(--goa-space-2xs);
+    gap: var(--goa-table-sort-header-gap, var(--goa-space-2xs));
     align-items: flex-end;
     text-align: var(--header-align, left);
   }
 
   /* User set classes */
   button:hover {
-    background-color: var(--goa-color-greyscale-100);
+    background-color: var(--goa-table-color-bg-heading-hover, var(--goa-color-greyscale-100));
     cursor: pointer;
-    color: var(--goa-color-interactive-hover);
+    color: var(--goa-table-color-heading-hover, var(--goa-color-interactive-hover));
   }
 
   button goa-icon {


### PR DESCRIPTION
  ## Summary

  Updates the Table component to support V2 design system styling while maintaining full backward
  compatibility with V1. Includes version prop, zebra striping feature, 7 CSS helper classes for cell
  alignment, and comprehensive token integration.

  ## Changes

  ### New Props
  - **`version`** (`"1" | "2"`, default `"1"`): Controls V1 vs V2 styling
  - **`striped`** (`"true" | "false"`, default `"false"`): Enables alternating row backgrounds (V2 only)

  ### V2 Styling Updates

  **Container Border & Radius**
  - V2 adds 1px container border (greyscale.150) with 16px rounded corners
  - Uses `border-collapse: separate` (vs V1 `collapse`) to enable border-radius
  - Border removed from last row to prevent doubling with container border

  **Header Cells**
  - Background: Grey 50 (vs V1 white)
  - Text color: Grey 600
  - Typography: Body XS from tokens (vs V1 browser default bold)
  - Padding: 18px top, 16px sides, 16px bottom
  - Hover: Grey 100 background with blue text
  - Height: 56px (same for both normal and relaxed variants)

  **Data Cells**
  - Normal variant: 48px minimum height with 12px vertical padding
  - Relaxed variant: 64px minimum height with 18px vertical padding
  - Horizontal padding: 16px left/right (consistent across all cells)
  - Border: Grey 150 (updated from V1 greyscale.200)

  **Outer Edge Padding (V2 Only)**
  - First and last columns get 24px horizontal padding (vs 16px for middle columns)
  - Provides better visual breathing room at table edges
  - Handles both regular headers and TableSortHeader via CSS token override pattern

  **Zebra Striping**
  - Optional feature via `striped="true"` prop
  - Even rows get grey 50 background for improved readability
  - Only works when `version="2"`

  ### CSS Helper Classes (7 classes)

  Helper classes provide component-specific vertical padding to achieve consistent row heights when mixing
   different component types in the same table.

  **Component-Specific Padding (4):**
  - `.goa-table-cell--text` - Text content (12px normal, 20px relaxed)
  - `.goa-table-cell--checkbox` - Checkboxes (2px normal, 10px relaxed)
  - `.goa-table-cell--badge` - Badges/status (12px normal, 20px relaxed)
  - `.goa-table-cell--form-field` - Form controls: inputs, dropdowns, etc. (3px normal, 11px relaxed)

  **Alignment & Layout (3):**
  - `.goa-table-cell--numeric` - Right-aligned numbers with `font-variant-numeric: tabular-nums`
  - `.goa-table-cell--actions` - Right-aligned action buttons with `white-space: nowrap` (7px normal, 14px
   relaxed)
  - `.goa-table-cell--text-supporting` - Text with supporting info (12px normal, 8px relaxed)

  **Helper Class Pattern:**
  - Override vertical padding only (`padding-top`, `padding-bottom`)
  - Horizontal padding inherited from base table cell styles
  - Apply to `<td>` elements: `<td class="goa-table-cell--badge">`
  - Semantic naming based on purpose, not specific component

  ### Files Modified

  **Table.svelte:**
  - Added `version` and `striped` props with reflection
  - Added version validator and boolean converter
  - Applied `.v2` and `.striped` conditional classes
  - Added V2 border and border-radius styles in scoped `<style>` block

  **TableSortHeader.svelte:**
  - Updated padding to use `--goa-table-padding-heading` token
  - Updated hover colors to use table-specific tokens
  - Increased gap from 4px to 8px via `--goa-table-sort-header-gap` token
  - Added `.goa-table-cell--numeric` to class detection selector

  **components.css:**
  - Updated header styles with tokens and V1 fallbacks
  - Updated data cell styles with tokens and V1 fallbacks
  - Added V2 last-row border removal
  - Added V2 zebra striping rule
  - Added V2 outer edge padding rules (first/last columns)
  - Added 7 CSS helper classes (normal + relaxed variants)
  - Changed `height` to `min-height` for consistency across variants

  
  ## Known Dependencies

  **Helper class padding values are based on current component dimensions.** After the following
  components are updated to V2, helper class padding will need recalculation:

  1. **Checkbox** - `.goa-table-cell--checkbox`
  2. **Badge** - `.goa-table-cell--badge`
  3. **Input/Dropdown** - `.goa-table-cell--form-field`
  4. **Button/IconButton** - `.goa-table-cell--actions`

## Other Issues Covered
- https://github.com/GovAlta/ui-components/issues/1828

  ## Related
  - Parent issue: #2998
  - Component issue: #3143
  - Design tokens PR for Table: https://github.com/GovAlta/design-tokens/pull/107
  - [V2 Figma component](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=9558-364557&t=2quuZJx8tACAldNs-4)


## Testing
Playground page: https://github.com/twjeffery/goa-v2-component-playground/blob/main/src/pages/TablePage.svelte

### V2
<img width="1058" height="238" alt="image" src="https://github.com/user-attachments/assets/61e4b295-aa30-4d88-bddc-a41e63175d7a" />

### V1
<img width="908" height="238" alt="image" src="https://github.com/user-attachments/assets/5650f4d7-e305-4942-bbf7-71f8a291280b" />

