### PR TITLE
feat(#3151): update Drawer component for V2

### DIFF
--- a/libs/web-components/src/components/drawer/Drawer.svelte
+++ b/libs/web-components/src/components/drawer/Drawer.svelte
@@ -9,7 +9,7 @@
   import { fly } from "svelte/transition";
   import noscroll from "../../common/no-scroll";
   import { onDestroy, onMount, tick } from "svelte";
-  import { dispatch, style, styles } from "../../common/utils";
+  import { dispatch, style, styles, typeValidator } from "../../common/utils";
   import { DrawerPosition, DrawerSize } from "../../common/types";
 
   // ******
@@ -21,6 +21,12 @@
   export let heading: string = "";
   export let maxsize: DrawerSize = undefined; // is set based on the anchor value
   export let testid: string = "drawer";
+
+  // version
+  type VersionType = "1" | "2";
+  const [Version, validateVersion] = typeValidator("Version", ["1", "2"]);
+  export let version: VersionType = "1";
+
   // *******
   // Private
   // *******
@@ -31,7 +37,10 @@
 
   // computes the required absolute position offset to hide the drawer when not shown
   let _drawerSize: number;
+  let _actionsHeight: number = 0;
+  let _headerHeight: number = 0;
   let _actionsSlotHasContent: boolean = false;
+  let _scrollableHeight: string = "";
   let _scrollPos: "top" | "middle" | "bottom" | null = "top"; // to add the box-shadow to the drawer content
 
   // ========
@@ -53,6 +62,22 @@
     }
   }
 
+  // Add reactive statement for height calculations
+  $: if (open && _contentEl) {
+    updateHeights();
+  }
+
+  // V2: Check initial scroll state when drawer opens
+  $: if (open && version === "2" && _contentEl) {
+    tick().then(() => {
+      const drawerContent = _contentEl?.querySelector('.drawer-content');
+      if (drawerContent) {
+        const { scrollTop, scrollHeight, clientHeight } = drawerContent;
+        _scrollPos = calculateScrollPos(scrollTop, scrollHeight, clientHeight);
+      }
+    });
+  }
+
   $: {
     if (!open) {
       setTimeout(() => {
@@ -67,6 +92,7 @@
 
   onMount(async () => {
     await tick();
+    validateVersion(version);
 
     if (position === "bottom") {
       _drawerSize = _contentEl?.getBoundingClientRect().height ?? 0;
@@ -86,9 +112,21 @@
   // Functions
   // *********
 
+  // to set the scrollable height
+  function updateHeights() {
+    const headerEl = _contentEl?.querySelector(".header");
+    const actionsEl = _contentEl?.querySelector(".drawer-actions");
+
+    _headerHeight = headerEl?.clientHeight ?? 0;
+    _actionsHeight = actionsEl?.clientHeight ?? 0;
+    _scrollableHeight = scrollableHeight();
+  }
+
   async function checkActionsSlotContent() {
     await tick();
     _actionsSlotHasContent = !!$$slots.actions;
+    // Trigger height recalculation after checking slot content
+    updateHeights();
   }
 
   function close(e: Event) {
@@ -107,16 +145,30 @@
     }
   };
 
-  // handle scroll event to set the scroll position in order to add the box-shadow to the drawer content depending on the scroll position
+  function scrollableHeight() {
+    // V2: Let flex container handle sizing
+    if (version === "2") return "100%";
+
+    const edgeMargin = 16; // box shadow top and bottom
+
+    // V1: Calculate available height by subtracting:
+    // - header height
+    // - actions height (if actions exist)
+    // - edge margins (for left/right) or drawer chrome (for bottom)
+    if (position === "bottom") {
+      return `calc(${maxsize} - ${_headerHeight}px - ${_actionsSlotHasContent ? _actionsHeight : 0}px)`;
+    }
+    return `calc(100vh - ${_headerHeight}px - ${_actionsSlotHasContent ? _actionsHeight : 0}px - ${edgeMargin}px)`;
+  }
+
+  // V1: handle scroll event from goa-scrollable to set _scrollPos for shadows
   function handleScroll(e: CustomEvent) {
     const hasScroll = e.detail.scrollHeight > e.detail.offsetHeight;
     if (!open || !hasScroll) return;
 
-    // top
     if (e.detail.scrollTop == 0) {
       _scrollPos = "top";
     } else if (
-      // bottom
       Math.abs(
         e.detail.scrollHeight - e.detail.scrollTop - e.detail.offsetHeight,
       ) < 1
@@ -125,6 +177,23 @@
     } else {
       _scrollPos = "middle";
     }
+  }
+
+  // V2: handle scroll event from drawer-content to set _scrollPos for borders
+  function handleV2Scroll(e: Event) {
+    if (!open) return;
+    const target = e.target as HTMLElement;
+    const { scrollTop, scrollHeight, clientHeight } = target;
+    _scrollPos = calculateScrollPos(scrollTop, scrollHeight, clientHeight);
+  }
+
+  // Shared helper to calculate scroll position from scroll metrics
+  function calculateScrollPos(scrollTop: number, scrollHeight: number, clientHeight: number): "top" | "middle" | "bottom" | null {
+    const hasScroll = scrollHeight > clientHeight;
+    if (!hasScroll) return null;
+    if (scrollTop < 1) return "top";
+    if (Math.abs(scrollHeight - scrollTop - clientHeight) < 1) return "bottom";
+    return "middle";
   }
 </script>
 
@@ -146,14 +215,16 @@
       use:noscroll={{ enable: open }}
       style={styles(
         style("--drawer-offset", `-${_drawerSize}px`),
-        style("max-height", position === "bottom" ? maxsize : "100vh"),
-        style("max-width", position === "bottom" ? "100%" : maxsize),
-        style("width", position === "bottom" ? "100%" : maxsize),
+        style("height", position === "bottom" ? "unset" : undefined),
+        style("max-width", position === "bottom" ? "unset" : (version === "2" ? `min(${maxsize}, calc(100vw - 2 * var(--goa-drawer-offset, 0)))` : `min(${maxsize}, 100vw)`)),
+        style("width", position === "bottom" ? "100%" : (version === "2" ? `min(${maxsize}, calc(100vw - 2 * var(--goa-drawer-offset, 0)))` : `min(${maxsize}, 100vw)`)),
+        style("max-height", position === "bottom" ? (version === "2" ? `min(${maxsize}, calc(100vh - 2 * var(--goa-drawer-offset, 0)))` : `min(${maxsize}, 100vh)`) : undefined),
       )}
       in:fly={_flyParams}
       out:fly={{ ..._flyParams, delay: 200 }}
       class:open={open}
       class:closing={!open}
+      class:v2={version === "2"}
       class={`drawer drawer-${position}`}
       class:drawer-open-bottom={position === "bottom" && open}
       class:drawer-open-right={position === "right" && open}
@@ -169,7 +240,11 @@
       <div class="header" id="goa-drawer-heading">
         {#if heading || $$slots.heading}
           {#if heading}
-            <goa-text size="heading-m" as="h3" mt="none" mb="none">{heading}</goa-text>
+            {#if version === "2"}
+              <goa-text size="heading-s" as="h3" mt="2xs" mb="none">{heading}</goa-text>
+            {:else}
+              <goa-text size="heading-m" as="h3" mt="none" mb="none">{heading}</goa-text>
+            {/if}
           {:else}
             <slot name="heading" />
           {/if}
@@ -188,17 +263,27 @@
       </div>
 
       <!-- Content -->
-      <div data-testid="drawer-content" class="drawer-content">
-        <goa-scrollable
-          direction="vertical"
-          maxheight="100%"
-          on:_scroll={handleScroll}
-          bind:this={_scrollEl}
-        >
+      <div
+        data-testid="drawer-content"
+        class="drawer-content"
+        on:scroll={version === "2" ? handleV2Scroll : undefined}
+      >
+        {#if version === "1"}
+          <goa-scrollable
+            direction="vertical"
+            maxheight={_scrollableHeight}
+            on:_scroll={handleScroll}
+            bind:this={_scrollEl}
+          >
+            <div class="scroll-content">
+              <slot />
+            </div>
+          </goa-scrollable>
+        {:else}
           <div class="scroll-content">
             <slot />
           </div>
-        </goa-scrollable>
+        {/if}
       </div>
 
       <!-- Actions -->
@@ -242,6 +327,11 @@
       inset 0 -8px 8px -8px rgba(0, 0, 0, 0.2);
   }
 
+  /* V2: Remove scroll shadows (sticky elements provide visual feedback) */
+  .root .drawer.v2 .drawer-content {
+    box-shadow: none !important;
+  }
+
   /* Background overlay */
   .background {
     position: fixed;
@@ -280,33 +370,80 @@
     border-bottom: var(--goa-border-width-s) solid
     var(--goa-color-greyscale-200);
     display: flex;
-    padding: var(--goa-space-l) var(--goa-space-l) var(--goa-space-s)
-    var(--goa-space-l);
+    padding: var(--goa-space-l) var(--goa-space-l) var(--goa-space-s) var(--goa-space-l);
+    /* Padding: 24px top/right/left, 12px bottom */
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start; /* Align to top instead of center */
+  }
+
+  /* V2: Header uses flexbox positioning (stays at top) */
+  .v2.drawer-right .header,
+  .v2.drawer-left .header,
+  .v2.drawer-bottom .header {
+    flex: 0 0 auto; /* Don't grow or shrink */
+    gap: var(--goa-space-2xs); /* 4px gap between heading and close icon */
+    background-color: var(--goa-color-greyscale-white);
+    border-bottom: none; /* Remove border by default */
+  }
+
+  /* V2: Show header border when scrolled from top (middle or bottom position) */
+  .root.middle .drawer.v2 .header,
+  .root.bottom .drawer.v2 .header {
+    border-bottom: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
   }
 
   /* Content styles */
   .drawer-content {
     box-shadow: none;
-    flex: 1 1 auto;
-    min-height: 0;
+    flex: 0 1 auto; /* Don't grow, but can shrink - keeps actions below content */
+    min-height: 0; /* Allow flexbox to shrink this element */
+    overflow: hidden; /* Contain the scrollable content */
   }
 
-  .drawer-content goa-scrollable {
-    height: 100%;
+  /* V2: drawer-content scrolls and takes remaining space */
+  .v2.drawer-right .drawer-content,
+  .v2.drawer-left .drawer-content,
+  .v2.drawer-bottom .drawer-content {
+    flex: 1 1 auto; /* Take remaining space */
+    overflow-y: auto; /* V2 scrolls here, not via goa-scrollable */
   }
 
   .scroll-content {
-    padding: var(--goa-space-l) var(--goa-space-xl);
+    padding: var(--goa-drawer-content-padding-vertical, var(--goa-space-l)) var(--goa-drawer-content-padding-horizontal, var(--goa-space-xl));
+  }
+
+  /* Remove margin-top from first child in content to prevent double spacing */
+  .scroll-content > :first-child {
+    margin-top: 0;
   }
 
   /* Actions styles */
   .drawer-actions {
     width: 100%;
-    padding: var(--goa-space-l) var(--goa-space-xl) var(--goa-space-xl);
+    padding: var(--goa-drawer-actions-padding-top, var(--goa-space-l)) var(--goa-drawer-content-padding-horizontal, var(--goa-space-xl)) var(--goa-drawer-actions-padding-bottom, var(--goa-space-xl));
     border-top: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
     background: var(--goa-color-greyscale-white);
+  }
+
+  /* V2: Actions use flexbox positioning (stay at bottom) */
+  .v2.drawer-right .drawer-actions,
+  .v2.drawer-left .drawer-actions,
+  .v2.drawer-bottom .drawer-actions {
+    flex: 0 0 auto; /* Don't grow or shrink */
+    background-color: var(--goa-color-greyscale-white);
+    border-top: none; /* Remove border by default */
+  }
+
+  /* V2: Show actions border when has overflow AND not at bottom (top or middle position) */
+  .root.top .drawer.v2 .drawer-actions,
+  .root.middle .drawer.v2 .drawer-actions {
+    border-top: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
+  }
+
+  /* V2: Bottom drawer actions rounded corners */
+  .v2.drawer-bottom .drawer-actions {
+    border-bottom-left-radius: var(--goa-drawer-border-radius, 24px);
+    border-bottom-right-radius: var(--goa-drawer-border-radius, 24px);
   }
 
   .drawer-actions.empty-actions {
@@ -319,46 +456,117 @@
     margin-top: var(--goa-space-2xs);
   }
 
-  /* Position-specific styles */
+  /* Bottom */
+
   .drawer-bottom {
     bottom: var(--drawer-offset);
     width: 100%;
-    min-height: 300px;
-    border-top-left-radius: 0.5rem;
-    border-top-right-radius: 0.5rem;
+    height: 300px;
+    border-top-left-radius: var(--goa-drawer-border-radius, 0.5rem);
+    border-top-right-radius: var(--goa-drawer-border-radius, 0.5rem);
     transform: translateY(100%);
     box-shadow: var(--goa-drawer-bottom-shadow);
-  }
-
-  .drawer-bottom .drawer-content {
-    overflow-y: auto;
   }
 
   .drawer-open-bottom {
     bottom: 0;
   }
 
+  /* V2: Border radius + 16px offset from edges */
+  .drawer-bottom.v2 {
+    left: var(--goa-drawer-offset, 0);
+    right: var(--goa-drawer-offset, 0);
+    width: auto !important; /* Override base width: 100% */
+    height: auto;
+    overflow-y: hidden; /* No scroll on drawer itself */
+    border-radius: var(--goa-drawer-border-radius, 24px); /* All corners 24px */
+    box-shadow: var(--goa-drawer-shadow);
+    transform: translateY(100%); /* Start off-screen at bottom */
+    transition: transform 0.2s ease-out;
+  }
+  .drawer-bottom.v2.open,
+  .drawer-bottom.v2.drawer-open-bottom {
+    bottom: var(--goa-drawer-offset, 0);
+    transform: translateY(0); /* Slide in */
+  }
+
   /* Right */
 
   .drawer-right {
     right: var(--drawer-offset);
-    height: 100%;
+    height: auto; /* Content-driven height */
+    min-height: 100vh; /* V1: Full height background */
     transform: translateX(100%);
     box-shadow: var(--goa-drawer-right-shadow);
   }
+
   .drawer-open-right {
     right: 0;
+  }
+
+  /* V2: Border radius + 16px offset from edges + content-driven height */
+  .v2.drawer-right {
+    right: var(--drawer-offset);
+    top: var(--goa-drawer-offset, 0);
+    /* No bottom positioning - allows height: auto to work naturally */
+    height: auto;
+    min-height: 0; /* Override V1 min-height */
+    /* Max-height accounts for BOTH top and bottom margins (modal stays floating) */
+    max-height: calc(100vh - 2 * var(--goa-drawer-offset, 0));
+    overflow-y: hidden; /* No scroll on drawer itself */
+    border-radius: var(--goa-drawer-border-radius, 24px);
+    box-shadow: var(--goa-drawer-shadow);
+    transform: translateX(100%); /* Start off-screen to the right */
+    /* Smooth transitions for position and transform */
+    transition: bottom 0.15s ease-out, transform 0.2s ease-out;
+  }
+  .v2.drawer-open-right {
+    right: var(--goa-drawer-offset, 0);
+    transform: translateX(0); /* Slide in */
+  }
+
+  /* V2: When scrolled to bottom, add bottom constraint to lift drawer up */
+  .root.bottom .v2.drawer-right {
+    bottom: var(--goa-drawer-offset, 0);
   }
 
   /* Left */
 
   .drawer-left {
     left: var(--drawer-offset);
-    height: 100%;
-    box-shadow: var(--goa-drawer-left-shadow);
+    height: auto; /* Content-driven height */
+    min-height: 100vh; /* V1: Full height background */
     transform: translateX(-100%);
+    box-shadow: var(--goa-drawer-left-shadow);
   }
+
   .drawer-open-left {
     left: 0;
+  }
+
+  /* V2: Border radius + 16px offset from edges + content-driven height */
+  .v2.drawer-left {
+    left: var(--drawer-offset);
+    top: var(--goa-drawer-offset, 0);
+    /* No bottom positioning - allows height: auto to work naturally */
+    height: auto;
+    min-height: 0; /* Override V1 min-height */
+    /* Max-height accounts for BOTH top and bottom margins (modal stays floating) */
+    max-height: calc(100vh - 2 * var(--goa-drawer-offset, 0));
+    overflow-y: hidden; /* No scroll on drawer itself */
+    border-radius: var(--goa-drawer-border-radius, 24px);
+    box-shadow: var(--goa-drawer-shadow);
+    transform: translateX(-100%); /* Start off-screen to the left */
+    /* Smooth transitions for position and transform */
+    transition: bottom 0.15s ease-out, transform 0.2s ease-out;
+  }
+  .v2.drawer-open-left {
+    left: var(--goa-drawer-offset, 0);
+    transform: translateX(0); /* Slide in */
+  }
+
+  /* V2: When scrolled to bottom, add bottom constraint to lift drawer up */
+  .root.bottom .v2.drawer-left {
+    bottom: var(--goa-drawer-offset, 0);
   }
 </style>

--- a/libs/web-components/src/components/drawer/drawer.spec.ts
+++ b/libs/web-components/src/components/drawer/drawer.spec.ts
@@ -120,7 +120,7 @@ describe("Drawer", () => {
     const drawerEl = await el.findByTestId("drawer");
     await waitFor(() => {
       const drawer = drawerEl.querySelector(".drawer") as HTMLElement;
-      expect(drawer?.style.maxWidth).toBe(maxsize);
+      expect(drawer?.getAttribute("style") ?? "").toContain(maxsize);
     });
   });
 


### PR DESCRIPTION
  ## Summary

  Updates the Drawer component to support V2 design system styling. Maintains full backward compatibility with V1 while adding modern UX enhancements.

  ## Changes

  ### New Props
  - **`version`** (`"1" | "2"`, default `"1"`): Controls V1 vs V2 styling and behavior

  ### V2 Visual Updates

  **Border Radius & Shadows**
  - All corners: 24px border radius (was 8px for bottom position only in V1)
  - Bottom drawer: Rounded top corners
  - Left/Right drawers: All corners rounded (NEW in V2)
  - Unified elevation shadow for all positions (replaces position-specific shadows)

  **16px Screen Edge Offset**
  - V2 drawers float with 16px margin from all screen edges
  - Creates visual breathing room and modern appearance
  - V1 drawers remain flush to screen edges

  **Spacing Refinements**
  - Content padding: 24px horizontal, 16px vertical (reduced from 32px/24px in V1)
  - Actions padding: 16px top, 24px horizontal/bottom (reduced from 24px/32px in V1)
  - Tighter spacing creates more compact, focused experience

  **Typography**
  - Heading: 24px (heading-s) in V2, down from 28px (heading-m) in V1
  - Better visual hierarchy with icon button alignment

  **Overlay**
  - Darker overlay: `rgba(51,51,51,0.5)` vs `rgba(0,0,0,0.3)` in V1
  - Improved contrast and focus

 ## Other bugs fixed with this PR (in v1)
- https://github.com/GovAlta/ui-components/issues/2677
    - Maxsize viewport constraints working

  ## Related
  - Parent issue: #2998
  - Component issue: #3151
  - [Design tokens PR for Drawer](https://github.com/GovAlta/design-tokens/pull/108)
  - [V2 Figma Drawer](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=57009-59751&t=3ftbUXXtAZcFsynO-4)

## Testing
Playground page: https://github.com/twjeffery/goa-v2-component-playground/blob/main/src/pages/DrawerPage.svelte

### V2
<img width="552" height="994" alt="image" src="https://github.com/user-attachments/assets/5647d16a-5c65-4aa5-9a6d-da76cd754995" />

### V1
<img width="552" height="994" alt="image" src="https://github.com/user-attachments/assets/46ceb69b-ee13-4e81-9241-07de17a4b948" />
