### PR TITLE
feat(#3160): update Popover component for V2

### DIFF
--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -464,7 +464,9 @@
     border-radius: var(--goa-popover-border-radius);
     outline: none;
     overflow: visible;
-    filter: var(--goa-popover-shadow);
+    box-shadow: var(--goa-popover-box-shadow, none);
+    filter: var(--goa-popover-shadow, none);
+    border: var(--goa-popover-border, none);
     margin-top: var(--offset-top, 3px);
     margin-bottom: var(--offset-bottom, 3px);
     margin-left: var(--offset-left, 0);


### PR DESCRIPTION
  ## Summary

  Updates the Popover component to support V2 design system styling while maintaining full backward compatibility with V1.

  ## Changes

  ### New Props
  - **`version`** (`"1" | "2"`, default `"1"`): Controls V1 vs V2 styling

  ### V2 Styling Updates

  **Border & Shadow**
  - V2 adds a thin container border (0.5px solid, greyscale-150)
  - V2 uses refined layered box-shadow instead of V1's filter drop-shadow
  - V1 filter is explicitly removed in V2 to avoid doubling effects

  **Visual Refinements**
  - **Border Radius**: Increased from 4px to 8px for modernized appearance
  - **Padding**: Reduced from 12px to 8px for tighter content spacing
  - **Shadow**: Changed from simple drop-shadow to layered box-shadow for refined
  elevation

  **Note**: During testing, discovered pre-existing positioning bug when popover is used
  inside `<goa-container>`. This is a separate issue and will be reported independently.

  ### V2 Styling Verification
  - ✅ Thin border appears in V2
  - ✅ Refined layered shadow in V2
  - ✅ Border radius updated (8px)
  - ✅ Padding tightened (8px)
  - ✅ V1 styling unchanged

  ## Related
  - Parent issue: https://github.com/GovAlta/ui-components/issues/2998
  - Component issue: https://github.com/GovAlta/ui-components/issues/3160
  - [Design Tokens PR for Popover](https://github.com/GovAlta/design-tokens/pull/111)
  - [V2 Figma component](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=32486-707969&t=B3wAonZXzOuNkg9O-4) 