### PR TITLE
feat(#3193): update side-menu to v2

### DIFF
--- a/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
+++ b/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
@@ -14,6 +14,7 @@
   import type { GoAIconType } from "../icon/Icon.svelte";
   import { calculateMargin, Spacing } from "../../common/styling";
 
+  export let version: "1" | "2" = "1";
   export let heading: string;
   export let icon: GoAIconType | null = null;
   export let testid: string = "";
@@ -121,6 +122,7 @@
 
 <div bind:this={_rootEl}
      class="side-menu-group"
+     class:v2={version === "2"}
      class:current={_current}
      data-testid={testid}
      style={`
@@ -130,18 +132,29 @@
   <a href={`#${_slug}`} class="heading" class:open={_open} on:click={handleClick}>
     {#if icon}
       <div class="leading-icon">
-        <goa-icon type={icon} />
+        {#if version === "2"}
+          <goa-icon type={icon} size="3" />
+        {:else}
+          <goa-icon type={icon} />
+        {/if}
       </div>
     {/if}
     {heading}
     <div class="trailing-icon">
-      {#if _open}
-        <goa-icon type="chevron-down"/>
+      {#if version === "2"}
+        {#if _open}
+          <goa-icon type="chevron-down" size="3" />
+        {:else}
+          <goa-icon type="chevron-forward" size="3" />
+        {/if}
       {:else}
-        <goa-icon type="chevron-forward"/>
+        {#if _open}
+          <goa-icon type="chevron-down" />
+        {:else}
+          <goa-icon type="chevron-forward" />
+        {/if}
       {/if}
     </div>
-
   </a>
   <div class:hidden={!_open} class="group" data-testid="group">
     <slot />
@@ -153,9 +166,9 @@
   :global(::slotted(goa-side-menu-heading)),
   :global(::slotted(a:visited)) {
     /* required to override base styles */
-    color: var(--goa-side-menu-color-menu-item) !important;
+    color: var(--goa-side-menu-color-item, var(--goa-color-text-default)) !important;
     display: block;
-    font: var(--goa-side-menu-typography-item);
+    font: var(--goa-side-menu-group-item-typography, var(--goa-side-menu-typography-item));
     margin-left: var(--goa-side-menu-child-margin);
     background-color: var(--goa-side-menu-group-color-bg);
   }
@@ -168,11 +181,11 @@
   }
 
   :global(::slotted(a.current)) {
-    font: var(--goa-side-menu-typography-item-current);
+    font: var(--goa-side-menu-group-item-typography-current, var(--goa-side-menu-typography-item-current));
     border-left: var(--goa-side-menu-child-border-left-selected);
     background: var(--goa-side-menu-child-color-bg-selected);
     /* required to override base styles & above :global(::slotted(a) !important */
-    color: var(--goa-side-menu-child-color-text-selected)!important;
+    color: var(--goa-side-menu-color-item-current, var(--goa-color-text-default))!important;
   }
 
   :global(::slotted(a:hover:not(.current))) {
@@ -183,7 +196,7 @@
   :global(::slotted(a:focus-visible)),
   .heading:focus-visible {
     outline: var(--goa-side-menu-item-focus-border);
-    outline-offset: -3px;
+    outline-offset: var(--goa-side-menu-item-focus-outline-offset, -3px);
   }
 
 
@@ -191,11 +204,7 @@
     gap: var(--goa-space-xs); /* 8px - the minimum space between the text and the chevron icon */
     display: flex;
     flex-direction: row;
-    align-items: flex-start;
-  }
-
-  goa-icon {
-    margin-top: var(--goa-space-2xs); /* vertically centering the icon with text */
+    align-items: center;
   }
 
   /**
@@ -204,17 +213,20 @@
    */
   :host([child="true"]) a.heading,
   .heading {
-    color: var(--goa-side-menu-color-menu-item);
+    color: var(--goa-side-menu-color-item, var(--goa-color-text-default));
     display: flex;
     justify-content: space-between;
     font: var(--goa-side-menu-typography-item);
     padding: var(--goa-side-menu-parent-padding);
     text-decoration: none;
-    font: var(--goa-side-menu-typography-item);
     border-radius: var(--goa-side-menu-group-border-radius);
   }
   .heading.open {
+    font: var(--goa-side-menu-typography-item);
+  }
+  .heading.open.current {
     font: var(--goa-side-menu-typography-item-current);
+    color: var(--goa-side-menu-color-item-current, var(--goa-color-text-default));
   }
 
   :host([child="true"]) a.heading {
@@ -261,5 +273,73 @@
   }
   .leading-icon {
     height: var(--goa-icon-size-l); /* to make sure the icon vertical center */
+  }
+
+  /* V2 Styles */
+
+  /* V2: Open group heading */
+  .side-menu-group.v2 .heading.open {
+    border-radius: var(--goa-side-menu-group-border-radius-open, 0);
+    background: var(--goa-color-greyscale-100);
+  }
+
+  /* V2: Nested child links - typography, padding, border-radius, colors */
+  .side-menu-group.v2 :global(::slotted(a)) {
+    border-radius: var(--goa-border-radius-l, 6px);
+    font: var(--goa-side-menu-group-item-typography, var(--goa-side-menu-typography-item));
+    padding: var(--goa-space-2xs) var(--goa-space-xs);
+    border-left: none;
+    margin-left: 0;
+    color: var(--goa-color-text-secondary) !important;
+  }
+
+  /* V2: Group container - left border on container instead of individual items */
+  .side-menu-group.v2 .group {
+    border-left: var(--goa-side-menu-child-border-width) solid var(--goa-color-greyscale-100);
+    margin-left: var(--goa-side-menu-group-container-margin-left, 20px);
+    padding-left: var(--goa-space-s);
+    margin-top: var(--goa-space-xs);
+    margin-bottom: var(--goa-side-menu-group-container-margin-bottom, 6px);
+  }
+
+  /* V2: Current state - background, bold text, default text color */
+  .side-menu-group.v2 :global(::slotted(a.current)) {
+    border-left: none;
+    background: var(--goa-side-menu-color-bg-menu-item-hover);
+    color: var(--goa-color-text-default) !important;
+    font-weight: var(--goa-font-weight-bold);
+  }
+
+  /* V2: Hover state */
+  .side-menu-group.v2 :global(::slotted(a:hover:not(.current))) {
+    border-left: none;
+    background: var(--goa-side-menu-color-bg-menu-item-hover);
+  }
+
+  /* V2: Group heading - padding, alignment, color */
+  .side-menu-group.v2 .heading {
+    padding: var(--goa-space-xs) var(--goa-space-s);
+    align-items: flex-start;
+    color: var(--goa-color-text-secondary);
+  }
+
+  .side-menu-group.v2 .heading:hover {
+    border-radius: var(--goa-side-menu-group-border-radius-open, 0);
+  }
+
+  .side-menu-group.v2 .heading:focus-visible {
+    border-radius: var(--goa-side-menu-group-border-radius-open, 0);
+  }
+
+  /* V2: Nested groups (child attribute) */
+  :host([child="true"]) .side-menu-group.v2 a.heading {
+    border-radius: var(--goa-side-menu-group-border-radius-open, 0);
+  }
+
+  /* V2: Icon containers - smaller height for size-3 icons, align with first line */
+  .side-menu-group.v2 .leading-icon,
+  .side-menu-group.v2 .trailing-icon {
+    height: var(--goa-icon-size-3, 1.25rem);
+    margin-top: 1px;
   }
 </style>

--- a/libs/web-components/src/components/side-menu-heading/SideMenuHeading.svelte
+++ b/libs/web-components/src/components/side-menu-heading/SideMenuHeading.svelte
@@ -3,15 +3,20 @@
 <script lang="ts">
   import type { GoAIconType } from "../icon/Icon.svelte";
 
-  export let icon: GoAIconType = null;
+  export let version: "1" | "2" = "1";
+  export let icon: GoAIconType | null = null;
   export let testid: string = "section-heading";
 </script>
 
-<h2 data-testid={testid} class:icon>
+<h2 data-testid={testid} class:icon class:v2={version === "2"}>
   {#if icon}
-    <goa-icon id="heading-icon" type={icon} theme="filled" />
+    {#if version === "2"}
+      <goa-icon id="heading-icon" type={icon} theme="outline" size="3" />
+    {:else}
+      <goa-icon id="heading-icon" type={icon} theme="filled" size="4" />
+    {/if}
   {/if}
-  <slot />
+  <span class="label"><slot /></span>
   <slot name="meta" />
 </h2>
 
@@ -21,21 +26,45 @@
     align-items: center;
   }
 
+  /* V2: Icon aligns with first line of text */
+  h2.v2.icon {
+    align-items: flex-start;
+  }
+
   goa-icon {
     color: var(--goa-side-menu-icon-color);
-    font-size: var(--goa-side-menu-icon-size);
     margin-right: var(--goa-side-menu-heading-icon-gap);
-}
+  }
+
+  /* V2: Remove margin-right from icon, match text color */
+  h2.v2 goa-icon {
+    margin-right: 0;
+    color: var(--goa-side-menu-heading-color);
+  }
 
   h2 {
     border-top: var(--goa-side-menu-heading-border);
     background: var(--goa-side-menu-heading-color-bg);
     padding: var(--goa-side-menu-heading-padding);
-    color: var(--goa-side-menu-heading-color, #666);
+    color: var(--goa-side-menu-heading-color);
     font: var(--goa-side-menu-heading-typography);
     display: flex;
     align-items: flex-start;
     margin: var(--goa-side-menu-heading-margin);
     gap: var(--goa-side-menu-heading-gap);
+  }
+
+  /* V2 Styles */
+  h2.v2 {
+    border-top: none;
+    border-bottom: var(--goa-side-menu-heading-border);
+    margin-bottom: var(--goa-space-2xs);
+    margin-right: var(--goa-space-xs);
+    padding: var(--goa-side-menu-heading-padding-top, 14px) var(--goa-space-s) var(--goa-space-xs) var(--goa-space-s);
+  }
+
+  /* V2: Adjust label vertical alignment */
+  h2.v2 .label {
+    margin-top: 2px;
   }
 </style>

--- a/libs/web-components/src/components/side-menu/SideMenu.svelte
+++ b/libs/web-components/src/components/side-menu/SideMenu.svelte
@@ -6,6 +6,7 @@
   import { isUrlMatch, getMatchedLink } from "../../common/urls";
   import { SideMenuGroupProps } from "../side-menu-group/SideMenuGroup.svelte";
 
+  export let version: "1" | "2" = "1";
   export let testid: string = "";
 
   let _rootEl: HTMLElement;
@@ -101,7 +102,7 @@
   }
 </script>
 
-<div bind:this={_rootEl} class="side-menu" data-testid={testid}>
+<div bind:this={_rootEl} class="side-menu" class:v2={version === "2"} data-testid={testid}>
   <slot />
 </div>
 
@@ -109,7 +110,7 @@
   :global(::slotted(a)),
   :global(::slotted(a:visited)) {
     /* required to override base styles */
-    color: var(--goa-side-menu-text-color, var(--goa-color-text-default)) !important;
+    color: var(--goa-side-menu-color-item, var(--goa-color-text-default)) !important;
     display: block;
     font: var(--goa-side-menu-typography-item);
     padding: var(--goa-side-menu-padding-item);
@@ -118,6 +119,7 @@
 
   :global(::slotted(a.current)) {
     font: var(--goa-side-menu-typography-item-current);
+    color: var(--goa-side-menu-color-item-current, var(--goa-color-text-default)) !important;
     background: var(--goa-side-menu-color-bg-menu-item-hover);
   }
 
@@ -127,7 +129,7 @@
 
   :global(::slotted(a:focus-visible)) {
     outline: var(--goa-side-menu-item-focus-border);
-    outline-offset: -3px;
+    outline-offset: var(--goa-side-menu-item-focus-outline-offset, -3px);
   }
 
   .side-menu {
@@ -135,5 +137,21 @@
     height: 100%;
     flex-direction: column;
     gap: var(--goa-side-menu-items-gap);
+    background-color: var(--goa-side-menu-color-bg);
+    border-right: var(--goa-side-menu-border-right);
+  }
+
+  /* V2 Styles */
+  .side-menu.v2 {
+    padding: var(--goa-side-menu-padding);
+  }
+
+  .side-menu.v2 :global(::slotted(a)) {
+    border-radius: var(--goa-side-menu-item-border-radius, 0);
+    padding: var(--goa-space-xs) var(--goa-space-s);
+    display: flex;
+    align-items: flex-start;
+    gap: var(--goa-space-xs);
+    color: var(--goa-color-text-secondary) !important;
   }
 </style>


### PR DESCRIPTION
  ## Summary

  Updates the Side Menu component family (SideMenu, SideMenuGroup, SideMenuHeading) to support V2 design system styling while maintaining full backward compatibility with V1.

  ## Changes

  ### New Props
  - **`version`** (`"1" | "2"`, default `"1"`): Controls V1 vs V2 styling on all three components
  - Version cascades from parent SideMenu to child components automatically

  ### V2 Styling Updates

  **Typography & Colors**
  - Menu items: 16px/22px regular, secondary text color
  - Current/active items: Bold weight, default text color
  - Group headings: Secondary text color

  **Spacing & Layout**
  - Container padding: 16px 8px 16px 16px
  - Items gap: 4px vertical
  - Border-radius: 6px on menu items, 8px on open group headings
  - Right border on container (1px greyscale.150)

  **Structural Changes**
  - Heading border moved from top to bottom
  - Group container has left border instead of individual items
  - Icons use size-3 (20px) with outline theme in V2

  **State Styling**
  - Hover: Grey background with border-radius
  - Current: Grey background, bold text
  - Focus: Preserved focus outline

## Testing
Playground page: https://github.com/twjeffery/goa-v2-component-playground/blob/main/src/pages/SideMenuPage.svelte

### V2
<img width="293" height="496" alt="image" src="https://github.com/user-attachments/assets/92e3242a-50da-4223-ac5b-b2f09e5fa553" />

### V1
<img width="293" height="511" alt="image" src="https://github.com/user-attachments/assets/c6e7121a-3c58-4057-ac87-108e7db9cfb2" />

  ## Related
  - Parent issue: #2998
  - Component issue: #3193
  - [Design tokens PR](https://github.com/GovAlta/design-tokens/pull/116)