### PR TITLE
feat(#3207): update pagination to v2

### DIFF
--- a/libs/web-components/src/components/pagination/Pagination.svelte
+++ b/libs/web-components/src/components/pagination/Pagination.svelte
@@ -12,9 +12,11 @@
     "links-only",
   ]);
   type Variant = (typeof Variants)[number];
+  type Version = "1" | "2";
 
   // public
 
+  export let version: Version = "1";
   export let pagenumber: number;
   export let itemcount: number;
   export let perpagecount: number = 10;
@@ -99,6 +101,8 @@
         <input bind:this={hiddenEl} type="hidden" />
         {#if itemcount <= 0}
           <goa-dropdown
+            {version}
+            size={version === "2" ? "compact" : "default"}
             bind:this={pageDropdownEl}
             value="1"
             on:_change={handlePageChange}
@@ -108,6 +112,8 @@
         {:else}
           {#key _pageCount}
             <goa-dropdown
+              {version}
+              size={version === "2" ? "compact" : "default"}
               bind:this={pageDropdownEl}
               value={pagenumber}
               on:_change={handlePageChange}
@@ -125,15 +131,19 @@
       <!-- svelte-ignore a11y-no-static-element-interactions -->
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <goa-button
+        {version}
         on:click={(e) => goto(e, -1)}
         type="tertiary"
+        size={version === "2" ? "compact" : "normal"}
         leadingicon="arrow-back"
         disabled={itemcount <= 0 || pagenumber <= 1 ? "true" : "false"}>Previous</goa-button>
       <!-- svelte-ignore a11y-no-static-element-interactions -->
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <goa-button
+        {version}
         on:click={(e) => goto(e, 1)}
         type="tertiary"
+        size={version === "2" ? "compact" : "normal"}
         trailingicon="arrow-forward"
         disabled={itemcount <= 0 || pagenumber >= _pageCount ? "true" : "false"}>Next</goa-button>
     </goa-block>
@@ -143,11 +153,13 @@
 <style>
   span {
     white-space: nowrap;
+    font: var(--goa-pagination-text-size);
+    color: var(--goa-pagination-text-color);
   }
 
   .controls {
     display: flex;
-    gap: 1rem;
+    gap: var(--goa-pagination-gap, 1rem);
     flex-direction: column;
     align-items: center;
     width: 100%;


### PR DESCRIPTION
## Summary

Updates the Pagination component to support V2 design system styling while maintaining full backward compatibility with V1.

  ## Changes

  ### New Props
  - **`version`** (`"1" | "2"`, default `"1"`): Controls V1 vs V2 styling

  ### V2 Styling Updates

  **Composed Component Pattern**
  - Pagination passes `version` prop to child components (goa-button, goa-dropdown)
  - V2 uses compact size variants for buttons and dropdown
  - Child components handle their own V2 styling

  **Token Integration**
  - Gap between sections: `var(--goa-pagination-gap)` (replaces hardcoded `1rem`)
  - Label typography: `var(--goa-pagination-text-size)`
  - Label color: `var(--goa-pagination-text-color)`

  ### Technical Implementation

  **Version Prop Passthrough**
  - `goa-button`: Receives `version` and `size="compact"` for V2
  - `goa-dropdown`: Receives `version` and `size="compact"` for V2
  - No `.v2` CSS scoping needed - child component  handle styling

## Testing
Playground page: https://github.com/twjeffery/goa-v2-component-playground/blob/main/src/pages/TextFieldPage.svelte

### V2
<img width="1126" height="630" alt="image" src="https://github.com/user-attachments/assets/009fac2e-91c8-4b10-9bbd-9f4a8c2756b0" />

### V1
<img width="945" height="609" alt="image" src="https://github.com/user-attachments/assets/397ca19f-96fc-4bce-bbec-65705d68cbd1" />

  ## Related
  - Parent issue: #2998
  - Component issue: #3207
  - [Design tokens PR for Pagination](https://github.com/GovAlta/design-tokens/pull/117)