### PR TITLE
fix(#3231): restore focus state for v2 read-only Input

### DIFF
--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -500,12 +500,12 @@
     --goa-text-input-space-btw-icon-text: var(--goa-text-input-space-btw-icon-text-compact);
   }
 
-  .goa-input:not(.error):not(.input--disabled):not(:has(input:read-only)):hover:not(:has(input:focus-visible)) {
+  .goa-input:not(.error):not(.input--disabled):hover:not(:has(input:focus-visible)) {
     /* hover border */
     box-shadow: var(--goa-text-input-border-hover);
   }
 
-  .goa-input:not(.error):not(:has(input:read-only)):has(input:focus-visible) {
+  .goa-input:not(.error):has(input:focus-visible) {
     /* focus border(s) */
     box-shadow:
       var(--goa-text-input-border), var(--goa-text-input-border-focus);
@@ -517,14 +517,14 @@
   }
 
   /* Focus state (including when in error state) */
-  .goa-input:not(:has(input:read-only)):has(input:focus-visible),
-  .goa-input.error:not(:has(input:read-only)):has(input:focus-visible) {
+  .goa-input:has(input:focus-visible),
+  .goa-input.error:has(input:focus-visible) {
     box-shadow:
       var(--goa-text-input-border), var(--goa-text-input-border-focus);
   }
 
   /* V2: Focus state shows only blue focus border (no default border) */
-  .container.v2 .goa-input:not(:has(input:read-only)):has(input:focus-visible) {
+  .container.v2 .goa-input:has(input:focus-visible) {
     box-shadow: var(--goa-text-input-border-focus);
   }
 
@@ -572,7 +572,7 @@
   }
 
   input:read-only {
-    cursor: default;
+    cursor: var(--goa-text-input-cursor-readonly, default);
   }
 
   input[type="number"] {
@@ -650,6 +650,10 @@
   /* V2: Read-only input field styling (exclude disabled inputs) */
   .container.v2 .goa-input:has(input:read-only:not(:disabled)) {
     background-color: var(--goa-text-input-color-bg-readonly);
+  }
+
+  /* V2: Read-only input field styling (exclude disabled inputs) */
+  .container.v2.goa-input:not(.error)::has(input:read-only:not(:disabled):not(:focus-visible):not(:hover)) {
     box-shadow: var(--goa-text-input-border-readonly);
   }
 


### PR DESCRIPTION
Our v2 changes to the read-only state of an Input in https://github.com/GovAlta/ui-components/pull/3082 assumed that a user doesn't interact with a read-only input. But we discovered in https://github.com/GovAlta/ui-components/pull/3226 that we use an interactive read-only Input in our Date Picker. 

[MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/readonly#attribute_interactions) on `readonly` writes the following:

> The difference between [disabled](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/disabled) and readonly is that read-only controls can still function and are still focusable, whereas disabled controls can not receive focus and are not submitted with the form and generally do not function as controls until they are enabled.

This PR restores the focus state to a read-only v2 Input.

### Before

Date Picker doesn't have a hover or focus state

![readonly-no-focus](https://github.com/user-attachments/assets/7d51e306-5a67-47b2-b20e-9a1720a2be99)

### After

Date Picker has a hover  and focus state

![read-only-input-focused](https://github.com/user-attachments/assets/80a98200-cea3-4fbe-be7d-9c14ffb2a03f)
