### PR TITLE
fix(#3232): GoabText tag size fix

### DIFF
--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -53,6 +53,7 @@ export function App() {
               <Link to="/bugs/3118">3118 Text Component ID</Link>
               <Link to="/bugs/3201">3201 Input Component Events</Link>
               <Link to="/bugs/3215">3215 Drawer Initial Height</Link>
+              <Link to="/bugs/3232">3232 GoabText Tag Size</Link>
               <Link to="/bugs/3248">3248 Dropdown Dynamic Children Sync</Link>
               <Link to="/bugs/3322">3322 App Header Menu Hover</Link>
             </GoabSideMenuGroup>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -37,6 +37,7 @@ import { Bug2977Route } from "./routes/bugs/bug2977";
 import { Bug3118Route } from "./routes/bugs/bug3118";
 import { Bug3201Route } from "./routes/bugs/bug3201";
 import { Bug3215Route } from "./routes/bugs/bug3215";
+import { Bug3232Route } from "./routes/bugs/bug3232";
 import { Bug3248Route } from "./routes/bugs/bug3248";
 import { Bug3322Route } from "./routes/bugs/bug3322";
 
@@ -104,6 +105,7 @@ root.render(
           <Route path="bugs/3118" element={<Bug3118Route />} />
           <Route path="bugs/3201" element={<Bug3201Route />} />
           <Route path="bugs/3215" element={<Bug3215Route />} />
+          <Route path="bugs/3232" element={<Bug3232Route />} />
           <Route path="bugs/3248" element={<Bug3248Route />} />
           <Route path="bugs/3322" element={<Bug3322Route />} />
 

--- a/apps/prs/react/src/routes/bugs/bug3232.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3232.tsx
@@ -1,0 +1,163 @@
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabDetails,
+  GoabLink,
+} from "@abgov/react-components";
+
+export function Bug3232Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug #3232: GoabText tag prop should auto-apply heading size
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a href="https://github.com/GovAlta/ui-components/issues/3232" target="_blank" rel="noopener">
+            View on GitHub
+          </a>
+        </GoabLink>
+
+        <GoabDetails heading="Issue Description">
+          <GoabText tag="p">
+            When using GoabText with a heading tag (h1-h5) but without explicitly setting
+            the size prop, the component renders the semantic HTML element but doesn't
+            apply the design system typography styles. Instead, it falls back to browser
+            defaults, which don't match our design tokens.
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      <GoabText tag="p">
+        Left column uses just tag. Center column uses tag + explicit size.
+        Right column uses just explicit size. They should all match.
+      </GoabText>
+
+      <GoabText tag="h3">Test 1: H1 → heading-xl</GoabText>
+      <div style={{ display: "flex", gap: "var(--goa-space-xl)", flexWrap: "wrap" }}>
+        <div>
+          <GoabText tag="h1">Heading XL</GoabText>
+          <code>tag="h1"</code>
+        </div>
+        <div>
+          <GoabText tag="h1" size="heading-xl">Heading XL</GoabText>
+          <code>tag="h1" size="heading-xl"</code>
+        </div>
+        <div>
+          <GoabText size="heading-xl">Heading XL</GoabText>
+          <code>size="heading-xl"</code>
+        </div>
+      </div>
+
+      <GoabText tag="h3">Test 2: H2 → heading-l</GoabText>
+      <div style={{ display: "flex", gap: "var(--goa-space-xl)", flexWrap: "wrap" }}>
+        <div>
+          <GoabText tag="h2">Heading L</GoabText>
+          <code>tag="h2"</code>
+        </div>
+        <div>
+          <GoabText tag="h2" size="heading-l">Heading L</GoabText>
+          <code>tag="h2" size="heading-l"</code>
+        </div>
+        <div>
+          <GoabText size="heading-l">Heading L</GoabText>
+          <code>size="heading-l"</code>
+        </div>
+      </div>
+
+      <GoabText tag="h3">Test 3: H3 → heading-m</GoabText>
+      <div style={{ display: "flex", gap: "var(--goa-space-xl)", flexWrap: "wrap" }}>
+        <div>
+          <GoabText tag="h3">Heading M</GoabText>
+          <code>tag="h3"</code>
+        </div>
+        <div>
+          <GoabText tag="h3" size="heading-m">Heading M</GoabText>
+          <code>tag="h3" size="heading-m"</code>
+        </div>
+        <div>
+          <GoabText size="heading-m">Heading M</GoabText>
+          <code>size="heading-m"</code>
+        </div>
+      </div>
+
+      <GoabText tag="h3">Test 4: H4 → heading-s</GoabText>
+      <div style={{ display: "flex", gap: "var(--goa-space-xl)", flexWrap: "wrap" }}>
+        <div>
+          <GoabText tag="h4">Heading S</GoabText>
+          <code>tag="h4"</code>
+        </div>
+        <div>
+          <GoabText tag="h4" size="heading-s">Heading S</GoabText>
+          <code>tag="h4" size="heading-s"</code>
+        </div>
+        <div>
+          <GoabText size="heading-s">Heading S</GoabText>
+          <code>size="heading-s"</code>
+        </div>
+      </div>
+
+      <GoabText tag="h3">Test 5: H5 → heading-xs</GoabText>
+      <div style={{ display: "flex", gap: "var(--goa-space-xl)", flexWrap: "wrap" }}>
+        <div>
+          <GoabText tag="h5">Heading XS</GoabText>
+          <code>tag="h5"</code>
+        </div>
+        <div>
+          <GoabText tag="h5" size="heading-xs">Heading XS</GoabText>
+          <code>tag="h5" size="heading-xs"</code>
+        </div>
+        <div>
+          <GoabText size="heading-xs">Heading XS</GoabText>
+          <code>size="heading-xs"</code>
+        </div>
+      </div>
+
+      <GoabDivider mt="xl" mb="l" />
+
+      <GoabText tag="h3">Test 6: Non-heading tags (no auto-size)</GoabText>
+      <GoabText tag="p">
+        These should remain unstyled unless size is explicitly set.
+      </GoabText>
+
+      <div>
+        <div>
+          <GoabText tag="p">Paragraph with no size - should be unstyled</GoabText>
+          <code>tag="p" (no size)</code>
+        </div>
+        <div>
+          <GoabText tag="p" size="body-m">Paragraph with body-m size</GoabText>
+          <code>tag="p" size="body-m"</code>
+        </div>
+        <div>
+          <GoabText tag="span">Span with no size - should be unstyled</GoabText>
+          <code>tag="span" (no size)</code>
+        </div>
+      </div>
+
+      <GoabDivider mt="xl" mb="l" />
+
+      <GoabText tag="h3">Test 7: Explicit size overrides tag default</GoabText>
+      <GoabText tag="p">
+        Setting size explicitly should override the tag-based default.
+      </GoabText>
+
+      <div>
+        <div>
+          <GoabText tag="h1" size="body-s">H1 with body-s size (explicit override)</GoabText>
+          <code>tag="h1" size="body-s"</code>
+        </div>
+        <div>
+          <GoabText tag="h2" size="heading-xs">H2 with heading-xs size (explicit override)</GoabText>
+          <code>tag="h2" size="heading-xs"</code>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/web-components/src/components/text/Text.svelte
+++ b/libs/web-components/src/components/text/Text.svelte
@@ -1,11 +1,4 @@
-<svelte:options
-  customElement={{
-    tag: "goa-text",
-    props: {
-      id: { attribute: "id", type: "String", reflect: true },
-    },
-  }}
-/>
+<svelte:options customElement="goa-text" />
 
 <script lang="ts" context="module">
   export type HeadingElement = "h1" | "h2" | "h3" | "h4" | "h5";
@@ -43,7 +36,30 @@
   let _marginTop: Spacing = null;
 
   /**
-   * Returns a bottom margin value based on the `size` prop
+   * Returns a default size based on the heading tag when size is not explicitly set
+   */
+  function getDefaultSizeForTag(tag: TextElement | HeadingElement): Size | undefined {
+    switch (tag) {
+      case "h1":
+        return "heading-xl";
+      case "h2":
+        return "heading-l";
+      case "h3":
+        return "heading-m";
+      case "h4":
+        return "heading-s";
+      case "h5":
+        return "heading-xs";
+      default:
+        return undefined;
+    }
+  }
+
+  // Derive effective size from explicit size prop or from tag
+  $: effectiveSize = size ?? getDefaultSizeForTag(as);
+
+  /**
+   * Returns a bottom margin value based on the effective size
    */
   function getBottomMargin(): Spacing {
     // override takes precedence
@@ -51,7 +67,7 @@
       return mb;
     }
 
-    switch (size) {
+    switch (effectiveSize) {
       case "heading-xl":
         return "l";
       case "heading-l":
@@ -78,7 +94,7 @@
       return mt;
     }
 
-    switch (size) {
+    switch (effectiveSize) {
       case "heading-xl":
       case "heading-l":
       case "heading-m":
@@ -107,7 +123,7 @@
 
 <svelte:element
   this={as}
-  class={size}
+  class={effectiveSize}
   style={styles(
     style(
       "color",


### PR DESCRIPTION
When using `GoabText` with a heading tag (h1-h5) without explicitly setting the `size` prop, the component now correctly applies the corresponding design system typography instead of incorrect sizes.

# Before (the change)
When text includes a tag prop without the size prop, the heading gets incorrect sizing.
Video of mismatched text size: [jam.dev/c/30cffcdd-0095-45c2-8c9c-e35f42753a85](https://jam.dev/c/30cffcdd-0095-45c2-8c9c-e35f42753a85)

# After (the change)

**Mapping:**
   - `tag="h1"` → `heading-xl`
   - `tag="h2"` → `heading-l`
   - `tag="h3"` → `heading-m`
   - `tag="h4"` → `heading-s`
   - `tag="h5"` → `heading-xs`

<img width="968" height="910" alt="image" src="https://github.com/user-attachments/assets/e80b01d7-1a3f-41a1-a579-5a4023d035f9" />

## Steps needed to test
- [ ] Navigate to playground `/bugs/3232` to see comparison examples
- [ ] Verify `<GoabText tag="h1">` matches `<GoabText tag="h1" size="heading-xl">`
- [ ] Verify non-heading tags (p, span, div) remain unstyled without explicit size
- [ ] Verify explicit size prop still overrides tag-base default"
