### PR TITLE
fix: browser specs failing based on date calculations

### DIFF
--- a/libs/react-components/specs/calendar.browser.spec.tsx
+++ b/libs/react-components/specs/calendar.browser.spec.tsx
@@ -66,12 +66,20 @@ describe("Calendar", () => {
 
   it("respects min date constraint", async () => {
     const handleChange = vi.fn();
-    const today = new Date();
+    const value = "2025-11-15";
+    const today = new Date(value);
     const minDate = format(today, "yyyy-MM-dd");
     const pastDate = format(addDays(today, -5), "yyyy-MM-dd");
 
     const Component = () => {
-      return <GoabCalendar testId="calendar" min={minDate} onChange={handleChange} />;
+      return (
+        <GoabCalendar
+          testId="calendar"
+          min={minDate}
+          value={value}
+          onChange={handleChange}
+        />
+      );
     };
 
     const result = render(<Component />);


### PR DESCRIPTION
# Before (the change)

The test failed:

```
 FAIL   react-browser (firefox)  libs/react-components/specs/calendar.browser.spec.tsx:67:6 > Calendar > respects min date constraint
VitestBrowserElementError: Cannot find element with locator: locator('body').getByTestId('2025-11-27')
 ❯ libs/react-components/specs/calendar.browser.spec.tsx:81:28
     79|
     80|     await vi.waitFor(() => {
     81|       expect(pastDateButton.element().classList.contains("disabled")).toBe(true);
       |                            ^
     82|     });
     83|
 ❯ libs/react-components/specs/calendar.browser.spec.tsx:80:13
```

This was because 2025-11-27 wasn't visible on the calculator as viewed from 2025-12-02:
<img width="313" height="373" alt="image" src="https://github.com/user-attachments/assets/0c97e234-aced-4f42-8b49-f0af46995499" />

# After (the change)

I hard-coded the date value for the test to the 15th, in the middle of the month, where a past date would be visible, but disabled, per the Calendar's expected functionality.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

✅ Browser Specs pass.

![https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGRjN2Q3c3B0cm1tcHhhbXQ4Znh6Z2xvcjlmMmVtNDY0MnIxOWlzbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/T4m0GlM2qdgC7RWk5r/giphy.gif](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGRjN2Q3c3B0cm1tcHhhbXQ4Znh6Z2xvcjlmMmVtNDY0MnIxOWlzbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/T4m0GlM2qdgC7RWk5r/giphy.gif)