### PR TITLE
feat(#3235): update details to v2

### DIFF
--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -56,12 +56,12 @@
     aria-controls={`${_detailsId}-content`}
   >
     <goa-icon
-      mt="2"
+      mt="1"
       mr="2"
       type="chevron-forward"
       fillcolor={_isMouseOver
-        ? "var(--goa-color-interactive-hover)"
-        : "var(--goa-color-interactive-default)"}
+        ? "var(--goa-details-icon-color-hover, var(--goa-color-interactive-hover))"
+        : "var(--goa-details-icon-color, var(--goa-color-interactive-default))"}
     />
     <span id={`${_detailsId}-heading`}>{heading}</span>
   </summary>
@@ -84,7 +84,7 @@
     position: relative;
   }
   details :global(::slotted(*)) {
-    font: var(--goa-typography-body-m);
+    font: var(--goa-details-content-typography, var(--goa-typography-body-m));
   }
   details[open] goa-icon {
     transform: translateX(-1px) translateY(-0px) rotate(90deg);
@@ -106,6 +106,7 @@
     display: flex;
     align-items: flex-start;
     border-radius: var(--goa-details-border-radius); /* 4px */
+    width: var(--goa-details-heading-width, auto);
   }
   summary:focus-visible {
     outline: var(--goa-details-focus-border);


### PR DESCRIPTION
This PR updates the the Details component to match the [v2 design update](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=15932-569233&t=mcddBZXIk6dfqF0X-1) while keeping the original v1 design with design token fallbacks.

It adds the following new tokens with v1 fallbacks:
- Icon color
- Icon hover color
- Heading width
- Content typography