### PR TITLE
feat(#3254): update file uploader to v2

### DIFF
--- a/libs/web-components/src/components/file-upload-card/FileUploadCard.svelte
+++ b/libs/web-components/src/components/file-upload-card/FileUploadCard.svelte
@@ -11,6 +11,7 @@
   export let progress: number = -1;
   export let error: string = "";
   export let testid: string = "";
+  export let version: "1" | "2" = "1";
 
   // Private
 
@@ -135,12 +136,14 @@
         <goa-button
           type="tertiary"
           size="compact"
+          {version}
           on:click={() => dispatch("_cancel")}>Cancel</goa-button
         >
       {:else if _status === "uploaded"}
         <goa-button
           type="tertiary"
           size="compact"
+          {version}
           on:click={() => dispatch("_delete")}
           leadingicon="trash">Remove</goa-button
         >
@@ -148,6 +151,7 @@
         <goa-button
           type="tertiary"
           size="compact"
+          {version}
           on:click={() => dispatch("_delete")}
           variant="destructive">Cancel</goa-button
         >

--- a/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
+++ b/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
@@ -16,6 +16,7 @@
   export let accept: string = "*";
   export let maxfilesize: string = "5MB";
   export let testid: string = "";
+  export let version: "1" | "2" = "1";
 
   // Private
 
@@ -223,7 +224,7 @@
 
 {#if variant === "button"}
   <div class="button" bind:this={_el}>
-    <goa-button on:click={openFilePicker} type="secondary">
+    <goa-button on:click={openFilePicker} type="secondary" {version}>
       Choose file
     </goa-button>
 


### PR DESCRIPTION
This PR updates the file uploader components to match the [v2 Figma design.](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=27335-606170&t=mcddBZXIk6dfqF0X-1) It adds a version property so it can use the correct version of button.
