### PR TITLE
fix(#3215): Fixed actions slot position for Drawer

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -47,6 +47,7 @@
           <a href="/bugs/3072">3072</a>
           <a href="/bugs/3118">3118</a>
           <a href="/bugs/3156">3156</a>
+          <a href="/bugs/3215">3215</a>
           <a href="/bugs/3248">3248</a>
         </goab-side-menu-group>
         <goab-side-menu-group heading="Features">

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -32,6 +32,7 @@ import { Bug2991Component } from "../routes/bugs/2991/bug2991.component";
 import { Bug3072Component } from "../routes/bugs/3072/bug3072.component";
 import { Bug3118Component } from "../routes/bugs/3118/bug3118.component";
 import { Bug3156Component } from "../routes/bugs/3156/bug3156.component";
+import { Bug3215Component } from "../routes/bugs/3215/bug3215.component";
 import { Bug3248Component } from "../routes/bugs/3248/bug3248.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
@@ -82,6 +83,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3072", component: Bug3072Component },
   { path: "bugs/3118", component: Bug3118Component },
   { path: "bugs/3156", component: Bug3156Component },
+  { path: "bugs/3215", component: Bug3215Component },
   { path: "bugs/3248", component: Bug3248Component },
 
   { path: "features/1328", component: Feat1328Component },

--- a/apps/prs/angular/src/routes/bugs/3215/bug3215.component.html
+++ b/apps/prs/angular/src/routes/bugs/3215/bug3215.component.html
@@ -1,0 +1,81 @@
+<goab-button-group alignmnent="start">
+  <goab-button type="primary" (onClick)="openRightDrawer()"
+    >Open Drawer (Right)</goab-button
+  >
+  <goab-button type="secondary" (onClick)="openBottomDrawer()"
+    >Open Drawer (Bottom)</goab-button
+  >
+</goab-button-group>
+
+<ng-template #drawerActionsRight>
+  <goab-button-group alignment="end" gap="relaxed">
+    <goab-button type="secondary" (onClick)="closeRightDrawer()">Cancel</goab-button>
+    <goab-button type="primary" (onClick)="closeRightDrawer()">Save</goab-button>
+  </goab-button-group>
+</ng-template>
+
+<ng-template #drawerActionsBottom>
+  <goab-button-group alignment="end" gap="relaxed">
+    <goab-button type="secondary" (onClick)="closeBottomDrawer()">Cancel</goab-button>
+    <goab-button type="primary" (onClick)="closeBottomDrawer()">Save</goab-button>
+  </goab-button-group>
+</ng-template>
+
+<ng-template #drawerContent>
+  <p>
+    Use the buttons below to close this right-positioned drawer. The content area
+    stretches to fill the available vertical space for layout testing.
+  </p>
+  <goab-text tag="h4">Review checklist</goab-text>
+  <ul>
+    <li>Confirm scope alignment</li>
+    <li>Validate stakeholder sign-offs</li>
+    <li>Verify accessibility and QA coverage</li>
+  </ul>
+  <p>
+    This panel expands to the full viewport height so you can test scrolling and layout
+    behavior. Add or remove content here to simulate different drawer payloads.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse
+    lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse
+    lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse
+    lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse
+    lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse
+    lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+  </p>
+</ng-template>
+
+<goab-drawer
+  [open]="rightDrawerOpen"
+  position="right"
+  heading="Project Review Panel"
+  [actions]="drawerActionsRight"
+  maxSize="400px"
+  (onClose)="closeRightDrawer()"
+>
+  <ng-container *ngTemplateOutlet="drawerContent"></ng-container>
+</goab-drawer>
+
+<goab-drawer
+  [open]="bottomDrawerOpen"
+  position="bottom"
+  heading="Project Review Panel"
+  [actions]="drawerActionsBottom"
+  maxSize="400px"
+  (onClose)="closeBottomDrawer()"
+>
+  <ng-container *ngTemplateOutlet="drawerContent"></ng-container>
+</goab-drawer>

--- a/apps/prs/angular/src/routes/bugs/3215/bug3215.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3215/bug3215.component.ts
@@ -1,0 +1,35 @@
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+import {
+  GoabButton,
+  GoabButtonGroup,
+  GoabDrawer,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3215",
+  templateUrl: "./bug3215.component.html",
+  imports: [CommonModule, GoabButton, GoabButtonGroup, GoabDrawer, GoabText],
+})
+export class Bug3215Component {
+  rightDrawerOpen = false;
+  bottomDrawerOpen = false;
+
+  openRightDrawer() {
+    this.rightDrawerOpen = true;
+  }
+
+  openBottomDrawer() {
+    this.bottomDrawerOpen = true;
+  }
+
+  closeRightDrawer() {
+    this.rightDrawerOpen = false;
+  }
+
+  closeBottomDrawer() {
+    this.bottomDrawerOpen = false;
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -52,6 +52,7 @@ export function App() {
               <Link to="/bugs/2943">2943</Link>
               <Link to="/bugs/2948">2948</Link>
               <Link to="/bugs/3118">3118</Link>
+              <Link to="/bugs/3215">3215</Link>
               <Link to="/bugs/3248">3248</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Features">

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -32,8 +32,9 @@ import { Bug2892Route } from "./routes/bugs/bug2892";
 import { Bug2922Route } from "./routes/bugs/bug2922";
 import { Bug2943Route } from "./routes/bugs/bug2943";
 import { Bug2948Route } from "./routes/bugs/bug2948";
+import { Bug3118Route } from "./routes/bugs/bug3118";
+import { Bug3215Route } from "./routes/bugs/bug3215";
 import { Bug3248Route } from "./routes/bugs/bug3248";
-import Bug3118Route from "./routes/bugs/bug3118";
 
 import { EverythingRoute } from "./routes/everything";
 import { Feat1547Route } from "./routes/features/feat1547";
@@ -86,6 +87,7 @@ root.render(
           <Route path="bugs/2943" element={<Bug2943Route />} />
           <Route path="bugs/2948" element={<Bug2948Route />} />
           <Route path="bugs/3118" element={<Bug3118Route />} />
+          <Route path="bugs/3215" element={<Bug3215Route />} />
           <Route path="bugs/3248" element={<Bug3248Route />} />
 
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3118.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3118.tsx
@@ -8,7 +8,7 @@ import {
 } from "@abgov/react-components";
 import type { GoabMenuButtonOnActionDetail } from "@abgov/ui-components-common";
 
-export default function TestComponent() {
+export function Bug3118Route() {
   const onAction = (detail: GoabMenuButtonOnActionDetail) => {
     console.log(detail);
   };
@@ -35,9 +35,7 @@ export default function TestComponent() {
       <GoabDivider mt="xl" mb="xl" />
 
       {/* Critical Test Cases for the Fix */}
-      <GoabText tag="h2">
-        Long Elements aren't forced to wrap
-      </GoabText>
+      <GoabText tag="h2">Long Elements aren't forced to wrap</GoabText>
 
       <GoabMenuButton text="Baseline actions" onAction={onAction}>
         <GoabMenuAction key="1" text="Action 1" action="action-1" icon="search" />
@@ -51,9 +49,7 @@ export default function TestComponent() {
       </GoabMenuButton>
 
       {/* Critical Test Cases for the Fix */}
-      <GoabText tag="h2">
-        Max width can be set forcing long elements to wrap
-      </GoabText>
+      <GoabText tag="h2">Max width can be set forcing long elements to wrap</GoabText>
 
       <GoabMenuButton maxWidth="500px" text="Baseline actions" onAction={onAction}>
         <GoabMenuAction key="1" text="Action 1" action="action-1" icon="search" />
@@ -75,9 +71,7 @@ export default function TestComponent() {
       <GoabText tag="h2">
         Components on the right side of the screen will right align the menu options
       </GoabText>
-      <GoabText tag="p">
-        You may may have to resize the browser to test this
-      </GoabText>
+      <GoabText tag="p">You may may have to resize the browser to test this</GoabText>
 
       <GoabBlock direction="row" gap="l" width="100%">
         <div style={{ width: "100%" }}></div>
@@ -93,14 +87,10 @@ export default function TestComponent() {
         </GoabMenuButton>
       </GoabBlock>
 
-
       <GoabDivider mt="xl" mb="xl" />
 
-
       {/*  */}
-      <GoabText tag="h2">
-        Regression tests
-      </GoabText>
+      <GoabText tag="h2">Regression tests</GoabText>
 
       <GoabGrid minChildWidth="320px" gap="l">
         <GoabBlock direction="column" gap="l" maxWidth="320px">

--- a/apps/prs/react/src/routes/bugs/bug3215.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3215.tsx
@@ -1,0 +1,129 @@
+import {
+  GoabButton,
+  GoabButtonGroup,
+  GoabText,
+  GoabDrawer,
+} from "@abgov/react-components";
+import { useState } from "react";
+
+export function Bug3215Route() {
+  const [rightDrawerOpen, setRightDrawerOpen] = useState<boolean>(false);
+  const [bottomDrawerOpen, setBottomDrawerOpen] = useState<boolean>(false);
+
+  const drawerActionsRight = (
+    <GoabButtonGroup alignment="end" gap="relaxed">
+      <GoabButton type="secondary" onClick={() => closeRightDrawer()}>
+        Cancel
+      </GoabButton>
+      <GoabButton type="primary" onClick={() => closeRightDrawer()}>
+        Save
+      </GoabButton>
+    </GoabButtonGroup>
+  );
+
+  const drawerActionsBottom = (
+    <GoabButtonGroup alignment="end" gap="relaxed">
+      <GoabButton type="secondary" onClick={() => closeBottomDrawer()}>
+        Cancel
+      </GoabButton>
+      <GoabButton type="primary" onClick={() => closeBottomDrawer()}>
+        Save
+      </GoabButton>
+    </GoabButtonGroup>
+  );
+
+  const drawerContent = (
+    <div>
+      <p>
+        Use the buttons below to close this right-positioned drawer. The content area
+        stretches to fill the available vertical space for layout testing.
+      </p>
+      <GoabText tag="h4">Review checklist</GoabText>
+      <ul>
+        <li>Confirm scope alignment</li>
+        <li>Validate stakeholder sign-offs</li>
+        <li>Verify accessibility and QA coverage</li>
+      </ul>
+      <p>
+        This panel expands to the full viewport height so you can test scrolling and
+        layout behavior. Add or remove content here to simulate different drawer payloads.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
+        Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed,
+        dolor.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
+        Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed,
+        dolor.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
+        Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed,
+        dolor.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
+        Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed,
+        dolor.
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
+        Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed,
+        dolor.
+      </p>
+    </div>
+  );
+
+  const openRightDrawer = () => {
+    setRightDrawerOpen(true);
+  };
+
+  const openBottomDrawer = () => {
+    setBottomDrawerOpen(true);
+  };
+
+  const closeRightDrawer = () => {
+    setRightDrawerOpen(false);
+  };
+
+  const closeBottomDrawer = () => {
+    setBottomDrawerOpen(false);
+  };
+
+  return (
+    <main>
+      <GoabButtonGroup alignment="start">
+        <GoabButton type="primary" onClick={() => openRightDrawer()}>
+          Open Drawer (Right)
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => openBottomDrawer()}>
+          Open Drawer (Bottom)
+        </GoabButton>
+      </GoabButtonGroup>
+
+      <GoabDrawer
+        open={rightDrawerOpen}
+        position="right"
+        heading="Project Review Panel"
+        actions={drawerActionsRight}
+        maxSize="400px"
+        onClose={() => closeRightDrawer()}
+      >
+        {drawerContent}
+      </GoabDrawer>
+
+      <GoabDrawer
+        open={bottomDrawerOpen}
+        position="bottom"
+        heading="Project Review Panel"
+        actions={drawerActionsBottom}
+        maxSize="400px"
+        onClose={() => closeBottomDrawer()}
+      >
+        {drawerContent}
+      </GoabDrawer>
+    </main>
+  );
+}

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -1167,7 +1167,7 @@ export type GoabPublicFormTaskStatus = "completed" | "not-started" | "cannot-sta
 
 // Drawer
 export type GoabDrawerPosition = "bottom" | "left" | "right" | undefined;
-export type GoabDrawerSizeUnit = "px" | "rem" | "ch" | "vh" | "vw";
+export type GoabDrawerSizeUnit = "px" | "rem" | "ch" | "vh" | "vw" | "%";
 export type GoabDrawerSize = `${number}${GoabDrawerSizeUnit}` | undefined;
 
 // Work side menu

--- a/libs/web-components/src/common/types.ts
+++ b/libs/web-components/src/common/types.ts
@@ -1,4 +1,4 @@
 // Drawer
 export type DrawerPosition = "bottom" | "left" | "right" | undefined;
-export type DrawerSizeUnit = "px" | "rem" | "ch" | "vh" | "vw";
+export type DrawerSizeUnit = "px" | "rem" | "ch" | "vh" | "vw" | "%";
 export type DrawerSize = `${number}${DrawerSizeUnit}` | undefined;

--- a/libs/web-components/src/components/drawer/Drawer.svelte
+++ b/libs/web-components/src/components/drawer/Drawer.svelte
@@ -31,10 +31,7 @@
 
   // computes the required absolute position offset to hide the drawer when not shown
   let _drawerSize: number;
-  let _actionsHeight: number = 0;
-  let _headerHeight: number = 0;
   let _actionsSlotHasContent: boolean = false;
-  let _scrollableHeight: string = "";
   let _scrollPos: "top" | "middle" | "bottom" | null = "top"; // to add the box-shadow to the drawer content
 
   // ========
@@ -54,11 +51,6 @@
       const hasScroll = _scrollEl.scrollHeight > _scrollEl.offsetHeight;
       _scrollPos = hasScroll ? "top" : null;
     }
-  }
-
-  // Add reactive statement for height calculations
-  $: if (open && _contentEl) {
-    updateHeights();
   }
 
   $: {
@@ -94,21 +86,9 @@
   // Functions
   // *********
 
-  // to set the scrollable height
-  function updateHeights() {
-    const headerEl = _contentEl?.querySelector(".header");
-    const actionsEl = _contentEl?.querySelector(".drawer-actions");
-
-    _headerHeight = headerEl?.clientHeight ?? 0;
-    _actionsHeight = actionsEl?.clientHeight ?? 0;
-    _scrollableHeight = scrollableHeight();
-  }
-
   async function checkActionsSlotContent() {
     await tick();
     _actionsSlotHasContent = !!$$slots.actions;
-    // Trigger height recalculation after checking slot content
-    updateHeights();
   }
 
   function close(e: Event) {
@@ -126,19 +106,6 @@
         break;
     }
   };
-
-  function scrollableHeight() {
-    const edgeMargin = 16; // box shadow top and bottom
-
-    if (position === "bottom") {
-      return maxsize; // maxsize will be the height when drawer is in the bottom position
-    }
-    // Calculate available height by subtracting:
-    // - header height
-    // - actions height (if actions exist)
-    // - edge margins
-    return `calc(100vh - ${_headerHeight}px - ${_actionsSlotHasContent ? _actionsHeight : 0}px - ${edgeMargin}px)`;
-  }
 
   // handle scroll event to set the scroll position in order to add the box-shadow to the drawer content depending on the scroll position
   function handleScroll(e: CustomEvent) {
@@ -179,8 +146,8 @@
       use:noscroll={{ enable: open }}
       style={styles(
         style("--drawer-offset", `-${_drawerSize}px`),
-        style("height", position === "bottom" ? "unset" : "100vh"),
-        style("max-width", position === "bottom" ? "unset" : maxsize),
+        style("max-height", position === "bottom" ? maxsize : "100vh"),
+        style("max-width", position === "bottom" ? "100%" : maxsize),
         style("width", position === "bottom" ? "100%" : maxsize),
       )}
       in:fly={_flyParams}
@@ -199,7 +166,7 @@
       aria-labelledby="goa-drawer-heading"
     >
       <!-- Header -->
-      <div class="header" bind:clientHeight={_headerHeight} id="goa-drawer-heading">
+      <div class="header" id="goa-drawer-heading">
         {#if heading || $$slots.heading}
           {#if heading}
             <goa-text size="heading-m" as="h3" mt="none" mb="none">{heading}</goa-text>
@@ -224,7 +191,7 @@
       <div data-testid="drawer-content" class="drawer-content">
         <goa-scrollable
           direction="vertical"
-          maxheight={_scrollableHeight}
+          maxheight="100%"
           on:_scroll={handleScroll}
           bind:this={_scrollEl}
         >
@@ -240,7 +207,6 @@
           class="drawer-actions"
           data-testid="drawer-actions"
           class:empty-actions={!_actionsSlotHasContent}
-          bind:clientHeight={_actionsHeight}
         >
           <slot name="actions" />
         </section>
@@ -323,6 +289,12 @@
   /* Content styles */
   .drawer-content {
     box-shadow: none;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .drawer-content goa-scrollable {
+    height: 100%;
   }
 
   .scroll-content {
@@ -351,12 +323,17 @@
   .drawer-bottom {
     bottom: var(--drawer-offset);
     width: 100%;
-    height: 300px;
+    min-height: 300px;
     border-top-left-radius: 0.5rem;
     border-top-right-radius: 0.5rem;
     transform: translateY(100%);
     box-shadow: var(--goa-drawer-bottom-shadow);
   }
+
+  .drawer-bottom .drawer-content {
+    overflow-y: auto;
+  }
+
   .drawer-open-bottom {
     bottom: 0;
   }


### PR DESCRIPTION
# Before (the change)

This is what a Drawer with full content and an action slot would like:
<img width="322" height="939" alt="image" src="https://github.com/user-attachments/assets/33bbb970-6ef5-43a5-a5cd-30e2f2099f3f" />

# After (the change)

Now, the action slot should appear normally and not be cut off at the bottom

I didn't add any unit tests, as I'm not sure there are any that would catch something like this.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Manual test files are located under Bug 3215