### PR TITLE
feat(#2469) Push Drawer variant

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -65,8 +65,9 @@
           <a href="/features/2054">2054</a>
           <a href="/features/2267">2267</a>
           <a href="/features/2328">2328</a>
-          <a href="/features/2361">2361</a>
           <a href="/features/2440">2440</a>
+          <a href="/features/2469">2469</a>
+          <a href="/features/2361">2361</a>
           <a href="/features/2492">2492</a>
           <a href="/features/2609">2609</a>
           <a href="/features/2611">2611</a>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -65,6 +65,7 @@ import { FeatV2IconsComponent } from "../routes/features/featV2Icons/feat-v2-ico
 import { Feat3137Component } from "../routes/features/feat3137/feat3137.component";
 import { Feat3241Component } from "../routes/features/feat3241/feat3241.component";
 import { Feat3306Component } from "../routes/features/feat3306/feat3306.component";
+import { Feat2469Component } from "../routes/features/feat2469/feat2469.component";
 
 export const appRoutes: Route[] = [
   { path: "everything", component: EverythingComponent },
@@ -119,6 +120,7 @@ export const appRoutes: Route[] = [
   { path: "features/2328", component: Feat2328Component },
   { path: "features/2361", component: Feat2361Component },
   { path: "features/2440", component: Feat2440Component },
+  { path: "features/2469", component: Feat2469Component },
   { path: "features/2492", component: Feat2492Component },
   { path: "features/2609", component: Feat2609Component },
   { path: "features/2611", component: Feat2611Component },

--- a/apps/prs/angular/src/routes/features/feat2469/feat2469.component.html
+++ b/apps/prs/angular/src/routes/features/feat2469/feat2469.component.html
@@ -1,0 +1,56 @@
+<goab-page-block width="100%">
+  <div style="display: flex; flex-direction: row; min-height: 80vh">
+    <div
+      style="flex: 1 1 0%; overflow: hidden; border: 1px solid green"
+      test-id="container"
+    >
+      <h1>Pushed In Content</h1>
+      <div style="display: flex; gap: 10px; margin-top: 20px">
+        <goab-button (click)="togglePushDrawerOpen()">
+          {{ pushDrawerOpen ? "Close" : "Open" }} Push Drawer
+        </goab-button>
+      </div>
+      <div style="margin-top: 10px; max-width: 300px">
+        <goab-input name="width" [(ngModel)]="drawerWidth" variant="goa">
+          Width
+        </goab-input>
+      </div>
+      <div style="display: flex; gap: 10px; margin-top: 10px">
+        <goab-button (click)="clearTableData()">Clear Table Data</goab-button>
+        <goab-button (click)="addTableData()">Add Table Data</goab-button>
+        <goab-button (click)="addDrawerContent()">Add Drawer Content</goab-button>
+      </div>
+      <goab-table width="100%">
+        <thead>
+          <tr>
+            <th>First</th>
+            <th>Last</th>
+            <th class="goa-table-number-header">Number Column</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let row of tableData">
+            <td>{{ row.firstName }}</td>
+            <td>{{ row.lastName }}</td>
+            <td class="goa-table-number-column">{{ row.numberCol }}</td>
+          </tr>
+        </tbody>
+      </goab-table>
+    </div>
+    <goab-push-drawer
+      testid="drawer"
+      [open]="pushDrawerOpen"
+      heading="Push Drawer"
+      [width]="drawerWidth"
+      [actions]="drawerActions"
+      (onClose)="closePushDrawer()"
+    >
+      <div [innerHTML]="pushDrawerControls"></div>
+      <goab-button (click)="closePushDrawer()">Close</goab-button>
+    </goab-push-drawer>
+  </div>
+</goab-page-block>
+
+<ng-template #drawerActions>
+  <goab-button (click)="closePushDrawer()">Close</goab-button>
+</ng-template>

--- a/apps/prs/angular/src/routes/features/feat2469/feat2469.component.ts
+++ b/apps/prs/angular/src/routes/features/feat2469/feat2469.component.ts
@@ -1,0 +1,85 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { FormsModule } from "@angular/forms";
+import {
+  GoabButton,
+  GoabInput,
+  GoabPageBlock,
+  GoabPushDrawer,
+  GoabTable,
+} from "@abgov/angular-components";
+
+type DataTableFields = {
+  firstName: string;
+  lastName: string;
+  numberCol: number;
+};
+
+const fakeFirstNames = ["Christian", "Brian", "Neha", "Tristan"];
+const fakeLastNames = ["Batz", "Wisozk", "Jones", "Buckridge"];
+
+function generateFakeData(numRows: number): DataTableFields[] {
+  const data: DataTableFields[] = [];
+  for (let i = 0; i < numRows; i++) {
+    const firstName = fakeFirstNames[Math.floor(Math.random() * fakeFirstNames.length)];
+    const lastName = fakeLastNames[Math.floor(Math.random() * fakeLastNames.length)];
+    const numberCol = Math.floor(Math.random() * 100000000);
+    data.push({ firstName, lastName, numberCol });
+  }
+  return data;
+}
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat2469",
+  templateUrl: "./feat2469.component.html",
+  styleUrls: ["./feat2469.component.css"],
+  imports: [
+    CommonModule,
+    FormsModule,
+    GoabButton,
+    GoabInput,
+    GoabPageBlock,
+    GoabPushDrawer,
+    GoabTable,
+  ],
+})
+export class Feat2469Component {
+  pushDrawerOpen = false;
+  drawerWidth = "500px";
+  tableData: DataTableFields[] = generateFakeData(5);
+  pushDrawerControls = `
+    <div>
+      <h1>Drawer</h1>
+      <p>This is a drawer</p>
+    </div>
+  `;
+
+  togglePushDrawerOpen(): void {
+    this.pushDrawerOpen = !this.pushDrawerOpen;
+  }
+
+  clearTableData(): void {
+    this.tableData = [];
+  }
+
+  addTableData(): void {
+    this.tableData = [...this.tableData, ...generateFakeData(5)];
+  }
+
+  closePushDrawer(): void {
+    this.pushDrawerOpen = false;
+  }
+
+  addDrawerContent(): void {
+    this.pushDrawerControls += `
+      <h2>Additional Content</h2>
+      <p>More drawer content added at ${new Date().toLocaleTimeString()}</p>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+      </ul>
+    `;
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -76,6 +76,7 @@ export function App() {
               <Link to="/features/2328">2328 Container Height Property</Link>
               <Link to="/features/2361">2361 Radio/Checkbox Clickable Area</Link>
               <Link to="/features/2440">2440 MenuButton Icon</Link>
+              <Link to="/features/2469">2469 Push Drawer</Link>
               <Link to="/features/2492">2492 TextArea onBlur</Link>
               <Link to="/features/2609">2609 Data Table Base Component</Link>
               <Link to="/features/2611">2611 Segmented Tab</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -70,6 +70,7 @@ import { Feat3241Route } from "./routes/features/feat3241";
 import { FeatV2IconsRoute } from "./routes/features/featV2Icons";
 import { Feat3137Route } from "./routes/features/feat3137";
 import { Feat3306Route } from "./routes/features/feat3306";
+import { Feat2469Route } from "./routes/features/feat2469";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 
@@ -129,6 +130,7 @@ root.render(
           <Route path="features/2267" element={<Feat2267Route />} />
           <Route path="features/2328" element={<Feat2328Route />} />
           <Route path="features/2440" element={<Feat2440Route />} />
+          <Route path="features/2469" element={<Feat2469Route />} />
           <Route path="features/2492" element={<Feat2492Route />} />
           <Route path="features/2611" element={<Feat2611Route />} />
           <Route

--- a/apps/prs/react/src/routes/features/feat2469.tsx
+++ b/apps/prs/react/src/routes/features/feat2469.tsx
@@ -1,0 +1,155 @@
+import { JSX, useState } from "react";
+import {
+  GoabButton,
+  GoabFormItem,
+  GoabInput,
+  GoabPageBlock,
+  GoabPushDrawer,
+  GoabTable,
+} from "@abgov/react-components";
+import { GoabInputOnChangeDetail } from "@abgov/ui-components-common";
+
+type DataTableFields = {
+  firstName: string;
+  lastName: string;
+  numberCol: number;
+};
+
+const fakeFirstNames = ["Christian", "Brian", "Neha", "Tristan"];
+const fakeLastNames = ["Batz", "Wisozk", "Jones", "Buckridge"];
+
+function generateFakeData(numRows: number): DataTableFields[] {
+  const data: DataTableFields[] = [];
+  for (let i = 0; i < numRows; i++) {
+    const firstName = fakeFirstNames[Math.floor(Math.random() * fakeFirstNames.length)];
+    const lastName = fakeLastNames[Math.floor(Math.random() * fakeLastNames.length)];
+    const numberCol = Math.floor(Math.random() * 100000000);
+    data.push({ firstName, lastName, numberCol });
+  }
+  return data;
+}
+
+export function Feat2469Route(): JSX.Element {
+  const smallDrawerControlSet = (
+    <div key={`key=${Date.now()}`}>
+      <h1>Drawer</h1>
+      <p>This is a drawer</p>
+    </div>
+  );
+
+  const pageStyle: React.CSSProperties = {
+    display: "flex",
+    flexDirection: "row",
+    minHeight: "80vh",
+  };
+
+  const pageContainerStyles: React.CSSProperties = {
+    flex: "1 1 0%",
+    overflow: "hidden",
+    border: "1px solid green",
+  };
+
+  const [pushDrawerOpen, setPushDrawerOpen] = useState(false);
+  const [drawerWidth, setDrawerWidth] = useState("500px");
+  const [tableData, setTableData] = useState<DataTableFields[]>(generateFakeData(5));
+  const [pushDrawerControls, setPushDrawerControls] = useState<JSX.Element[]>([
+    smallDrawerControlSet,
+  ]);
+  const togglePushDrawerOpen = () => {
+    setPushDrawerOpen(!pushDrawerOpen);
+  };
+  const closePushDrawer = () => {
+    setPushDrawerOpen(false);
+  };
+  const clearTableData = () => {
+    setTableData([]);
+  };
+  const addTableData = () => {
+    setTableData([...tableData, ...generateFakeData(1)]);
+  };
+  const addDrawerContent = () => {
+    setPushDrawerControls([
+      ...pushDrawerControls,
+      <div key={Date.now()}>
+        <h2>Additional Content</h2>
+        <p>More drawer content added at ${new Date().toLocaleTimeString()}</p>
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+        </ul>
+      </div>,
+    ]);
+  };
+  const clearDrawerContent = () => {
+    setPushDrawerControls([smallDrawerControlSet]);
+  };
+  const onWidthChange = (detail: GoabInputOnChangeDetail<string>) => {
+    setDrawerWidth(detail.value);
+  };
+
+  const actions = (
+    <GoabButton type="secondary" onClick={() => togglePushDrawerOpen()}>
+      Close
+    </GoabButton>
+  );
+
+  return (
+    <GoabPageBlock width="100%">
+      <div style={pageStyle}>
+        <div style={pageContainerStyles} test-id="container">
+          <h1>Pushed In Content</h1>
+          <div style={{ display: "flex", gap: "10px", marginTop: "20px" }}>
+            <GoabButton onClick={togglePushDrawerOpen}>
+              {pushDrawerOpen ? "Close" : "Open"} Push Drawer
+            </GoabButton>
+          </div>
+          <GoabFormItem label="Width">
+            <GoabInput
+              name="width"
+              type="text"
+              value={drawerWidth}
+              width="20ch"
+              onChange={onWidthChange}
+            ></GoabInput>
+          </GoabFormItem>
+          <div style={{ display: "flex", gap: "10px", marginTop: "10px" }}>
+            <GoabButton onClick={clearTableData}>Clear Table Data</GoabButton>
+            <GoabButton onClick={addTableData}>Add Table Data</GoabButton>
+            <GoabButton onClick={clearDrawerContent}>Clear Drawer Content</GoabButton>
+            <GoabButton onClick={addDrawerContent}>Add Drawer Content</GoabButton>
+          </div>
+          <GoabTable width="100%">
+            <thead>
+              <tr>
+                <th>First</th>
+                <th>Last</th>
+                <th className="goa-table-number-header">Number Column</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tableData.map((row, index) => (
+                <tr key={index}>
+                  <td>{row.firstName}</td>
+                  <td>{row.lastName}</td>
+                  <td className="goa-table-number-column">{row.numberCol}</td>
+                </tr>
+              ))}
+            </tbody>
+          </GoabTable>
+        </div>
+        <GoabPushDrawer
+          testid="drawer"
+          open={pushDrawerOpen}
+          heading="Push Drawer"
+          width={drawerWidth}
+          onClose={closePushDrawer}
+          actions={actions}
+        >
+          {pushDrawerControls}
+          <GoabButton onClick={closePushDrawer}>Close</GoabButton>
+        </GoabPushDrawer>
+      </div>
+    </GoabPageBlock>
+  );
+}

--- a/libs/angular-components/src/lib/components/index.ts
+++ b/libs/angular-components/src/lib/components/index.ts
@@ -61,6 +61,7 @@ export * from "./page-block/page-block";
 export * from "./pages/pages";
 export * from "./pagination/pagination";
 export * from "./popover/popover";
+export * from "./push-drawer/push-drawer";
 export * from "./radio-group/radio-group";
 export * from "./radio-item/radio-item";
 export * from "./side-menu/side-menu";

--- a/libs/angular-components/src/lib/components/push-drawer/push-drawer.spec.ts
+++ b/libs/angular-components/src/lib/components/push-drawer/push-drawer.spec.ts
@@ -1,0 +1,70 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { GoabPushDrawer } from "./push-drawer";
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { By } from "@angular/platform-browser";
+
+@Component({
+  standalone: true,
+  imports: [GoabPushDrawer],
+  template: `
+    <goab-push-drawer
+      [open]="open"
+      [heading]="heading"
+      [testId]="testId"
+      [width]="width"
+      (onClose)="closePushDrawer()"
+    >
+      <p>This is the content of the push drawer.</p>
+      <button (click)="closePushDrawer()">Close</button>
+    </goab-push-drawer>
+  `,
+})
+class TestPushDrawerComponent {
+  open = true;
+  heading = "Push Drawer";
+  testId = "test-drawer";
+  width = "400px";
+
+  closePushDrawer = () => {
+    this.open = false;
+  };
+}
+
+describe("GoabPushDrawer", () => {
+  let fixture: ComponentFixture<TestPushDrawerComponent>;
+  let component: TestPushDrawerComponent;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [GoabPushDrawer, TestPushDrawerComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestPushDrawerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick(); // Wait for component initialization
+    fixture.detectChanges();
+  }));
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("renders a goab-push-drawer", fakeAsync(() => {
+    const el = fixture.debugElement.query(By.css("goa-push-drawer"));
+    expect(el).toBeTruthy();
+  }));
+
+  describe("attributes", () => {
+    it("renders with testId", fakeAsync(() => {
+      const el = fixture.debugElement.query(By.css("goa-push-drawer"));
+      expect(el.attributes["test-id"]).toBe("test-drawer");
+    }));
+
+    it("passes heading", fakeAsync(() => {
+      const el = fixture.debugElement.query(By.css("goa-push-drawer"));
+      expect(el.attributes["heading"]).toBe("Push Drawer");
+    }));
+  });
+});

--- a/libs/angular-components/src/lib/components/push-drawer/push-drawer.ts
+++ b/libs/angular-components/src/lib/components/push-drawer/push-drawer.ts
@@ -1,0 +1,75 @@
+import { NgTemplateOutlet, CommonModule } from "@angular/common";
+import {
+  booleanAttribute,
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  EventEmitter,
+  Input,
+  Output,
+  TemplateRef,
+  OnInit,
+  ChangeDetectorRef,
+} from "@angular/core";
+
+@Component({
+  standalone: true,
+  selector: "goab-push-drawer",
+  imports: [NgTemplateOutlet, CommonModule],
+  template: `
+    <goa-push-drawer
+      *ngIf="isReady"
+      [open]="open"
+      [attr.heading]="getHeadingAsString()"
+      [attr.test-id]="testId"
+      [attr.width]="width"
+      (_close)="_onClose()"
+    >
+      <ng-content></ng-content>
+      @if (getHeadingAsTemplate()) {
+        <div slot="heading">
+          <ng-container [ngTemplateOutlet]="getHeadingAsTemplate()"></ng-container>
+        </div>
+      }
+      @if (actions) {
+        <div slot="actions">
+          <ng-container [ngTemplateOutlet]="actions"></ng-container>
+        </div>
+      }
+    </goa-push-drawer>
+  `,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class GoabPushDrawer implements OnInit {
+  @Input({ transform: booleanAttribute }) open?: boolean;
+  @Input() heading?: string | TemplateRef<any>;
+  @Input() testId?: string;
+  @Input() width?: string;
+  @Input() actions?: TemplateRef<any>;
+  @Output() onClose = new EventEmitter();
+
+  isReady = false;
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngOnInit(): void {
+    // For Angular 20, we need to delay rendering the web component
+    // to ensure all attributes are properly bound before the component initializes
+    setTimeout(() => {
+      this.isReady = true;
+      this.cdr.detectChanges();
+    }, 0);
+  }
+
+  _onClose() {
+    this.onClose.emit();
+  }
+
+  getHeadingAsString(): string {
+    return this.heading instanceof TemplateRef ? "" : this.heading || "";
+  }
+
+  getHeadingAsTemplate(): TemplateRef<any> | null {
+    if (!this.heading) return null;
+    return this.heading instanceof TemplateRef ? this.heading : null;
+  }
+}

--- a/libs/react-components/specs/drawer.browser.spec.tsx
+++ b/libs/react-components/specs/drawer.browser.spec.tsx
@@ -1,0 +1,70 @@
+import { render } from "vitest-browser-react";
+import { expect, describe, it, vi } from "vitest";
+import { GoabDrawer } from "../src";
+
+describe("Drawer", () => {
+  const testId = "DrawerBrowserTestId";
+  let isOpen = false;
+  const handleOnClose = vi.fn();
+  const Component = () => {
+    return <GoabDrawer testId={testId} open={isOpen} onClose={handleOnClose} />;
+  };
+
+  it("renders", async () => {
+    const { getByTestId } = await render(<Component />);
+
+    await vi.waitFor(async () => {
+      const drawer = getByTestId(testId);
+      expect(drawer).toBeInTheDocument();
+      expect(drawer).toHaveStyle({ visibility: "hidden" });
+    });
+  });
+
+  describe("when open is true", () => {
+    beforeEach(() => {
+      isOpen = true;
+    });
+
+    afterEach(() => {
+      isOpen = false;
+    });
+
+    it("is visible", async () => {
+      const { getByTestId } = await render(<Component />);
+
+      await vi.waitFor(async () => {
+        const drawer = getByTestId(testId);
+        expect(drawer).toHaveStyle({ visibility: "visible" });
+      });
+    });
+
+    it("calls onClose when the close button is clicked", async () => {
+      const { getByTestId } = await render(<Component />);
+
+      await vi.waitFor(async () => {
+        const closeButton = getByTestId("drawer-close-button");
+        expect(closeButton).toBeTruthy();
+        await closeButton.click();
+
+        vi.waitFor(() => {
+          expect(handleOnClose).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("when open is false", () => {
+    beforeEach(() => {
+      isOpen = false;
+    });
+
+    it("is hidden", async () => {
+      const { getByTestId } = await render(<Component />);
+
+      await vi.waitFor(async () => {
+        const drawer = getByTestId(testId);
+        expect(drawer).toHaveStyle({ visibility: "hidden" });
+      });
+    });
+  });
+});

--- a/libs/react-components/specs/pushdrawer.browser.spec.tsx
+++ b/libs/react-components/specs/pushdrawer.browser.spec.tsx
@@ -1,0 +1,100 @@
+import { render } from "vitest-browser-react";
+import { expect, describe, it, vi } from "vitest";
+import { GoabPushDrawer } from "../src";
+
+describe("PushDrawer", () => {
+  const testId = "PushDrawerBrowserTestId";
+  let isOpen = false;
+  const handleOnClose = vi.fn();
+  const pageStyle: React.CSSProperties = {
+    display: "flex",
+    flexDirection: "row",
+    minWidth: "1024px", // Prevent the drawer from falling back to mobile drawer
+    minHeight: "80vh",
+  };
+
+  const pageContainerStyles: React.CSSProperties = {
+    flex: "1 1 0%",
+    overflow: "hidden",
+    border: "1px solid green",
+  };
+  const Component = () => {
+    return (
+      <div style={pageStyle}>
+        <div style={pageContainerStyles} test-id="container">
+          <h1>Pushed In Content</h1>
+          <p>This is pushed in</p>
+        </div>
+        <GoabPushDrawer
+          testid={testId}
+          open={isOpen}
+          heading="Push Drawer"
+          width={"450px"}
+          onClose={handleOnClose}
+        >
+          <h2>Drawer Content</h2>
+          <p>This is the content of the push drawer.</p>
+        </GoabPushDrawer>
+      </div>
+    );
+  };
+
+  it("renders", async () => {
+    const result = await render(<Component />);
+    console.log(result.baseElement.innerHTML);
+
+    await vi.waitFor(async () => {
+      const drawer = result.getByTestId(testId);
+      console.log(drawer, drawer.element());
+      expect(drawer).toBeInTheDocument();
+    });
+  });
+
+  describe("when open is true", () => {
+    beforeEach(() => {
+      isOpen = true;
+    });
+
+    afterEach(() => {
+      isOpen = false;
+    });
+
+    it("is visible", async () => {
+      const { getByTestId } = await render(<Component />);
+
+      await vi.waitFor(async () => {
+        const drawer = getByTestId(`drawer-${testId}`);
+        expect(drawer).toHaveStyle({ visibility: "visible" });
+      });
+    });
+
+    it("calls onClose when the close button is clicked", async () => {
+      const { getByTestId } = await render(<Component />);
+
+      await vi.waitFor(async () => {
+        const closeButton = getByTestId("drawer-close-button");
+        expect(closeButton).toBeTruthy();
+        await closeButton.click();
+
+        vi.waitFor(() => {
+          expect(handleOnClose).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("when open is false", () => {
+    beforeEach(() => {
+      isOpen = false;
+    });
+
+    it("is hidden", async () => {
+      const { getByTestId } = await render(<Component />);
+
+      await vi.waitFor(async () => {
+        const drawer = getByTestId(`drawer-${testId}`);
+        expect(drawer).toHaveStyle({ visibility: "hidden" });
+      });
+    });
+  });
+});

--- a/libs/react-components/src/index.ts
+++ b/libs/react-components/src/index.ts
@@ -55,6 +55,7 @@ export * from "./lib/page-block/page-block";
 export * from "./lib/pages/pages";
 export * from "./lib/pagination/pagination";
 export * from "./lib/popover/popover";
+export * from "./lib/push-drawer/push-drawer";
 export * from "./lib/radio-group/radio-group";
 export * from "./lib/side-menu-group/side-menu-group";
 export * from "./lib/side-menu-heading/side-menu-heading";

--- a/libs/react-components/src/lib/push-drawer/push-drawer.spec.tsx
+++ b/libs/react-components/src/lib/push-drawer/push-drawer.spec.tsx
@@ -1,0 +1,83 @@
+import { render, waitFor } from "@testing-library/react";
+import { GoabPushDrawer } from "./push-drawer";
+import { GoabButton } from "../button/button";
+
+function testElement(open: boolean, drawerWidth: string) {
+  const closePushDrawer = vi.fn(() => {
+    open = false;
+  });
+
+  const actions = (
+    <div>
+      <button>Action 1</button>
+      <button>Action 2</button>
+    </div>
+  );
+
+  const pushDrawerControls = (
+    <div>
+      <p>This is the content of the push drawer.</p>
+    </div>
+  );
+
+  return (
+    <GoabPushDrawer
+      testid="test-drawer"
+      open={open}
+      heading="Push Drawer"
+      width="400px"
+      onClose={closePushDrawer}
+      actions={actions}
+    >
+      {pushDrawerControls}
+      <GoabButton onClick={closePushDrawer}>Close</GoabButton>
+    </GoabPushDrawer>
+  );
+}
+
+describe("GoabPushDrawer", () => {
+  it("renders a goab-push-drawer", async () => {
+    const { container } = render(testElement(true, "400px"));
+    const el = container.querySelector("goa-push-drawer");
+    await waitFor(() => {
+      expect(el).toBeTruthy();
+    });
+  });
+
+  describe("attributes", () => {
+    it("renders with testid", async () => {
+      const { container } = render(testElement(true, "400px"));
+      const el = container.querySelector("goa-push-drawer");
+      await waitFor(() => {
+        expect(el?.getAttribute("testid")).toBe("test-drawer");
+      });
+    });
+
+    it("opens when open is true", async () => {
+      const { container } = render(testElement(true, "400px"));
+      const el = container.querySelector("goa-push-drawer");
+
+      await waitFor(() => {
+        expect(el?.getAttribute("open")).toBe("");
+      });
+    });
+
+    it("opens when open is false", async () => {
+      const { container } = render(testElement(false, "400px"));
+      const el = container.querySelector("goa-push-drawer");
+
+      await waitFor(() => {
+        expect(el?.getAttribute("open")).toBeFalsy();
+      });
+    });
+
+    it("passes heading", async () => {
+      const { container } = render(testElement(false, "400px"));
+      const el = container.querySelector("goa-push-drawer");
+
+      await waitFor(() => {
+        expect(el?.getAttribute("heading")).toBe("Push Drawer");
+      });
+    });
+  });
+});

--- a/libs/react-components/src/lib/push-drawer/push-drawer.tsx
+++ b/libs/react-components/src/lib/push-drawer/push-drawer.tsx
@@ -1,0 +1,67 @@
+import { ReactNode, useEffect, useRef } from "react";
+
+interface WCProps {
+  open?: boolean;
+  testid?: string;
+  heading?: string;
+  width?: string;
+  ref: React.RefObject<HTMLElement | null>;
+}
+declare module "react" {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      "goa-push-drawer": WCProps & React.HTMLAttributes<HTMLElement>;
+    }
+  }
+}
+
+export interface GoabPushDrawerProps {
+  testid?: string;
+  open?: boolean;
+  heading?: string;
+  width?: string;
+  actions?: ReactNode | undefined;
+  children: ReactNode;
+  onClose: () => void;
+}
+
+export function GoabPushDrawer({
+  testid,
+  open,
+  heading,
+  width,
+  actions,
+  children,
+  onClose,
+}: GoabPushDrawerProps) {
+  // console.log("GoabPushDrawer:", testId, open, heading);
+  const el = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const elCurrent = el?.current;
+    if (!elCurrent || !onClose) {
+      return;
+    }
+    elCurrent.addEventListener("_close", onClose);
+    return () => {
+      elCurrent.removeEventListener("_close", onClose);
+    };
+  }, [el, onClose]);
+
+  return (
+    <goa-push-drawer
+      ref={el}
+      testid={testid}
+      open={open ?? false}
+      heading={typeof heading === "string" ? heading : undefined}
+      width={width}
+    >
+      {heading && typeof heading !== "string" && <div slot="heading">{heading}</div>}
+      {actions && <div slot="actions">{actions}</div>}
+      {children}
+    </goa-push-drawer>
+  );
+}
+
+export default GoabPushDrawer;

--- a/libs/web-components/src/components/push-drawer/PushDrawer.spec.ts
+++ b/libs/web-components/src/components/push-drawer/PushDrawer.spec.ts
@@ -1,0 +1,69 @@
+import { render, waitFor } from "@testing-library/svelte";
+import GoAPushDrawer from "./PushDrawer.svelte";
+import { it, describe, beforeEach, afterEach, vi, expect } from "vitest";
+
+describe("GoAPushDrawer", () => {
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalInnerWidth = window.innerWidth;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  it("should render goa-push-drawer-internal on desktop (>=1024px)", async () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+
+    const { container } = render(GoAPushDrawer, {
+      props: {
+        open: true,
+        heading: "Test Drawer",
+      },
+    });
+
+    await waitFor(() => {
+      const pushDrawerInternal = container.querySelector(
+        "goa-push-drawer-internal",
+      );
+      const drawer = container.querySelector("goa-drawer");
+
+      expect(pushDrawerInternal).toBeTruthy();
+      expect(drawer).toBeNull();
+    });
+  });
+
+  it("should render goa-drawer on mobile (<=1023px)", async () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 1023,
+    });
+
+    const { container } = render(GoAPushDrawer, {
+      props: {
+        open: true,
+        heading: "Test Drawer",
+      },
+    });
+
+    await waitFor(() => {
+      const pushDrawerInternal = container.querySelector(
+        "goa-push-drawer-internal",
+      );
+      const drawer = container.querySelector("goa-drawer");
+
+      expect(drawer).toBeTruthy();
+      expect(pushDrawerInternal).toBeNull();
+    });
+  });
+});

--- a/libs/web-components/src/components/push-drawer/PushDrawer.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawer.svelte
@@ -1,0 +1,68 @@
+<svelte:options
+  customElement={{
+    tag: "goa-push-drawer",
+    props: {
+      testid: { type: "String", attribute: "testid", reflect: true },
+      open: { type: "Boolean", reflect: true },
+      heading: { type: "String", reflect: true },
+      width: { type: "String", reflect: true },
+    },
+  }}
+/>
+
+<script lang="ts">
+  import PushDrawerInternal from "./PushDrawerInternal.svelte";
+
+  export let testid: string | undefined = undefined;
+  export let open: boolean = false;
+  export let heading: string = "";
+  export let width: string = "492px";
+
+  // Minimum window width for desktop layout from vite.config.js
+  const minimumDesktopWidth = 1023;
+
+  $: windowWidth = window.innerWidth;
+  $: windowIsSmallerThanDesktop = windowWidth <= minimumDesktopWidth;
+
+  export const drawerTestId = !!testid ? `drawer-${testid}` : undefined;
+  export const pushDrawerTestId = !!testid
+    ? `push-drawer-${testid}`
+    : undefined;
+</script>
+
+<svelte:window bind:innerWidth={windowWidth} />
+
+{#if windowIsSmallerThanDesktop}
+  <goa-drawer
+    data-testid={testid}
+    testid={drawerTestId}
+    {open}
+    position="right"
+    maxsize={width}
+    {heading}
+  >
+    <span slot="actions">
+      <slot name="actions" />
+    </span>
+    <slot />
+  </goa-drawer>
+{:else}
+  <goa-push-drawer-internal
+    data-testid={testid}
+    testid={pushDrawerTestId}
+    {open}
+    {width}
+    {heading}
+  >
+    <span slot="actions">
+      <slot name="actions" />
+    </span>
+    <slot />
+  </goa-push-drawer-internal>
+{/if}
+
+<style>
+  :host {
+    display: contents;
+  }
+</style>

--- a/libs/web-components/src/components/push-drawer/PushDrawerInternal.spec.ts
+++ b/libs/web-components/src/components/push-drawer/PushDrawerInternal.spec.ts
@@ -1,0 +1,136 @@
+import { render, RenderResult, waitFor } from "@testing-library/svelte";
+import PushDrawerInternalWrapper from "./PushDrawerInternalWrapper.svelte";
+import PushDrawerInternal from "./PushDrawerInternal.svelte";
+import { it, describe, beforeEach, afterEach, vi, expect } from "vitest";
+import { SvelteComponent } from "svelte";
+
+describe("GoAPushDrawerInternal", () => {
+  it("should open when open attribute is true", async () => {
+    const result = render(PushDrawerInternalWrapper, {
+      props: {
+        testId: "test-drawer",
+        open: true,
+      },
+    });
+
+    const drawer = result.getByTestId("test-drawer");
+    expect(drawer).toHaveClass("open");
+    expect(drawer).not.toHaveClass("closed");
+  });
+
+  it("should be closed when open attribute is false", async () => {
+    const result = render(PushDrawerInternalWrapper, {
+      props: {
+        testId: "test-drawer",
+        open: false,
+      },
+    });
+
+    const drawer = result.getByTestId("test-drawer");
+    expect(drawer).not.toHaveClass("open");
+    expect(drawer).toHaveClass("closed");
+  });
+
+  describe("closing animation", () => {
+    let clock: ReturnType<typeof vi.useFakeTimers>;
+    let result: RenderResult<SvelteComponent<any, any, any>>;
+    let drawer: HTMLElement;
+
+    beforeEach(() => {
+      result = render(PushDrawerInternalWrapper, {
+        props: {
+          testId: "test-drawer",
+          open: true,
+        },
+      });
+      drawer = result.getByTestId("test-drawer");
+
+      clock = vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should be open initially", () => {
+      expect(drawer).toHaveClass("open");
+      expect(drawer).not.toHaveClass("closing");
+      expect(drawer).not.toHaveClass("closed");
+    });
+
+    describe("when open is set to false", () => {
+      beforeEach(async () => {
+        // Update to closed
+        await result.rerender({ testId: "test-drawer", open: false });
+      });
+
+      it("should add 'closing' class", async () => {
+        // 'closing' class should be added
+        await waitFor(() => {
+          expect(drawer).not.toHaveClass("open");
+          expect(drawer).toHaveClass("closing");
+          expect(drawer).not.toHaveClass("closed");
+        });
+      });
+
+      describe("after animation completes", () => {
+        beforeEach(async () => {
+          // Advance timers by animation duration (251ms)
+          clock.advanceTimersByTime(300);
+        });
+
+        it("should add 'closed' class", async () => {
+          // 'closing' class should be removed after animation
+          await waitFor(() => {
+            expect(drawer).not.toHaveClass("open");
+            expect(drawer).not.toHaveClass("closing");
+            expect(drawer).toHaveClass("closed");
+          });
+        });
+      });
+    });
+  });
+
+  it("should populate actions slot correctly", async () => {
+    const result = render(PushDrawerInternalWrapper, {
+      props: {
+        testId: "test-drawer",
+        open: true,
+      },
+    });
+
+    const actions = result.getByTestId("drawer-actions");
+    const actionsChildren = actions?.getElementsByTagName("p");
+
+    await waitFor(() => {
+      expect(actions).toBeTruthy();
+      expect(actionsChildren.length).toBe(2);
+      expect(actionsChildren[0].textContent).toBe("Action 1");
+      expect(actionsChildren[1].textContent).toBe("Action 2");
+    });
+  });
+
+  it("should log error when width is a percentage", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {
+        /* noop */
+      });
+
+    render(PushDrawerInternalWrapper, {
+      props: {
+        testId: "test-drawer",
+        open: true,
+        width: "50%",
+      },
+    });
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "PushDrawer does not support percentage widths. Please use a fixed width instead.",
+      );
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
@@ -1,0 +1,288 @@
+<svelte:options
+  customElement={{
+    tag: "goa-push-drawer-internal",
+    props: {
+      testid: { type: "String", attribute: "testid", reflect: true },
+      open: { type: "Boolean", reflect: true },
+      heading: { type: "String", reflect: true },
+      width: { type: "String", reflect: true },
+    },
+  }}
+/>
+
+<script lang="ts">
+  type DrawerState = "initial" | "open" | "closed" | "closing";
+  import { onMount, onDestroy, tick } from "svelte";
+  import { dispatch } from "../../common/utils";
+
+  export let testid: string | undefined = undefined;
+  export let open: boolean = false;
+  export let heading: string = "";
+  export let width: string = "492px";
+  let _contentEl: HTMLElement | null = null;
+  let drawerState: DrawerState = "initial";
+  let closingTimeout: number | null = null;
+
+  $: if (open && drawerState !== "open") {
+    drawerState = "open";
+  } else if (!open && drawerState === "open") {
+    drawerState = "closing";
+
+    closingTimeout = setTimeout(() => {
+      drawerState = "closed";
+      closingTimeout = null;
+    }, 250);
+  } else if (open && closingTimeout) {
+    // In case the drawer closing animation got interrupted
+    clearTimeout(closingTimeout);
+    closingTimeout = null;
+    drawerState = "open";
+  }
+
+  onMount(() => {
+    drawerState = open ? "open" : "closed";
+    if (width.endsWith("%")) {
+      console.error(
+        "PushDrawer does not support percentage widths. Please use a fixed width instead.",
+      );
+    }
+  });
+
+  onDestroy(() => {
+    if (closingTimeout) {
+      clearTimeout(closingTimeout);
+    }
+  });
+
+  const close = (e: Event) => {
+    if (open) {
+      dispatch(_contentEl, "_close", {}, { bubbles: true });
+    }
+
+    e.stopPropagation();
+  };
+
+  // Scrolling ---
+  let _scrollEl: HTMLElement | null = null;
+  let _scrollPos: "top" | "middle" | "bottom" | null = null; // to add the box-shadow to the drawer content
+  let _actionsSlotHasContent: boolean = false;
+  async function checkActionsSlotContent() {
+    await tick();
+    _actionsSlotHasContent = !!$$slots.actions;
+  }
+
+  // Add reactive statement for checking actions slot content (for class style and height calculations) and scroll position (for box-shadow)
+  $: if (open) {
+    checkActionsSlotContent();
+    if (_scrollEl) {
+      const hasScroll = _scrollEl.scrollHeight > _scrollEl.offsetHeight;
+      _scrollPos = hasScroll ? "top" : null;
+    }
+  }
+
+  function onScroll(e: Event) {
+    const target = e.currentTarget as HTMLDivElement;
+    const hasScroll = target.scrollHeight > target.offsetHeight;
+    if (!open || !hasScroll) return;
+
+    // top
+    if (target.scrollTop == 0) {
+      _scrollPos = "top";
+    } else if (
+      // bottom
+      Math.abs(target.scrollHeight - target.scrollTop - target.offsetHeight) < 1
+    ) {
+      _scrollPos = "bottom";
+    } else {
+      _scrollPos = "middle";
+    }
+  }
+</script>
+
+<div
+  data-testid={testid}
+  class="goa-push-drawer"
+  class:open={!!open}
+  class:closed={drawerState === "closed"}
+  class:closing={drawerState === "closing"}
+  bind:this={_contentEl}
+  aria-labelledby="goa-drawer-heading"
+  style="--goa-push-drawer-width: {width};"
+>
+  <div id="goa-drawer-heading" class="drawer-header">
+    <div class="drawer-default-header">
+      {#if heading || $$slots.heading}
+        {#if heading}
+          <goa-text size="heading-m" as="h3" mt="none" mb="none">
+            {heading}
+          </goa-text>
+        {:else}
+          <slot name="heading" />
+        {/if}
+      {/if}
+
+      <goa-icon-button
+        size="medium"
+        data-ignore-focus="true"
+        data-testid="drawer-close-button"
+        arialabel="Close the drawer"
+        variant="dark"
+        icon="close"
+        theme="filled"
+        on:click={close}
+      />
+    </div>
+  </div>
+
+  <div
+    data-testid="drawer-content"
+    class="drawer-content {_scrollPos ?? ''}"
+    on:scroll={onScroll}
+  >
+    <div class="scroll-content">
+      <slot />
+    </div>
+  </div>
+
+  {#if $$slots.actions}
+    <section
+      class="drawer-actions"
+      data-testid="drawer-actions"
+      class:empty-actions={!_actionsSlotHasContent}
+    >
+      <slot name="actions" />
+    </section>
+  {/if}
+</div>
+
+<style>
+  :host * {
+    box-sizing: border-box;
+  }
+
+  @keyframes opening {
+    0% {
+      display: flex;
+      transform: translateX(100%);
+    }
+    100% {
+      transform: translateX(0%);
+    }
+  }
+
+  @keyframes closing {
+    0% {
+      transform: translateX(0%);
+    }
+    99% {
+      transform: translateX(99%);
+    }
+    100% {
+      transform: translateX(100%);
+    }
+  }
+
+  .goa-push-drawer {
+    display: flex;
+    flex-direction: column;
+    width: var(--goa-push-drawer-width, 492px);
+    padding: var(--goa-space-none);
+    flex-direction: column;
+    align-items: flex-start;
+    align-self: stretch;
+    margin-left: var(--goa-drawer-padding);
+    height: 100%; /* fill parent height */
+    border-radius: var(--goa-push-drawer-border-radius);
+    background: var(--goa-color-greyscale-white);
+    border: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
+  }
+
+  /* Shadow styles for scrollable content */
+  .top {
+    box-shadow: inset 0 -8px 8px -8px rgba(0, 0, 0, 0.3);
+  }
+
+  .bottom {
+    box-shadow: inset 0 8px 8px -8px rgba(0, 0, 0, 0.3);
+  }
+
+  .middle {
+    box-shadow:
+      inset 0 8px 8px -8px rgba(0, 0, 0, 0.2),
+      inset 0 -8px 8px -8px rgba(0, 0, 0, 0.2);
+  }
+
+  @starting-style {
+    .goa-push-drawer.closed {
+      display: none;
+    }
+  }
+
+  .goa-push-drawer.open {
+    animation: opening ease-in-out var(--goa-push-drawer-transition-time) normal
+      1;
+  }
+
+  .goa-push-drawer.closing {
+    animation: closing ease-in-out var(--goa-push-drawer-transition-time)
+      forwards 1;
+  }
+
+  .goa-push-drawer.closed {
+    display: none;
+  }
+
+  .drawer-header {
+    position: sticky;
+    top: 0;
+    box-sizing: border-box;
+    display: flex;
+    padding: var(--goa-space-l) var(--goa-space-l) var(--goa-space-s)
+      var(--goa-space-l);
+    justify-content: space-between;
+    align-items: flex-start;
+    align-self: stretch;
+    border-bottom: 1px solid var(--goa-color-greyscale-200);
+    background: var(--goa-color-greyscale-white);
+  }
+
+  .drawer-default-header {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    font: var(--goa-push-drawer-heading-typography);
+  }
+
+  .drawer-actions {
+    position: sticky;
+    bottom: 0;
+    width: 100%;
+    padding: var(--goa-push-drawer-actions-padding-top)
+      var(--goa-push-drawer-content-padding-horizontal)
+      var(--goa-push-drawer-actions-padding-bottom)
+      var(--goa-push-drawer-content-padding-horizontal);
+    border-top: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
+    background: var(--goa-color-greyscale-white);
+  }
+
+  .drawer-actions.empty-actions {
+    padding: 0;
+    border-top: none;
+  }
+
+  .drawer-content {
+    display: flex;
+    width: 100%;
+    flex: 1 0 0;
+    flex-direction: column;
+    align-items: flex-start;
+    align-self: stretch;
+    overflow-y: auto;
+  }
+
+  .scroll-content {
+    width: 100%;
+    padding: var(--goa-push-drawer-content-padding-vertical)
+      var(--goa-push-drawer-content-padding-horizontal);
+  }
+</style>

--- a/libs/web-components/src/components/push-drawer/PushDrawerInternalWrapper.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawerInternalWrapper.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import PushDrawerInternal from "./PushDrawerInternal.svelte";
+
+  export let testId: string = "";
+  export let open: boolean = false;
+  export let heading: string = "Test Heading";
+  export let width: string = "999px";
+
+  function closeDrawer() {
+    open = false;
+  }
+
+  function openDrawer() {
+    open = true;
+  }
+</script>
+
+<button on:click={openDrawer} data-testid="openButton">Open</button>
+<button on:click={closeDrawer} data-testid="closeButton">Close</button>
+
+<PushDrawerInternal testid={testId} {open} {width} {heading}>
+  <div slot="actions">
+    <p>Action 1</p>
+    <p>Action 2</p>
+  </div>
+  <slot />
+</PushDrawerInternal>

--- a/libs/web-components/src/index.ts
+++ b/libs/web-components/src/index.ts
@@ -63,6 +63,7 @@ export * from "./components/page-block/PageBlock.svelte";
 export * from "./components/pages/Pages.svelte";
 export * from "./components/pagination/Pagination.svelte";
 export * from "./components/popover/Popover.svelte";
+export * from "./components/push-drawer/PushDrawer.svelte";
 export * from "./components/radio-group/RadioGroup.svelte";
 export * from "./components/radio-item/RadioItem.svelte";
 export * from "./components/scrollable/Scrollable.svelte";

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "zone.js": "0.15.1"
       },
       "devDependencies": {
-        "@abgov/design-tokens": "^1.8.0",
+        "@abgov/design-tokens": "^1.10.0",
         "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@^2.0.0",
         "@abgov/nx-release": "^10.0.0",
         "@angular-devkit/build-angular": "^20.3.10",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@^2.0.0",
-    "@abgov/design-tokens": "^1.8.0",
+    "@abgov/design-tokens": "^1.10.0",
     "@abgov/nx-release": "^10.0.0",
     "@angular-devkit/build-angular": "^20.3.10",
     "@angular-devkit/core": "20.1.5",


### PR DESCRIPTION
# Before (the change)

Only Drawer, no push.

# After (the change)

The Push Drawer pushes content over from the right-hand side towards the left showing content or controls.

https://github.com/user-attachments/assets/fb313e61-4eb7-4484-9ce5-cf9b2a1b174c

In this example the main content has the green border and gets squished over as the push drawer expands.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

- http://localhost:4201/features/2469 React
- http://localhost:4200/features/2469 Angular

- To be responsive, if the screen width is below 1024px the Push Drawer becomes the Drawer.