### PR TITLE
feat(#1383): Added the ability to supply theme within the type property

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -52,6 +52,7 @@
         </goab-side-menu-group>
         <goab-side-menu-group heading="Features">
           <a href="/features/1328">1328</a>
+          <a href="/features/1383">1383</a>
           <a href="/features/1547">1547</a>
           <a href="/features/1813">1813</a>
           <a href="/features/1908">1908</a>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -36,6 +36,7 @@ import { Bug3215Component } from "../routes/bugs/3215/bug3215.component";
 import { Bug3248Component } from "../routes/bugs/3248/bug3248.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
+import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
 import { Feat1547Component } from "../routes/features/feat1547/feat1547.component";
 import { Feat1813Component } from "../routes/features/feat1813/feat1813.component";
 import { Feat2054Component } from "../routes/features/feat2054/feat2054.component";
@@ -90,6 +91,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3248", component: Bug3248Component },
 
   { path: "features/1328", component: Feat1328Component },
+  { path: "features/1383", component: Feat1383Component },
   { path: "features/1547", component: Feat1547Component },
   { path: "features/1813", component: Feat1813Component },
   { path: "features/1908", component: Feat1908Component },

--- a/apps/prs/angular/src/routes/features/feat1383/feat1383.component.html
+++ b/apps/prs/angular/src/routes/features/feat1383/feat1383.component.html
@@ -1,0 +1,164 @@
+<main>
+  <goab-text tag="h1">1383: Button: Filled Icons</goab-text>
+
+  <goab-grid minChildWidth="400px" gap="l">
+    @for (scenario of scenarios; track scenario.id) {
+      <goab-block direction="column" gap="s">
+        <goab-text tag="h2" size="heading-m">
+          {{ scenario.title }}
+        </goab-text>
+        <goab-text tag="p" size="body-s">
+          {{ scenario.description }}
+        </goab-text>
+
+        <goab-block direction="row" gap="m">
+          <goab-icon size="large" [type]="scenario.type" [theme]="scenario.theme" />
+          <goab-block direction="column" gap="xs">
+            <goab-text tag="p" size="body-s"> type: {{ scenario.type }} </goab-text>
+            <goab-text tag="p" size="body-s">
+              theme property: {{ scenario.theme ? scenario.theme : "(none)" }}
+            </goab-text>
+          </goab-block>
+        </goab-block>
+      </goab-block>
+    }
+  </goab-grid>
+
+  <goab-text tag="h2" size="heading-m"> Default icons (outline theme) </goab-text>
+  <goab-grid minChildWidth="200px" gap="m">
+    @for (icon of iconTypes; track icon.id) {
+      <goab-block direction="column" gap="xs" alignment="center">
+        <goab-icon size="large" [type]="icon.icon" />
+        <goab-text tag="p" size="body-s">
+          {{ icon.icon }}
+        </goab-text>
+      </goab-block>
+    }
+  </goab-grid>
+
+  <goab-text tag="h2" size="heading-m"> Filled via theme attribute </goab-text>
+  <goab-grid minChildWidth="200px" gap="m">
+    @for (icon of iconTypes; track icon.id) {
+      <goab-block direction="column" gap="xs" alignment="center">
+        <goab-icon size="large" [type]="icon.icon" theme="filled" />
+        <goab-text tag="p" size="body-s"> {{ icon.icon }} (theme=filled) </goab-text>
+      </goab-block>
+    }
+  </goab-grid>
+
+  <goab-text tag="h2" size="heading-m"> Filled via type suffix </goab-text>
+  <goab-grid minChildWidth="200px" gap="m">
+    @for (icon of iconTypes; track icon.id) {
+      <goab-block direction="column" gap="xs" alignment="center">
+        <goab-icon size="large" [type]="filled(icon)" />
+        <goab-text tag="p" size="body-s"> {{ icon.icon }}:filled </goab-text>
+      </goab-block>
+    }
+  </goab-grid>
+
+  <goab-text tag="h2" size="heading-m"> GoabBadge iconType property </goab-text>
+  <goab-grid minChildWidth="260px" gap="m">
+    <goab-block direction="column" gap="xs" alignment="center">
+      <goab-badge
+        type="information"
+        icon="true"
+        iconType="accessibility"
+        content="accessibility"
+      >
+        Badge
+      </goab-badge>
+    </goab-block>
+    <goab-block direction="column" gap="xs" alignment="center">
+      <goab-badge
+        type="information"
+        icon="true"
+        iconType="accessibility:filled"
+        content="accessibility:filled"
+      >
+        Badge
+      </goab-badge>
+    </goab-block>
+  </goab-grid>
+
+  <goab-text tag="h2" size="heading-m">
+    GoabButton leading/trailing icons properties
+  </goab-text>
+  <goab-grid minChildWidth="260px" gap="m">
+    <goab-block direction="column" gap="xs" alignment="center">
+      <goab-button
+        type="primary"
+        leadingIcon="accessibility"
+        trailingIcon="accessibility"
+      >
+        accessibility
+      </goab-button>
+    </goab-block>
+    <goab-block direction="column" gap="xs" alignment="center">
+      <goab-button
+        type="primary"
+        leadingIcon="accessibility:filled"
+        trailingIcon="accessibility:filled"
+      >
+        accessibility:filled
+      </goab-button>
+    </goab-block>
+  </goab-grid>
+
+  <goab-text tag="h2" size="heading-m"> GoabIconButton icon property </goab-text>
+  <goab-grid minChildWidth="200px" gap="m">
+    <goab-block direction="column" gap="xs" alignment="center">
+      <goab-icon-button
+        icon="accessibility"
+        ariaLabel="icon button"
+        size="large"
+        title="accessibility"
+      />
+    </goab-block>
+    <goab-block direction="column" gap="xs" alignment="center">
+      <goab-icon-button
+        icon="accessibility:filled"
+        ariaLabel="icon button"
+        size="large"
+        title="accessibility:filled"
+      />
+    </goab-block>
+  </goab-grid>
+
+  <goab-text tag="h2" size="heading-m">
+    GoabInput leading/trailing icon properties
+  </goab-text>
+  <goab-grid minChildWidth="320px" gap="m">
+    <goab-block direction="column" gap="xs">
+      <goab-input
+        placeholder="accessibility"
+        leadingIcon="accessibility"
+        trailingIcon="accessibility"
+      />
+    </goab-block>
+    <goab-block direction="column" gap="xs">
+      <goab-input
+        placeholder="accessibility:filled"
+        leadingIcon="accessibility:filled"
+        trailingIcon="accessibility:filled"
+      />
+    </goab-block>
+  </goab-grid>
+
+  <goab-text tag="h2" size="heading-m"> GoabMenuButton icon property </goab-text>
+  <goab-grid minChildWidth="320px" gap="m">
+    <goab-block direction="column" gap="xs">
+      <goab-menu-button text="accessibility">
+        <goab-menu-action text="accessibility" action="action" icon="accessibility" />
+      </goab-menu-button>
+    </goab-block>
+    <goab-block direction="column" gap="xs">
+      <goab-menu-button text="accessibility:filled">
+        <goab-menu-action
+          text="accessibility:filled"
+          action="action"
+          icon="accessibility:filled"
+        />
+      </goab-menu-button>
+    </goab-block>
+  </goab-grid>
+</main>

--- a/apps/prs/angular/src/routes/features/feat1383/feat1383.component.ts
+++ b/apps/prs/angular/src/routes/features/feat1383/feat1383.component.ts
@@ -1,0 +1,136 @@
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+import {
+  GoabBadge,
+  GoabBlock,
+  GoabButton,
+  GoabGrid,
+  GoabIcon,
+  GoabIconButton,
+  GoabInput,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabText,
+} from "@abgov/angular-components";
+import {
+  GoabIconBaseType,
+  GoabIconOverridesType,
+  GoabIconTheme,
+  GoabIconType,
+} from "@abgov/ui-components-common";
+
+type IconType = {
+  id: number;
+  icon: GoabIconBaseType | GoabIconOverridesType;
+};
+
+const iconTypes: IconType[] = [
+  { id: 1, icon: "accessibility" },
+  { id: 2, icon: "backspace" },
+  { id: 3, icon: "cafe" },
+  { id: 4, icon: "desktop" },
+  { id: 5, icon: "ear" },
+  { id: 6, icon: "fast-food" },
+  { id: 7, icon: "game-controller" },
+  { id: 8, icon: "hammer" },
+  { id: 9, icon: "ice-cream" },
+  { id: 10, icon: "journal" },
+  { id: 11, icon: "key" },
+  { id: 12, icon: "laptop" },
+  { id: 13, icon: "magnet" },
+  { id: 14, icon: "navigate-circle" },
+  { id: 15, icon: "open" },
+  { id: 16, icon: "paper-plane" },
+  { id: 17, icon: "qr-code" },
+  { id: 18, icon: "radio" },
+  { id: 19, icon: "sad" },
+  { id: 20, icon: "tablet-landscape" },
+  { id: 21, icon: "umbrella" },
+  { id: 22, icon: "videocam-off" },
+  { id: 23, icon: "walk" },
+  { id: 24, icon: "add-circle" },
+  { id: 25, icon: "bookmark" },
+  { id: 26, icon: "calendar" },
+  { id: 27, icon: "documents" },
+  { id: 28, icon: "eye-off" },
+  { id: 29, icon: "filter" },
+  { id: 30, icon: "help-circle" },
+  { id: 31, icon: "information-circle" },
+  { id: 32, icon: "mail" },
+  { id: 33, icon: "notifications" },
+  { id: 34, icon: "open" },
+  { id: 35, icon: "pencil" },
+  { id: 36, icon: "remove" },
+  { id: 37, icon: "search" },
+  { id: 38, icon: "trash" },
+  { id: 39, icon: "warning" },
+];
+
+const scenarios: {
+  id: number;
+  title: string;
+  description: string;
+  type: GoabIconType;
+  theme?: GoabIconTheme;
+}[] = [
+  {
+    id: 1,
+    title: "New syntax :filled for type",
+    description: "type uses :filled and no theme property is set.",
+    type: "accessibility:filled",
+  },
+  {
+    id: 2,
+    title: "New syntax :outline for type",
+    description: "type uses :outline and no theme property is set",
+    type: "accessibility:outline",
+  },
+  {
+    id: 3,
+    title: "Conflicting type and theme",
+    description: "type uses :filled, theme prop is outline. Type should win.",
+    type: "accessibility:filled",
+    theme: "outline",
+  },
+  {
+    id: 4,
+    title: "Legacy theme property - filled",
+    description: "Setting filled via theme property, should still work",
+    type: "accessibility",
+    theme: "filled",
+  },
+  {
+    id: 5,
+    title: "Default outline",
+    description:
+      "No theme property, and no type setting the theme. Default should be outline",
+    type: "accessibility",
+  },
+];
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat1383",
+  templateUrl: "./feat1383.component.html",
+  imports: [
+    CommonModule,
+    GoabText,
+    GoabGrid,
+    GoabBlock,
+    GoabIcon,
+    GoabBadge,
+    GoabButton,
+    GoabIconButton,
+    GoabInput,
+    GoabMenuButton,
+    GoabMenuAction,
+  ],
+})
+export class Feat1383Component {
+  readonly iconTypes = iconTypes;
+  readonly scenarios = scenarios;
+
+  filled(icon: IconType): GoabIconType {
+    return `${icon.icon}:filled` as GoabIconType;
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -56,6 +56,7 @@ export function App() {
               <Link to="/bugs/3248">3248</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Features">
+              <Link to="/features/1383">1383</Link>
               <Link to="/features/1547">1547</Link>
               <Link to="/features/1813">1813</Link>
               <Link to="/features/1908">1908</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -37,6 +37,7 @@ import { Bug3215Route } from "./routes/bugs/bug3215";
 import { Bug3248Route } from "./routes/bugs/bug3248";
 
 import { EverythingRoute } from "./routes/everything";
+import Feat1383Route from "./routes/features/feat1383";
 import { Feat1547Route } from "./routes/features/feat1547";
 import { Feat1813Route } from "./routes/features/feat1813";
 import { Feat1908Route } from "./routes/features/feat1908";
@@ -46,12 +47,12 @@ import { Feat2054Route } from "./routes/features/feat2054";
 import { Feat2267Route } from "./routes/features/feat2267";
 import { Feat2440Route } from "./routes/features/feat2440";
 import { Feat2492Route } from "./routes/features/feat2492";
+import { Feat2609Route } from "./routes/features/feat2609";
 import { Feat2682Route } from "./routes/features/feat2682";
 import { Feat2722Route } from "./routes/features/feat2722";
 import { Feat2730Route } from "./routes/features/feat2730";
 import { Feat2829Route } from "./routes/features/feat2829";
 import Feat3102Route from "./routes/features/feat3102";
-import { Feat2609Route } from "./routes/features/feat2609";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 
@@ -93,6 +94,7 @@ root.render(
           <Route path="bugs/3215" element={<Bug3215Route />} />
           <Route path="bugs/3248" element={<Bug3248Route />} />
 
+          <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />
           <Route path="features/1813" element={<Feat1813Route />} />
           <Route path="features/1908" element={<Feat1908Route />} />

--- a/apps/prs/react/src/routes/features/feat1383.tsx
+++ b/apps/prs/react/src/routes/features/feat1383.tsx
@@ -1,0 +1,308 @@
+import {
+  GoabBadge,
+  GoabBlock,
+  GoabButton,
+  GoabGrid,
+  GoabIcon,
+  GoabIconButton,
+  GoabInput,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabText,
+} from "@abgov/react-components";
+import {
+  GoabIconBaseType,
+  GoabIconOverridesType,
+  GoabIconTheme,
+  GoabIconType,
+} from "@abgov/ui-components-common";
+
+type IconType = {
+  id: number;
+  icon: GoabIconBaseType | GoabIconOverridesType;
+};
+
+const iconTypes: IconType[] = [
+  { id: 1, icon: "accessibility" },
+  { id: 2, icon: "backspace" },
+  { id: 3, icon: "cafe" },
+  { id: 4, icon: "desktop" },
+  { id: 5, icon: "ear" },
+  { id: 6, icon: "fast-food" },
+  { id: 7, icon: "game-controller" },
+  { id: 8, icon: "hammer" },
+  { id: 9, icon: "ice-cream" },
+  { id: 10, icon: "journal" },
+  { id: 11, icon: "key" },
+  { id: 12, icon: "laptop" },
+  { id: 13, icon: "magnet" },
+  { id: 14, icon: "navigate-circle" },
+  { id: 15, icon: "open" },
+  { id: 16, icon: "paper-plane" },
+  { id: 17, icon: "qr-code" },
+  { id: 18, icon: "radio" },
+  { id: 19, icon: "sad" },
+  { id: 20, icon: "tablet-landscape" },
+  { id: 21, icon: "umbrella" },
+  { id: 22, icon: "videocam-off" },
+  { id: 23, icon: "walk" },
+  { id: 24, icon: "add-circle" },
+  { id: 25, icon: "bookmark" },
+  { id: 26, icon: "calendar" },
+  { id: 27, icon: "documents" },
+  { id: 28, icon: "eye-off" },
+  { id: 29, icon: "filter" },
+  { id: 30, icon: "help-circle" },
+  { id: 31, icon: "information-circle" },
+  { id: 32, icon: "mail" },
+  { id: 33, icon: "notifications" },
+  { id: 34, icon: "open" },
+  { id: 35, icon: "pencil" },
+  { id: 36, icon: "remove" },
+  { id: 37, icon: "search" },
+  { id: 38, icon: "trash" },
+  { id: 39, icon: "warning" },
+];
+
+const scenarios: {
+  id: number;
+  title: string;
+  description: string;
+  type: GoabIconType;
+  theme?: GoabIconTheme;
+}[] = [
+  {
+    id: 1,
+    title: "New syntax :filled for type",
+    description: "type uses :filled and no theme property is set.",
+    type: "accessibility:filled",
+  },
+  {
+    id: 2,
+    title: "New syntax :outline for type",
+    description: "type uses :outline and no theme property is set",
+    type: "accessibility:outline",
+  },
+  {
+    id: 3,
+    title: "Conflicting type and theme",
+    description: "type uses :filled, theme prop is outline. Type should win.",
+    type: "accessibility:filled",
+    theme: "outline",
+  },
+  {
+    id: 4,
+    title: "Legacy theme property - filled",
+    description: "Setting filled via theme property, should still work",
+    type: "accessibility",
+    theme: "filled",
+  },
+  {
+    id: 5,
+    title: "Default outline",
+    description:
+      "No theme property, and no type setting the theme. Default should be outline",
+    type: "accessibility",
+  },
+];
+
+function filled(icon: IconType): GoabIconType {
+  return `${icon.icon}:filled` as GoabIconType;
+}
+
+export function Feat1383Route() {
+  return (
+    <main>
+      <GoabText tag="h1">1383: Button: Filled Icons</GoabText>
+
+      <GoabGrid minChildWidth="400px" gap="l">
+        {scenarios.map((scenario) => (
+          <GoabBlock key={scenario.id} direction="column" gap="s">
+            <GoabText tag="h2" size="heading-m">
+              {scenario.title}
+            </GoabText>
+            <GoabText tag="p" size="body-s">
+              {scenario.description}
+            </GoabText>
+
+            <GoabBlock direction="row" gap="m">
+              <GoabIcon size="large" type={scenario.type} theme={scenario.theme} />
+              <GoabBlock direction="column" gap="xs">
+                <GoabText tag="p" size="body-s">
+                  type: {scenario.type}
+                </GoabText>
+                <GoabText tag="p" size="body-s">
+                  theme property: {scenario.theme ?? "(none)"}
+                </GoabText>
+              </GoabBlock>
+            </GoabBlock>
+          </GoabBlock>
+        ))}
+      </GoabGrid>
+
+      <GoabText tag="h2" size="heading-m">
+        Default icons (outline theme)
+      </GoabText>
+      <GoabGrid minChildWidth="200px" gap="m">
+        {iconTypes.map((icon) => (
+          <GoabBlock key={icon.id} direction="column" gap="xs" alignment="center">
+            <GoabIcon size="large" type={icon.icon} />
+            <GoabText tag="p" size="body-s">
+              {icon.icon}
+            </GoabText>
+          </GoabBlock>
+        ))}
+      </GoabGrid>
+
+      <GoabText tag="h2" size="heading-m">
+        Filled via theme attribute
+      </GoabText>
+      <GoabGrid minChildWidth="200px" gap="m">
+        {iconTypes.map((icon) => (
+          <GoabBlock
+            key={`theme-${icon.id}`}
+            direction="column"
+            gap="xs"
+            alignment="center"
+          >
+            <GoabIcon size="large" type={icon.icon} theme="filled" />
+            <GoabText tag="p" size="body-s">
+              {icon.icon} (theme=filled)
+            </GoabText>
+          </GoabBlock>
+        ))}
+      </GoabGrid>
+
+      <GoabText tag="h2" size="heading-m">
+        Filled via type suffix
+      </GoabText>
+      <GoabGrid minChildWidth="200px" gap="m">
+        {iconTypes.map((icon) => (
+          <GoabBlock
+            key={`filled-${icon.id}`}
+            direction="column"
+            gap="xs"
+            alignment="center"
+          >
+            <GoabIcon size="large" type={filled(icon)} />
+            <GoabText tag="p" size="body-s">
+              {icon.icon}:filled
+            </GoabText>
+          </GoabBlock>
+        ))}
+      </GoabGrid>
+
+      <GoabText tag="h2" size="heading-m">
+        GoabBadge iconType property
+      </GoabText>
+      <GoabGrid minChildWidth="260px" gap="m">
+        <GoabBlock direction="column" gap="xs" alignment="center">
+          <GoabBadge
+            type="information"
+            icon
+            iconType="accessibility"
+            content="accessibility"
+          />
+        </GoabBlock>
+        <GoabBlock direction="column" gap="xs" alignment="center">
+          <GoabBadge
+            type="information"
+            icon
+            iconType="accessibility:filled"
+            content="accessibility:filled"
+          />
+        </GoabBlock>
+      </GoabGrid>
+
+      <GoabText tag="h2" size="heading-m">
+        GoabButton leading/trailing icons properties
+      </GoabText>
+      <GoabGrid minChildWidth="260px" gap="m">
+        <GoabBlock direction="column" gap="xs" alignment="center">
+          <GoabButton
+            type="primary"
+            leadingIcon="accessibility"
+            trailingIcon="accessibility"
+          >
+            accessibility
+          </GoabButton>
+        </GoabBlock>
+        <GoabBlock direction="column" gap="xs" alignment="center">
+          <GoabButton
+            type="primary"
+            leadingIcon="accessibility:filled"
+            trailingIcon="accessibility:filled"
+          >
+            accessibility:filled
+          </GoabButton>
+        </GoabBlock>
+      </GoabGrid>
+
+      <GoabText tag="h2" size="heading-m">
+        GoabIconButton icon property
+      </GoabText>
+      <GoabGrid minChildWidth="200px" gap="m">
+        <GoabBlock direction="column" gap="xs" alignment="center">
+          <GoabIconButton
+            icon="accessibility"
+            ariaLabel="icon button"
+            size="large"
+            title="accessibility"
+          />
+        </GoabBlock>
+        <GoabBlock direction="column" gap="xs" alignment="center">
+          <GoabIconButton
+            icon="accessibility:filled"
+            ariaLabel="icon button"
+            size="large"
+            title="accessibility:filled"
+          />
+        </GoabBlock>
+      </GoabGrid>
+
+      <GoabText tag="h2" size="heading-m">
+        GoabInput leading/trailing icon properties
+      </GoabText>
+      <GoabGrid minChildWidth="320px" gap="m">
+        <GoabBlock direction="column" gap="xs">
+          <GoabInput
+            name="base-icon"
+            placeholder="accessibility"
+            leadingIcon="accessibility"
+            trailingIcon="accessibility"
+          />
+        </GoabBlock>
+        <GoabBlock direction="column" gap="xs">
+          <GoabInput
+            name="filled-icon"
+            placeholder="accessibility:filled"
+            leadingIcon="accessibility:filled"
+            trailingIcon="accessibility:filled"
+          />
+        </GoabBlock>
+      </GoabGrid>
+
+      <GoabText tag="h2" size="heading-m">
+        GoabMenuButton icon property
+      </GoabText>
+      <GoabGrid minChildWidth="320px" gap="m">
+        <GoabBlock direction="column" gap="xs">
+          <GoabMenuButton text="accessibility">
+            <GoabMenuAction text="accessibility" action="action" icon="accessibility" />
+          </GoabMenuButton>
+        </GoabBlock>
+        <GoabBlock direction="column" gap="xs">
+          <GoabMenuButton text="accessibility:filled">
+            <GoabMenuAction
+              text="accessibility:filled"
+              action="action"
+              icon="accessibility:filled"
+            />
+          </GoabMenuButton>
+        </GoabBlock>
+      </GoabGrid>
+    </main>
+  );
+}
+
+export default Feat1383Route;

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -422,8 +422,7 @@ interface BaseProps extends Margins {
 
 // Icon
 
-export type GoabIconFilledType = `${GoabIconType}-${GoabIconTheme}`;
-export type GoabIconType =
+export type GoabIconBaseType =
   | "accessibility"
   | "add-circle"
   | "add"
@@ -1020,6 +1019,8 @@ export type GoabIconOverridesType =
   | "trash"
   | "warning-filled"
   | "warning";
+
+export type GoabIconType = GoabIconBaseType | `${GoabIconBaseType}:${GoabIconTheme}`;
 
 export type GoabIconSize =
   | "1"

--- a/libs/react-components/src/lib/icon/icon.tsx
+++ b/libs/react-components/src/lib/icon/icon.tsx
@@ -1,5 +1,4 @@
 import {
-  GoabIconFilledType,
   GoabIconOverridesType,
   GoabIconSize,
   GoabIconTheme,
@@ -10,21 +9,8 @@ import {
 import type { JSX } from "react";
 import { transformProps, lowercase } from "../common/extract-props";
 
-interface IonIconProps {
-  name: GoabIconType | GoabIconFilledType;
-}
-
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface IonIconElement extends HTMLElement {}
-
-declare module "react" {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {
-      "ion-icon": IonIconProps & React.HTMLAttributes<IonIconElement>;
-    }
-  }
-}
 
 declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/libs/web-components/src/components/icon/Icon.spec.ts
+++ b/libs/web-components/src/components/icon/Icon.spec.ts
@@ -51,6 +51,31 @@ describe("Icon", () => {
   });
 });
 
+describe("Icon Theme", () => {
+  it("should render the filled variant when provided in the type", async () => {
+    const filled = render(GoAIcon, {
+      testid: "icon-filled",
+      type: "ellipse:filled",
+    });
+
+    const filledIcon = await filled.findByTestId("icon-filled");
+    const filledIonIcon = filledIcon.querySelector("ion-icon");
+
+    expect(filledIcon.getAttribute("data-type")).toBe("ellipse");
+    expect(filledIonIcon?.getAttribute("name")).toBe("ellipse"); // filled variant has no "-outline"
+
+    const outline = render(GoAIcon, {
+      testid: "icon-outline",
+      type: "ellipse",
+    });
+
+    const outlineIcon = await outline.findByTestId("icon-outline");
+    const outlineIonIcon = outlineIcon.querySelector("ion-icon");
+
+    expect(outlineIonIcon?.getAttribute("name")).toBe("ellipse-outline"); // default outline theme
+  });
+});
+
 describe("Icon Sizes", () => {
   const sizes = [
     {
@@ -107,6 +132,7 @@ describe("Icon Sizes", () => {
     it(`should render the correct width and height for size "${size}"`, async () => {
       const baseElement = render(GoAIcon, {
         testid: "icon-test",
+        type: "ellipse",
         size,
       });
       const icon = await baseElement.findByTestId("icon-test");

--- a/libs/web-components/src/components/icon/Icon.svelte
+++ b/libs/web-components/src/components/icon/Icon.svelte
@@ -549,6 +549,10 @@
   import { style, toBoolean } from "../../common/utils";
   import { calculateMargin } from "../../common/styling";
 
+  type GoAIconTypeWithTheme =
+    | `${GoAIconType}:${IconTheme}`
+    | `${GoAIconOverridesType}:${IconTheme}`;
+
   export let mt: Spacing = null;
   export let mr: Spacing = null;
   export let mb: Spacing = null;
@@ -556,7 +560,7 @@
 
   // Required
 
-  export let type: GoAIconType & GoAIconOverridesType;
+  export let type: GoAIconType | GoAIconOverridesType | GoAIconTypeWithTheme;
 
   // Optional
 
@@ -572,15 +576,20 @@
   export let ariaexpanded: string = "";
   export let role: string = "img";
 
+  let _iconType: GoAIconType | GoAIconOverridesType;
+  let _iconTheme: IconTheme;
   // Reactive
 
   $: _isInverted = toBoolean(inverted);
   $: _ariaExpanded = toBoolean(ariaexpanded);
-  $: _iconName = iconName(type, theme);
+  $: ({ iconType: _iconType, iconTheme: _iconTheme, name: _iconName } = parseProperties(
+    type,
+    theme
+  ));
   // Private
 
   const _iconOverrides: Record<
-    GoAIconOverridesType & GoAIconOverridesTypeWithTheme,
+    GoAIconOverridesType | GoAIconOverridesTypeWithTheme,
     string
   > = {
     "goa-file": `<svg style="width: 100%; height: 100%;" width="39" height="48" viewBox="0 0 39 48" fill="none" xmlns="http://www.w3.org/2000/svg"> <g clip-path="url(#clip0_1357_108691)"> <path stroke-width="0.5" vector-effect="non-scaling-stroke" stroke="currentcolor" d="M38.741 14C38.541 13.07 38.081 12.22 37.401 11.54L36.861 11L27.861 2L27.321 1.46C26.641 0.78 25.781 0.32 24.861 0.12C24.511 0.04 24.151 0 23.791 0H5.86096C3.10096 0 0.860962 2.24 0.860962 5V43C0.860962 45.76 3.10096 48 5.86096 48H33.861C36.621 48 38.861 45.76 38.861 43V15.07C38.861 14.71 38.811 14.35 38.741 14ZM35.041 12H29.871C28.221 12 26.871 10.65 26.871 9V3.83L35.041 12ZM36.871 43C36.871 44.65 35.521 46 33.871 46H5.87097C4.22097 46 2.87097 44.65 2.87097 43V5C2.87097 3.35 4.22097 2 5.87097 2H23.801C24.171 2 24.531 2.07 24.871 2.2V9C24.871 11.76 27.111 14 29.871 14H36.671C36.801 14.34 36.871 14.7 36.871 15.07V43Z" fill="currentcolor"/> </g> <defs> <clipPath id="clip0_1357_108691"><rect width="38" height="48" fill="white" transform="translate(0.861328)"/></clipPath></defs></svg>`,
@@ -674,15 +683,25 @@
     warning: `<svg style="width: 100%; height: 100%;" width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg"><path stroke-width="0.5" vector-effect="non-scaling-stroke" d="M19.9867 22.4045H4.01173C3.64142 22.4045 3.2711 22.3107 2.94767 22.1373C2.41798 21.8514 2.0336 21.3779 1.86017 20.8014C1.68673 20.2248 1.74767 19.6154 2.0336 19.0904L10.0164 4.25449C10.4102 3.52324 11.1695 3.07324 11.9992 3.07324C12.8289 3.07324 13.5883 3.52793 13.982 4.25449L21.9695 19.0904C22.1477 19.4186 22.2367 19.7842 22.2367 20.1592C22.2367 20.7592 22.0024 21.3264 21.5758 21.7482C21.1539 22.1748 20.5914 22.4045 19.9867 22.4045ZM4.01173 20.9045H19.9914C20.193 20.9045 20.3805 20.8248 20.5211 20.6842C20.6617 20.5436 20.7414 20.3561 20.7414 20.1545C20.7414 20.0326 20.7086 19.9061 20.6524 19.7982L12.6602 4.96699C12.468 4.61074 12.1352 4.57324 11.9992 4.57324C11.8633 4.57324 11.5305 4.61074 11.3383 4.96699L3.35079 19.8029C3.25704 19.9811 3.2336 20.1826 3.29454 20.3748C3.35079 20.567 3.48204 20.7264 3.65548 20.8201C3.76329 20.8764 3.88517 20.9045 4.01173 20.9045Z" fill="currentcolor"/><path stroke-width="0.5" vector-effect="non-scaling-stroke" d="M11.9992 16.3668C11.6008 16.3668 11.268 16.0527 11.2492 15.6543L10.982 9.93556C10.982 9.93087 10.982 9.92618 10.982 9.92149V9.89806C10.9774 9.33556 11.4274 8.87618 11.9899 8.87149C12.0086 8.87149 12.0274 8.87149 12.0461 8.87149C12.6086 8.89493 13.0446 9.37306 13.0164 9.93556L12.7492 15.6543C12.7305 16.0527 12.3977 16.3668 11.9992 16.3668Z" fill="currentcolor"/><path stroke-width="0.5" vector-effect="non-scaling-stroke" d="M11.9992 19.3573C11.4836 19.3573 11.0617 18.9354 11.0617 18.4198C11.0617 17.9041 11.4836 17.4823 11.9992 17.4823C12.5148 17.4823 12.9367 17.9041 12.9367 18.4198C12.9367 18.9354 12.5148 19.3573 11.9992 19.3573Z" fill="currentcolor"/></svg>`,
   };
 
-  function iconName(type: GoAIconType, theme: IconTheme): string {
-    if (type) {
-      const name =
-        theme === "filled" || (type as string).indexOf("logo") === 0
-          ? type
-          : `${type}-${theme}`;
-      return name;
-    }
-    return "";
+  function parseProperties(
+    type: GoAIconType | GoAIconOverridesType | GoAIconTypeWithTheme,
+    fallbackTheme: IconTheme
+  ) {
+    const [iconType, maybeTheme] = type.split(":");
+    const iconTheme =
+      maybeTheme === "filled" || maybeTheme === "outline"
+        ? (maybeTheme as IconTheme)
+        : fallbackTheme;
+    const name =
+      iconTheme === "filled" || (type as string).indexOf("logo") === 0
+        ? iconType
+        : `${iconType}-${iconTheme}`;
+
+    return {
+      iconType: iconType as GoAIconType | GoAIconOverridesType,
+      iconTheme,
+      name
+    };
   }
 </script>
 
@@ -694,7 +713,7 @@
   class={`goa-icon goa-icon--${size}`}
   class:inverted={_isInverted}
   data-testid={testid}
-  data-type={type}
+  data-type={_iconType || type}
   title={title}
   style={`
     ${calculateMargin(mt, mr, mb, ml)}
@@ -702,10 +721,12 @@
     ${style("--opacity", opacity)};
   `}
 >
-  {#if type}
-    {#if type in _iconOverrides}
+  {#if _iconType}
+    {#if _iconType in _iconOverrides}
       <div class="icon-override">
-        {@html _iconOverrides[`${type}-${theme}`] || _iconOverrides[type]}
+        {@html
+          _iconOverrides[`${_iconType}-${_iconTheme}`] ||
+            _iconOverrides[_iconType]}
       </div>
     {:else}
       <ion-icon name={_iconName} />


### PR DESCRIPTION
# Before (the change)

`theme` had to be supplied via the `theme` property.

# After (the change)

Now `theme` can be supplied via the `type` property, as such:
* "accessibility:filled"
* "accessibility:outline"

Thus making it so that theme can be supplied via anything that has an icon, such as GoabInput `leadingIcon` and `trailingIcon`

I didn't create browser tests for this, because for some reason, `type` and `theme` aren't output inside `goa-icon` in React. So there doesn't seem to be a way to test this accurately within React.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

PR Manual tests created for Angular and React under Feature/1383
