### PR TITLE
fix(#3279): fix keyboard nav for work side nav with groups

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -55,6 +55,7 @@
           <a href="/bugs/3275">3275 Can't unset month</a>
           <a href="/bugs/3281">3281</a>
           <a href="/bugs/3337">3337 - Autocomplete styling</a>
+          <a href="/bugs/3279">3279</a>
         </goab-side-menu-group>
         <goab-side-menu-group heading="Features">
           <a href="/features/1328">1328</a>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -41,6 +41,7 @@ import { Bug3248Component } from "../routes/bugs/3248/bug3248.component";
 import { Bug3275Component } from "../routes/bugs/3275/bug3275.component";
 import { Bug3281Component } from "../routes/bugs/3281/bug3281.component";
 import { Bug3337Component } from "../routes/bugs/3337/bug3337.component";
+import { Bug3279Component } from "../routes/bugs/3279/bug3279.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -108,6 +109,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3275", component: Bug3275Component },
   { path: "bugs/3281", component: Bug3281Component },
   { path: "bugs/3337", component: Bug3337Component },
+  { path: "bugs/3279", component: Bug3279Component },
 
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1383", component: Feat1383Component },

--- a/apps/prs/angular/src/routes/bugs/3279/bug3279.component.html
+++ b/apps/prs/angular/src/routes/bugs/3279/bug3279.component.html
@@ -1,0 +1,45 @@
+<div style="width: 1024px; margin: 0 auto; padding: 2rem">
+  <goab-text size="heading-l" mb="xl">Bug 3279 - Work Side Menu keyboard navigation</goab-text>
+  <goab-text size="body-m" mb="2xl">
+    This shows that keyboard navigation works correctly with various elements in the Work Side Menu component.
+  </goab-text>
+
+  <goabx-work-side-menu heading="Bug 3279" url="#" userName="Jane Doe" userSecondaryText="jane.doe@gov.ab.ca"
+    [open]="open" (onToggle)="onToggle()" [primaryContent]="primaryTemplate" [secondaryContent]="secondaryTemplate"
+    [accountContent]="accountTemplate">
+  </goabx-work-side-menu>
+
+  <ng-template #primaryTemplate>
+    <goabx-work-side-menu-item label="Primary item 1" icon="home" url="#primary-1" />
+    <goabx-work-side-menu-item label="Primary item 2" icon="bookmark" badge="2" url="#primary-2" />
+
+    <goabx-work-side-menu-group heading="Primary group" icon="folder">
+      <goabx-work-side-menu-item label="Grouped item 1" icon="document" url="#primary-group-1" />
+      <goabx-work-side-menu-item label="Grouped item 2" icon="document-text" url="#primary-group-2" />
+    </goabx-work-side-menu-group>
+
+    <goabx-work-side-menu-item label="Primary item 3" icon="list" url="#primary-3" />
+
+    <div style="display: flex; flex-direction: column; gap: 1rem">
+      <goab-container type="non-interactive" padding="compact">
+        <goab-button type="primary" (click)="onActionClick()">Action</goab-button>
+      </goab-container>
+
+      <goab-link href="#testthis">Link</goab-link>
+
+      <goab-details heading="Details">
+        <p>This is some details content inside the primary content area.</p>
+      </goab-details>
+    </div>
+  </ng-template>
+
+  <ng-template #secondaryTemplate>
+    <goabx-work-side-menu-item label="Secondary item 1" icon="analytics" url="#secondary-1" />
+    <goabx-work-side-menu-item label="Secondary item 2" icon="settings" url="#secondary-2" />
+  </ng-template>
+
+  <ng-template #accountTemplate>
+    <goabx-work-side-menu-item label="Account" icon="person" url="#account" />
+    <goabx-work-side-menu-item label="Sign out" icon="log-out" type="emergency" url="#signout" />
+  </ng-template>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3279/bug3279.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3279/bug3279.component.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+import {
+  GoabButton,
+  GoabContainer,
+  GoabDetails,
+  GoabLink,
+  GoabText,
+  GoabxWorkSideMenu,
+  GoabxWorkSideMenuGroup,
+  GoabxWorkSideMenuItem,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3279",
+  templateUrl: "./bug3279.component.html",
+  imports: [
+    CommonModule,
+    GoabButton,
+    GoabContainer,
+    GoabDetails,
+    GoabLink,
+    GoabText,
+    GoabxWorkSideMenu,
+    GoabxWorkSideMenuGroup,
+    GoabxWorkSideMenuItem,
+  ],
+})
+export class Bug3279Component {
+  open = true;
+
+  onToggle(): void {
+    this.open = !this.open;
+  }
+
+  onActionClick(): void {
+    alert("Action button in primary content clicked");
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -65,6 +65,7 @@ export function App() {
               <Link to="/bugs/3322">3322 App Header Menu Hover</Link>
               <Link to="/bugs/3281">3281 GoabText p tag margin issues</Link>
               <Link to="/bugs/3337">3337 Input autocomplete styling</Link>
+              <Link to="/bugs/3279">3279 Work Side Menu Key Nav</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Features">
               <Link to="/features/1383">1383 Button Filled Icons</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -38,6 +38,7 @@ import { Bug3118Route } from "./routes/bugs/bug3118";
 import { Bug3201Route } from "./routes/bugs/bug3201";
 import { Bug3215Route } from "./routes/bugs/bug3215";
 import { Bug3232Route } from "./routes/bugs/bug3232";
+import { Bug3279Route } from "./routes/bugs/bug3279";
 import { Bug3248Route } from "./routes/bugs/bug3248";
 import { Bug3275Route } from "./routes/bugs/bug3275";
 import { Bug3322Route } from "./routes/bugs/bug3322";
@@ -78,6 +79,7 @@ root.render(
     <BrowserRouter>
       <Routes>
         <Route path="/everything/b" element={<EverythingBRoute />} />
+        <Route path="/bugs/3279" element={<Bug3279Route />} />
         <Route path="/" element={<App />}>
           <Route path="everything" element={<EverythingRoute />} />
 

--- a/apps/prs/react/src/routes/bugs/bug3279.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3279.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from "react";
+import {
+  GoabButton,
+  GoabContainer,
+  GoabDetails,
+  GoabLink,
+} from "@abgov/react-components";
+import {
+  GoabxWorkSideMenu,
+  GoabxWorkSideMenuGroup,
+  GoabxWorkSideMenuItem,
+} from "@abgov/react-components/experimental";
+
+export function Bug3279Route() {
+  const [open, setOpen] = useState(true);
+
+  function onToggle() {
+    setOpen((prev) => !prev);
+  }
+
+  return (
+    <div>
+      <h1>Bug 3279 - Work Side Menu keyboard navigation</h1>
+      <p>
+        This shows that keyboard navigation works correctly with various elements in the
+        Work Side Menu component.
+      </p>
+
+      <GoabxWorkSideMenu
+        heading="Bug 3279"
+        url="#"
+        userName="Jane Doe"
+        userSecondaryText="jane.doe@gov.ab.ca"
+        open={open}
+        onToggle={onToggle}
+        primaryContent={
+          <>
+            <GoabxWorkSideMenuItem url="#primary-1" label="Primary item 1" icon="home" />
+            <GoabxWorkSideMenuItem
+              url="#primary-2"
+              label="Primary item 2"
+              badge="2"
+              icon="bookmark"
+            />
+            <GoabxWorkSideMenuGroup heading="Primary group" icon="folder">
+              <GoabxWorkSideMenuItem
+                url="#primary-group-1"
+                label="Grouped item 1"
+                icon="document"
+              />
+              <GoabxWorkSideMenuItem
+                url="#primary-group-2"
+                label="Grouped item 2"
+                icon="document-text"
+              />
+            </GoabxWorkSideMenuGroup>
+            <GoabxWorkSideMenuItem url="#primary-3" label="Primary item 3" icon="list" />
+            <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+              <GoabContainer type="non-interactive" padding="compact">
+                <GoabButton
+                  type="primary"
+                  width="100%"
+                  onClick={() => alert("Action button in primary content clicked")}
+                >
+                  Action
+                </GoabButton>
+              </GoabContainer>
+              <GoabLink>
+                <a href="#testthis">Link</a>
+              </GoabLink>
+              <GoabDetails heading="Details">
+                <p>This is some details content inside the primary content area.</p>
+              </GoabDetails>
+            </div>
+          </>
+        }
+        secondaryContent={
+          <>
+            <GoabxWorkSideMenuItem
+              url="#secondary-1"
+              label="Secondary item 1"
+              icon="analytics"
+            />
+            <GoabxWorkSideMenuItem
+              url="#secondary-2"
+              label="Secondary item 2"
+              icon="settings"
+            />
+          </>
+        }
+        accountContent={
+          <>
+            <GoabxWorkSideMenuItem url="#account" label="Account" icon="person" />
+            <GoabxWorkSideMenuItem
+              url="#signout"
+              label="Sign out"
+              type="emergency"
+              icon="log-out"
+            />
+            <GoabxWorkSideMenuItem url="#item1" label="item1" icon="person" />
+            <GoabxWorkSideMenuItem url="#item2" label="item2" icon="person" />
+            <GoabxWorkSideMenuItem url="#item3" label="item3" icon="person" />
+            <GoabxWorkSideMenuItem url="#item4" label="item4" icon="person" />
+          </>
+        }
+      />
+    </div>
+  );
+}

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
@@ -48,16 +48,11 @@
   let _showAccountMenu = false;
   let _showTooltip = false;
 
-  let _focusedIndex: number = -1;
-  let _focusItems: HTMLElement[] = [];
-
   let _menuEl: HTMLElement;
   let _menuLinks: HTMLElement[] = [];
   let _rootEl: HTMLElement;
   let _scrollEl: HTMLElement;
   let _tooltipEl: HTMLElement;
-  let _profileButtonEl: HTMLElement;
-  let _toggleButtonEl: HTMLElement;
   let _tooltipLabel: string = "";
 
   let _bindTimeoutId: any;
@@ -117,13 +112,11 @@
       _menuLinks = [..._menuLinks, link];
     }
 
-    // set URL, check scrolling, and get focusable items after all menu links are added
     performOnce(
       _bindTimeoutId,
       () => {
         setCurrentUrl();
         setMenuScrolling();
-        getFocusItems();
       },
       1,
     );
@@ -136,7 +129,7 @@
     el: HTMLElement,
   ) {
     if (!open && menuType !== "account") {
-      updateTooltip(label, el);
+      setTooltipPos(label, el);
       showTooltip();
     } else {
       hideTooltip();
@@ -151,7 +144,7 @@
     }, 300);
   }
 
-  function updateTooltip(label: string, el: HTMLElement) {
+  function setTooltipPos(label: string, el: HTMLElement) {
     let top = el?.getBoundingClientRect().top - 2;
     _tooltipEl.style.top = `${top}px`;
     _tooltipLabel = label;
@@ -170,9 +163,6 @@
     _showAccountMenu = true;
 
     await tick();
-    let firstAccountItem =
-      _focusItems[_focusItems.indexOf(_profileButtonEl) + 1];
-    setFocusedIndexToElement(firstAccountItem);
     document.body.addEventListener("click", closeAccountMenu);
   }
 
@@ -203,120 +193,12 @@
 
   function handleKeyDown(e: KeyboardEvent) {
     switch (e?.key) {
-      case "ArrowDown":
-        onArrow("down");
-        break;
-      case "ArrowUp":
-        onArrow("up");
-        break;
       case "[":
         if (e?.ctrlKey) dispatch(_rootEl, "_toggle", {}, {});
         break;
       case "Escape":
         closeAccountMenu();
         break;
-    }
-  }
-
-  function onArrow(direction: "up" | "down") {
-    changeFocusedMenuItem(direction === "up" ? -1 : 1);
-  }
-
-  function isFocusable(element: HTMLElement): boolean {
-    // Check if element has tabindex >= 0 or is naturally focusable
-    const tabindex = element.getAttribute("tabindex");
-    if (tabindex !== null && parseInt(tabindex) >= 0) {
-      return true;
-    }
-
-    const focusableElements = [
-      "WORK-SIDE-MENU",
-      "A",
-      "BUTTON",
-      "INPUT",
-      "SELECT",
-      "TEXTAREA",
-    ];
-    if (focusableElements.some((tag) => element.tagName.includes(tag))) {
-      return !element.hasAttribute("disabled");
-    }
-
-    return false;
-  }
-
-  function getMenuSlotItems(slotName: string): HTMLElement[] {
-    let slot = _menuEl.querySelector(
-      `slot[name='${slotName}']`,
-    ) as HTMLSlotElement;
-    if (!slot) return [];
-    let assignedNodes = slot.assignedElements({ flatten: true });
-    let items: HTMLElement[] = [];
-    assignedNodes.forEach((node) => {
-      Array.from(node.children).forEach((child) => {
-        const element = child as HTMLElement;
-        if (isFocusable(element)) {
-          items.push(element);
-        }
-      });
-    });
-    return items;
-  }
-
-  function getFocusItems() {
-    _focusItems = [
-      ...getMenuSlotItems("primary"),
-      ...getMenuSlotItems("secondary"),
-      _profileButtonEl,
-      ...getMenuSlotItems("account"),
-      _toggleButtonEl,
-    ];
-  }
-
-  function changeFocusedMenuItem(offset: number) {
-    let oldItem = _focusItems[_focusedIndex];
-    let index = _focusedIndex;
-    index += offset;
-    if (index < 0) {
-      index = _focusItems.length - 1;
-    } else if (index >= _focusItems.length) {
-      index = 0;
-    }
-
-    _focusedIndex = index;
-    let newItem = _focusItems[_focusedIndex];
-
-    if (oldItem === _profileButtonEl && offset > 0 && !_showAccountMenu) {
-      setFocusedIndexToElement(_toggleButtonEl);
-    }
-
-    if (oldItem === _toggleButtonEl && offset < 0 && !_showAccountMenu) {
-      setFocusedIndexToElement(_profileButtonEl);
-    }
-
-    if (newItem === _profileButtonEl && offset < 0 && _showAccountMenu) {
-      closeAccountMenu();
-    }
-
-    if (newItem === _toggleButtonEl && offset > 0 && _showAccountMenu) {
-      closeAccountMenu();
-    }
-
-    tick().then(() => {
-      focusOnMenuItem(newItem);
-    });
-  }
-
-  function setFocusedIndexToElement(el: HTMLElement) {
-    _focusedIndex = _focusItems.indexOf(el);
-    focusOnMenuItem(el);
-  }
-
-  function focusOnMenuItem(el: HTMLElement) {
-    if (el.tagName.includes("WORK-SIDE-MENU")) {
-      let link = getShadowLinkEl(el);
-      link?.focus();
-    } else {
-      el.focus();
     }
   }
 
@@ -336,6 +218,12 @@
     closeAccountMenu();
     window.removeEventListener("click", closeAccountMenu);
     dispatch(_rootEl, "_toggle", {}, { bubbles: true });
+  }
+
+  function handleAccountFocusOut(e: FocusEvent) {
+    const target = e.relatedTarget as HTMLElement;
+    if (target?.closest?.('[slot="account"]') || target?.closest?.('.profile')) return;
+    closeAccountMenu();
   }
 
   function handleWindowResize() {
@@ -375,6 +263,7 @@
     window.removeEventListener("popstate", setCurrentUrl);
     window.removeEventListener("keydown", handleKeyDown);
     window.removeEventListener("resize", handleWindowResize);
+    document.body.removeEventListener("click", closeAccountMenu);
   }
 </script>
 
@@ -433,6 +322,7 @@
             role="presentation"
             class:show={_showAccountMenu}
             on:mouseleave={handleMouseLeave}
+            on:focusout={handleAccountFocusOut}
           >
             <slot name="account"></slot>
           </div>
@@ -440,9 +330,9 @@
           <button
             class="profile"
             on:click={handleProfileClick}
+            on:focusout={handleAccountFocusOut}
             aria-haspopup="true"
             aria-expanded={_showAccountMenu}
-            bind:this={_profileButtonEl}
           >
             <div class="profile-image">
               <goa-icon
@@ -467,7 +357,6 @@
             class="toggle-button"
             data-testid="toggle-menu"
             on:click={handleToggleClick}
-            bind:this={_toggleButtonEl}
             aria-label={open ? "Collapse menu" : "Expand menu"}
           >
             <goa-icon


### PR DESCRIPTION
This PR removes arrow key navigation for the Work Side Menu and instead relies on the tab key for navigation.

### Before

Navigating with arrows only works with menu items:

![nav-not-working](https://github.com/user-attachments/assets/4c5408f0-b0fc-4f7e-99be-3d0a9fbfb0f6)


### After

Navigating with tab works with various interactive elements.


![nav-working](https://github.com/user-attachments/assets/38b7df6b-600c-4b63-b35c-bb121f42cde8)

I made this decision for the following reasons:

- The previous arrow key implementation relied on lots of brittle custom code.
- Delivery teams will put various components in the menu slots. Many will also break arrow keyboard navigation.
- Tab navigation should reliably work in most situations.