### PR TITLE
fix(#3201): Input component onChange doesn't fire onBlur

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -47,6 +47,7 @@
           <a href="/bugs/3072">3072</a>
           <a href="/bugs/3118">3118</a>
           <a href="/bugs/3156">3156</a>
+          <a href="/bugs/3201">3201</a>
           <a href="/bugs/3215">3215</a>
           <a href="/bugs/3248">3248</a>
         </goab-side-menu-group>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -32,6 +32,7 @@ import { Bug2991Component } from "../routes/bugs/2991/bug2991.component";
 import { Bug3072Component } from "../routes/bugs/3072/bug3072.component";
 import { Bug3118Component } from "../routes/bugs/3118/bug3118.component";
 import { Bug3156Component } from "../routes/bugs/3156/bug3156.component";
+import { Bug3201Component } from "../routes/bugs/3201/bug3201.component";
 import { Bug3215Component } from "../routes/bugs/3215/bug3215.component";
 import { Bug3248Component } from "../routes/bugs/3248/bug3248.component";
 
@@ -84,6 +85,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3072", component: Bug3072Component },
   { path: "bugs/3118", component: Bug3118Component },
   { path: "bugs/3156", component: Bug3156Component },
+  { path: "bugs/3201", component: Bug3201Component },
   { path: "bugs/3215", component: Bug3215Component },
   { path: "bugs/3248", component: Bug3248Component },
 

--- a/apps/prs/angular/src/routes/bugs/3201/bug3201.component.html
+++ b/apps/prs/angular/src/routes/bugs/3201/bug3201.component.html
@@ -1,0 +1,38 @@
+<goab-text tag="h1" mb="s">#3201: Modify GoabInput onChange to not fire on tab</goab-text>
+<goab-text tag="p" mb="s"
+  >This is to test the GoabInput and GoabTextArea components. Specifically the onChange
+  event, it should only fire when a change is detected inside the component. It should not
+  fire when you tab out of the component.</goab-text
+>
+<goab-text tag="p" mb="xl"
+  >You can see the events fire in the UI for 500ms, or you can check the console
+  log.</goab-text
+>
+<goab-form-item label="Text Area Component" maxWidth="50%">
+  <goab-textarea
+    name="area-event"
+    (onChange)="handleAreaChange($event)"
+    (onBlur)="handleAreaBlur($event)"
+    width="100%"
+    [value]="textAreaValue"
+  />
+</goab-form-item>
+<div>Change: {{ this.areaChange }} || Blur: {{ this.areaBlur }}</div>
+<goab-form-item label="Input Component" mb="s" maxWidth="50%" mt="xl">
+  <goab-input
+    name="input-event"
+    (onChange)="handleInputChange($event)"
+    (onBlur)="handleInputBlur($event)"
+    width="100%"
+    [value]="inputValue"
+  />
+</goab-form-item>
+<div>Change: {{ this.inputChange }} || Blur: {{ this.inputBlur }}</div>
+<goab-text tag="p" mt="l"
+  >The buttons below will add text to each component. No change event should be
+  fired.</goab-text
+>
+<goab-button-group mt="xl">
+  <goab-button (onClick)="addInputText()">Add Input Text</goab-button>
+  <goab-button (onClick)="addTextAreaText()">Add</goab-button>
+</goab-button-group>

--- a/apps/prs/angular/src/routes/bugs/3201/bug3201.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3201/bug3201.component.ts
@@ -1,0 +1,74 @@
+import { Component } from "@angular/core";
+import {
+  GoabInput,
+  GoabText,
+  GoabTextArea,
+  GoabFormItem,
+  GoabButton,
+  GoabButtonGroup,
+} from "@abgov/angular-components";
+import {
+  GoabInputOnChangeDetail,
+  GoabInputOnBlurDetail,
+  GoabTextAreaOnChangeDetail,
+  GoabTextAreaOnBlurDetail,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3201",
+  templateUrl: "./bug3201.component.html",
+  imports: [GoabText, GoabInput, GoabTextArea, GoabFormItem, GoabButton, GoabButtonGroup],
+})
+export class Bug3201Component {
+  inputValue = "";
+  textAreaValue = "";
+  inputChange = "";
+  inputBlur = "";
+  areaChange = "";
+  areaBlur = "";
+
+  handleInputChange(detail: GoabInputOnChangeDetail) {
+    this.inputValue = detail.value;
+    this.inputChange = "Input Change event fired";
+    setTimeout(() => {
+      this.inputChange = "";
+    }, 500);
+    console.log("Input change event fired");
+  }
+
+  handleInputBlur(detail: GoabInputOnBlurDetail) {
+    this.inputValue = detail.value;
+    this.inputBlur = "Input Blur event fired";
+    setTimeout(() => {
+      this.inputBlur = "";
+    }, 500);
+    console.log("Input blur event fired");
+  }
+
+  handleAreaChange(detail: GoabTextAreaOnChangeDetail) {
+    this.textAreaValue = detail.value;
+    this.areaChange = "Text Area Change event fired";
+    setTimeout(() => {
+      this.areaChange = "";
+    }, 500);
+    console.log("Text Area change event fired");
+  }
+
+  handleAreaBlur(detail: GoabTextAreaOnBlurDetail) {
+    this.textAreaValue = detail.value;
+    this.areaBlur = "Text Area Blur event fired";
+    setTimeout(() => {
+      this.areaBlur = "";
+    }, 500);
+    console.log("Text area blur event fired");
+  }
+
+  addInputText() {
+    this.inputValue = "Different";
+  }
+
+  addTextAreaText() {
+    this.textAreaValue = "This is some new text added to the text area";
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -52,6 +52,7 @@ export function App() {
               <Link to="/bugs/2943">2943</Link>
               <Link to="/bugs/2948">2948</Link>
               <Link to="/bugs/3118">3118</Link>
+              <Link to="/bugs/3201">3201</Link>
               <Link to="/bugs/3215">3215</Link>
               <Link to="/bugs/3248">3248</Link>
             </GoabSideMenuGroup>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -33,6 +33,7 @@ import { Bug2922Route } from "./routes/bugs/bug2922";
 import { Bug2943Route } from "./routes/bugs/bug2943";
 import { Bug2948Route } from "./routes/bugs/bug2948";
 import { Bug3118Route } from "./routes/bugs/bug3118";
+import { Bug3201Route } from "./routes/bugs/bug3201";
 import { Bug3215Route } from "./routes/bugs/bug3215";
 import { Bug3248Route } from "./routes/bugs/bug3248";
 
@@ -88,6 +89,7 @@ root.render(
           <Route path="bugs/2943" element={<Bug2943Route />} />
           <Route path="bugs/2948" element={<Bug2948Route />} />
           <Route path="bugs/3118" element={<Bug3118Route />} />
+          <Route path="bugs/3201" element={<Bug3201Route />} />
           <Route path="bugs/3215" element={<Bug3215Route />} />
           <Route path="bugs/3248" element={<Bug3248Route />} />
 

--- a/apps/prs/react/src/routes/bugs/bug3201.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3201.tsx
@@ -1,0 +1,118 @@
+import {
+  GoabText,
+  GoabFormItem,
+  GoabTextarea,
+  GoabInput,
+  GoabButton,
+  GoabButtonGroup,
+} from "@abgov/react-components";
+import {
+  GoabInputOnChangeDetail,
+  GoabInputOnBlurDetail,
+  GoabTextAreaOnChangeDetail,
+  GoabTextAreaOnBlurDetail,
+} from "@abgov/ui-components-common";
+import { useState } from "react";
+
+export function Bug3201Route() {
+  const [inputValue, setInputValue] = useState<string>("");
+  const [textAreaValue, setTextAreaValue] = useState<string>("");
+  const [inputChange, setInputChange] = useState<string>("");
+  const [inputBlur, setInputBlur] = useState<string>("");
+  const [areaChange, setAreaChange] = useState<string>("");
+  const [areaBlur, setAreaBlur] = useState<string>("");
+
+  function handleInputChange(detail: GoabInputOnChangeDetail) {
+    setInputValue(detail.value);
+    setInputChange("Input Change event fired");
+    setTimeout(() => {
+      setInputChange("");
+    }, 500);
+    console.log("Input change event fired");
+  }
+
+  function handleInputBlur(detail: GoabInputOnBlurDetail) {
+    setInputValue(detail.value);
+    setInputBlur("Input Blur event fired");
+    setTimeout(() => {
+      setInputBlur("");
+    }, 500);
+    console.log("Input blur event fired");
+  }
+
+  function handleAreaChange(detail: GoabTextAreaOnChangeDetail) {
+    setTextAreaValue(detail.value);
+    setAreaChange("Text Area Change event fired");
+    setTimeout(() => {
+      setAreaChange("");
+    }, 500);
+    console.log("Text Area change event fired");
+  }
+
+  function handleAreaBlur(detail: GoabTextAreaOnBlurDetail) {
+    setTextAreaValue(detail.value);
+    setAreaBlur("Text Area Blur event fired");
+    setTimeout(() => {
+      setAreaBlur("");
+    }, 500);
+    console.log("Text area blur event fired");
+  }
+
+  function addInputText() {
+    setInputValue("Different");
+  }
+
+  function addTextAreaText() {
+    setTextAreaValue("This is some new text added to the text area");
+  }
+
+  return (
+    <main>
+      <GoabText tag="h1" mb="s">
+        #3201: Modify GoabInput onChange to not fire on tab
+      </GoabText>
+      <GoabText tag="p" mb="s">
+        This is to test the GoabInput and GoabTextArea components. Specifically the
+        onChange event, it should only fire when a change is detected inside the
+        component. It should not fire when you tab out of the component.
+      </GoabText>
+      <GoabText tag="p" mb="xl">
+        You can see the events fire in the UI for 500ms, or you can check the console log.
+      </GoabText>
+      <GoabFormItem label="Text Area Component" maxWidth="50%">
+        <GoabTextarea
+          name="area-event"
+          onChange={(e) => handleAreaChange(e)}
+          onBlur={(e) => handleAreaBlur(e)}
+          width="100%"
+          value={textAreaValue}
+        />
+      </GoabFormItem>
+      <div>
+        Change: {areaChange} || Blur: {areaBlur}
+      </div>
+      <GoabFormItem label="Input Component" mb="s" maxWidth="50%" mt="xl">
+        <GoabInput
+          name="input-event"
+          onChange={(e) => handleInputChange(e)}
+          onBlur={(e) => handleInputBlur(e)}
+          width="100%"
+          value={inputValue}
+        />
+      </GoabFormItem>
+      <div>
+        Change: {inputChange} || Blur: {inputBlur}
+      </div>
+      <GoabText tag="p" mt="l">
+        The buttons below will add text to each component. No change event should be
+        fired.
+      </GoabText>
+      <GoabButtonGroup alignment="start" mt="xl">
+        <GoabButton onClick={() => addInputText()}>Add Input Text</GoabButton>
+        <GoabButton onClick={() => addTextAreaText()}>Add</GoabButton>
+      </GoabButtonGroup>
+    </main>
+  );
+}
+
+export default Bug3201Route;

--- a/libs/web-components/src/components/input/Input.spec.ts
+++ b/libs/web-components/src/components/input/Input.spec.ts
@@ -217,6 +217,7 @@ describe("GoAInput Component", () => {
       keypress();
     });
 
+    await fireEvent.input(input, { target: { value: "foobar" } });
     await fireEvent.keyUp(input, { target: { value: "foobar" }, key: "r" });
     await waitFor(() => {
       expect(change).toBeCalledTimes(1);
@@ -231,6 +232,7 @@ describe("GoAInput Component", () => {
       name: "test-name",
       testid: "input-test",
       type: "date",
+      value: "2024-01-01",
     });
     const input = await findByTestId("input-test");
     const change = vi.fn();
@@ -239,7 +241,7 @@ describe("GoAInput Component", () => {
       change();
     });
 
-    await fireEvent.change(input);
+    await fireEvent.input(input, { target: { value: "2024-01-02" } });
     await waitFor(() => {
       expect(change).toBeCalledTimes(1);
     });
@@ -305,6 +307,7 @@ describe("GoAInput Component", () => {
         name: "test-name",
         testid: "input-test",
         type: "search",
+        value: "foo",
       });
       const input = await findByTestId("input-test");
       const search = vi.fn();
@@ -313,7 +316,7 @@ describe("GoAInput Component", () => {
         search();
       });
 
-      await fireEvent(input, new Event("search"));
+      await fireEvent.input(input, { target: { value: "" } });
       await waitFor(() => {
         expect(search).toBeCalledTimes(1);
       });
@@ -385,7 +388,8 @@ describe("GoAInput Component", () => {
         ml: "xl",
       });
       const input = await baseElement.findByTestId("input-test");
-      const containerElement = baseElement.container.querySelector(".container");
+      const containerElement =
+        baseElement.container.querySelector(".container");
 
       expect(input).toBeTruthy();
       expect(containerElement).toBeTruthy();
@@ -440,7 +444,7 @@ describe("GoAInput Component", () => {
       fn();
     });
 
-    await fireEvent.keyUp(input, { target: { value: "foobar" } });
+    await fireEvent.input(input, { target: { value: "foobar" } });
     await waitFor(
       () => {
         expect(fn).not.toBeCalled();

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -231,7 +231,7 @@
   }
 
   function dispatchOnChange(value: string) {
-    dispatch(_rootEl, "_change", { name, value }, { bubbles: true });
+    dispatch(_rootEl, "_change", { name, value: value }, { bubbles: true });
   }
 
   // Relay message up the chain to allow any parent element to have a reference to the input element
@@ -246,7 +246,7 @@
     }
   }
 
-  function onKeyUp(e: Event) {
+  function onInput(e: Event) {
     const input = e.target as HTMLInputElement;
 
     if (!input) return;
@@ -266,6 +266,13 @@
         }),
       );
     }, debounce);
+  }
+
+  function onKeyUp(e: Event) {
+    const input = e.target as HTMLInputElement;
+
+    if (!input) return;
+    if (isReadonly) return;
 
     input.dispatchEvent(
       new CustomEvent("_keyPress", {
@@ -405,8 +412,8 @@
       aria-label={arialabel}
       aria-labelledby={arialabelledby}
       aria-invalid={_error ? "true" : "false"}
+      on:input={onInput}
       on:keyup={onKeyUp}
-      on:change={onKeyUp}
       on:focus={onFocus}
       on:blur={onBlur}
     />
@@ -497,7 +504,9 @@
     --goa-text-input-padding: var(--goa-text-input-padding-compact);
     --goa-text-input-padding-lr: var(--goa-text-input-padding-compact-lr);
     --goa-text-input-typography: var(--goa-text-input-typography-compact);
-    --goa-text-input-space-btw-icon-text: var(--goa-text-input-space-btw-icon-text-compact);
+    --goa-text-input-space-btw-icon-text: var(
+      --goa-text-input-space-btw-icon-text-compact
+    );
   }
 
   .goa-input:not(.error):not(.input--disabled):hover:not(:has(input:focus-visible)) {
@@ -658,16 +667,24 @@
   }
 
   /* V2: Read-only leading/trailing content - background, border, and text color */
-  .container.v2.leading-content:has(input:read-only:not(:disabled)) .leading-content-slot :global(::slotted(div)),
-  .container.v2.trailing-content:has(input:read-only:not(:disabled)) .trailing-content-slot :global(::slotted(div)) {
+  .container.v2.leading-content:has(input:read-only:not(:disabled))
+    .leading-content-slot
+    :global(::slotted(div)),
+  .container.v2.trailing-content:has(input:read-only:not(:disabled))
+    .trailing-content-slot
+    :global(::slotted(div)) {
     background-color: var(--goa-text-input-lt-content-color-bg-readonly);
     box-shadow: var(--goa-text-input-border-readonly);
     color: var(--goa-text-input-color-text);
   }
 
   /* V2: Disabled leading/trailing content - text color and border (must come after all default slot styles) */
-  .container.v2.leading-content:has(.input--disabled) .leading-content-slot :global(::slotted(div)),
-  .container.v2.trailing-content:has(.input--disabled) .trailing-content-slot :global(::slotted(div)) {
+  .container.v2.leading-content:has(.input--disabled)
+    .leading-content-slot
+    :global(::slotted(div)),
+  .container.v2.trailing-content:has(.input--disabled)
+    .trailing-content-slot
+    :global(::slotted(div)) {
     color: var(--goa-text-input-color-text-disabled);
     box-shadow: var(--goa-text-input-border-disabled);
   }

--- a/libs/web-components/src/components/text-area/TextArea.spec.ts
+++ b/libs/web-components/src/components/text-area/TextArea.spec.ts
@@ -26,8 +26,8 @@ describe("GoATextArea", () => {
     expect(el).toHaveAttribute("autocomplete", "off");
   });
 
-  it("handles the change event", async () => {
-    const onChange = vi.fn();
+  it("handles the input event", async () => {
+    const onInput = vi.fn();
     const result = render(GoATextArea, {
       name: "name",
       testid: "test-id",
@@ -37,19 +37,19 @@ describe("GoATextArea", () => {
     el.addEventListener("_change", (e: CustomEvent) => {
       expect(e.detail.name).toBe("name");
       expect(e.detail.value).toBe("b");
-      onChange();
+      onInput();
     });
 
-    await fireEvent.change(el, { target: { value: "b" } });
+    await fireEvent.input(el, { target: { value: "b" } });
 
     await waitFor(() => {
-      expect(onChange).toBeCalledTimes(1);
+      expect(onInput).toBeCalledTimes(1);
     });
   });
 
   it("handles the keypress event", async () => {
     const onKeyPress = vi.fn();
-    const onChange = vi.fn();
+    const onInput = vi.fn();
     const result = render(GoATextArea, {
       name: "name",
       value: "foo",
@@ -59,22 +59,23 @@ describe("GoATextArea", () => {
     const textarea = result.queryByTestId("keypress");
     textarea.addEventListener("_keyPress", (e: CustomEvent) => {
       expect(e.detail.name).toBe("name");
-      expect(e.detail.value).toBe("foo");
+      expect(e.detail.value).toBe("fooo");
       expect(e.detail.key).toBe("o");
       onKeyPress();
     });
 
     textarea.addEventListener("_change", (e: CustomEvent) => {
       expect(e.detail.name).toBe("name");
-      expect(e.detail.value).toBe("foo");
-      onChange();
+      expect(e.detail.value).toBe("fooo");
+      onInput();
     });
 
-    await fireEvent.keyUp(textarea, { target: { value: "foo" }, key: "o" });
+    await fireEvent.input(textarea, { target: { value: "fooo" } });
+    await fireEvent.keyUp(textarea, { target: { value: "fooo" }, key: "o" });
 
     await waitFor(() => {
       expect(onKeyPress).toBeCalledTimes(1);
-      expect(onChange).toBeCalledTimes(1);
+      expect(onInput).toBeCalledTimes(1);
     });
   });
 

--- a/libs/web-components/src/components/text-area/TextArea.svelte
+++ b/libs/web-components/src/components/text-area/TextArea.svelte
@@ -130,7 +130,7 @@
     );
   }
 
-  function onChange(e: Event) {
+  function onInput(_e: Event) {
     if (isDisabled) return;
     dispatchChange(_textareaEl.value);
   }
@@ -138,7 +138,6 @@
   function onKeyPress(e: KeyboardEvent) {
     if (isDisabled) return;
     dispatchKeyPress(e);
-    dispatchChange(_textareaEl.value);
   }
 
   function dispatchChange(value: string) {
@@ -194,8 +193,8 @@
       data-testid={testid}
       {autocomplete}
       bind:value
+      on:input={onInput}
       on:keyup={onKeyPress}
-      on:change={onChange}
       on:focus={onFocus}
       on:blur={onBlur}
     />


### PR DESCRIPTION
# Before (the change)

When you tabbed out of an Input or TextArea component, the onChange event would fire.

# After (the change)

When you tab out of an Input or TextArea component, the onChange event will not fire

**NOTE:** I didn't add any additional tests, as I figured the current tests that have been changed are sufficient

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

PR test Bug 3201
