### PR TITLE
spike(#3285): experimental wrappers for v2 button

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -69,6 +69,9 @@
           <a href="/features/1908">1908</a>
           <a href="/features/2609">2609</a>
         </goab-side-menu-group>
+        <goab-side-menu-group heading="Spikes">
+          <a href="/spikes/3285">3285</a>
+        </goab-side-menu-group>
       </goab-side-menu>
     </section>
     <section style="padding: 30px; width: 100%" role="main">

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -52,6 +52,8 @@ import { Feat3102Component } from "../routes/features/feat3102/feat3102.componen
 import { Feat1908Component } from "../routes/features/feat1908/feat1908.component";
 import { Feat2609Component } from "../routes/features/feat2609/feat2609.component";
 
+import { Spike3285Component } from "../routes/Spikes/spike3285/spike3285.component";
+
 export const appRoutes: Route[] = [
   { path: "everything", component: EverythingComponent },
 
@@ -105,4 +107,7 @@ export const appRoutes: Route[] = [
   { path: "features/2829", component: Feat2829Component },
   { path: "features/3102", component: Feat3102Component },
   { path: "features/2609", component: Feat2609Component },
+  { path: "features/1908", component: Feat1908Component },
+
+  { path: "spikes/3285", component: Spike3285Component },
 ];

--- a/apps/prs/angular/src/routes/Spikes/spike3285/spike3285.component.html
+++ b/apps/prs/angular/src/routes/Spikes/spike3285/spike3285.component.html
@@ -1,0 +1,51 @@
+<goab-block direction="column" gap="l">
+  <goab-block direction="column" gap="s">
+    <goab-text tag="h1" mb="0" mt="0">
+      <a href="https://github.com/GovAlta/ui-components/issues/3285" target="_blank">3285</a>
+      - Experimental Angular Button wrapper
+    </goab-text>
+    <goab-text tag="p" mt="0">
+      This demonstrates an experimental wrapper that renders a v2 Svelte component with experimental design tokens.
+      These components can be used alongside current ones.
+    </goab-text>
+  </goab-block>
+
+  <goab-text tag="h2" mt="0" mb="0">Experimental (GoabxButton)</goab-text>
+
+  <goab-block gap="m">
+    <goabx-button type="primary" (onClick)="onExperimentalClick()">Primary</goabx-button>
+    <goabx-button type="secondary" (onClick)="onExperimentalClick()">Secondary</goabx-button>
+    <goabx-button type="tertiary" (onClick)="onExperimentalClick()">Tertiary</goabx-button>
+  </goab-block>
+
+  <goab-block gap="m" mb="xl">
+    <goabx-button type="primary" leadingIcon="add" (onClick)="onExperimentalClick()">
+      Leading icon
+    </goabx-button>
+    <goabx-button type="primary" trailingIcon="arrow-forward" (onClick)="onExperimentalClick()">
+      Trailing icon
+    </goabx-button>
+    <goabx-button type="secondary" disabled="true">Disabled</goabx-button>
+  </goab-block>
+
+
+  <goab-block direction="column" gap="m">
+    <goab-text tag="h2" mt="0" mb="0">Non-experimental (GoabButton)</goab-text>
+
+    <goab-block gap="m">
+      <goab-button type="primary" (onClick)="onExperimentalClick()">Primary</goab-button>
+      <goab-button type="secondary" (onClick)="onExperimentalClick()">Secondary</goab-button>
+      <goab-button type="tertiary" (onClick)="onExperimentalClick()">Tertiary</goab-button>
+    </goab-block>
+
+    <goab-block gap="m">
+      <goab-button type="primary" leadingIcon="add" (onClick)="onExperimentalClick()">
+        Leading icon
+      </goab-button>
+      <goab-button type="primary" trailingIcon="arrow-forward" (onClick)="onExperimentalClick()">
+        Trailing icon
+      </goab-button>
+      <goab-button type="secondary" disabled="true">Disabled</goab-button>
+    </goab-block>
+  </goab-block>
+</goab-block>

--- a/apps/prs/angular/src/routes/Spikes/spike3285/spike3285.component.ts
+++ b/apps/prs/angular/src/routes/Spikes/spike3285/spike3285.component.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+import {
+  GoabBlock,
+  GoabButton,
+  GoabDivider,
+  GoabText,
+  GoabxButton,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-spike3285",
+  templateUrl: "./spike3285.component.html",
+  imports: [CommonModule, GoabBlock, GoabText, GoabDivider, GoabButton, GoabxButton],
+})
+export class Spike3285Component {
+  clickCount = 0;
+
+  onExperimentalClick(): void {
+    this.clickCount += 1;
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -72,6 +72,9 @@ export function App() {
               <Link to="/features/2829">2829</Link>
               <Link to="/features/3102">3102</Link>
             </GoabSideMenuGroup>
+            <GoabSideMenuGroup heading="Spikes">
+              <Link to="/spikes/3285">3285</Link>
+            </GoabSideMenuGroup>
           </GoabSideMenu>
         </section>
         <section style={{ padding: "30px", width: "100%" }} role="main">

--- a/apps/prs/react/src/custom-elements.d.ts
+++ b/apps/prs/react/src/custom-elements.d.ts
@@ -1,0 +1,34 @@
+import type * as React from "react";
+import type { GoabButtonType, GoabIconType } from "@abgov/ui-components-common";
+
+declare global {
+  namespace React {
+    namespace JSX {
+      interface IntrinsicElements {
+        "goa-button": React.DetailedHTMLProps<
+          React.HTMLAttributes<HTMLElement>,
+          HTMLElement
+        > & {
+          version?: string;
+          type?: GoabButtonType;
+          size?: string;
+          variant?: string;
+          leadingicon?: GoabIconType;
+          trailingicon?: GoabIconType;
+          width?: string;
+          disabled?: string;
+          testid?: string;
+          action?: string;
+          "action-arg"?: string;
+          "action-args"?: string;
+          mt?: string;
+          mb?: string;
+          ml?: string;
+          mr?: string;
+        };
+      }
+    }
+  }
+}
+
+export { };

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -52,6 +52,7 @@ import { Feat2730Route } from "./routes/features/feat2730";
 import { Feat2829Route } from "./routes/features/feat2829";
 import Feat3102Route from "./routes/features/feat3102";
 import { Feat2609Route } from "./routes/features/feat2609";
+import { Spike3285Route } from "./routes/spikes/spike3285";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 
@@ -108,6 +109,9 @@ root.render(
           <Route path="features/2730" element={<Feat2730Route />} />
           <Route path="features/2829" element={<Feat2829Route />} />
           <Route path="features/3102" element={<Feat3102Route />} />
+          <Route path="features/1908" element={<Feat1908Route />} />
+
+          <Route path="spikes/3285" element={<Spike3285Route />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/apps/prs/react/src/routes/spikes/spike3285.tsx
+++ b/apps/prs/react/src/routes/spikes/spike3285.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import {
+  GoabBlock,
+  GoabButton,
+  GoabDivider,
+  GoabText,
+} from "@abgov/react-components";
+import { GoabxButton } from "@abgov/react-components/experimental";
+
+export function Spike3285Route() {
+  const [clickCount, setClickCount] = useState(0);
+
+  return (
+    <GoabBlock direction="column" gap="l">
+      <GoabBlock direction="column" gap="s">
+        <GoabText tag="h1" mb="0" mt="0">
+          <a
+            href="https://github.com/GovAlta/ui-components/issues/3285"
+            target="_blank"
+            rel="noreferrer"
+          >
+            3285
+          </a>
+          {" "}- Experimental React Button wrapper
+        </GoabText>
+        <GoabText tag="p" mt="0">
+          This demonstrates an experimental wrapper that renders a v2 Svelte component with experimental design tokens.
+          These components can be used alongside current ones.
+        </GoabText>
+      </GoabBlock>
+
+      <GoabText tag="h2" mt="0" mb="0">Experimental (GoabxButton)</GoabText>
+
+      <GoabBlock gap="m">
+        <GoabxButton type="primary" onClick={() => setClickCount((c) => c + 1)}>
+          Primary
+        </GoabxButton>
+        <GoabxButton type="secondary" onClick={() => setClickCount((c) => c + 1)}>
+          Secondary
+        </GoabxButton>
+        <GoabxButton type="tertiary" onClick={() => setClickCount((c) => c + 1)}>
+          Tertiary
+        </GoabxButton>
+      </GoabBlock>
+
+      <GoabBlock gap="m" mb="xl">
+        <GoabxButton
+          type="primary"
+          leadingIcon="add"
+          onClick={() => setClickCount((c) => c + 1)}
+        >
+          Leading icon
+        </GoabxButton>
+        <GoabxButton
+          type="primary"
+          trailingIcon="arrow-forward"
+          onClick={() => setClickCount((c) => c + 1)}
+        >
+          Trailing icon
+        </GoabxButton>
+        <GoabxButton type="secondary" disabled>
+          Disabled
+        </GoabxButton>
+      </GoabBlock>
+
+      <GoabBlock direction="column" gap="m">
+        <GoabText tag="h2" mt="0" mb="0">Non-experimental (GoabButton)</GoabText>
+
+        <GoabBlock gap="m">
+          <GoabButton type="primary" onClick={() => setClickCount((c) => c + 1)}>
+            Primary
+          </GoabButton>
+          <GoabButton type="secondary" onClick={() => setClickCount((c) => c + 1)}>
+            Secondary
+          </GoabButton>
+          <GoabButton type="tertiary" onClick={() => setClickCount((c) => c + 1)}>
+            Tertiary
+          </GoabButton>
+        </GoabBlock>
+
+        <GoabBlock gap="m">
+          <GoabButton type="primary" leadingIcon="add" onClick={() => setClickCount((c) => c + 1)}>
+            Leading icon
+          </GoabButton>
+          <GoabButton type="primary" trailingIcon="arrow-forward" onClick={() => setClickCount((c) => c + 1)}>
+            Trailing icon
+          </GoabButton>
+          <GoabButton type="secondary" disabled>
+            Disabled
+          </GoabButton>
+        </GoabBlock>
+
+        <GoabDivider mt="l" mb="l"></GoabDivider>
+        <GoabText tag="p" mt="0" mb="0">Clicks: {clickCount}</GoabText>
+      </GoabBlock>
+    </GoabBlock>
+  );
+}
+
+export default Spike3285Route;

--- a/libs/angular-components/src/experimental/button/button.spec.ts
+++ b/libs/angular-components/src/experimental/button/button.spec.ts
@@ -1,0 +1,117 @@
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from "@angular/core/testing";
+import { GoabxButton } from "./button";
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import {
+  GoabButtonSize,
+  GoabButtonVariant,
+  GoabIconType,
+  Spacing,
+  GoabButtonType,
+} from "@abgov/ui-components-common";
+import { By } from "@angular/platform-browser";
+import { fireEvent } from "@testing-library/dom";
+
+@Component({
+  standalone: true,
+  imports: [GoabxButton],
+  template: `
+    <goabx-button
+      [type]="type"
+      [size]="size"
+      [variant]="variant"
+      [disabled]="disabled"
+      [leadingIcon]="leadingIcon"
+      [trailingIcon]="trailingIcon"
+      [testId]="testId"
+      [mt]="mt"
+      [mb]="mb"
+      [ml]="ml"
+      [mr]="mr"
+      (onClick)="onClick()"
+    >
+      {{ buttonText }}
+    </goabx-button>
+  `,
+})
+class TestButtonComponent {
+  type?: GoabButtonType;
+  size?: GoabButtonSize;
+  variant?: GoabButtonVariant;
+  disabled?: boolean;
+  leadingIcon?: GoabIconType;
+  trailingIcon?: GoabIconType;
+  testId?: string;
+  mt?: Spacing;
+  mb?: Spacing;
+  ml?: Spacing;
+  mr?: Spacing;
+  buttonText?: string;
+
+  onClick() {
+    /* do nothing */
+  }
+}
+
+describe("GoabxButton", () => {
+  let fixture: ComponentFixture<TestButtonComponent>;
+  let component: TestButtonComponent;
+
+  beforeEach(
+    fakeAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [GoabxButton, TestButtonComponent],
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(TestButtonComponent);
+      component = fixture.componentInstance;
+      component.buttonText = "Click me";
+      component.type = "primary";
+      component.size = "compact";
+      component.variant = "destructive";
+      component.leadingIcon = "car";
+      component.trailingIcon = "bag";
+      component.mt = "s";
+      component.mr = "m";
+      component.mb = "l";
+      component.ml = "xl";
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+    }),
+  );
+
+  it("should render the properties", () => {
+    const buttonElement = fixture.debugElement.query(
+      By.css("goa-button"),
+    ).nativeElement;
+
+    expect(buttonElement.getAttribute("version")).toBe("2");
+    expect(buttonElement.getAttribute("type")).toBe("primary");
+    expect(buttonElement.getAttribute("size")).toBe("compact");
+    expect(buttonElement.getAttribute("variant")).toBe("destructive");
+    expect(buttonElement.getAttribute("leadingicon")).toBe("car");
+    expect(buttonElement.getAttribute("trailingicon")).toBe("bag");
+    expect(buttonElement.getAttribute("mt")).toBe("s");
+    expect(buttonElement.getAttribute("mr")).toBe("m");
+    expect(buttonElement.getAttribute("mb")).toBe("l");
+    expect(buttonElement.getAttribute("ml")).toBe("xl");
+    // it should render the content
+    expect(buttonElement.textContent).toContain("Click me");
+  });
+
+  it("should respond to click event", fakeAsync(() => {
+    const onClick = jest.spyOn(component, "onClick");
+    const buttonElement = fixture.debugElement.query(
+      By.css("goa-button"),
+    ).nativeElement;
+
+    fireEvent(buttonElement, new CustomEvent("_click"));
+    expect(onClick).toHaveBeenCalled();
+  }));
+});

--- a/libs/angular-components/src/experimental/button/button.ts
+++ b/libs/angular-components/src/experimental/button/button.ts
@@ -1,0 +1,86 @@
+import {
+  GoabButtonSize,
+  GoabButtonType,
+  GoabButtonVariant,
+  GoabIconType,
+} from "@abgov/ui-components-common";
+import {
+  CUSTOM_ELEMENTS_SCHEMA,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  booleanAttribute,
+  OnInit,
+  ChangeDetectorRef,
+} from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { GoabBaseComponent } from "../../lib/components/base.component";
+
+@Component({
+  standalone: true,
+  selector: "goabx-button", // eslint-disable-line
+  imports: [CommonModule],
+  template: `
+    <div class="v2-experimental-tokens">
+      <goa-button
+        *ngIf="isReady"
+        [attr.version]="'2'"
+        [attr.type]="type"
+        [attr.size]="size"
+        [attr.variant]="variant"
+        [disabled]="disabled"
+        [attr.leadingicon]="leadingIcon"
+        [attr.trailingicon]="trailingIcon"
+        [attr.width]="width"
+        [attr.testid]="testId"
+        [attr.action]="action"
+        [attr.action-arg]="actionArg"
+        [attr.action-args]="JSON.stringify(actionArgs)"
+        [attr.mt]="mt"
+        [attr.mb]="mb"
+        [attr.ml]="ml"
+        [attr.mr]="mr"
+        (_click)="_onClick()"
+      >
+        <ng-content />
+      </goa-button>
+    </div>
+  `,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class GoabxButton extends GoabBaseComponent implements OnInit {
+  @Input() type?: GoabButtonType = "primary";
+  @Input() size?: GoabButtonSize;
+  @Input() variant?: GoabButtonVariant;
+  @Input({ transform: booleanAttribute }) disabled?: boolean;
+  @Input() leadingIcon?: GoabIconType;
+  @Input() trailingIcon?: GoabIconType;
+  @Input() width?: string;
+  @Input() action?: string;
+  @Input() actionArg?: string;
+  @Input() actionArgs?: Record<string, unknown>;
+
+  @Output() onClick = new EventEmitter();
+
+  isReady = false;
+
+  constructor(private cdr: ChangeDetectorRef) {
+    super();
+  }
+
+  ngOnInit(): void {
+    // For Angular 20, we need to delay rendering the web component
+    // to ensure all attributes are properly bound before the component initializes
+    setTimeout(() => {
+      this.isReady = true;
+      this.cdr.detectChanges();
+    }, 0);
+  }
+
+  _onClick() {
+    this.onClick.emit();
+  }
+
+  protected readonly JSON = JSON;
+}

--- a/libs/angular-components/src/experimental/index.ts
+++ b/libs/angular-components/src/experimental/index.ts
@@ -1,2 +1,3 @@
 export * from "./work-side-menu/work-side-menu";
 export * from "./work-side-menu-item/work-side-menu-item";
+export * from "./button/button";

--- a/libs/react-components/src/experimental/button/button.spec.tsx
+++ b/libs/react-components/src/experimental/button/button.spec.tsx
@@ -1,0 +1,105 @@
+import { render } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/dom";
+import GoabxButton from "./button";
+import { describe, it, expect, vi } from "vitest";
+import { GoabButtonSize, GoabButtonType } from "@abgov/ui-components-common";
+
+describe("GoabxButton", () => {
+  const buttonText = "Test Title";
+
+  const noop = () => {
+    /* do nothing */
+  };
+
+  it("should render", () => {
+    const { container } = render(<GoabxButton></GoabxButton>);
+
+    const el = container.querySelector("goa-button");
+    expect(el?.getAttribute("disabled")).toBeNull();
+    expect(el?.getAttribute("version")).toBe("2");
+  });
+
+  it("should render the properties", () => {
+    const { container } = render(
+      <GoabxButton
+        disabled
+        type="primary"
+        size="compact"
+        variant="destructive"
+        leadingIcon="car"
+        trailingIcon="bag"
+        mt="s"
+        mr="m"
+        mb="l"
+        ml="xl"
+      />,
+    );
+    const el = container.querySelector("goa-button");
+
+    expect(el?.getAttribute("disabled")).toBe("true");
+    expect(el?.getAttribute("type")).toBe("primary");
+    expect(el?.getAttribute("size")).toBe("compact");
+    expect(el?.getAttribute("variant")).toBe("destructive");
+    expect(el?.getAttribute("leadingicon")).toBe("car");
+    expect(el?.getAttribute("trailingicon")).toBe("bag");
+
+    expect(el?.getAttribute("mt")).toBe("s");
+    expect(el?.getAttribute("mr")).toBe("m");
+    expect(el?.getAttribute("mb")).toBe("l");
+    expect(el?.getAttribute("ml")).toBe("xl");
+  });
+
+  it("should render content", () => {
+    const { baseElement } = render(
+      <GoabxButton onClick={noop}>{buttonText}</GoabxButton>,
+    );
+
+    expect(baseElement).toBeTruthy();
+    expect(screen.getByText(buttonText));
+  });
+
+  describe("size", () => {
+    (["compact", "normal"] as const).forEach((size: GoabButtonSize) => {
+      it(`should render ${size} size`, async () => {
+        const { container } = render(
+          <GoabxButton size={size} onClick={noop}>
+            Button
+          </GoabxButton>,
+        );
+
+        const button = container.querySelector("goa-button");
+        expect(button).toBeTruthy();
+        expect(button?.getAttribute("size")).toEqual(size);
+      });
+    });
+  });
+
+  describe("type", () => {
+    (["primary", "submit", "secondary", "tertiary"] as const).forEach(
+      (type: GoabButtonType) => {
+        it(`should render ${type} type`, async () => {
+          const { container } = render(
+            <GoabxButton type={type} onClick={noop}>
+              Button
+            </GoabxButton>,
+          );
+          const button = container.querySelector("goa-button");
+
+          expect(button).toBeTruthy();
+          expect(button?.getAttribute("type")).toEqual(type);
+        });
+      },
+    );
+  });
+
+  it("responds to events", async () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <GoabxButton onClick={onClick}>Button</GoabxButton>,
+    );
+    const button = container.querySelector("goa-button");
+    expect(button).toBeTruthy();
+    button && fireEvent(button, new CustomEvent("_click"));
+    expect(onClick).toBeCalled();
+  });
+});

--- a/libs/react-components/src/experimental/button/button.tsx
+++ b/libs/react-components/src/experimental/button/button.tsx
@@ -1,0 +1,91 @@
+import { ReactNode, useEffect, useRef, type JSX } from "react";
+import {
+  GoabButtonSize,
+  GoabButtonType,
+  GoabButtonVariant,
+  GoabIconType,
+  Margins,
+} from "@abgov/ui-components-common";
+
+export interface GoabxButtonProps extends Margins {
+  type?: GoabButtonType;
+  size?: GoabButtonSize;
+  variant?: GoabButtonVariant;
+  disabled?: boolean;
+  leadingIcon?: GoabIconType;
+  trailingIcon?: GoabIconType;
+  width?: string;
+  onClick?: () => void;
+  testId?: string;
+  action?: string;
+  actionArgs?: Record<string, unknown>;
+  actionArg?: string;
+  children?: ReactNode;
+}
+
+export function GoabxButton({
+  disabled,
+  type,
+  size,
+  variant,
+  leadingIcon,
+  trailingIcon,
+  width,
+  testId,
+  children,
+  onClick,
+  mt,
+  mr,
+  mb,
+  ml,
+  action,
+  actionArgs,
+  actionArg,
+}: GoabxButtonProps): JSX.Element {
+  const el = useRef<HTMLElement>(null);
+  useEffect(() => {
+    if (!el.current) {
+      return;
+    }
+    if (!onClick) {
+      return;
+    }
+    const current = el.current;
+    const listener = () => {
+      onClick();
+    };
+
+    current.addEventListener("_click", listener);
+    return () => {
+      current.removeEventListener("_click", listener);
+    };
+  }, [el, onClick]);
+
+  return (
+    <div className="v2-experimental-tokens">
+      <goa-button
+        {...{ version: "2" }}
+        ref={el}
+        type={type}
+        size={size}
+        variant={variant}
+        disabled={disabled ? "true" : undefined}
+        leadingicon={leadingIcon}
+        trailingicon={trailingIcon}
+        width={width}
+        testid={testId}
+        action={action}
+        action-arg={actionArg}
+        action-args={JSON.stringify(actionArgs)}
+        mt={mt}
+        mr={mr}
+        mb={mb}
+        ml={ml}
+      >
+        {children}
+      </goa-button>
+    </div>
+  );
+}
+
+export default GoabxButton;

--- a/libs/react-components/src/experimental/index.ts
+++ b/libs/react-components/src/experimental/index.ts
@@ -1,4 +1,5 @@
 export * from "./resizable-panel/ResizablePanel";
 export * from "../lib/drawer/drawer";
+export * from "./button/button";
 export * from "./work-side-menu/work-side-menu";
 export * from "./work-side-menu-item/work-side-menu-item";

--- a/libs/web-components/src/index.svelte
+++ b/libs/web-components/src/index.svelte
@@ -6,4 +6,5 @@
   import "./assets/css/variables.css";
   import "./assets/css/components.css";
   import "@abgov/design-tokens/dist/tokens.css";
+  import "@abgov/design-tokens/dist/experimental-tokens.css";
 </script>


### PR DESCRIPTION
This PR demonstrates a possible way to have experimental v2 React/Angular wrappers alongside the current components. It lets a team use the components without using a v2 design token package.

### How to test
1. Link or install this Design Tokens branch: https://github.com/GovAlta/design-tokens/pull/125
2. Start Angular or React `serve:prs`
3. Navigate to **Spikes > 3285**
4. You should see experimental v2 buttons alongside v1 ones

<img width="1049" height="707" alt="image" src="https://github.com/user-attachments/assets/3282ede6-a788-471c-86d2-6a4bc737e56d" />

### Benefits

- Lets a team try individual v2 components without needing to upgrade everything
- Lets the team easily compare appearance and features with v1 components
- Allows us to maintain new tokens alongside the old ones

### Drawbacks

- It could set a false expectation of mixing v1 and v2 components after the v2 release
- It wraps Svelte components in a `<div>` which could lead to unexpected layout issues
- Adds an additional 1000+ line / 84kb CSS file