### PR TITLE
feat(#2328): Added minheight and maxheight properties to Container

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -54,17 +54,18 @@
           <a href="/features/1328">1328</a>
           <a href="/features/1547">1547</a>
           <a href="/features/1813">1813</a>
+          <a href="/features/1908">1908</a>
           <a href="/features/2054">2054</a>
           <a href="/features/2267">2267</a>
-          <a href="/features/2440">2440</a>
+          <a href="/features/2328">2328</a>
           <a href="/features/2361">2361</a>
+          <a href="/features/2440">2440</a>
           <a href="/features/2492">2492</a>
           <a href="/features/2682">2682</a>
           <a href="/features/2722">2722</a>
           <a href="/features/2730">2730</a>
           <a href="/features/2829">2829</a>
           <a href="/features/3102">3102</a>
-          <a href="/features/1908">1908</a>
         </goab-side-menu-group>
       </goab-side-menu>
     </section>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -38,9 +38,11 @@ import { Bug3248Component } from "../routes/bugs/3248/bug3248.component";
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1547Component } from "../routes/features/feat1547/feat1547.component";
 import { Feat1813Component } from "../routes/features/feat1813/feat1813.component";
-import { Feat2361Component } from "../routes/features/feat2361/feat2361.component";
+import { Feat1908Component } from "../routes/features/feat1908/feat1908.component";
 import { Feat2054Component } from "../routes/features/feat2054/feat2054.component";
 import { Feat2267Component } from "../routes/features/feat2267/feat2267.component";
+import { Feat2328Component } from "../routes/features/feat2328/feat2328.component";
+import { Feat2361Component } from "../routes/features/feat2361/feat2361.component";
 import { Feat2440Component } from "../routes/features/feat2440/feat2440.component";
 import { Feat2492Component } from "../routes/features/feat2492/feat2492.component";
 import { Feat2682Component } from "../routes/features/feat2682/feat2682.component";
@@ -48,7 +50,6 @@ import { Feat2722Component } from "../routes/features/feat2722/feat2722.componen
 import { Feat2730Component } from "../routes/features/feat2730/feat2730.component";
 import { Feat2829Component } from "../routes/features/feat2829/feat2829.component";
 import { Feat3102Component } from "../routes/features/feat3102/feat3102.component";
-import { Feat1908Component } from "../routes/features/feat1908/feat1908.component";
 
 export const appRoutes: Route[] = [
   { path: "everything", component: EverythingComponent },
@@ -90,9 +91,11 @@ export const appRoutes: Route[] = [
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1547", component: Feat1547Component },
   { path: "features/1813", component: Feat1813Component },
-  { path: "features/2361", component: Feat2361Component },
+  { path: "features/1908", component: Feat1908Component },
   { path: "features/2054", component: Feat2054Component },
   { path: "features/2267", component: Feat2267Component },
+  { path: "features/2328", component: Feat2328Component },
+  { path: "features/2361", component: Feat2361Component },
   { path: "features/2440", component: Feat2440Component },
   { path: "features/2492", component: Feat2492Component },
   { path: "features/2682", component: Feat2682Component },
@@ -100,5 +103,4 @@ export const appRoutes: Route[] = [
   { path: "features/2730", component: Feat2730Component },
   { path: "features/2829", component: Feat2829Component },
   { path: "features/3102", component: Feat3102Component },
-  { path: "features/1908", component: Feat1908Component },
 ];

--- a/apps/prs/angular/src/routes/features/feat2328/feat2328.component.html
+++ b/apps/prs/angular/src/routes/features/feat2328/feat2328.component.html
@@ -1,0 +1,110 @@
+<goab-text tag="h1" mb="m">Container height scenarios</goab-text>
+<goab-block gap="l" direction="column">
+  <goab-text tag="h2" mb="m">No maxHeight or minHeight</goab-text>
+  <goab-block gap="l">
+    <goab-container maxWidth="400px">
+      <p>Basic simple text to extend to 400px width</p>
+    </goab-container>
+    <goab-container maxWidth="400px">
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare velit.
+        Duis mi est, hendrerit sit amet eleifend nec, faucibus non nisl. Vestibulum ante
+        ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed ornare
+        odio odio, quis iaculis mi ultricies a. Sed vehicula, ante sit amet porttitor
+        sollicitudin, arcu mi pharetra enim, aliquam posuere sapien odio in nisi.
+        Curabitur congue odio quam, a fringilla metus ullamcorper vel. Nulla magna urna,
+        ultrices eu nibh ac, dictum pulvinar justo. Nam porta massa pulvinar, congue
+        turpis eget, finibus nulla. Suspendisse potenti. Class aptent taciti sociosqu ad
+        litora torquent per conubia nostra, per inceptos himenaeos. Cras quis risus
+        libero.
+      </p>
+    </goab-container>
+  </goab-block>
+  <goab-text tag="h2" mb="m">minHeight 300px or equivalent</goab-text>
+  <goab-block gap="l">
+    <goab-container maxWidth="400px" minHeight="300px">
+      <p>Basic simple text to extend to 400px width</p>
+    </goab-container>
+    <goab-container maxWidth="400px" minHeight="31ch">
+      <p>31ch</p>
+      <p>Basic simple text to extend to 400px width</p>
+    </goab-container>
+    <goab-container maxWidth="400px" minHeight="19rem">
+      <p>19rem</p>
+      <p>Basic simple text to extend to 400px width</p>
+    </goab-container>
+  </goab-block>
+  <goab-text tag="h2" mb="m">maxHeight 300px or equivalent</goab-text>
+  <goab-block gap="l">
+    <goab-container maxWidth="400px" maxHeight="300px">
+      <p>Basic simple text to extend to 400px width</p>
+    </goab-container>
+    <goab-container maxWidth="400px" maxHeight="31ch">
+      <p>31ch</p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare velit.
+        Duis mi est, hendrerit sit amet eleifend nec, faucibus non nisl. Vestibulum ante
+        ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed ornare
+        odio odio, quis iaculis mi ultricies a. Sed vehicula, ante sit amet porttitor
+        sollicitudin, arcu mi pharetra enim, aliquam posuere sapien odio in nisi.
+        Curabitur congue odio quam, a fringilla metus ullamcorper vel. Nulla magna urna,
+        ultrices eu nibh ac, dictum pulvinar justo. Nam porta massa pulvinar, congue
+        turpis eget, finibus nulla. Suspendisse potenti. Class aptent taciti sociosqu ad
+        litora torquent per conubia nostra, per inceptos himenaeos. Cras quis risus
+        libero.
+      </p>
+    </goab-container>
+    <goab-container maxWidth="400px" maxHeight="19rem">
+      <p>19rem</p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare velit.
+        Duis mi est, hendrerit sit amet eleifend nec, faucibus non nisl. Vestibulum ante
+        ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed ornare
+        odio odio, quis iaculis mi ultricies a. Sed vehicula, ante sit amet porttitor
+        sollicitudin, arcu mi pharetra enim, aliquam posuere sapien odio in nisi.
+        Curabitur congue odio quam, a fringilla metus ullamcorper vel. Nulla magna urna,
+        ultrices eu nibh ac, dictum pulvinar justo. Nam porta massa pulvinar, congue
+        turpis eget, finibus nulla. Suspendisse potenti. Class aptent taciti sociosqu ad
+        litora torquent per conubia nostra, per inceptos himenaeos. Cras quis risus
+        libero.
+      </p>
+    </goab-container>
+  </goab-block>
+
+  <goab-text tag="h2" mb="m">minHeight 300px and maxHeight 400px or equivalent</goab-text>
+  <goab-block gap="l">
+    <goab-container maxWidth="400px" minHeight="300px" maxHeight="400px">
+      <p>Basic simple text to extend to 400px width</p>
+    </goab-container>
+    <goab-container maxWidth="400px" minHeight="31ch" maxHeight="41ch">
+      <p>31ch and 41ch</p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare velit.
+        Duis mi est, hendrerit sit amet eleifend nec, faucibus non nisl. Vestibulum ante
+        ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed ornare
+        odio odio, quis iaculis mi ultricies a. Sed vehicula, ante sit amet porttitor
+        sollicitudin, arcu mi pharetra enim, aliquam posuere sapien odio in nisi.
+        Curabitur congue odio quam, a fringilla metus ullamcorper vel. Nulla magna urna,
+        ultrices eu nibh ac, dictum pulvinar justo. Nam porta massa pulvinar, congue
+        turpis eget, finibus nulla. Suspendisse potenti. Class aptent taciti sociosqu ad
+        litora torquent per conubia nostra, per inceptos himenaeos. Cras quis risus
+        libero.
+      </p>
+    </goab-container>
+    <goab-container maxWidth="400px" minHeight="19rem" maxHeight="25rem">
+      <p>19rem and 25rem</p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare velit.
+        Duis mi est, hendrerit sit amet eleifend nec, faucibus non nisl. Vestibulum ante
+        ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed ornare
+        odio odio, quis iaculis mi ultricies a. Sed vehicula, ante sit amet porttitor
+        sollicitudin, arcu mi pharetra enim, aliquam posuere sapien odio in nisi.
+        Curabitur congue odio quam, a fringilla metus ullamcorper vel. Nulla magna urna,
+        ultrices eu nibh ac, dictum pulvinar justo. Nam porta massa pulvinar, congue
+        turpis eget, finibus nulla. Suspendisse potenti. Class aptent taciti sociosqu ad
+        litora torquent per conubia nostra, per inceptos himenaeos. Cras quis risus
+        libero.
+      </p>
+    </goab-container>
+  </goab-block>
+</goab-block>

--- a/apps/prs/angular/src/routes/features/feat2328/feat2328.component.ts
+++ b/apps/prs/angular/src/routes/features/feat2328/feat2328.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabContainer, GoabText, GoabBlock } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat2328",
+  templateUrl: "./feat2328.component.html",
+  imports: [GoabText, GoabBlock, GoabContainer],
+})
+export class Feat2328Component {}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -58,8 +58,10 @@ export function App() {
             <GoabSideMenuGroup heading="Features">
               <Link to="/features/1547">1547</Link>
               <Link to="/features/1813">1813</Link>
+              <Link to="/features/1908">1908</Link>
               <Link to="/features/2054">2054</Link>
               <Link to="/features/2267">2267</Link>
+              <Link to="/features/2328">2328</Link>
               <Link to="/features/2361">2361</Link>
               <Link to="/features/2440">2440</Link>
               <Link to="/features/2492">2492</Link>
@@ -68,7 +70,6 @@ export function App() {
               <Link to="/features/2730">2730</Link>
               <Link to="/features/2829">2829</Link>
               <Link to="/features/3102">3102</Link>
-              <Link to="/features/1908">1908</Link>
             </GoabSideMenuGroup>
           </GoabSideMenu>
         </section>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -39,6 +39,8 @@ import { Bug3248Route } from "./routes/bugs/bug3248";
 import { EverythingRoute } from "./routes/everything";
 import { Feat1547Route } from "./routes/features/feat1547";
 import { Feat1813Route } from "./routes/features/feat1813";
+import { Feat1908Route } from "./routes/features/feat1908";
+import { Feat2328Route } from "./routes/features/feat2328";
 import { Feat2361Route } from "./routes/features/feat2361";
 import { Feat2054Route } from "./routes/features/feat2054";
 import { Feat2267Route } from "./routes/features/feat2267";
@@ -49,7 +51,6 @@ import { Feat2722Route } from "./routes/features/feat2722";
 import { Feat2730Route } from "./routes/features/feat2730";
 import { Feat2829Route } from "./routes/features/feat2829";
 import Feat3102Route from "./routes/features/feat3102";
-import { Feat1908Route } from "./routes/features/feat1908";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 
@@ -93,9 +94,11 @@ root.render(
 
           <Route path="features/1547" element={<Feat1547Route />} />
           <Route path="features/1813" element={<Feat1813Route />} />
+          <Route path="features/1908" element={<Feat1908Route />} />
           <Route path="features/2361" element={<Feat2361Route />} />
           <Route path="features/2054" element={<Feat2054Route />} />
           <Route path="features/2267" element={<Feat2267Route />} />
+          <Route path="features/2328" element={<Feat2328Route />} />
           <Route path="features/2440" element={<Feat2440Route />} />
           <Route path="features/2492" element={<Feat2492Route />} />
           <Route path="features/2682" element={<Feat2682Route />} />
@@ -103,7 +106,6 @@ root.render(
           <Route path="features/2730" element={<Feat2730Route />} />
           <Route path="features/2829" element={<Feat2829Route />} />
           <Route path="features/3102" element={<Feat3102Route />} />
-          <Route path="features/1908" element={<Feat1908Route />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/apps/prs/react/src/routes/features/feat2328.tsx
+++ b/apps/prs/react/src/routes/features/feat2328.tsx
@@ -1,0 +1,130 @@
+import { GoabContainer, GoabText, GoabBlock } from "@abgov/react-components";
+
+export function Feat2328Route() {
+  return (
+    <main>
+      <GoabText tag="h1" mb="m">
+        Container height scenarios
+      </GoabText>
+      <GoabBlock gap="l" direction="column">
+        <GoabText tag="h2" mb="m">
+          No maxHeight or minHeight
+        </GoabText>
+        <GoabBlock gap="l">
+          <GoabContainer maxWidth="400px">
+            <p>Basic simple text to extend to 400px width</p>
+          </GoabContainer>
+          <GoabContainer maxWidth="400px">
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare
+              velit. Duis mi est, hendrerit sit amet eleifend nec, faucibus non nisl.
+              Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+              cubilia curae; Sed ornare odio odio, quis iaculis mi ultricies a. Sed
+              vehicula, ante sit amet porttitor sollicitudin, arcu mi pharetra enim,
+              aliquam posuere sapien odio in nisi. Curabitur congue odio quam, a fringilla
+              metus ullamcorper vel. Nulla magna urna, ultrices eu nibh ac, dictum
+              pulvinar justo. Nam porta massa pulvinar, congue turpis eget, finibus nulla.
+              Suspendisse potenti. Class aptent taciti sociosqu ad litora torquent per
+              conubia nostra, per inceptos himenaeos. Cras quis risus libero.
+            </p>
+          </GoabContainer>
+        </GoabBlock>
+        <GoabText tag="h2" mb="m">
+          minHeight 300px or equivalent
+        </GoabText>
+        <GoabBlock gap="l">
+          <GoabContainer maxWidth="400px" minHeight="300px">
+            <p>Basic simple text to extend to 400px width</p>
+          </GoabContainer>
+          <GoabContainer maxWidth="400px" minHeight="31ch">
+            <p>31ch</p>
+            <p>Basic simple text to extend to 400px width</p>
+          </GoabContainer>
+          <GoabContainer maxWidth="400px" minHeight="19rem">
+            <p>19rem</p>
+            <p>Basic simple text to extend to 400px width</p>
+          </GoabContainer>
+        </GoabBlock>
+        <GoabText tag="h2" mb="m">
+          maxHeight 300px or equivalent
+        </GoabText>
+        <GoabBlock gap="l">
+          <GoabContainer maxWidth="400px" maxHeight="300px">
+            <p>Basic simple text to extend to 400px width</p>
+          </GoabContainer>
+          <GoabContainer maxWidth="400px" maxHeight="31ch">
+            <p>31ch</p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare
+              velit. Duis mi est, hendrerit sit amet eleifend nec, faucibus non nisl.
+              Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+              cubilia curae; Sed ornare odio odio, quis iaculis mi ultricies a. Sed
+              vehicula, ante sit amet porttitor sollicitudin, arcu mi pharetra enim,
+              aliquam posuere sapien odio in nisi. Curabitur congue odio quam, a fringilla
+              metus ullamcorper vel. Nulla magna urna, ultrices eu nibh ac, dictum
+              pulvinar justo. Nam porta massa pulvinar, congue turpis eget, finibus nulla.
+              Suspendisse potenti. Class aptent taciti sociosqu ad litora torquent per
+              conubia nostra, per inceptos himenaeos. Cras quis risus libero.
+            </p>
+          </GoabContainer>
+          <GoabContainer maxWidth="400px" maxHeight="19rem">
+            <p>19rem</p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare
+              velit. Duis mi est, hendrerit sit amet eleifend nec, faucibus non nisl.
+              Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+              cubilia curae; Sed ornare odio odio, quis iaculis mi ultricies a. Sed
+              vehicula, ante sit amet porttitor sollicitudin, arcu mi pharetra enim,
+              aliquam posuere sapien odio in nisi. Curabitur congue odio quam, a fringilla
+              metus ullamcorper vel. Nulla magna urna, ultrices eu nibh ac, dictum
+              pulvinar justo. Nam porta massa pulvinar, congue turpis eget, finibus nulla.
+              Suspendisse potenti. Class aptent taciti sociosqu ad litora torquent per
+              conubia nostra, per inceptos himenaeos. Cras quis risus libero.
+            </p>
+          </GoabContainer>
+        </GoabBlock>
+
+        <GoabText tag="h2" mb="m">
+          minHeight 300px and maxHeight 400px or equivalent
+        </GoabText>
+        <GoabBlock gap="l">
+          <GoabContainer maxWidth="400px" minHeight="300px" maxHeight="400px">
+            <p>Basic simple text to extend to 400px width</p>
+          </GoabContainer>
+          <GoabContainer maxWidth="400px" minHeight="31ch" maxHeight="41ch">
+            <p>31ch and 41ch</p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare
+              velit. Duis mi est, hendrerit sit amet eleifend nec, faucibus non nisl.
+              Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+              cubilia curae; Sed ornare odio odio, quis iaculis mi ultricies a. Sed
+              vehicula, ante sit amet porttitor sollicitudin, arcu mi pharetra enim,
+              aliquam posuere sapien odio in nisi. Curabitur congue odio quam, a fringilla
+              metus ullamcorper vel. Nulla magna urna, ultrices eu nibh ac, dictum
+              pulvinar justo. Nam porta massa pulvinar, congue turpis eget, finibus nulla.
+              Suspendisse potenti. Class aptent taciti sociosqu ad litora torquent per
+              conubia nostra, per inceptos himenaeos. Cras quis risus libero.
+            </p>
+          </GoabContainer>
+          <GoabContainer maxWidth="400px" minHeight="19rem" maxHeight="25rem">
+            <p>19rem and 25rem</p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at ornare
+              velit. Duis mi est, hendrerit sit amet eleifend nec, faucibus non nisl.
+              Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+              cubilia curae; Sed ornare odio odio, quis iaculis mi ultricies a. Sed
+              vehicula, ante sit amet porttitor sollicitudin, arcu mi pharetra enim,
+              aliquam posuere sapien odio in nisi. Curabitur congue odio quam, a fringilla
+              metus ullamcorper vel. Nulla magna urna, ultrices eu nibh ac, dictum
+              pulvinar justo. Nam porta massa pulvinar, congue turpis eget, finibus nulla.
+              Suspendisse potenti. Class aptent taciti sociosqu ad litora torquent per
+              conubia nostra, per inceptos himenaeos. Cras quis risus libero.
+            </p>
+          </GoabContainer>
+        </GoabBlock>
+      </GoabBlock>
+    </main>
+  );
+}
+
+export default Feat2328Route;

--- a/libs/angular-components/src/lib/components/container/container.spec.ts
+++ b/libs/angular-components/src/lib/components/container/container.spec.ts
@@ -5,7 +5,8 @@ import {
   GoabContainerAccent,
   GoabContainerPadding,
   GoabContainerType,
-  GoabContainerWidth, Spacing,
+  GoabContainerWidth,
+  Spacing,
 } from "@abgov/ui-components-common";
 import { GoabButton } from "../button/button";
 import { By } from "@angular/platform-browser";
@@ -14,28 +15,32 @@ import { By } from "@angular/platform-browser";
   standalone: true,
   imports: [GoabContainer, GoabButton],
   template: `
-  <goab-container [type]="type"
-                  [accent]="accent"
-                  [padding]="padding"
-                  [width]="width"
-                  [testId]="testId"
-                  maxWidth="480px"
-                  [mt]="mt"
-                  [mr]="mr"
-                  [mb]="mb"
-                  [ml]="ml"
-                  [actions]="actions"
-                  [title]="title">
-    <ng-template #actions>
-      <goab-button (onClick)="onClick()">Save</goab-button>
-    </ng-template>
-    <ng-template #title>
-      <div>This is a title</div>
-    </ng-template>
+    <goab-container
+      [type]="type"
+      [accent]="accent"
+      [padding]="padding"
+      [width]="width"
+      [testId]="testId"
+      [maxWidth]="maxWidth"
+      [minHeight]="minHeight"
+      [maxHeight]="maxHeight"
+      [mt]="mt"
+      [mr]="mr"
+      [mb]="mb"
+      [ml]="ml"
+      [actions]="actions"
+      [title]="title"
+    >
+      <ng-template #actions>
+        <goab-button (onClick)="onClick()">Save</goab-button>
+      </ng-template>
+      <ng-template #title>
+        <div>This is a title</div>
+      </ng-template>
 
-    Container content
-  </goab-container>
-  `
+      Container content
+    </goab-container>
+  `,
 })
 class TestContainerComponent {
   type?: GoabContainerType = "interactive";
@@ -47,6 +52,9 @@ class TestContainerComponent {
   mb?: Spacing;
   ml?: Spacing;
   mr?: Spacing;
+  maxWidth?: string;
+  minHeight?: string;
+  maxHeight?: string;
 
   onClick() {
     /* do nothing */
@@ -60,7 +68,7 @@ describe("GoABContainer", () => {
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [GoabButton, GoabContainer, TestContainerComponent],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestContainerComponent);
@@ -75,6 +83,9 @@ describe("GoABContainer", () => {
     component.mb = "l";
     component.ml = "xl";
     component.width = "content";
+    component.maxWidth = "480px";
+    component.minHeight = "120px";
+    component.maxHeight = "240px";
 
     fixture.detectChanges();
     tick();
@@ -85,19 +96,23 @@ describe("GoABContainer", () => {
     const el = fixture.debugElement.query(By.css("goa-container")).nativeElement;
     expect(el).toBeTruthy();
 
-   expect(el?.getAttribute("type")).toBe(component.type);
-   expect(el?.getAttribute("accent")).toBe(component.accent);
-   expect(el?.getAttribute("padding")).toBe(component.padding);
-   expect(el?.getAttribute("mt")).toBe(component.mt);
-   expect(el?.getAttribute("mr")).toBe(component.mr);
-   expect(el?.getAttribute("mb")).toBe(component.mb);
-   expect(el?.getAttribute("ml")).toBe(component.ml);
-   expect(el?.getAttribute("width")).toBe(component.width);
-   expect(el?.getAttribute("maxwidth")).toBe("480px");
+    expect(el?.getAttribute("type")).toBe(component.type);
+    expect(el?.getAttribute("accent")).toBe(component.accent);
+    expect(el?.getAttribute("padding")).toBe(component.padding);
+    expect(el?.getAttribute("mt")).toBe(component.mt);
+    expect(el?.getAttribute("mr")).toBe(component.mr);
+    expect(el?.getAttribute("mb")).toBe(component.mb);
+    expect(el?.getAttribute("ml")).toBe(component.ml);
+    expect(el?.getAttribute("width")).toBe(component.width);
+    expect(el?.getAttribute("maxwidth")).toBe(component.maxWidth);
+    expect(el?.getAttribute("minheight")).toBe(component.minHeight);
+    expect(el?.getAttribute("maxheight")).toBe(component.maxHeight);
 
-   expect(el?.querySelector("[slot='title']")?.innerHTML).toContain("This is a title");
-   expect(el?.querySelector("[slot='actions']")?.querySelector("goa-button")).not.toBeFalsy();
+    expect(el?.querySelector("[slot='title']")?.innerHTML).toContain("This is a title");
+    expect(
+      el?.querySelector("[slot='actions']")?.querySelector("goa-button"),
+    ).not.toBeFalsy();
 
-   expect(el?.innerHTML).toContain("Container content");
-  })
-})
+    expect(el?.innerHTML).toContain("Container content");
+  });
+});

--- a/libs/angular-components/src/lib/components/container/container.ts
+++ b/libs/angular-components/src/lib/components/container/container.ts
@@ -26,6 +26,8 @@ import { GoabBaseComponent } from "../base.component";
     [attr.padding]="padding"
     [attr.width]="width"
     [attr.maxwidth]="maxWidth"
+    [attr.minheight]="minHeight"
+    [attr.maxheight]="maxHeight"
     [attr.testid]="testId"
     [attr.mt]="mt"
     [attr.mb]="mb"
@@ -48,6 +50,8 @@ export class GoabContainer extends GoabBaseComponent implements OnInit {
   @Input() padding?: GoabContainerPadding = "relaxed";
   @Input() width?: GoabContainerWidth = "full";
   @Input() maxWidth?: string;
+  @Input() minHeight?: string;
+  @Input() maxHeight?: string;
   @Input() title!: TemplateRef<any>;
   @Input() actions!: TemplateRef<any>;
 

--- a/libs/react-components/src/lib/container/container.spec.tsx
+++ b/libs/react-components/src/lib/container/container.spec.tsx
@@ -12,6 +12,8 @@ describe("Container", () => {
         title={"Text title"}
         width="content"
         maxWidth="480px"
+        minHeight="240px"
+        maxHeight="360px"
         mt="s"
         mr="m"
         mb="l"
@@ -42,6 +44,8 @@ describe("Container", () => {
     expect(el?.getAttribute("ml")).toBe("xl");
     expect(el?.getAttribute("width")).toBe("content");
     expect(el?.getAttribute("maxwidth")).toBe("480px");
+    expect(el?.getAttribute("minheight")).toBe("240px");
+    expect(el?.getAttribute("maxheight")).toBe("360px");
 
     expect(el?.querySelector("*[slot=title]")?.innerHTML).toContain("Text title");
     expect(

--- a/libs/react-components/src/lib/container/container.tsx
+++ b/libs/react-components/src/lib/container/container.tsx
@@ -13,6 +13,8 @@ interface WCProps extends Margins {
   padding?: GoabContainerPadding;
   width?: GoabContainerWidth;
   maxwidth?: string;
+  minheight?: string;
+  maxheight?: string;
   testid?: string;
 }
 
@@ -35,6 +37,8 @@ export interface GoabContainerProps extends Margins {
   children?: ReactNode;
   width?: GoabContainerWidth;
   maxWidth?: string;
+  minHeight?: string;
+  maxHeight?: string;
   testId?: string;
 }
 
@@ -48,6 +52,8 @@ export function GoabContainer({
   type,
   width,
   maxWidth,
+  minHeight,
+  maxHeight,
   mt,
   mr,
   mb,
@@ -62,6 +68,8 @@ export function GoabContainer({
       accent={accent}
       width={width}
       maxwidth={maxWidth}
+      minheight={minHeight}
+      maxheight={maxHeight}
       mt={mt}
       mr={mr}
       mb={mb}

--- a/libs/web-components/src/components/container/Container.spec.ts
+++ b/libs/web-components/src/components/container/Container.spec.ts
@@ -1,10 +1,9 @@
 import { render } from "@testing-library/svelte";
-import GoAContainerWrapper from "./ContainerWrapper.test.svelte"
+import GoAContainerWrapper from "./ContainerWrapper.test.svelte";
 import GoAContainer from "./Container.svelte";
 import { it, describe } from "vitest";
 
 describe("GoA Container", () => {
-
   it("should render", async () => {
     render(GoAContainerWrapper, {
       title: "Test Title",
@@ -31,17 +30,33 @@ describe("GoA Container", () => {
       const container = await baseElement.findByTestId("container-test");
 
       expect(container).toBeTruthy();
-      expect(container?.classList).toContain('width--content');
-
+      expect(container?.classList).toContain("width--content");
     });
 
-    it('should set a max width', async () => {
+    it("should set a max width", async () => {
       const baseElement = render(GoAContainer, {
         testid: "container-test",
-        maxwidth: "480px",
+        maxWidth: "480px",
       });
       const container = await baseElement.findByTestId("container-test");
-      expect(container?.getAttribute("style")).toContain("max-width: 480px;")
+      expect(container?.getAttribute("style")).toContain("max-width: 480px;");
+    });
+  });
+
+  describe("Heights", () => {
+    it("should set min and max heights when provided", async () => {
+      const baseElement = render(GoAContainer, {
+        testid: "container-test",
+        minHeight: "120px",
+        maxHeight: "360px",
+      });
+      const container = await baseElement.findByTestId("container-test");
+      const computedStyle = window.getComputedStyle(container);
+      expect(container?.getAttribute("style")).toContain("min-height: 120px;");
+      expect(container?.getAttribute("style")).toContain("max-height: 360px;");
+      expect(computedStyle.alignSelf).toBe("flex-start");
+      const content = container?.querySelector(".content");
+      expect(content).not.toBeNull();
     });
   });
 

--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -1,4 +1,13 @@
-<svelte:options customElement="goa-container" />
+<svelte:options
+  customElement={{
+    tag: "goa-container",
+    props: {
+      maxWidth: { type: "String", attribute: "maxwidth" },
+      minHeight: { type: "String", attribute: "minheight" },
+      maxHeight: { type: "String", attribute: "maxheight" },
+    },
+  }}
+/>
 
 <!-- Script -->
 <script lang="ts">
@@ -42,7 +51,9 @@
   export let accent: Accent = "filled";
   export let padding: Padding = "relaxed";
   export let width: Width = "full";
-  export let maxwidth: string = "none";
+  export let maxWidth: string = "none";
+  export let minHeight = "";
+  export let maxHeight = "";
   export let testid: string = "";
   export let mt: Spacing = null;
   export let mr: Spacing = null;
@@ -71,7 +82,9 @@
   data-testid={testid}
   style={`
     ${calculateMargin(mt, mr, mb, ml)}
-    max-width: ${maxwidth};
+    max-width: ${maxWidth};
+    ${minHeight ? `min-height: ${minHeight};` : ""}
+    ${maxHeight ? `max-height: ${maxHeight};` : ""}
   `}
   class={`
     goa-container
@@ -113,6 +126,7 @@
     flex-direction: column;
     box-shadow: var(--goa-container-shadow, none);
     border-radius: var(--goa-container-border-radius, 0);
+    align-self: flex-start;
   }
 
   .goa-container * {
@@ -139,6 +153,8 @@
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
+    min-height: 0;
+    overflow-y: auto;
   }
 
   .content :global(::slotted(*:last-child)) {


### PR DESCRIPTION
# Before (the change)

`minHeight` and `maxHeight` didn't exist on Container

# After (the change)

`minHeight` and `maxHeight` are now properties available on Container, and affect the CSS appropriately

**NOTE:** I didn't add browser tests because I was unsure if they were necessary given our svelte unit tests, if you think they are, let me know.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Manual tests are included via Feature 2328. Please add more if you find issues.
