### PR TITLE
fix(#2873): Updated Drawer to not auto-scroll when an element is clicked

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -38,6 +38,7 @@
           <a href="/bugs/2839">2839</a>
           <a href="/bugs/2849">2849</a>
           <a href="/bugs/2852">2852</a>
+          <a href="/bugs/2873">2873</a>
           <a href="/bugs/2878">2878</a>
           <a href="/bugs/2892">2892</a>
           <a href="/bugs/2922">2922</a>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -23,6 +23,7 @@ import { Bug2837Component } from "../routes/bugs/2837/bug2837.component";
 import { Bug2839Component } from "../routes/bugs/2839/bug2839.component";
 import { Bug2849Component } from "../routes/bugs/2849/bug2849.component";
 import { Bug2852Component } from "../routes/bugs/2852/bug2852.component";
+import { Bug2873Component } from "../routes/bugs/2873/bug2873.component";
 import { Bug2878Component } from "../routes/bugs/2878/bug2878.component";
 import { Bug2892Component } from "../routes/bugs/2892/bug2892.component";
 import { Bug2922Component } from "../routes/bugs/2922/bug2922.component";
@@ -76,6 +77,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/2839", component: Bug2839Component },
   { path: "bugs/2849", component: Bug2849Component },
   { path: "bugs/2852", component: Bug2852Component },
+  { path: "bugs/2873", component: Bug2873Component },
   { path: "bugs/2878", component: Bug2878Component },
   { path: "bugs/2892", component: Bug2892Component },
   { path: "bugs/2922", component: Bug2922Component },

--- a/apps/prs/angular/src/routes/bugs/2873/bug2873.component.html
+++ b/apps/prs/angular/src/routes/bugs/2873/bug2873.component.html
@@ -1,0 +1,109 @@
+<goab-block direction="column" gap="l">
+  <goab-text tag="h2">Bug 2873 - Drawer scroll and interactive content</goab-text>
+  <goab-text tag="p">
+    Use the buttons below to open the right and bottom drawers. Each drawer shares the
+    same long content so scrolling, focus, and interactive elements can be tested
+    consistently.
+  </goab-text>
+  <goab-text tag="p">
+    Expected: When scrolling, keep the Details component and Accordion component near the
+    bottom or the top. Attempt to click them, they should focus and activate. The bug is
+    currently that it auto scrolls to them but doesn't activate them.
+  </goab-text>
+  <goab-text tag="p">
+    Expected: When using tab navigation, tabbing to the next interactive element in the
+    Drawer should move the scrolling to that element.
+  </goab-text>
+
+  <goab-button-group alignment="start" gap="relaxed">
+    <goab-button type="primary" (onClick)="openRightDrawer()">
+      Open Drawer (Right)
+    </goab-button>
+    <goab-button type="secondary" (onClick)="openBottomDrawer()">
+      Open Drawer (Bottom)
+    </goab-button>
+  </goab-button-group>
+</goab-block>
+
+<ng-template #drawerContent>
+  <goab-input name="first-input" placeholder="First Input" />
+  <goab-text tag="h3" maxWidth="400px">Review notes and long-form content</goab-text>
+  <goab-text tag="p" maxWidth="400px">
+    This drawer includes extended content to force scrolling beyond two screen heights,
+    with interactive elements placed throughout for testing.
+  </goab-text>
+
+  <goab-text tag="p" maxWidth="400px">
+    Paragraph 1: Review the drawer scroll behavior while reading this extended narrative
+    that stretches across multiple lines and keeps the content dense enough to require
+    more scrolling.
+  </goab-text>
+  <goab-text tag="p" maxWidth="400px">
+    Paragraph 2: Confirm focus handling and keyboard navigation as you move through long
+    text blocks in the drawer.
+  </goab-text>
+  <goab-text tag="p" maxWidth="400px">
+    Paragraph 3: Continue scanning through the content to ensure the drawer retains scroll
+    position and keeps focus within the panel.
+  </goab-text>
+  <goab-text tag="p" maxWidth="400px">
+    Paragraph 4: Validate that the drawer content continues to flow naturally while
+    maintaining readable spacing and consistent focus order.
+  </goab-text>
+
+  <goab-details heading="Supporting context" [open]="true">
+    <goab-block direction="column" gap="s">
+      <goab-text tag="p" maxWidth="400px">
+        Use this details panel to verify expandable content within a long drawer.
+      </goab-text>
+      <goab-text tag="p" maxWidth="400px">
+        The panel remains interactive while scrolling, and can be toggled while other
+        content remains visible.
+      </goab-text>
+    </goab-block>
+  </goab-details>
+
+  <goab-text tag="p" maxWidth="400px">
+    Paragraph 5: Final confirmation text to keep the drawer scrolling beyond two full
+    screens, ensuring the bottom content is reachable and usable.
+  </goab-text>
+
+  <goab-accordion heading="Verification checklist" [open]="true">
+    <goab-block direction="column" gap="s">
+      <goab-text tag="p" maxWidth="400px">
+        Expand and collapse this accordion to confirm that layout changes do not jump the
+        scroll position unexpectedly.
+      </goab-text>
+      <goab-text tag="p" maxWidth="400px">
+        Keep the content long enough to require scrolling before and after the accordion
+        section.
+      </goab-text>
+    </goab-block>
+  </goab-accordion>
+
+  <goab-text tag="h4" maxWidth="400px">Follow-up inputs</goab-text>
+  <goab-input name="drawer-first-name" placeholder="First name" mr="l" />
+  <goab-input name="drawer-last-name" placeholder="Last name" />
+
+  <goab-text tag="h4" maxWidth="400px">Additional notes</goab-text>
+  <goab-textarea name="drawer-notes" rows="6" placeholder="Add any extra details here" />
+</ng-template>
+
+<goab-drawer
+  [open]="rightDrawerOpen"
+  position="right"
+  heading="Bug 2873 - Right Drawer"
+  maxSize="500px"
+  (onClose)="closeRightDrawer()"
+>
+  <ng-container *ngTemplateOutlet="drawerContent"></ng-container>
+</goab-drawer>
+
+<goab-drawer
+  [open]="bottomDrawerOpen"
+  position="bottom"
+  heading="Bug 2873 - Bottom Drawer"
+  (onClose)="closeBottomDrawer()"
+>
+  <ng-container *ngTemplateOutlet="drawerContent"></ng-container>
+</goab-drawer>

--- a/apps/prs/angular/src/routes/bugs/2873/bug2873.component.ts
+++ b/apps/prs/angular/src/routes/bugs/2873/bug2873.component.ts
@@ -1,0 +1,51 @@
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+import {
+  GoabAccordion,
+  GoabBlock,
+  GoabButton,
+  GoabButtonGroup,
+  GoabDetails,
+  GoabDrawer,
+  GoabInput,
+  GoabText,
+  GoabTextArea,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug2873",
+  templateUrl: "./bug2873.component.html",
+  imports: [
+    CommonModule,
+    GoabAccordion,
+    GoabBlock,
+    GoabButton,
+    GoabButtonGroup,
+    GoabDetails,
+    GoabDrawer,
+    GoabInput,
+    GoabText,
+    GoabTextArea,
+  ],
+})
+export class Bug2873Component {
+  rightDrawerOpen = false;
+  bottomDrawerOpen = false;
+
+  openRightDrawer() {
+    this.rightDrawerOpen = true;
+  }
+
+  openBottomDrawer() {
+    this.bottomDrawerOpen = true;
+  }
+
+  closeRightDrawer() {
+    this.rightDrawerOpen = false;
+  }
+
+  closeBottomDrawer() {
+    this.bottomDrawerOpen = false;
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -46,6 +46,7 @@ export function App() {
               <Link to="/bugs/2839">2839</Link>
               <Link to="/bugs/2849">2849</Link>
               <Link to="/bugs/2852">2852</Link>
+              <Link to="/bugs/2873">2873</Link>
               <Link to="/bugs/2878">2878</Link>
               <Link to="/bugs/2892">2892</Link>
               <Link to="/bugs/2922">2922</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -27,6 +27,7 @@ import { Bug2837Route } from "./routes/bugs/bug2837";
 import { Bug2839Route } from "./routes/bugs/bug2839";
 import { Bug2849Route } from "./routes/bugs/bug2849";
 import { Bug2852Route } from "./routes/bugs/bug2852";
+import { Bug2873Route } from "./routes/bugs/bug2873";
 import { Bug2878Route } from "./routes/bugs/bug2878";
 import { Bug2892Route } from "./routes/bugs/bug2892";
 import { Bug2922Route } from "./routes/bugs/bug2922";
@@ -83,6 +84,7 @@ root.render(
           <Route path="bugs/2839" element={<Bug2839Route />} />
           <Route path="bugs/2849" element={<Bug2849Route />} />
           <Route path="bugs/2852" element={<Bug2852Route />} />
+          <Route path="bugs/2873" element={<Bug2873Route />} />
           <Route path="bugs/2878" element={<Bug2878Route />} />
           <Route path="bugs/2892" element={<Bug2892Route />} />
           <Route path="bugs/2922" element={<Bug2922Route />} />

--- a/apps/prs/react/src/routes/bugs/bug2873.tsx
+++ b/apps/prs/react/src/routes/bugs/bug2873.tsx
@@ -1,0 +1,144 @@
+import {
+  GoabAccordion,
+  GoabBlock,
+  GoabButton,
+  GoabButtonGroup,
+  GoabDetails,
+  GoabDrawer,
+  GoabInput,
+  GoabText,
+  GoabTextArea,
+} from "@abgov/react-components";
+import { useState } from "react";
+
+export function Bug2873Route() {
+  const [rightDrawerOpen, setRightDrawerOpen] = useState(false);
+  const [bottomDrawerOpen, setBottomDrawerOpen] = useState(false);
+
+  const drawerContent = (
+    <>
+      <GoabInput name="first-input" placeholder="First Input" />
+      <GoabText tag="h3" maxWidth="400px">
+        Review notes and long-form content
+      </GoabText>
+      <GoabText tag="p" maxWidth="400px">
+        This drawer includes extended content to force scrolling beyond two screen
+        heights, with interactive elements placed throughout for testing.
+      </GoabText>
+
+      <GoabText tag="p" maxWidth="400px">
+        Paragraph 1: Review the drawer scroll behavior while reading this extended
+        narrative that stretches across multiple lines and keeps the content dense enough
+        to require more scrolling.
+      </GoabText>
+      <GoabText tag="p" maxWidth="400px">
+        Paragraph 2: Confirm focus handling and keyboard navigation as you move through
+        long text blocks in the drawer.
+      </GoabText>
+      <GoabText tag="p" maxWidth="400px">
+        Paragraph 3: Continue scanning through the content to ensure the drawer retains
+        scroll position and keeps focus within the panel.
+      </GoabText>
+      <GoabText tag="p" maxWidth="400px">
+        Paragraph 4: Validate that the drawer content continues to flow naturally while
+        maintaining readable spacing and consistent focus order.
+      </GoabText>
+
+      <GoabDetails heading="Supporting context" open>
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="p" maxWidth="400px">
+            Use this details panel to verify expandable content within a long drawer.
+          </GoabText>
+          <GoabText tag="p" maxWidth="400px">
+            The panel remains interactive while scrolling, and can be toggled while other
+            content remains visible.
+          </GoabText>
+        </GoabBlock>
+      </GoabDetails>
+
+      <GoabText tag="p" maxWidth="400px">
+        Paragraph 5: Final confirmation text to keep the drawer scrolling beyond two full
+        screens, ensuring the bottom content is reachable and usable.
+      </GoabText>
+
+      <GoabAccordion heading="Verification checklist" open>
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="p" maxWidth="400px">
+            Expand and collapse this accordion to confirm that layout changes do not jump
+            the scroll position unexpectedly.
+          </GoabText>
+          <GoabText tag="p" maxWidth="400px">
+            Keep the content long enough to require scrolling before and after the
+            accordion section.
+          </GoabText>
+        </GoabBlock>
+      </GoabAccordion>
+
+      <GoabText tag="h4" maxWidth="400px">
+        Follow-up inputs
+      </GoabText>
+      <GoabInput name="drawer-first-name" placeholder="First name" mr="l" />
+      <GoabInput name="drawer-last-name" placeholder="Last name" />
+
+      <GoabText tag="h4" maxWidth="400px">
+        Additional notes
+      </GoabText>
+      <GoabTextArea
+        name="drawer-notes"
+        rows={6}
+        placeholder="Add any extra details here"
+      />
+    </>
+  );
+
+  return (
+    <main>
+      <GoabBlock direction="column" gap="l">
+        <GoabText tag="h2">Bug 2873 - Drawer scroll and interactive content</GoabText>
+        <GoabText tag="p">
+          Use the buttons below to open the right and bottom drawers. Each drawer shares
+          the same long content so scrolling, focus, and interactive elements can be
+          tested consistently.
+        </GoabText>
+        <GoabText tag="p">
+          Expected: When scrolling, keep the Details component and Accordion component
+          near the bottom or the top. Attempt to click them, they should focus and
+          activate. The bug is currently that it auto scrolls to them but doesn't activate
+          them.
+        </GoabText>
+        <GoabText tag="p">
+          Expected: When using tab navigation, tabbing to the next interactive element in
+          the Drawer should move the scrolling to that element.
+        </GoabText>
+
+        <GoabButtonGroup alignment="start" gap="relaxed">
+          <GoabButton type="primary" onClick={() => setRightDrawerOpen(true)}>
+            Open Drawer (Right)
+          </GoabButton>
+          <GoabButton type="secondary" onClick={() => setBottomDrawerOpen(true)}>
+            Open Drawer (Bottom)
+          </GoabButton>
+        </GoabButtonGroup>
+      </GoabBlock>
+
+      <GoabDrawer
+        open={rightDrawerOpen}
+        position="right"
+        heading="Bug 2873 - Right Drawer"
+        maxSize="500px"
+        onClose={() => setRightDrawerOpen(false)}
+      >
+        {drawerContent}
+      </GoabDrawer>
+
+      <GoabDrawer
+        open={bottomDrawerOpen}
+        position="bottom"
+        heading="Bug 2873 - Bottom Drawer"
+        onClose={() => setBottomDrawerOpen(false)}
+      >
+        {drawerContent}
+      </GoabDrawer>
+    </main>
+  );
+}

--- a/libs/web-components/src/components/drawer/Drawer.svelte
+++ b/libs/web-components/src/components/drawer/Drawer.svelte
@@ -128,7 +128,7 @@
   }
 </script>
 
-<goa-focus-trap open={open}>
+<goa-focus-trap open={open} prevent-scroll-into-view={true}>
   <div
     class={`root ${_scrollPos ?? ""}`}
     style={style("visibility", open ? "visible" : "hidden")}


### PR DESCRIPTION
# Before (the change)

Using a Details or Accordion component inside a Drawer, would cause the Drawer to scroll to that component but not activate the component, so you ended up needing to click the component twice.

# After (the change)

Now the Drawer will not auto-scroll when you click Details or Accordion, and will activate the component. Scrolling to interactive elements is retained though if using keyboard navigation.

**NOTE** No specific tests were added for this, as this is a purely visual issue

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the included PR files for both Angular and React. Bug 2873.
