### PR TITLE
fix(#2977): Added event properties to all input components

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -43,6 +43,7 @@
           <a href="/bugs/2922">2922</a>
           <a href="/bugs/2943">2943</a>
           <a href="/bugs/2948">2948</a>
+          <a href="/bugs/2977">2977</a>
           <a href="/bugs/2991">2991</a>
           <a href="/bugs/3072">3072</a>
           <a href="/bugs/3118">3118</a>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -28,6 +28,7 @@ import { Bug2892Component } from "../routes/bugs/2892/bug2892.component";
 import { Bug2922Component } from "../routes/bugs/2922/bug2922.component";
 import { Bug2943Component } from "../routes/bugs/2943/bug2943.component";
 import { Bug2948Component } from "../routes/bugs/2948/bug2948.component";
+import { Bug2977Component } from "../routes/bugs/2977/bug2977.component";
 import { Bug2991Component } from "../routes/bugs/2991/bug2991.component";
 import { Bug3072Component } from "../routes/bugs/3072/bug3072.component";
 import { Bug3118Component } from "../routes/bugs/3118/bug3118.component";
@@ -84,6 +85,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/2922", component: Bug2922Component },
   { path: "bugs/2943", component: Bug2943Component },
   { path: "bugs/2948", component: Bug2948Component },
+  { path: "bugs/2977", component: Bug2977Component },
   { path: "bugs/2991", component: Bug2991Component },
   { path: "bugs/3072", component: Bug3072Component },
   { path: "bugs/3118", component: Bug3118Component },

--- a/apps/prs/angular/src/routes/bugs/2977/bug2977.component.html
+++ b/apps/prs/angular/src/routes/bugs/2977/bug2977.component.html
@@ -1,0 +1,106 @@
+<goab-form-item label="Input (test onChange, onFocus, onBlur, onKeyPress)" mb="l">
+  <goab-input
+    name="demo-input"
+    placeholder="Type here"
+    (onChange)="handleInputChange($event)"
+    (onFocus)="handleInputFocus($event)"
+    (onBlur)="handleInputBlur($event)"
+    (onKeyPress)="handleInputKeyPress($event)"
+  />
+</goab-form-item>
+
+<goab-form-item label="Checkbox (test onChange)" mb="l">
+  <goab-checkbox
+    name="demo-checkbox"
+    text="Accept terms"
+    (onChange)="handleCheckboxChange($event)"
+  />
+</goab-form-item>
+
+<goab-form-item label="Checkbox List (test onChange)" mb="l">
+  <goab-checkbox-list
+    name="demo-checkbox-list"
+    (onChange)="handleCheckboxListChange($event)"
+  >
+    <goab-checkbox name="demo-checkbox-list-1" text="Option 1" value="option1" />
+    <goab-checkbox name="demo-checkbox-list-2" text="Option 2" value="option2" />
+    <goab-checkbox name="demo-checkbox-list-3" text="Option 3" value="option3" />
+  </goab-checkbox-list>
+</goab-form-item>
+
+<goab-form-item label="Date Picker (test onChange)">
+  <goab-date-picker
+    name="demo-date"
+    width="20ch"
+    (onChange)="handleDatePickerChange($event)"
+  />
+</goab-form-item>
+
+<goab-form-item label="Dropdown (test onChange)" mb="l">
+  <goab-dropdown
+    name="demo-dropdown"
+    placeholder="Select an option"
+    (onChange)="handleDropdownChange($event)"
+  >
+    <goab-dropdown-item value="one" label="Option One"></goab-dropdown-item>
+    <goab-dropdown-item value="two" label="Option Two"></goab-dropdown-item>
+    <goab-dropdown-item value="three" label="Option Three"></goab-dropdown-item>
+  </goab-dropdown>
+</goab-form-item>
+
+<goab-form-item label="File Upload (test onSelectFile)" mb="l">
+  <goab-file-upload-input
+    variant="button"
+    accept=".txt"
+    (onSelectFile)="handleFileSelect($event)"
+  />
+</goab-form-item>
+
+<goab-form-item label="Radio (test onChange)" mb="l">
+  <goab-radio-group name="demo-radio" (onChange)="handleRadioGroupChange($event)">
+    <goab-radio-item name="demo-radio" value="a" label="Option A"></goab-radio-item>
+    <goab-radio-item name="demo-radio" value="b" label="Option B"></goab-radio-item>
+    <goab-radio-item name="demo-radio" value="c" label="Option C"></goab-radio-item>
+  </goab-radio-group>
+</goab-form-item>
+
+<goab-form-item label="Text Area (test onChange, onKeyPress, onBlur)" mb="l">
+  <goab-textarea
+    name="demo-textarea"
+    placeholder="Enter multi-line text"
+    (onChange)="handleTextareaChange($event)"
+    (onKeyPress)="handleTextareaKeyPress($event)"
+    (onBlur)="handleTextareaBlur($event)"
+  />
+</goab-form-item>
+
+<goab-text tag="h1">Testing #2977 Issue</goab-text>
+<goab-text tag="p">
+  Tab 1 input should not fire the Tab onChange. Tab 2 and 3 will fire the Tab onChange.
+</goab-text>
+<goab-tabs (onChange)="handleTabsChange($event)">
+  <goab-tab heading="Tab 1 - stopPropagation">
+    <goab-text tag="p">Type here to confirm onChange can stop bubbling.</goab-text>
+    <goab-input
+      name="tab1-input"
+      placeholder="Tab 1 input"
+      (onChange)="handleTabInputOne($event)"
+    />
+  </goab-tab>
+  <goab-tab heading="Tab 2 - normal bubbling">
+    <goab-text tag="p">Type here to see bubbling continue.</goab-text>
+    <goab-input
+      name="tab2-input"
+      placeholder="Tab 2 input"
+      (onChange)="handleTabInputTwo($event)"
+    />
+  </goab-tab>
+  <goab-tab heading="Tab 3 - normal bubbling">
+    <goab-text tag="p">Type here to see bubbling continue.</goab-text>
+    <goab-input
+      name="tab3-input"
+      placeholder="Tab 3 input"
+      (onChange)="handleTabInputThree($event)"
+    />
+  </goab-tab>
+</goab-tabs>

--- a/apps/prs/angular/src/routes/bugs/2977/bug2977.component.ts
+++ b/apps/prs/angular/src/routes/bugs/2977/bug2977.component.ts
@@ -1,0 +1,129 @@
+import { Component } from "@angular/core";
+import {
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabDatePicker,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFileUploadInput,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabTextArea,
+  GoabFormItem,
+  GoabTab,
+  GoabTabs,
+  GoabText,
+} from "@abgov/angular-components";
+import {
+  GoabCheckboxListOnChangeDetail,
+  GoabCheckboxOnChangeDetail,
+  GoabDatePickerOnChangeDetail,
+  GoabDropdownOnChangeDetail,
+  GoabFileUploadInputOnSelectFileDetail,
+  GoabInputOnBlurDetail,
+  GoabInputOnChangeDetail,
+  GoabInputOnFocusDetail,
+  GoabInputOnKeyPressDetail,
+  GoabRadioGroupOnChangeDetail,
+  GoabTabsOnChangeDetail,
+  GoabTextAreaOnBlurDetail,
+  GoabTextAreaOnChangeDetail,
+  GoabTextAreaOnKeyPressDetail,
+} from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug2977",
+  templateUrl: "./bug2977.component.html",
+  imports: [
+    GoabCheckbox,
+    GoabCheckboxList,
+    GoabDatePicker,
+    GoabDropdown,
+    GoabDropdownItem,
+    GoabFileUploadInput,
+    GoabInput,
+    GoabRadioGroup,
+    GoabRadioItem,
+    GoabTextArea,
+    GoabFormItem,
+    GoabTab,
+    GoabTabs,
+    GoabText,
+  ],
+})
+export class Bug2977Component {
+  logEvent(label: string, detail: unknown) {
+    console.log(label, detail);
+  }
+
+  handleInputChange(detail: GoabInputOnChangeDetail) {
+    this.logEvent("input change", detail);
+  }
+
+  handleInputFocus(detail: GoabInputOnFocusDetail) {
+    this.logEvent("input focus", detail);
+  }
+
+  handleInputBlur(detail: GoabInputOnBlurDetail) {
+    this.logEvent("input blur", detail);
+  }
+
+  handleInputKeyPress(detail: GoabInputOnKeyPressDetail) {
+    this.logEvent("input keypress", detail);
+  }
+
+  handleCheckboxChange(detail: GoabCheckboxOnChangeDetail) {
+    this.logEvent("checkbox change", detail);
+  }
+
+  handleCheckboxListChange(detail: GoabCheckboxListOnChangeDetail) {
+    this.logEvent("checkbox list change", detail);
+  }
+
+  handleDatePickerChange(detail: GoabDatePickerOnChangeDetail) {
+    this.logEvent("date picker change", detail);
+  }
+
+  handleDropdownChange(detail: GoabDropdownOnChangeDetail) {
+    this.logEvent("dropdown change", detail);
+  }
+
+  handleFileSelect(detail: GoabFileUploadInputOnSelectFileDetail) {
+    this.logEvent("file upload select", detail);
+  }
+
+  handleRadioGroupChange(detail: GoabRadioGroupOnChangeDetail) {
+    this.logEvent("radio group change", detail);
+  }
+
+  handleTextareaChange(detail: GoabTextAreaOnChangeDetail) {
+    this.logEvent("textarea change", detail);
+  }
+
+  handleTextareaKeyPress(detail: GoabTextAreaOnKeyPressDetail) {
+    this.logEvent("textarea keypress", detail);
+  }
+
+  handleTextareaBlur(detail: GoabTextAreaOnBlurDetail) {
+    this.logEvent("textarea blur", detail);
+  }
+
+  handleTabsChange(detail: GoabTabsOnChangeDetail) {
+    this.logEvent("tabs change", detail);
+  }
+
+  handleTabInputOne(detail: GoabInputOnChangeDetail) {
+    detail.event?.stopPropagation();
+    this.logEvent("tab 1 input change (stopPropagation)", detail);
+  }
+
+  handleTabInputTwo(detail: GoabInputOnChangeDetail) {
+    this.logEvent("tab 2 input change", detail);
+  }
+
+  handleTabInputThree(detail: GoabInputOnChangeDetail) {
+    this.logEvent("tab 3 input change", detail);
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -51,6 +51,7 @@ export function App() {
               <Link to="/bugs/2922">2922</Link>
               <Link to="/bugs/2943">2943</Link>
               <Link to="/bugs/2948">2948</Link>
+              <Link to="/bugs/2977">2977</Link>
               <Link to="/bugs/3118">3118</Link>
               <Link to="/bugs/3201">3201</Link>
               <Link to="/bugs/3215">3215</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -32,6 +32,7 @@ import { Bug2892Route } from "./routes/bugs/bug2892";
 import { Bug2922Route } from "./routes/bugs/bug2922";
 import { Bug2943Route } from "./routes/bugs/bug2943";
 import { Bug2948Route } from "./routes/bugs/bug2948";
+import { Bug2977Route } from "./routes/bugs/bug2977";
 import { Bug3118Route } from "./routes/bugs/bug3118";
 import { Bug3201Route } from "./routes/bugs/bug3201";
 import { Bug3215Route } from "./routes/bugs/bug3215";
@@ -91,6 +92,7 @@ root.render(
           <Route path="bugs/2922" element={<Bug2922Route />} />
           <Route path="bugs/2943" element={<Bug2943Route />} />
           <Route path="bugs/2948" element={<Bug2948Route />} />
+          <Route path="bugs/2977" element={<Bug2977Route />} />
           <Route path="bugs/3118" element={<Bug3118Route />} />
           <Route path="bugs/3201" element={<Bug3201Route />} />
           <Route path="bugs/3215" element={<Bug3215Route />} />

--- a/apps/prs/react/src/routes/bugs/bug2977.tsx
+++ b/apps/prs/react/src/routes/bugs/bug2977.tsx
@@ -1,0 +1,199 @@
+import {
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabDatePicker,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFileUploadInput,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabTabs,
+  GoabTab,
+  GoabTextArea,
+  GoabFormItem,
+  GoabText,
+  GoabAccordion,
+} from "@abgov/react-components";
+import {
+  GoabCheckboxListOnChangeDetail,
+  GoabCheckboxOnChangeDetail,
+  GoabDatePickerOnChangeDetail,
+  GoabDropdownOnChangeDetail,
+  GoabFileUploadInputOnSelectFileDetail,
+  GoabInputOnBlurDetail,
+  GoabInputOnChangeDetail,
+  GoabInputOnFocusDetail,
+  GoabInputOnKeyPressDetail,
+  GoabRadioGroupOnChangeDetail,
+  GoabTabsOnChangeDetail,
+  GoabTextAreaOnBlurDetail,
+  GoabTextAreaOnChangeDetail,
+  GoabTextAreaOnKeyPressDetail,
+} from "@abgov/ui-components-common";
+
+export function Bug2977Route() {
+  const logEvent = (label: string, detail: unknown) => {
+    console.log(label, detail);
+  };
+
+  const handleInputChange = (detail: GoabInputOnChangeDetail) => {
+    logEvent("input change", detail);
+    detail.event?.stopPropagation();
+  };
+
+  const handleInputFocus = (detail: GoabInputOnFocusDetail) =>
+    logEvent("input focus", detail);
+  const handleInputBlur = (detail: GoabInputOnBlurDetail) =>
+    logEvent("input blur", detail);
+  const handleInputKeyPress = (detail: GoabInputOnKeyPressDetail) => {
+    logEvent("input keypress", detail);
+    detail.event?.stopPropagation();
+  };
+
+  const handleCheckboxChange = (detail: GoabCheckboxOnChangeDetail) =>
+    logEvent("checkbox change", detail);
+
+  const handleCheckboxListChange = (detail: GoabCheckboxListOnChangeDetail) => {
+    logEvent("checkbox list change", detail);
+  };
+
+  const handleDatePickerChange = (detail: GoabDatePickerOnChangeDetail) =>
+    logEvent("date picker change", detail);
+
+  const handleDropdownChange = (detail: GoabDropdownOnChangeDetail) =>
+    logEvent("dropdown change", detail);
+
+  const handleFileSelect = (detail: GoabFileUploadInputOnSelectFileDetail) =>
+    logEvent("file upload select", detail);
+
+  const handleRadioGroupChange = (detail: GoabRadioGroupOnChangeDetail) =>
+    logEvent("radio group change", detail);
+
+  const handleTextareaChange = (detail: GoabTextAreaOnChangeDetail) =>
+    logEvent("textarea change", detail);
+  const handleTextareaKeyPress = (detail: GoabTextAreaOnKeyPressDetail) =>
+    logEvent("textarea keypress", detail);
+  const handleTextareaBlur = (detail: GoabTextAreaOnBlurDetail) =>
+    logEvent("textarea blur", detail);
+
+  const handleTabsChange = (detail: GoabTabsOnChangeDetail) =>
+    logEvent("tabs change", detail);
+
+  const handleTabInputOne = (detail: GoabInputOnChangeDetail) => {
+    detail.event?.stopPropagation();
+    logEvent("tab 1 input change (stopPropagation)", detail);
+  };
+
+  const handleTabInputTwo = (detail: GoabInputOnChangeDetail) =>
+    logEvent("tab 2 input change", detail);
+  const handleTabInputThree = (detail: GoabInputOnChangeDetail) =>
+    logEvent("tab 3 input change", detail);
+
+  return (
+    <main>
+      <GoabFormItem label="Input (test onChange, onFocus, onBlur, onKeyPress)" mb="l">
+        <GoabInput
+          name="demo-input"
+          placeholder="Type here"
+          onChange={handleInputChange}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
+          onKeyPress={handleInputKeyPress}
+        />
+      </GoabFormItem>
+
+      <GoabFormItem label="Checkbox (test onChange)" mb="l">
+        <GoabCheckbox
+          name="demo-checkbox"
+          text="Accept terms"
+          onChange={handleCheckboxChange}
+        />
+      </GoabFormItem>
+
+      <GoabFormItem label="Checkbox List (test onChange)" mb="l">
+        <GoabCheckboxList name="demo-checkbox-list" onChange={handleCheckboxListChange}>
+          <GoabCheckbox name="demo-checkbox-list-1" value="option1" text="Option 1" />
+          <GoabCheckbox name="demo-checkbox-list-2" value="option2" text="Option 2" />
+          <GoabCheckbox name="demo-checkbox-list-3" value="option3" text="Option 3" />
+        </GoabCheckboxList>
+      </GoabFormItem>
+
+      <GoabFormItem label="Date Picker (test onChange)">
+        <GoabDatePicker name="demo-date" width="20ch" onChange={handleDatePickerChange} />
+      </GoabFormItem>
+
+      <GoabFormItem label="Dropdown (test onChange)" mb="l">
+        <GoabDropdown
+          name="demo-dropdown"
+          placeholder="Select an option"
+          onChange={handleDropdownChange}
+        >
+          <GoabDropdownItem value="one" label="Option One" />
+          <GoabDropdownItem value="two" label="Option Two" />
+          <GoabDropdownItem value="three" label="Option Three" />
+        </GoabDropdown>
+      </GoabFormItem>
+
+      <GoabFormItem label="File Upload (test onSelectFile)" mb="l">
+        <GoabFileUploadInput
+          variant="button"
+          accept=".txt"
+          onSelectFile={handleFileSelect}
+        />
+      </GoabFormItem>
+
+      <GoabFormItem label="Radio (test onChange)" mb="l">
+        <GoabRadioGroup name="demo-radio" onChange={handleRadioGroupChange}>
+          <GoabRadioItem name="demo-radio" value="a" label="Option A" />
+          <GoabRadioItem name="demo-radio" value="b" label="Option B" />
+          <GoabRadioItem name="demo-radio" value="c" label="Option C" />
+        </GoabRadioGroup>
+      </GoabFormItem>
+
+      <GoabFormItem label="Text Area (test onChange, onKeyPress, onBlur)" mb="l">
+        <GoabTextArea
+          name="demo-textarea"
+          placeholder="Enter multi-line text"
+          onChange={handleTextareaChange}
+          onKeyPress={handleTextareaKeyPress}
+          onBlur={handleTextareaBlur}
+        />
+      </GoabFormItem>
+
+      <GoabText tag="h1">Testing #2977 Issue</GoabText>
+      <GoabText tag="p">
+        Tab 1 input should not fire the Tab onChange. Tab 2 and 3 will fire the Tab
+        onChange.
+      </GoabText>
+      <GoabTabs onChange={handleTabsChange}>
+        <GoabTab heading="Tab 1 - stopPropagation">
+          <GoabText tag="p">Type here to confirm onChange can stop bubbling.</GoabText>
+          <GoabInput
+            name="tab1-input"
+            placeholder="Tab 1 input"
+            onChange={handleTabInputOne}
+          />
+        </GoabTab>
+        <GoabTab heading="Tab 2 - normal bubbling">
+          <GoabText tag="p">Type here to see bubbling continue.</GoabText>
+          <GoabInput
+            name="tab2-input"
+            placeholder="Tab 2 input"
+            onChange={handleTabInputTwo}
+          />
+        </GoabTab>
+        <GoabTab heading="Tab 3 - normal bubbling">
+          <GoabText tag="p">Type here to see bubbling continue.</GoabText>
+          <GoabInput
+            name="tab3-input"
+            placeholder="Tab 3 input"
+            onChange={handleTabInputThree}
+          />
+        </GoabTab>
+      </GoabTabs>
+    </main>
+  );
+}
+
+export default Bug2977Route;

--- a/libs/angular-components/src/lib/components/checkbox-list/checkbox-list.spec.ts
+++ b/libs/angular-components/src/lib/components/checkbox-list/checkbox-list.spec.ts
@@ -124,9 +124,11 @@ describe("GoabCheckboxList", () => {
       By.css("goa-checkbox-list"),
     ).nativeElement;
 
+    const changeEvent = new Event("change");
     const detail: GoabCheckboxListOnChangeDetail = {
       name: "fruits",
       value: ["apple", "banana"],
+      event: changeEvent,
     };
 
     fireEvent(
@@ -205,22 +207,30 @@ describe("GoabCheckboxList", () => {
     ).nativeElement;
 
     // First change
+    const changeEvent1 = new Event("change");
     const detail1: GoabCheckboxListOnChangeDetail = {
       name: "fruits",
       value: ["apple"],
+      event: changeEvent1,
     };
 
     fireEvent(el, new CustomEvent("_change", { detail: detail1 }));
-    expect(onChangeSpy).toHaveBeenCalledWith(detail1);
+    expect(onChangeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ ...detail1, event: expect.any(Event) }),
+    );
 
     // Second change
+    const changeEvent2 = new Event("change");
     const detail2: GoabCheckboxListOnChangeDetail = {
       name: "fruits",
       value: ["apple", "banana"],
+      event: changeEvent2,
     };
 
     fireEvent(el, new CustomEvent("_change", { detail: detail2 }));
-    expect(onChangeSpy).toHaveBeenCalledWith(detail2);
+    expect(onChangeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ ...detail2, event: expect.any(Event) }),
+    );
     expect(onChangeSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/libs/angular-components/src/lib/components/checkbox-list/checkbox-list.ts
+++ b/libs/angular-components/src/lib/components/checkbox-list/checkbox-list.ts
@@ -70,7 +70,7 @@ export class GoabCheckboxList extends GoabControlValueAccessor implements OnInit
 
   _onChange(e: Event) {
     try {
-      const detail = (e as CustomEvent<GoabCheckboxListOnChangeDetail>).detail;
+      const detail = { ...(e as CustomEvent<GoabCheckboxListOnChangeDetail>).detail, event: e };
       this.onChange.emit(detail);
       this.markAsTouched();
 

--- a/libs/angular-components/src/lib/components/checkbox/checkbox.ts
+++ b/libs/angular-components/src/lib/components/checkbox/checkbox.ts
@@ -104,7 +104,7 @@ export class GoabCheckbox extends GoabControlValueAccessor implements OnInit {
   }
 
   _onChange(e: Event) {
-    const detail = (e as CustomEvent<GoabCheckboxOnChangeDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabCheckboxOnChangeDetail>).detail, event: e };
     this.onChange.emit(detail);
     this.markAsTouched();
     this.fcChange?.(detail.binding === "check" ? detail.checked : detail.value || "");

--- a/libs/angular-components/src/lib/components/date-picker/date-picker.ts
+++ b/libs/angular-components/src/lib/components/date-picker/date-picker.ts
@@ -78,7 +78,7 @@ export class GoabDatePicker extends GoabControlValueAccessor implements OnInit {
   }
 
   _onChange(e: Event) {
-    const detail = (e as CustomEvent<GoabDatePickerOnChangeDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabDatePickerOnChangeDetail>).detail, event: e };
     this.onChange.emit(detail);
     this.markAsTouched();
     this.fcChange?.(detail.value);

--- a/libs/angular-components/src/lib/components/dropdown/dropdown.ts
+++ b/libs/angular-components/src/lib/components/dropdown/dropdown.ts
@@ -98,7 +98,7 @@ export class GoabDropdown extends GoabControlValueAccessor implements OnInit {
   }
 
   _onChange(e: Event) {
-    const detail = (e as CustomEvent<GoabDropdownOnChangeDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabDropdownOnChangeDetail>).detail, event: e };
     // Keep local value in sync with emitted detail
     this.value = detail.value || null;
     this.onChange.emit(detail);

--- a/libs/angular-components/src/lib/components/file-upload-card/file-upload-card.ts
+++ b/libs/angular-components/src/lib/components/file-upload-card/file-upload-card.ts
@@ -25,8 +25,8 @@ import { CommonModule } from "@angular/common";
     [attr.progress]="progress"
     [attr.error]="error"
     [attr.testid]="testId"
-    (_cancel)="_onCancel()"
-    (_delete)="_onDelete()"
+    (_cancel)="_onCancel($event)"
+    (_delete)="_onDelete($event)"
   >
   </goa-file-upload-card>`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -56,11 +56,11 @@ export class GoabFileUploadCard implements OnInit {
     }, 0);
   }
 
-  _onCancel() {
-    this.onCancel.emit({ filename: this.filename });
+  _onCancel(event: Event) {
+    this.onCancel.emit({ filename: this.filename, event });
   }
 
-  _onDelete() {
-    this.onDelete.emit({ filename: this.filename });
+  _onDelete(event: Event) {
+    this.onDelete.emit({ filename: this.filename, event });
   }
 }

--- a/libs/angular-components/src/lib/components/file-upload-input/file-upload-input.ts
+++ b/libs/angular-components/src/lib/components/file-upload-input/file-upload-input.ts
@@ -58,7 +58,7 @@ export class GoabFileUploadInput extends GoabBaseComponent implements OnInit {
   }
 
   _onSelectFile(e: Event) {
-    const detail = (e as CustomEvent<GoabFileUploadInputOnSelectFileDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabFileUploadInputOnSelectFileDetail>).detail, event: e };
     this.onSelectFile.emit(detail);
   }
 }

--- a/libs/angular-components/src/lib/components/input-number/input-number.spec.ts
+++ b/libs/angular-components/src/lib/components/input-number/input-number.spec.ts
@@ -191,9 +191,11 @@ describe("GoabInputNumber", () => {
 
     const validateOnChange = jest.spyOn(component, "onChange");
     const testValue = "99.9";
+    const changeEvent = new Event("input");
     const expectedDetail: GoabInputOnChangeDetail = {
       name: component.name,
       value: testValue,
+      event: changeEvent,
     };
 
     fireEvent(

--- a/libs/angular-components/src/lib/components/input/input.spec.ts
+++ b/libs/angular-components/src/lib/components/input/input.spec.ts
@@ -222,7 +222,9 @@ describe("GoABInput", () => {
       new CustomEvent("_change", { detail: { name: "foo", value: "new value" } }),
     );
 
-    expect(validateOnChange).toBeCalledWith({ name: "foo", value: "new value" });
+    expect(validateOnChange).toBeCalledWith(
+      expect.objectContaining({ name: "foo", value: "new value", event: expect.any(Event) }),
+    );
   });
 
   it("should handle onFocus event", () => {

--- a/libs/angular-components/src/lib/components/input/input.ts
+++ b/libs/angular-components/src/lib/components/input/input.ts
@@ -172,7 +172,7 @@ export class GoabInput extends GoabControlValueAccessor implements OnInit {
 
   _onChange(e: Event) {
     this.markAsTouched();
-    const detail = (e as CustomEvent<GoabInputOnChangeDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabInputOnChangeDetail>).detail, event: e };
     this.onChange.emit(detail);
 
     this.fcChange?.(detail.value);
@@ -180,7 +180,7 @@ export class GoabInput extends GoabControlValueAccessor implements OnInit {
 
   _onKeyPress(e: Event) {
     this.markAsTouched();
-    const detail = (e as CustomEvent<GoabInputOnKeyPressDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabInputOnKeyPressDetail>).detail, event: e };
     this.onKeyPress.emit(detail);
 
     this.fcTouched?.();
@@ -188,12 +188,12 @@ export class GoabInput extends GoabControlValueAccessor implements OnInit {
 
   _onFocus(e: Event) {
     this.markAsTouched();
-    const detail = (e as CustomEvent<GoabInputOnFocusDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabInputOnFocusDetail>).detail, event: e };
     this.onFocus.emit(detail);
   }
 
   _onBlur(e: Event) {
-    const detail = (e as CustomEvent<GoabInputOnBlurDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabInputOnBlurDetail>).detail, event: e };
     this.onBlur.emit(detail);
   }
 

--- a/libs/angular-components/src/lib/components/radio-group/radio-group.spec.ts
+++ b/libs/angular-components/src/lib/components/radio-group/radio-group.spec.ts
@@ -160,13 +160,16 @@ describe("GoABRadioGroup", () => {
 
   it("should dispatch onChange", () => {
     const onChange = jest.spyOn(component, "onChange");
+    const changeEvent = new Event("change");
 
     const radioGroup = fixture.nativeElement.querySelector("goa-radio-group");
     fireEvent(radioGroup, new CustomEvent("_change", {
-      detail: {"name": component.name, value: component.options[0].value}
+      detail: { name: component.name, value: component.options[0].value, event: changeEvent }
     }));
 
-    expect(onChange).toBeCalledWith({name: component.name, value: component.options[0].value});
+    expect(onChange).toBeCalledWith(
+      expect.objectContaining({ name: component.name, value: component.options[0].value, event: expect.any(Event) }),
+    );
   });
 
   describe("writeValue", () => {

--- a/libs/angular-components/src/lib/components/radio-group/radio-group.ts
+++ b/libs/angular-components/src/lib/components/radio-group/radio-group.ts
@@ -74,7 +74,7 @@ export class GoabRadioGroup extends GoabControlValueAccessor implements OnInit {
   @Output() onChange = new EventEmitter<GoabRadioGroupOnChangeDetail>();
 
   _onChange(e: Event) {
-    const detail = (e as CustomEvent<GoabRadioGroupOnChangeDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabRadioGroupOnChangeDetail>).detail, event: e };
     this.markAsTouched();
     this.onChange.emit(detail);
 

--- a/libs/angular-components/src/lib/components/textarea/textarea.ts
+++ b/libs/angular-components/src/lib/components/textarea/textarea.ts
@@ -97,20 +97,20 @@ export class GoabTextArea extends GoabControlValueAccessor implements OnInit {
   }
 
   _onChange(e: Event) {
-    const detail = (e as CustomEvent<GoabTextAreaOnChangeDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabTextAreaOnChangeDetail>).detail, event: e };
     this.onChange.emit(detail);
     this.markAsTouched();
     this.fcChange?.(detail.value);
   }
 
   _onKeyPress(e: Event) {
-    const detail = (e as CustomEvent<GoabTextAreaOnKeyPressDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabTextAreaOnKeyPressDetail>).detail, event: e };
     this.markAsTouched();
     this.onKeyPress.emit(detail);
   }
 
   _onBlur(e: Event) {
-    const detail = (e as CustomEvent<GoabTextAreaOnBlurDetail>).detail;
+    const detail = { ...(e as CustomEvent<GoabTextAreaOnBlurDetail>).detail, event: e };
     this.markAsTouched();
     this.onBlur.emit(detail);
   }

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -5,16 +5,19 @@ export type GoabSpinnerSize = "small" | "medium" | "large" | "xlarge";
 export type GoabRadioGroupOnChangeDetail = {
   name: string;
   value: string;
+  event: Event;
 };
 
 export type GoabCheckboxListOnChangeDetail = {
   name: string;
   value: string[];
+  event: Event;
 };
 
 export type GoabInputOnChangeDetail<T = string> = {
   name: string;
   value: T;
+  event: Event;
 };
 
 // @deprecated GoaInputOnBlurDetail has been deprecated. Use GoabInputOnBlurDetail instead.
@@ -22,6 +25,7 @@ export type GoaInputOnBlurDetail = GoabInputOnBlurDetail;
 export type GoabInputOnBlurDetail<T = string> = {
   name: string;
   value: T;
+  event: Event;
 };
 
 export type GoabInputOnFocusDetail<T = string> = GoabInputOnChangeDetail<T>;
@@ -42,6 +46,7 @@ export type GoabInputOnKeyPressDetail<T = string> = {
   name: string;
   value: T;
   key: T;
+  event: Event;
 };
 
 export type GoabFormStepperOnChangeDetail = {
@@ -50,14 +55,17 @@ export type GoabFormStepperOnChangeDetail = {
 
 export type GoabFileUploadInputOnSelectFileDetail = {
   file: File;
+  event: Event;
 };
 
 export type GoabFileUploadOnCancelDetail = {
   filename: string;
+  event: Event;
 };
 
 export type GoabFileUploadOnDeleteDetail = {
   filename: string;
+  event: Event;
 };
 
 export type GoabDropdownItemMountType = "append" | "prepend" | "reset";
@@ -66,6 +74,7 @@ export type GoabDropdownOnChangeDetail = {
   name?: string;
   value?: string;
   values?: string[];
+  event: Event;
 };
 
 export type GoabDatePickerOnChangeDetail = {
@@ -75,6 +84,7 @@ export type GoabDatePickerOnChangeDetail = {
    * @deprecated Use `valueStr` instead
    */
   value: Date;
+  event: Event;
 };
 export type GoabDatePickerInputType = "calendar" | "input";
 
@@ -88,6 +98,7 @@ export type GoabCheckboxOnChangeDetail = {
   value?: string;
   checked: boolean;
   binding: "value" | "check";
+  event: Event;
 };
 
 export type GoabCalendarOnChangeDetail = {
@@ -189,17 +200,20 @@ export type GoabTextAreaCountBy = "character" | "word" | "";
 export type GoabTextAreaOnChangeDetail = {
   name: string;
   value: string;
+  event: Event;
 };
 
 export type GoabTextAreaOnKeyPressDetail = {
   name: string;
   value: string;
   key: string;
+  event: Event;
 };
 
 export type GoabTextAreaOnBlurDetail = {
   name: string;
   value: string;
+  event: Event;
 };
 
 // Tabs
@@ -356,10 +370,15 @@ export type GoabAutoCapitalize =
   | "words"
   | "characters";
 
-export type OnChange<T = string> = (name: string, value: T) => void;
-export type OnFocus<T = string> = (name: string, value: T) => void;
-export type OnBlur<T = string> = (name: string, value: T) => void;
-export type OnKeyPress<T = string> = (name: string, value: T, key: string) => void;
+export type OnChange<T = string> = (name: string, value: T, event: Event) => void;
+export type OnFocus<T = string> = (name: string, value: T, event: Event) => void;
+export type OnBlur<T = string> = (name: string, value: T, event: Event) => void;
+export type OnKeyPress<T = string> = (
+  name: string,
+  value: T,
+  key: string,
+  event: Event,
+) => void;
 
 export interface GoabInputProps extends BaseProps {
   onChange: OnChange<string>;

--- a/libs/react-components/specs/checkbox-list.browser.spec.tsx
+++ b/libs/react-components/specs/checkbox-list.browser.spec.tsx
@@ -2,6 +2,7 @@ import { render } from "vitest-browser-react";
 import { GoabCheckboxList, GoabCheckbox } from "../src";
 import { expect, describe, it, vi } from "vitest";
 import { useState } from "react";
+import { userEvent } from "@vitest/browser/context";
 
 describe("CheckboxList", () => {
   it("should render a checkbox list with basic properties", async () => {
@@ -239,42 +240,30 @@ describe("CheckboxList", () => {
     expect(result.getByTestId("checkbox-list")).toBeTruthy();
   });
 
-  it("should handle onChange callback with correct event details", async () => {
-    const onChangeSpy = vi.fn();
+  it("passes the browser event in change detail", async () => {
+    const onChange = vi.fn();
 
-    const Component = () => {
-      return (
-        <div data-testid="container">
-          <GoabCheckboxList
-            name="test-list"
-            testId="checkbox-list"
-            onChange={onChangeSpy}
-          >
-            <GoabCheckbox name="option1" text="Option 1" testId="checkbox-1" />
-            <GoabCheckbox name="option2" text="Option 2" testId="checkbox-2" />
-          </GoabCheckboxList>
-        </div>
-      );
-    };
+    const Component = () => (
+      <GoabCheckboxList
+        name="event-list"
+        testId="event-checkbox-list"
+        onChange={onChange}
+      >
+        <GoabCheckbox name="event-option1" text="Option 1" testId="event-checkbox-1" />
+      </GoabCheckboxList>
+    );
 
     const result = render(<Component />);
+    const checkbox = result.getByTestId("event-checkbox-1");
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
-    const checkbox1 = result.getByTestId("checkbox-1");
-
-    // Click checkbox
-    await checkbox1.click();
+    await userEvent.click(checkbox);
 
     await vi.waitFor(() => {
-      expect(onChangeSpy).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const detail = onChange.mock.calls[0][0];
+      expect(detail.name).toBe("event-list");
+      expect(detail.value).toEqual(["event-option1"]);
+      expect(detail.event).toBeInstanceOf(Event);
     });
-
-    // Verify the callback was called with correct structure
-    const lastCall = onChangeSpy.mock.calls[onChangeSpy.mock.calls.length - 1];
-    expect(lastCall).toBeDefined();
-    expect(lastCall[0]).toHaveProperty("name", "test-list");
-    expect(lastCall[0]).toHaveProperty("value");
-    expect(Array.isArray(lastCall[0].value)).toBe(true);
   });
 });

--- a/libs/react-components/specs/checkbox.browser.spec.tsx
+++ b/libs/react-components/specs/checkbox.browser.spec.tsx
@@ -2,6 +2,7 @@ import { render } from "vitest-browser-react";
 import { GoabCheckbox } from "../src";
 import { expect, describe, it, vi } from "vitest";
 import { useState } from "react";
+import { userEvent } from "@vitest/browser/context";
 
 describe("Checkbox", () => {
   it("should handle _change fired inside reveal slot without affecting parent checkbox value", async () => {
@@ -87,7 +88,7 @@ describe("Checkbox", () => {
 
   it("should have a 44px x 44px touch target area", async () => {
     const result = render(
-      <GoabCheckbox testId="test-checkbox" name="test" text="Test Checkbox" />
+      <GoabCheckbox testId="test-checkbox" name="test" text="Test Checkbox" />,
     );
 
     const checkbox = result.getByTestId("test-checkbox");
@@ -130,6 +131,32 @@ describe("Checkbox", () => {
       expect(finalContainerStyles.position).toBe("relative");
       expect(finalBeforeStyles.width).toBe("44px");
       expect(finalBeforeStyles.height).toBe("44px");
+    });
+  });
+
+  it("passes the browser event in change detail", async () => {
+    const handleChange = vi.fn();
+    const result = render(
+      <GoabCheckbox
+        testId="event-checkbox"
+        name="event"
+        value="event-checkbox"
+        text="Event checkbox"
+        onChange={handleChange}
+      />,
+    );
+
+    const checkbox = result.getByTestId("event-checkbox");
+
+    await userEvent.click(checkbox);
+
+    await vi.waitFor(() => {
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      const detail = handleChange.mock.calls[0][0];
+      expect(detail.name).toBe("event");
+      expect(detail.value).toBe("event-checkbox");
+      expect(detail.checked).toBe(true);
+      expect(detail.event).toBeInstanceOf(Event);
     });
   });
 });

--- a/libs/react-components/specs/datepicker.browser.spec.tsx
+++ b/libs/react-components/specs/datepicker.browser.spec.tsx
@@ -48,43 +48,109 @@ describe("DatePicker", () => {
     });
   });
 
-  it("dispatches a value on date selection", async () => {
+  it("passes the browser event in change detail", async () => {
     const handleChange = vi.fn();
     const selectedDate = new Date();
+    const formattedDate = format(selectedDate, "yyyy-MM-dd");
 
     const Component = () => {
-      return <GoabDatePicker testId="date-picker" onChange={handleChange} />;
+      return (
+        <GoabDatePicker name="event-date" testId="date-picker" onChange={handleChange} />
+      );
     };
 
     const result = render(<Component />);
     const input = result.getByTestId("calendar-input");
-    const dateToSelect = result.getByTestId(format(selectedDate, "yyyy-MM-dd"));
+    const dateToSelect = result.getByTestId(formattedDate);
 
-    await input.click();
-    await dateToSelect.click();
+    await userEvent.click(input);
+
+    await vi.waitFor(async () => {
+      const dateEl = dateToSelect.element() as HTMLElement;
+      expect(dateEl).toBeTruthy();
+      await userEvent.click(dateEl);
+    });
 
     await vi.waitFor(() => {
-      expect(handleChange).toHaveBeenCalled();
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      const detail = handleChange.mock.calls[0][0];
+      expect(detail.name).toBe("event-date");
+      expect(detail.valueStr).toBe(formattedDate);
+      expect(detail.event).toBeInstanceOf(Event);
     });
   });
 
   describe("DatePicker Keyboard Navigation", () => {
     [
-      { value: "2025-03-01", expected: "2025-02-28", formatted: "February 28, 2025", desc: "previous day", key: "{ArrowLeft}" },
-      { value: "2025-03-01", expected: "2025-03-02", formatted: "March 2, 2025", desc: "next day", key: "{ArrowRight}" },
-      { value: "2025-03-01", expected: "2025-02-22", formatted: "February 22, 2025", desc: "previous week", key: "{ArrowUp}" },
-      { value: "2025-03-01", expected: "2025-03-08", formatted: "March 8, 2025", desc: "next week", key: "{ArrowDown}" },
-      { value: "2025-03-01", expected: "2025-02-01", formatted: "February 1, 2025", desc: "previous month", key: "{PageUp}" },
-      { value: "2025-03-01", expected: "2025-04-01", formatted: "April 1, 2025", desc: "next month", key: "{PageDown}" },
-      { value: "2025-03-01", expected: "2024-03-01", formatted: "March 1, 2024", desc: "previous year", key: "{Shift>}{PageUp}" },
-      { value: "2025-03-01", expected: "2026-03-01", formatted: "March 1, 2026", desc: "next year", key: "{Shift>}{PageDown}" },
+      {
+        value: "2025-03-01",
+        expected: "2025-02-28",
+        formatted: "February 28, 2025",
+        desc: "previous day",
+        key: "{ArrowLeft}",
+      },
+      {
+        value: "2025-03-01",
+        expected: "2025-03-02",
+        formatted: "March 2, 2025",
+        desc: "next day",
+        key: "{ArrowRight}",
+      },
+      {
+        value: "2025-03-01",
+        expected: "2025-02-22",
+        formatted: "February 22, 2025",
+        desc: "previous week",
+        key: "{ArrowUp}",
+      },
+      {
+        value: "2025-03-01",
+        expected: "2025-03-08",
+        formatted: "March 8, 2025",
+        desc: "next week",
+        key: "{ArrowDown}",
+      },
+      {
+        value: "2025-03-01",
+        expected: "2025-02-01",
+        formatted: "February 1, 2025",
+        desc: "previous month",
+        key: "{PageUp}",
+      },
+      {
+        value: "2025-03-01",
+        expected: "2025-04-01",
+        formatted: "April 1, 2025",
+        desc: "next month",
+        key: "{PageDown}",
+      },
+      {
+        value: "2025-03-01",
+        expected: "2024-03-01",
+        formatted: "March 1, 2024",
+        desc: "previous year",
+        key: "{Shift>}{PageUp}",
+      },
+      {
+        value: "2025-03-01",
+        expected: "2026-03-01",
+        formatted: "March 1, 2026",
+        desc: "next year",
+        key: "{Shift>}{PageDown}",
+      },
     ].forEach(({ value, expected, formatted, desc, key }) => {
       it(`navigates to the ${desc} when ${key} is pressed`, async () => {
         const handleChange = vi.fn();
         const Component = () => {
-          return <GoabDatePicker testId="date-picker" value={value} onChange={(detail) => {
-            handleChange(detail.valueStr)
-          }} />;
+          return (
+            <GoabDatePicker
+              testId="date-picker"
+              value={value}
+              onChange={(detail) => {
+                handleChange(detail.valueStr);
+              }}
+            />
+          );
         };
 
         const result = render(<Component />);
@@ -95,10 +161,10 @@ describe("DatePicker", () => {
         await vi.waitFor(() => {
           const inputEl = input.element() as HTMLInputElement;
           expect(inputEl.value).toBe(formatted);
-          expect(handleChange).toBeCalledWith(expected)
+          expect(handleChange).toBeCalledWith(expected);
         });
-      })
-    })
+      });
+    });
   });
 
   it("renders with disabled prop", async () => {
@@ -123,7 +189,9 @@ describe("DatePicker", () => {
     const handleChange = vi.fn();
 
     const Component = () => {
-      return <GoabDatePicker testId="date-picker" disabled={true} onChange={handleChange} />;
+      return (
+        <GoabDatePicker testId="date-picker" disabled={true} onChange={handleChange} />
+      );
     };
 
     const result = render(<Component />);
@@ -131,9 +199,9 @@ describe("DatePicker", () => {
 
     // verify input is disabled
     await vi.waitFor(() => {
-      const inputEl = (input.element()) as HTMLInputElement;
+      const inputEl = input.element() as HTMLInputElement;
       expect(inputEl.disabled).toBe(true);
-    })
+    });
   });
 
   describe("Width property", () => {

--- a/libs/react-components/specs/dropdown.browser.spec.tsx
+++ b/libs/react-components/specs/dropdown.browser.spec.tsx
@@ -81,10 +81,13 @@ describe("Dropdown", () => {
 
       // Result
 
-      expect(handleChange).toBeCalledWith({
-        name: "favcolor",
-        value: "red",
-      })
+      await vi.waitFor(() => {
+        expect(handleChange).toHaveBeenCalledTimes(1);
+        const detail = handleChange.mock.calls[0][0];
+        expect(detail.name).toEqual("favcolor");
+        expect(detail.value).toEqual("red");
+        expect(detail.event).toBeInstanceOf(Event);
+      });
     });
 
     describe("Width", () => {

--- a/libs/react-components/specs/file-upload-input.browser.spec.tsx
+++ b/libs/react-components/specs/file-upload-input.browser.spec.tsx
@@ -1,0 +1,43 @@
+import { render } from "vitest-browser-react";
+import { GoabFileUploadInput } from "../src";
+import { expect, describe, it, vi } from "vitest";
+import React from "react";
+
+describe("FileUploadInput Browser Tests", () => {
+  it("passes the browser event in select file detail", async () => {
+    const onSelectFile = vi.fn();
+    const file = new File(["hello"], "test.txt", { type: "text/plain" });
+
+    const result = render(
+      <GoabFileUploadInput
+        testId="file-upload-input"
+        onSelectFile={onSelectFile}
+        accept=".txt"
+        maxFileSize="1MB"
+      />,
+    );
+
+    const fileUpload = result.getByTestId("file-upload-input");
+
+    await vi.waitFor(() => {
+      expect(fileUpload.element()).toBeTruthy();
+    });
+
+    const host = result.container.querySelector("goa-file-upload-input") as HTMLElement | null;
+    expect(host).toBeTruthy();
+
+    const selectEvent = new CustomEvent("_selectFile", {
+      detail: { file },
+    });
+
+    host?.dispatchEvent(selectEvent);
+
+    await vi.waitFor(() => {
+      expect(onSelectFile).toHaveBeenCalledTimes(1);
+      const detail = onSelectFile.mock.calls[0][0];
+      expect(detail.file).toBe(file);
+      expect(detail.event).toBe(selectEvent);
+      expect(detail.event).toBeInstanceOf(Event);
+    });
+  });
+});

--- a/libs/react-components/specs/input.browser.spec.tsx
+++ b/libs/react-components/specs/input.browser.spec.tsx
@@ -1,0 +1,86 @@
+import { render } from "vitest-browser-react";
+import { GoabInput, GoabTabs } from "../src";
+import { expect, describe, it, vi } from "vitest";
+import { userEvent } from "@vitest/browser/context";
+import React from "react";
+
+describe("Input Browser Tests", () => {
+  it("passes the browser event on change, keypress, focus, and blur details", async () => {
+    const onChange = vi.fn((detail) => detail.event.stopPropagation());
+    const onKeyPress = vi.fn((detail) => detail.event.stopPropagation());
+    const onFocus = vi.fn((detail) => detail.event.stopPropagation());
+    const onBlur = vi.fn((detail) => detail.event.stopPropagation());
+    const tabsOnChange = vi.fn();
+
+    const result = render(
+      <GoabTabs onChange={tabsOnChange}>
+        <div>
+          <GoabInput
+            name="event-input"
+            testId="event-input"
+            onChange={onChange}
+            onKeyPress={onKeyPress}
+            onFocus={onFocus}
+            onBlur={onBlur}
+          />
+          <GoabInput
+            name="blur-target"
+            testId="blur-target"
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            onChange={() => {}}
+          />
+        </div>
+      </GoabTabs>,
+    );
+
+    const input = result.getByTestId("event-input");
+    const blurTarget = result.getByTestId("blur-target");
+
+    await vi.waitFor(() => {
+      expect(input.element()).toBeTruthy();
+    });
+
+    const inputEl = input.element() as HTMLElement;
+    inputEl.focus();
+    await userEvent.type(inputEl, "a");
+
+    await vi.waitFor(() => {
+      expect(onFocus).toHaveBeenCalledTimes(1);
+      const focusDetail = onFocus.mock.calls[0][0];
+      expect(focusDetail.name).toBe("event-input");
+      expect(focusDetail.value).toBe("");
+      expect(focusDetail.event).toBeInstanceOf(Event);
+
+      expect(onKeyPress).toHaveBeenCalledTimes(1);
+      const keyPressDetail = onKeyPress.mock.calls[0][0];
+      expect(keyPressDetail.name).toBe("event-input");
+      expect(keyPressDetail.value).toBe("a");
+      expect(keyPressDetail.key).toBe("a");
+      expect(keyPressDetail.event).toBeInstanceOf(Event);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const changeDetail = onChange.mock.calls[0][0];
+      expect(changeDetail.name).toBe("event-input");
+      expect(changeDetail.value).toBe("a");
+      expect(changeDetail.event).toBeInstanceOf(Event);
+    });
+
+    await vi.waitFor(() => {
+      const blurEl = blurTarget.element() as HTMLElement;
+      expect(blurEl).toBeTruthy();
+      blurEl.focus();
+    });
+
+    await vi.waitFor(() => {
+      expect(onBlur).toHaveBeenCalledTimes(1);
+      const blurDetail = onBlur.mock.calls[0][0];
+      expect(blurDetail.name).toBe("event-input");
+      expect(blurDetail.value).toBe("a");
+      expect(blurDetail.event).toBeInstanceOf(Event);
+    });
+
+    await vi.waitFor(() => {
+      expect(tabsOnChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/react-components/specs/radio.browser.spec.tsx
+++ b/libs/react-components/specs/radio.browser.spec.tsx
@@ -3,6 +3,7 @@ import { GoabButton, GoabRadioGroup, GoabRadioItem } from "../src";
 import { expect, describe, it, vi } from "vitest";
 import { useState } from "react";
 import React from "react";
+import { userEvent } from "@vitest/browser/context";
 
 describe("Radio", () => {
   it("should enable and disable radio group programmatically", async () => {
@@ -155,6 +156,36 @@ describe("Radio", () => {
       expect(finalIconStyles.position).toBe("relative");
       expect(finalBeforeStyles.width).toBe("44px");
       expect(finalBeforeStyles.height).toBe("44px");
+    });
+  });
+
+  it("passes the browser event in change detail", async () => {
+    const handleChange = vi.fn();
+    const result = render(
+      <GoabRadioGroup name="test" value="" onChange={handleChange}>
+        <GoabRadioItem name="test" value="option1" label="Option 1" />
+      </GoabRadioGroup>,
+    );
+
+    const radioInput = result.getByTestId("radio-option-option1");
+    await vi.waitFor(() => {
+      expect(radioInput.element()).toBeTruthy();
+    });
+
+    const radioEl = radioInput.element() as HTMLInputElement;
+    // This sets up the label to be clicked instead of the element
+    // I don't understand why this is necessary, but it works when the actual element doesn't
+    const radioLabel = radioEl.closest("label") as HTMLElement;
+    expect(radioLabel).toBeTruthy();
+
+    await userEvent.click(radioLabel);
+
+    await vi.waitFor(() => {
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      const detail = handleChange.mock.calls[0][0];
+      expect(detail.name).toBe("test");
+      expect(detail.value).toBe("option1");
+      expect(detail.event).toBeInstanceOf(Event);
     });
   });
 });

--- a/libs/react-components/specs/textarea.browser.spec.tsx
+++ b/libs/react-components/specs/textarea.browser.spec.tsx
@@ -2,7 +2,7 @@ import { render } from "vitest-browser-react";
 
 import { GoabInput, GoabTextArea } from "../src";
 import { expect, describe, it, vi } from "vitest";
-import { useState } from "react";
+import { userEvent } from "@vitest/browser/context";
 
 describe("TextArea Browser Tests", () => {
   const noop = () => {
@@ -37,25 +37,24 @@ describe("TextArea Browser Tests", () => {
     );
   });
 
-  it("should trigger onBlur event when focus leaves the textarea", async () => {
-    const onBlurSpy = vi.fn();
+  it("passes the browser event on change, keypress, and blur details", async () => {
+    const onChange = vi.fn();
+    const onKeyPress = vi.fn();
+    const onBlur = vi.fn();
 
     const Component = () => {
-      const [value, setValue] = useState("");
-
       return (
-        <div data-testid="container">
+        <div>
           <GoabTextArea
-            testId="test-textarea"
             name="test-textarea"
-            value={value}
-            onChange={(detail) => setValue(detail.value)}
-            onBlur={onBlurSpy}
+            testId="test-textarea"
+            onChange={onChange}
+            onKeyPress={onKeyPress}
+            onBlur={onBlur}
           />
           <GoabInput
-            type="text"
-            testId="focus-target"
-            name="focus-input"
+            name="test-input"
+            testId="test-input"
             // eslint-disable-next-line @typescript-eslint/no-empty-function
             onChange={() => {}}
           />
@@ -64,31 +63,46 @@ describe("TextArea Browser Tests", () => {
     };
 
     const result = render(<Component />);
-    const textareaEl = result.getByTestId("test-textarea");
-    const inputEl = result.getByTestId("focus-target");
-    const container = result.getByTestId("container");
+    const textarea = result.getByTestId("test-textarea");
+    const input = result.getByTestId("test-input");
 
     await vi.waitFor(async () => {
-      const textarea = textareaEl.element() as HTMLTextAreaElement;
+      const textareaEL = textarea.element() as HTMLTextAreaElement;
       expect(textarea).toBeTruthy();
-      textarea.focus();
-      textarea.value = "Test content for blur";
+      textareaEL.focus();
+
+      await userEvent.type(textareaEL, "s");
+    });
+
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const changeDetail = onChange.mock.calls[0][0];
+      expect(changeDetail.name).toBe("test-textarea");
+      expect(changeDetail.value).toBe("s");
+      expect(changeDetail.event).toBeInstanceOf(Event);
+
+      expect(onKeyPress).toHaveBeenCalledTimes(1);
+      const keyPressDetail = onKeyPress.mock.calls[0][0];
+      expect(keyPressDetail.name).toBe("test-textarea");
+      expect(keyPressDetail.value).toBe("s");
+      expect(keyPressDetail.key).toBe("s");
+      expect(keyPressDetail.event).toBeInstanceOf(Event);
     });
 
     // Trigger blur by focusing on the input element
     await vi.waitFor(() => {
-      const input = inputEl.element() as HTMLInputElement;
-      expect(input).toBeTruthy();
-      input.focus();
+      const inputEL = input.element() as HTMLInputElement;
+      expect(inputEL).toBeTruthy();
+      inputEL.focus();
     });
 
     // Verify onBlur was called with correct values
     await vi.waitFor(() => {
-      expect(onBlurSpy).toHaveBeenCalledTimes(1);
-      expect(onBlurSpy).toHaveBeenCalledWith({
-        name: "test-textarea",
-        value: "Test content for blur",
-      });
+      expect(onBlur).toHaveBeenCalledTimes(1);
+      const blurDetail = onBlur.mock.calls[0][0];
+      expect(blurDetail.name).toBe("test-textarea");
+      expect(blurDetail.value).toBe("s");
+      expect(blurDetail.event).toBeInstanceOf(Event);
     });
   });
 

--- a/libs/react-components/src/lib/checkbox-list/checkbox-list.spec.tsx
+++ b/libs/react-components/src/lib/checkbox-list/checkbox-list.spec.tsx
@@ -90,9 +90,11 @@ describe("GoabCheckboxList (React)", () => {
     const el = document.querySelector("goa-checkbox-list");
     expect(el).toBeTruthy();
 
+    const changeEvent = new Event("change");
     const detail: GoabCheckboxListOnChangeDetail = {
       name: "foo",
       value: ["x", "y"],
+      event: changeEvent,
     };
 
     el &&
@@ -104,7 +106,9 @@ describe("GoabCheckboxList (React)", () => {
       );
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith(detail);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ ...detail, event: expect.any(Event) }),
+    );
   });
 
   it("should update onChange handler when prop changes", () => {

--- a/libs/react-components/src/lib/checkbox-list/checkbox-list.tsx
+++ b/libs/react-components/src/lib/checkbox-list/checkbox-list.tsx
@@ -57,7 +57,7 @@ export function GoabCheckboxList({
     const listener = (e: Event) => {
       try {
         const detail = (e as CustomEvent<GoabCheckboxListOnChangeDetail>).detail;
-        onChange?.(detail);
+        onChange?.({ ...detail, event: e });
       } catch (error) {
         console.error("Error handling checkbox list change:", error);
       }

--- a/libs/react-components/src/lib/checkbox/checkbox.tsx
+++ b/libs/react-components/src/lib/checkbox/checkbox.tsx
@@ -77,7 +77,7 @@ export function GoabCheckbox({
     const current = el.current;
     const listener = (e: Event) => {
       const detail = (e as CustomEvent<GoabCheckboxOnChangeDetail>).detail;
-      onChange?.(detail);
+      onChange?.({ ...detail, event: e });
     };
 
     current.addEventListener("_change", listener);

--- a/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
@@ -55,6 +55,7 @@ describe("DatePicker", () => {
   it("should handle event", async () => {
     const name = "foo";
     const value = new Date();
+    const changeEvent = new Event("change");
 
     const onChange = vi.fn();
     const { baseElement } = render(
@@ -67,21 +68,22 @@ describe("DatePicker", () => {
       new CustomEvent("_change", {
         composed: true,
         bubbles: true,
-        detail: { type: "date", name, value },
+        detail: { type: "date", name, value, event: changeEvent },
       }),
     );
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toBeCalledWith({ name, value, type: "date" });
+    expect(onChange).toBeCalledWith({
+      name,
+      value,
+      type: "date",
+      event: expect.any(Event),
+    });
   });
 
   it("should pass data-grid attributes", () => {
     const { baseElement } = render(
-      <DatePicker
-        name="test"
-        onChange={noop}
-        data-grid="cell"
-      />
+      <DatePicker name="test" onChange={noop} data-grid="cell" />,
     );
     const el = baseElement.querySelector("goa-date-picker");
     expect(el?.getAttribute("data-grid")).toBe("cell");

--- a/libs/react-components/src/lib/date-picker/date-picker.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.tsx
@@ -75,7 +75,7 @@ export function GoabDatePicker({
 
     const handleChange = (e: Event) => {
       const detail = (e as CustomEvent<GoabDatePickerOnChangeDetail>).detail;
-      onChange?.(detail);
+      onChange?.({ ...detail, event: e });
     };
 
     if (onChange) {

--- a/libs/react-components/src/lib/dropdown/dropdown.spec.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown.spec.tsx
@@ -108,7 +108,13 @@ describe("GoabDropdown", () => {
         new CustomEvent("_change", { detail: { name: "favColor", value: "blue" } }),
       );
     await waitFor(() => {
-      expect(fn).toBeCalledWith({ name: "favColor", value: "blue" });
+      expect(fn).toBeCalledWith(
+        expect.objectContaining({
+          name: "favColor",
+          value: "blue",
+          event: expect.any(Event),
+        }),
+      );
     });
   });
 

--- a/libs/react-components/src/lib/dropdown/dropdown.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown.tsx
@@ -100,7 +100,7 @@ export function GoabDropdown({
     const current = el.current;
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<GoabDropdownOnChangeDetail>).detail;
-      onChange?.(detail);
+      onChange?.({ ...detail, event: e });
     };
     if (onChange) {
       current.addEventListener("_change", handler);

--- a/libs/react-components/src/lib/file-upload-card/file-upload-card.tsx
+++ b/libs/react-components/src/lib/file-upload-card/file-upload-card.tsx
@@ -52,8 +52,8 @@ export function GoabFileUploadCard({
     if (!el.current) return;
 
     const current = el.current;
-    const deleteHandler = () => onDelete?.({ filename });
-    const cancelHandler = () => onCancel?.({ filename });
+    const deleteHandler = (event: Event) => onDelete?.({ filename, event });
+    const cancelHandler = (event: Event) => onCancel?.({ filename, event });
     current.addEventListener("_delete", deleteHandler);
     current.addEventListener("_cancel", cancelHandler);
     return () => {

--- a/libs/react-components/src/lib/file-upload-input/file-upload-input.tsx
+++ b/libs/react-components/src/lib/file-upload-input/file-upload-input.tsx
@@ -47,7 +47,7 @@ export function GoabFileUploadInput({
     const current = el.current;
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<GoabFileUploadInputOnSelectFileDetail>).detail;
-      onSelectFile(detail);
+      onSelectFile({ ...detail, event: e });
     };
     current.addEventListener("_selectFile", handler);
     return () => {

--- a/libs/react-components/src/lib/input/input.spec.tsx
+++ b/libs/react-components/src/lib/input/input.spec.tsx
@@ -149,10 +149,13 @@ describe("Input", () => {
         inputElement,
         new CustomEvent("_change", { detail: { name: "dateInput", value: newDate } }),
       );
-    expect(mockOnChangeHandler).toBeCalledWith({
-      name: "dateInput",
-      value: new Date(newDate),
-    });
+    expect(mockOnChangeHandler).toBeCalledWith(
+      expect.objectContaining({
+        name: "dateInput",
+        value: new Date(newDate),
+        event: expect.any(Event),
+      }),
+    );
   });
 
   it("should handle decimal number for GoabInputNumber", () => {
@@ -171,10 +174,13 @@ describe("Input", () => {
           detail: { name: "numberInput", value: decimalValue },
         }),
       );
-    expect(mockOnChangeHandler).toBeCalledWith({
-      name: "numberInput",
-      value: decimalValue,
-    });
+    expect(mockOnChangeHandler).toBeCalledWith(
+      expect.objectContaining({
+        name: "numberInput",
+        value: decimalValue,
+        event: expect.any(Event),
+      }),
+    );
   });
 
   describe("Text Alignment", () => {

--- a/libs/react-components/src/lib/input/input.tsx
+++ b/libs/react-components/src/lib/input/input.tsx
@@ -156,7 +156,7 @@ export function GoabInput({
     const current = ref.current;
     const changeListener = (e: Event) => {
       const detail = (e as CustomEvent<GoabInputOnChangeDetail>).detail;
-      onChange?.(detail);
+      onChange?.({ ...detail, event: e });
     };
     const clickListener = () => {
       onTrailingIconClick?.();
@@ -164,17 +164,17 @@ export function GoabInput({
 
     const focusListener = (e: Event) => {
       const detail = (e as CustomEvent<GoabInputOnFocusDetail>).detail;
-      onFocus?.(detail);
+      onFocus?.({ ...detail, event: e });
     };
 
     const blurListener = (e: Event) => {
       const detail = (e as CustomEvent<GoabInputOnBlurDetail>).detail;
-      onBlur?.(detail);
+      onBlur?.({ ...detail, event: e });
     };
 
     const keypressListener = (e: Event) => {
       const detail = (e as CustomEvent<GoabInputOnKeyPressDetail>).detail;
-      onKeyPress?.(detail);
+      onKeyPress?.({ ...detail, event: e });
     };
 
     current.addEventListener("_change", changeListener);
@@ -209,31 +209,31 @@ export function GoabInput({
 }
 
 const onDateChangeHandler = (onChange?: OnChange<GoabDate>) => {
-  return ({ name, value }: GoabInputOnChangeDetail<string | Date>) => {
+  return ({ name, value, event }: GoabInputOnChangeDetail<string | Date>) => {
     if (!value) {
-      onChange?.({ name, value: "" });
+      onChange?.({ name, value: "", event });
       return;
     }
     // valid string date
     if (typeof value === "string" && isValid(new Date(value))) {
-      onChange?.({ name, value: parseISO(value) });
+      onChange?.({ name, value: parseISO(value), event });
       return;
     }
     // valid date
     if (isValid(value)) {
-      onChange?.({ name, value });
+      onChange?.({ name, value, event });
       return;
     }
   };
 };
 
 const onTimeChangeHandler = (onChange?: OnChange) => {
-  return ({ name, value }: GoabInputOnChangeDetail) => {
+  return ({ name, value, event }: GoabInputOnChangeDetail) => {
     if (!value) {
-      onChange?.({ name, value: "" });
+      onChange?.({ name, value: "", event });
       return;
     }
-    onChange?.({ name, value });
+    onChange?.({ name, value, event });
   };
 };
 
@@ -330,7 +330,13 @@ export function GoabInputFile(props: GoabInputProps): JSX.Element {
       id={props.id}
       name={props.name}
       type="file"
-      onChange={(e) => props.onChange?.({ name: e.target.name, value: e.target.value })}
+      onChange={(e) =>
+        props.onChange?.({
+          name: e.target.name,
+          value: e.target.value,
+          event: e.nativeEvent,
+        })
+      }
       style={{ backgroundColor: "revert" }}
     />
   );
@@ -347,17 +353,17 @@ export function GoabInputNumber({
   textAlign = "right",
   ...props
 }: GoabNumberInputProps): JSX.Element {
-  const onNumberChange = ({ name, value }: GoabInputOnChangeDetail) => {
-    props.onChange?.({ name, value: parseFloat(value) });
+  const onNumberChange = ({ name, value, event }: GoabInputOnChangeDetail) => {
+    props.onChange?.({ name, value: parseFloat(value), event });
   };
-  const onFocus = ({ name, value }: GoabInputOnFocusDetail) => {
-    props.onFocus?.({ name, value: parseFloat(value) });
+  const onFocus = ({ name, value, event }: GoabInputOnFocusDetail) => {
+    props.onFocus?.({ name, value: parseFloat(value), event });
   };
-  const onBlur = ({ name, value }: GoabInputOnBlurDetail) => {
-    props.onBlur?.({ name, value: parseFloat(value) });
+  const onBlur = ({ name, value, event }: GoabInputOnBlurDetail) => {
+    props.onBlur?.({ name, value: parseFloat(value), event });
   };
-  const onKeyPress = ({ name, value, key }: GoabInputOnKeyPressDetail) => {
-    props.onKeyPress?.({ name, value: parseFloat(value), key: parseInt(key) });
+  const onKeyPress = ({ name, value, key, event }: GoabInputOnKeyPressDetail) => {
+    props.onKeyPress?.({ name, value: parseFloat(value), key: parseInt(key), event });
   };
   return (
     <GoabInput

--- a/libs/react-components/src/lib/radio-group/radio-group.tsx
+++ b/libs/react-components/src/lib/radio-group/radio-group.tsx
@@ -60,7 +60,7 @@ export function GoabRadioGroup({
 
     const listener = (e: Event) => {
       const detail = (e as CustomEvent<GoabRadioGroupOnChangeDetail>).detail;
-      onChange?.(detail);
+      onChange?.({ ...detail, event: e });
     };
 
     const currentEl = el.current;

--- a/libs/react-components/src/lib/textarea/textarea.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.tsx
@@ -79,17 +79,17 @@ export function GoabTextArea({
 
     const changeListener: EventListener = (e: Event) => {
       const detail = (e as CustomEvent<GoabTextAreaOnChangeDetail>).detail;
-      onChange?.(detail);
+      onChange?.({ ...detail, event: e });
     };
 
     const keypressListener = (e: unknown) => {
       const detail = (e as CustomEvent<GoabTextAreaOnKeyPressDetail>).detail;
-      onKeyPress?.(detail);
+      onKeyPress?.({ ...detail, event: e as Event });
     };
 
     const blurListener = (e: unknown) => {
       const detail = (e as CustomEvent<GoabTextAreaOnBlurDetail>).detail;
-      onBlur?.(detail);
+      onBlur?.({ ...detail, event: e as Event });
     };
 
     current.addEventListener("_change", changeListener);


### PR DESCRIPTION
# Before (the change)

All Input components (Input, Radio, Checkbox, Checkbox List, Text Area, File Upload, Dropdown, Date Picker) send the value and name of component for all of their events.

# After (the change)

Now they send the actual event itself as well. So you can use that to stop propagation if needed.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use `npm run serve:prs:angular` and `npm run serve:prs:react`, and use Bug 2977. Use the console to see what's sent for all the events for all components. And at the bottom is an area to test stopping propagation, the first tab it should stop and thus the Tab onChange won't run, the second and third tab will show you what the problem is this was meant to fix.
