### PR TITLE
fix(#3323): Modified Callout to use overflow:visible

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -50,6 +50,7 @@
           <a href="/bugs/3201">3201</a>
           <a href="/bugs/3215">3215</a>
           <a href="/bugs/3248">3248</a>
+          <a href="/bugs/3323">3323</a>
         </goab-side-menu-group>
         <goab-side-menu-group heading="Features">
           <a href="/features/1328">1328</a>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -35,6 +35,7 @@ import { Bug3156Component } from "../routes/bugs/3156/bug3156.component";
 import { Bug3201Component } from "../routes/bugs/3201/bug3201.component";
 import { Bug3215Component } from "../routes/bugs/3215/bug3215.component";
 import { Bug3248Component } from "../routes/bugs/3248/bug3248.component";
+import { Bug3323Component } from "../routes/bugs/3323/bug3323.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -91,6 +92,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3201", component: Bug3201Component },
   { path: "bugs/3215", component: Bug3215Component },
   { path: "bugs/3248", component: Bug3248Component },
+  { path: "bugs/3323", component: Bug3323Component },
 
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1383", component: Feat1383Component },

--- a/apps/prs/angular/src/routes/bugs/3323/bug3323.component.html
+++ b/apps/prs/angular/src/routes/bugs/3323/bug3323.component.html
@@ -1,0 +1,27 @@
+<goab-text tag="h1">Bug 3323 - Tooltip cut off</goab-text>
+<goab-text tag="p">
+  This is to test a fairly simple CSS fix for the Callout component. Right now, nothing
+  can go past the borders of the Callout from inside the component. This includes things
+  like Tooltip. So for the below test, the expected result is that the Tooltip shows up
+  beyond the borders of the Callout.
+</goab-text>
+<goab-callout type="important">
+  <p>
+    Section 14 of the
+    <goab-tooltip content="This is a tooltip content">
+      <a target="_blank" href="#"><em>Public Trustee Act</em></a>
+    </goab-tooltip>
+    states that where a person
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi viverra rutrum
+    accumsan. Cras efficitur et velit ac pellentesque. Duis sodales quis eros at
+    sollicitudin. Praesent accumsan, mi nec eleifend tempor, turpis leo porttitor odio, at
+    consectetur ligula eros a turpis. Sed volutpat nunc a sem porta, sit amet commodo mi
+    ullamcorper. Praesent et bibendum ex, a dignissim ligula. Aliquam id molestie sem.
+    Duis lacus ipsum, maximus efficitur felis et, condimentum feugiat diam. Vivamus a nibh
+    lobortis justo faucibus placerat et at ipsum. Sed nec accumsan erat, vitae gravida
+    massa. Vestibulum id elit eget magna lacinia maximus. Morbi sed efficitur magna.
+    Pellentesque at interdum nisi.
+  </p>
+</goab-callout>

--- a/apps/prs/angular/src/routes/bugs/3323/bug3323.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3323/bug3323.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabCallout, GoabTooltip, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3248",
+  templateUrl: "./bug3323.component.html",
+  imports: [GoabCallout, GoabTooltip, GoabText],
+})
+export class Bug3323Component {}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -55,6 +55,7 @@ export function App() {
               <Link to="/bugs/3201">3201</Link>
               <Link to="/bugs/3215">3215</Link>
               <Link to="/bugs/3248">3248</Link>
+              <Link to="/bugs/3323">3323</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Features">
               <Link to="/features/1383">1383</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -36,6 +36,7 @@ import { Bug3118Route } from "./routes/bugs/bug3118";
 import { Bug3201Route } from "./routes/bugs/bug3201";
 import { Bug3215Route } from "./routes/bugs/bug3215";
 import { Bug3248Route } from "./routes/bugs/bug3248";
+import { Bug3323Route } from "./routes/bugs/bug3323";
 
 import { EverythingRoute } from "./routes/everything";
 import Feat1383Route from "./routes/features/feat1383";
@@ -95,6 +96,7 @@ root.render(
           <Route path="bugs/3201" element={<Bug3201Route />} />
           <Route path="bugs/3215" element={<Bug3215Route />} />
           <Route path="bugs/3248" element={<Bug3248Route />} />
+          <Route path="bugs/3323" element={<Bug3323Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3323.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3323.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { GoabTooltip, GoabCallout, GoabText } from "@abgov/react-components";
+
+export function Bug3323Route() {
+  return (
+    <main>
+      <GoabText tag="h1">Bug 3323 - Tooltip cut off</GoabText>
+      <GoabText tag="p">
+        This is to test a fairly simple CSS fix for the Callout component. Right now,
+        nothing can go past the borders of the Callout from inside the component. This
+        includes things like Tooltip. So for the below test, the expected result is that
+        the Tooltip shows up beyond the borders of the Callout.
+      </GoabText>
+      <GoabCallout type="important">
+        <p>
+          Section 14 of the
+          <GoabTooltip content="This is a tooltip content">
+            <a target="_blank" href="#">
+              <em>Public Trustee Act</em>
+            </a>
+          </GoabTooltip>
+          states that where a person
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi viverra rutrum
+          accumsan. Cras efficitur et velit ac pellentesque. Duis sodales quis eros at
+          sollicitudin. Praesent accumsan, mi nec eleifend tempor, turpis leo porttitor
+          odio, at consectetur ligula eros a turpis. Sed volutpat nunc a sem porta, sit
+          amet commodo mi ullamcorper. Praesent et bibendum ex, a dignissim ligula.
+          Aliquam id molestie sem. Duis lacus ipsum, maximus efficitur felis et,
+          condimentum feugiat diam. Vivamus a nibh lobortis justo faucibus placerat et at
+          ipsum. Sed nec accumsan erat, vitae gravida massa. Vestibulum id elit eget magna
+          lacinia maximus. Morbi sed efficitur magna. Pellentesque at interdum nisi.
+        </p>
+      </GoabCallout>
+    </main>
+  );
+}

--- a/libs/web-components/src/components/callout/Callout.svelte
+++ b/libs/web-components/src/components/callout/Callout.svelte
@@ -136,7 +136,7 @@
   .notification {
     display: flex;
     align-items: stretch;
-    overflow: hidden;
+    overflow: visible;
     font: var(--goa-callout-l-text-size);
     border: var(--goa-callout-l-border-width) solid;
     border-radius: var(--goa-callout-border-radius);


### PR DESCRIPTION
# Before (the change)

Callout wouldn't allow a Tooltip component to expand beyond its borders

# After (the change)

Callout should now allow anything like a pop-up (Tooltip) to expand beyond its borders

**NOTE:** no new tests have been added as this is a purely visual change

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Run `npm run serve:prs:angular` and `npm run serve:prs:react`. Test using Bug 3323.
