### PR TITLE
docs: add JSDoc prop descriptions to Svelte components

### DIFF
--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -34,7 +34,7 @@
   export let secondarytext: string = "";
   /** Sets the heading size of the accordion container heading. */
   export let headingsize: HeadingSize = "small";
-  /** Unique identifier for the accordion. Auto-generated if not provided. */
+  /** Unique identifier for the accordion. */
   export let id: string = "";
   /** Sets the maximum width of the accordion. */
   export let maxwidth: string = "none";

--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -26,17 +26,29 @@
 
   // Props
 
+  /** Sets the state of the accordion container open or closed. */
   export let open: string = "false";
+  /** @required Sets the heading text. */
   export let heading: string = "";
+  /** Sets secondary text. */
   export let secondarytext: string = "";
+  /** Sets the heading size of the accordion container heading. */
   export let headingsize: HeadingSize = "small";
+  /** Unique identifier for the accordion. Auto-generated if not provided. */
   export let id: string = "";
+  /** Sets the maximum width of the accordion. */
   export let maxwidth: string = "none";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = "xs";
+  /** Left margin. */
   export let ml: Spacing = null;
+  /** Sets the position of the expand/collapse icon. */
   export let iconposition: "left" | "right" = "left";
 
   // Private

--- a/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
+++ b/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
@@ -16,11 +16,17 @@
   import { TABLET_BP } from "../../common/breakpoints";
 
   // Required
+
+  /** @required The menu heading text displayed as the dropdown trigger. */
   export let heading: string;
 
   // Optional
+
+  /** Icon displayed before the heading text. */
   export let leadingicon: GoAIconType;
+  /** The menu style variant. Primary uses bold text, secondary uses regular weight. */
   export let type: "primary" | "secondary" = "primary";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "rootEl";
 
   // Private

--- a/libs/web-components/src/components/app-header/AppHeader.svelte
+++ b/libs/web-components/src/components/app-header/AppHeader.svelte
@@ -10,11 +10,17 @@
   import type { AppHeaderMenuProps } from "../app-header-menu/AppHeaderMenu.svelte";
 
   // optional
+  /** Set the service name to display in the app header. */
   export let heading: string = "";
+  /** Set the URL to link from the alberta.ca logo. A full url is required. */
   export let url: string = "";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Maximum width of the content area. */
   export let maxcontentwidth = "";
+  /** Sets the breakpoint in px for the full menu to display. */
   export let fullmenubreakpoint: number = TABLET_BP; // minimum window width to show all menu links
+  /** When true, clicking the menu button dispatches _menuClick event instead of toggling the menu. Use for custom menu handling. */
   export let hasmenuclickhandler: string = "false"; // If this is yes, we will not expand menu when clicking a toggle button
 
   // Private

--- a/libs/web-components/src/components/badge/Badge.svelte
+++ b/libs/web-components/src/components/badge/Badge.svelte
@@ -71,7 +71,7 @@
   type BadgeSize = (typeof badgeSizes)[number];
   type BadgeVersion = (typeof versions)[number];
 
-  /** @required Defines the context and colour of the badge. */
+  /** Defines the context and colour of the badge. */
   export let type: BadgeType;
 
   // Optional

--- a/libs/web-components/src/components/badge/Badge.svelte
+++ b/libs/web-components/src/components/badge/Badge.svelte
@@ -75,7 +75,7 @@
   export let type: BadgeType;
 
   // Optional
-  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
   /** Text label of the badge. */
   export let content: string = "";

--- a/libs/web-components/src/components/badge/Badge.svelte
+++ b/libs/web-components/src/components/badge/Badge.svelte
@@ -71,22 +71,34 @@
   type BadgeSize = (typeof badgeSizes)[number];
   type BadgeVersion = (typeof versions)[number];
 
+  /** @required Defines the context and colour of the badge. */
   export let type: BadgeType;
 
-  // optional
+  // Optional
+  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
   export let testid: string = "";
+  /** Text label of the badge. */
   export let content: string = "";
+  /** @deprecated Use icontype instead. Includes an icon in the badge. */
   export let icon: string = "";
+  /** Icon type to display in the badge. */
   export let icontype: GoAIconType | null = null;
+  /** Accessible label for screen readers. */
   export let arialabel: string = "";
+  /** Sets the size of the badge. */
   export let size: BadgeSize = "medium";
+  /** Sets the visual emphasis. 'subtle' for less prominent, 'strong' for more emphasis. */
   export let emphasis: (typeof emphasisLevels)[number] = "strong";
+  /** The design system version for styling purposes. */
   export let version: BadgeVersion = "1";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // private

--- a/libs/web-components/src/components/badge/Badge.svelte
+++ b/libs/web-components/src/components/badge/Badge.svelte
@@ -89,7 +89,7 @@
   export let size: BadgeSize = "medium";
   /** Sets the visual emphasis. 'subtle' for less prominent, 'strong' for more emphasis. */
   export let emphasis: (typeof emphasisLevels)[number] = "strong";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: BadgeVersion = "1";
 
   /** Top margin. */

--- a/libs/web-components/src/components/block/Block.svelte
+++ b/libs/web-components/src/components/block/Block.svelte
@@ -15,12 +15,19 @@
   import { ensureSlotExists } from "../../common/utils";
   import { style, styles } from "../../common/utils";
 
+  /** Spacing between items. Uses design system spacing tokens. */
   export let gap: Spacing = "m";
+  /** Stacking direction of child components. */
   export let direction: "row" | "column" = "row";
+  /** Primary axis alignment of child components. */
   export let alignment: "center" | "start" | "end" | "normal" = "normal";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Sets the minimum width of the block container. */
   export let minWidth: string = "";
+  /** Sets the maximum width of the block container. */
   export let maxWidth: string = "";
+  /** Sets the width of the block container. Defaults to max-content. */
   export let width: string = "";
 
   $: _alignment =
@@ -32,10 +39,13 @@
           ? "center"
           : "normal";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // Private

--- a/libs/web-components/src/components/button-group/ButtonGroup.svelte
+++ b/libs/web-components/src/components/button-group/ButtonGroup.svelte
@@ -7,8 +7,7 @@
   import { onMount } from "svelte";
   import { typeValidator } from "../../common/utils";
 
-  /** @required Positions the button group in the page layout. */
-
+  /** Positions the button group in the page layout. */
   export let alignment: ButtonAlignment = "start";
   /** Sets the spacing between buttons in the button group. */
   export let gap: Gap = "relaxed";

--- a/libs/web-components/src/components/button-group/ButtonGroup.svelte
+++ b/libs/web-components/src/components/button-group/ButtonGroup.svelte
@@ -11,7 +11,7 @@
   export let alignment: ButtonAlignment = "start";
   /** Sets the spacing between buttons in the button group. */
   export let gap: Gap = "relaxed";
-  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   /** Top margin. */

--- a/libs/web-components/src/components/button-group/ButtonGroup.svelte
+++ b/libs/web-components/src/components/button-group/ButtonGroup.svelte
@@ -7,14 +7,21 @@
   import { onMount } from "svelte";
   import { typeValidator } from "../../common/utils";
 
+  /** @required Positions the button group in the page layout. */
+
   export let alignment: ButtonAlignment = "start";
+  /** Sets the spacing between buttons in the button group. */
   export let gap: Gap = "relaxed";
+  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
   export let testid: string = "";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   const [BUTTON_ALIGNMENTS, validateAlignment] = typeValidator("alignment", [

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -68,7 +68,7 @@
   /** Sets a custom width for the button (e.g., "200px" or "100%"). */
   export let width: string = "";
 
-  /** Design system version. Version 2 includes updated styling and accessibility improvements. */
+  /** @internal Design system version for styling. */
   export let version: Version = "1";
 
   /** Sets the top margin using design system spacing tokens. */

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -44,20 +44,43 @@
   type Variant = (typeof Variants)[number];
   type Version = (typeof Versions)[number];
 
-  // optional
+  /** Sets the visual style of the button. Use "primary" for main actions, "secondary" for alternative actions, "tertiary" for low-emphasis actions, and "start" for prominent call-to-action buttons. */
   export let type: ButtonType = "primary";
+
+  /** Controls the size of the button. Use "compact" for inline actions or space-constrained layouts. */
   export let size: Size = "normal";
+
+  /** Sets the color variant for semantic meaning. Use "destructive" for delete or irreversible actions, "inverse" for dark backgrounds. */
   export let variant: Variant = "normal";
+
+  /** When true, prevents user interaction and applies disabled styling. */
   export let disabled: string = "false";
+
+  /** Icon displayed before the button text. */
   export let leadingicon: GoAIconType | null = null;
+
+  /** Icon displayed after the button text. */
   export let trailingicon: GoAIconType | null = null;
+
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+
+  /** Sets a custom width for the button (e.g., "200px" or "100%"). */
   export let width: string = "";
+
+  /** Design system version. Version 2 includes updated styling and accessibility improvements. */
   export let version: Version = "1";
 
+  /** Sets the top margin using design system spacing tokens. */
   export let mt: Spacing = null;
+
+  /** Sets the right margin using design system spacing tokens. */
   export let mr: Spacing = null;
+
+  /** Sets the bottom margin using design system spacing tokens. */
   export let mb: Spacing = null;
+
+  /** Sets the left margin using design system spacing tokens. */
   export let ml: Spacing = null;
 
   export let action: string = "";

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -83,8 +83,11 @@
   /** Sets the left margin using design system spacing tokens. */
   export let ml: Spacing = null;
 
+  /** Action identifier passed in click events for event delegation patterns. */
   export let action: string = "";
+  /** Single argument value passed with the action in click events. */
   export let actionArg: string = "";
+  /** Multiple argument values passed with the action in click events. */
   export let actionArgs: Record<string, unknown> = {};
 
   // ========

--- a/libs/web-components/src/components/calendar/Calendar.svelte
+++ b/libs/web-components/src/components/calendar/Calendar.svelte
@@ -10,23 +10,32 @@
   // Public
   // ******
 
+  /** Name identifier for the calendar, used in form submission and change events. */
   export let name: string = "";
+  /** The currently selected date value in YYYY-MM-DD format. */
   export let value: string = "";
+  /** The minimum selectable date in YYYY-MM-DD format. Defaults to 5 years in the past. */
   export let min: string = "";
+  /** The maximum selectable date in YYYY-MM-DD format. Defaults to 5 years in the future. */
   export let max: string = "";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
   export let version: "1" | "2" = "1";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // ****************
   // Exposed Privates
   // ****************
 
+  /** Shows a border around the calendar. Set to false when embedding within another component. */
   export let bordered: string = "true";
 
   // ********

--- a/libs/web-components/src/components/calendar/Calendar.svelte
+++ b/libs/web-components/src/components/calendar/Calendar.svelte
@@ -20,6 +20,7 @@
   export let max: string = "";
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
 
   /** Top margin. */

--- a/libs/web-components/src/components/calendar/Calendar.svelte
+++ b/libs/web-components/src/components/calendar/Calendar.svelte
@@ -10,7 +10,7 @@
   // Public
   // ******
 
-  /** Name identifier for the calendar, used in form submission and change events. */
+  /** Name identifier for the calendar, included in change events. */
   export let name: string = "";
   /** The currently selected date value in YYYY-MM-DD format. */
   export let value: string = "";

--- a/libs/web-components/src/components/callout/Callout.svelte
+++ b/libs/web-components/src/components/callout/Callout.svelte
@@ -37,20 +37,32 @@
   type AriaLiveType = (typeof AriaLive)[number];
   type VersionType = (typeof Version)[number];
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = "l";
+  /** Left margin. */
   export let ml: Spacing = null;
 
+  /** The medium callout has reduced padding and type size to adjust for a compact area and smaller viewport width when a smaller size is required. */
   export let size: CalloutSize = "large";
+  /** @required Define the context and colour of the callout. */
   export let type: CalloutType;
+  /** Sets the visual prominence. 'high' for full background, 'medium' for subtle, 'low' for minimal. */
   export let emphasis: CalloutEmphasisType = "medium";
+  /** Callout heading text. */
   export let heading: string = "";
+  /** Sets the maximum width of the callout. */
   export let maxwidth: string = "none";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Indicates how assistive technology should handle updates to the live region. */
   export let arialive: AriaLiveType = "off";
+  /** Sets the icon theme. 'outline' for stroked icons, 'filled' for solid icons. */
   export let icontheme: IconTheme = "outline";
+  /** The design system version for styling purposes. */
   export let version: VersionType = "1";
 
   // Private

--- a/libs/web-components/src/components/callout/Callout.svelte
+++ b/libs/web-components/src/components/callout/Callout.svelte
@@ -46,7 +46,7 @@
   /** Left margin. */
   export let ml: Spacing = null;
 
-  /** The medium callout has reduced padding and type size to adjust for a compact area and smaller viewport width when a smaller size is required. */
+  /** Sets the size of the callout. 'medium' has reduced padding and type size for compact areas. */
   export let size: CalloutSize = "large";
   /** @required Define the context and colour of the callout. */
   export let type: CalloutType;
@@ -62,7 +62,7 @@
   export let arialive: AriaLiveType = "off";
   /** Sets the icon theme. 'outline' for stroked icons, 'filled' for solid icons. */
   export let icontheme: IconTheme = "outline";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: VersionType = "1";
 
   // Private

--- a/libs/web-components/src/components/card-image/CardImage.svelte
+++ b/libs/web-components/src/components/card-image/CardImage.svelte
@@ -2,7 +2,9 @@
 
 <!-- Script -->
 <script lang="ts">
+  /** @required The URL of the image to display. */
   export let src: string;
+  /** Height of the image container. Accepts CSS values like "200px" or "100%". */
   export let height: string = "100%";
 </script>
 

--- a/libs/web-components/src/components/card-image/CardImage.svelte
+++ b/libs/web-components/src/components/card-image/CardImage.svelte
@@ -2,7 +2,7 @@
 
 <!-- Script -->
 <script lang="ts">
-  /** @required The URL of the image to display. */
+  /** The URL of the image to display. */
   export let src: string;
   /** Height of the image container. Accepts CSS values like "200px" or "100%". */
   export let height: string = "100%";

--- a/libs/web-components/src/components/card/Card.svelte
+++ b/libs/web-components/src/components/card/Card.svelte
@@ -5,17 +5,23 @@
   import type { Spacing } from "../../common/styling";
   import { calculateMargin } from "../../common/styling";
 
+  /** Adds a shadow to the card. 0 shows a border, 1-3 increase shadow intensity. */
   export let elevation: number = 0;
+  /** Sets the width of the card. */
   export let width: string = "100%";
+  /** Sets the height behavior. 'auto' fits content, 'max' fills available height. */
   export let height: "auto" | "max" = "auto";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
-  //optional
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 </script>
 

--- a/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
+++ b/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
@@ -25,17 +25,27 @@
     FieldsetErrorRelayDetail,
   } from "../../types/relay-types";
 
+  /** @required The name for the checkbox list group. Used for form submission. */
   export let name: string;
 
+  /** Array of currently selected checkbox values. */
   export let value: string[] = [];
+  /** Disables all checkboxes in the list. */
   export let disabled: string = "false";
+  /** Shows an error state on all checkboxes in the list. */
   export let error: string = "false";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Sets the maximum width of the checkbox list container. */
   export let maxwidth: string = "none";
 
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   type ChildRecord = { el: HTMLElement; name: string; label?: string };

--- a/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
+++ b/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
@@ -25,7 +25,7 @@
     FieldsetErrorRelayDetail,
   } from "../../types/relay-types";
 
-  /** @required The name for the checkbox list group. Used for form submission. */
+  /** The name for the checkbox list group. Used as group identifier in change events. */
   export let name: string;
 
   /** Array of currently selected checkbox values. */

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -53,7 +53,7 @@
   export let maxwidth: string = "none";
   /** Sets the size of the checkbox. 'compact' reduces spacing for dense layouts. */
   export let size: "default" | "compact" = "default";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
 
   /** Top margin. */

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -25,27 +25,44 @@
   } from "../../types/relay-types";
 
   // Required
+  /** Unique name to identify the checkbox. */
   export let name: string;
 
   // Optional values
+  /** Marks the checkbox item as selected. */
   export let checked: string = "false";
+  /** Shows a mixed/partial selection state. Used for 'Select All' checkboxes when some items are selected. */
   export let indeterminate: string = "false";
+  /** Label shown beside the checkbox. */
   export let text: string = "";
+  /** The value binding. */
   export let value: string = "";
+  /** Disable this control. It will not receive focus or events. */
   export let disabled: string = "false";
+  /** Shows an error on the checkbox item. */
   export let error: string = "false";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Defines how the text will be translated for the screen reader. If not specified it will fall back to the name. */
   export let arialabel: string = "";
+  /** Additional description text displayed below the checkbox label. */
   export let description: string = "";
-  export let revealarialabel: string = ""; // screen reader will announce this when reveal slot is displayed
+  /** Text announced by screen readers when the reveal slot content is displayed. */
+  export let revealarialabel: string = "";
+  /** Sets the maximum width of the checkbox. */
   export let maxwidth: string = "none";
+  /** Sets the size of the checkbox. 'compact' reduces spacing for dense layouts. */
   export let size: "default" | "compact" = "default";
+  /** The design system version for styling purposes. */
   export let version: "1" | "2" = "1";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // Private

--- a/libs/web-components/src/components/chip/Chip.svelte
+++ b/libs/web-components/src/components/chip/Chip.svelte
@@ -10,18 +10,28 @@
 
   type ChipVariant = "filter";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
+  /** @deprecated Use GoAFilterChip instead. Icon displayed at the start of the chip. */
   export let leadingicon: GoAIconType | null = null;
+  /** @deprecated Use GoAFilterChip instead. The icon theme - outline or filled. */
   export let icontheme: IconTheme = "outline";
+  /** @deprecated Use GoAFilterChip instead. Shows an error state on the chip. */
   export let error: string = "false";
+  /** @deprecated Use GoAFilterChip instead. When true, shows a delete icon and makes chip clickable. */
   export let deletable: string = "false";
+  /** @deprecated Use GoAFilterChip instead. The text content displayed in the chip. */
   export let content: string;
+  /** @deprecated Use GoAFilterChip instead. The chip variant style. */
   export let variant: ChipVariant;
+  /** @deprecated Use GoAFilterChip instead. Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   let el: HTMLElement;

--- a/libs/web-components/src/components/circular-progress/CircularProgress.svelte
+++ b/libs/web-components/src/components/circular-progress/CircularProgress.svelte
@@ -22,11 +22,17 @@
   type Variant = (typeof Variants)[number];
 
   // Optional
+  /** Stretch across the full screen or use it inline */
   export let variant: Variant = "inline";
+  /** Size of the progress indicator */
   export let size: Size = "large";
+  /** Loading message displayed under the progress indicator */
   export let message: string = "";
+  /** Set the progress value. Setting this value will change the type from infinite to progress */
   export let progress: number = -1;
+  /** Show/hide the page loader. This allows for fade transition to be applied in each transition. */
   export let visible: string = "false";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   $: isVisible = toBoolean(visible);

--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -47,17 +47,30 @@
 
   // Props
 
+  /** Sets the container and accent bar styling. */
+
   export let type: Type = "interactive";
+  /** Sets the style of accent on the container. */
   export let accent: Accent = "filled";
+  /** Sets the amount of white space in the container. */
   export let padding: Padding = "relaxed";
+  /** Sets the width of the container. */
   export let width: Width = "full";
+  /** Sets the maximum width of the container. */
   export let maxWidth: string = "none";
+  /** Sets the minimum height of the container. */
   export let minHeight = "";
+  /** Sets the maximum height of the container. */
   export let maxHeight = "";
+  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
   export let testid: string = "";
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = "m";
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // Private

--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -46,9 +46,7 @@
   type Width = (typeof Widths)[number];
 
   // Props
-
   /** Sets the container and accent bar styling. */
-
   export let type: Type = "interactive";
   /** Sets the style of accent on the container. */
   export let accent: Accent = "filled";
@@ -62,7 +60,7 @@
   export let minHeight = "";
   /** Sets the maximum height of the container. */
   export let maxHeight = "";
-  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
   /** Top margin. */
   export let mt: Spacing = null;

--- a/libs/web-components/src/components/data-grid/DataGrid.svelte
+++ b/libs/web-components/src/components/data-grid/DataGrid.svelte
@@ -15,8 +15,11 @@
   // Public
   // ******
 
+  /** Controls visibility of the keyboard navigation indicator icon. Use "visible" to show or "hidden" to hide. */
   export let keyboardIconVisibility: "visible" | "hidden" = "visible";
+  /** Navigation mode. "table" navigates like a table (up/down between rows), "layout" allows wrapping between rows with left/right arrows. */
   export let keyboardNav: "layout" | "table" = "table";
+  /** Position of the keyboard navigation indicator icon. */
   export let keyboardIconPosition: "left" | "right" = "left";
 
   // Reactive

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -31,26 +31,36 @@
     valueStr: string;
   };
 
+  /** Sets the date picker type. 'calendar' shows a calendar popup, 'input' shows just a date input. */
   export let type: "calendar" | "input" = "calendar";
+  /** Name of the date field. */
   export let name: string = "";
+  /** Value of the calendar date. */
   export let value: string = "";
+  /** Sets the input to an error state. */
   export let error: string = "false";
+  /** Minimum date value allowed. */
   export let min: string = "";
+  /** Maximum date value allowed. */
   export let max: string = "";
-  /***
-   * @deprecated This property has no effect and will be removed in a future version
-   */
+  /** @deprecated This property has no effect and will be removed in a future version. */
   export let relative: string = "";
+  /** Disables the date picker. */
   export let disabled: string = "false";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Sets the width of the date picker input. */
   export let width: string = "";
   export let size: "default" | "compact" = "default";
   export let version: "1" | "2" = "1";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   let _error: boolean = toBoolean(error);

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -51,7 +51,9 @@
   export let testid: string = "";
   /** Sets the width of the date picker input. */
   export let width: string = "";
+  /** Sets the size of the date picker. 'compact' reduces height for dense layouts. */
   export let size: "default" | "compact" = "default";
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
 
   /** Top margin. */

--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -10,13 +10,22 @@
   } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
 
+  /** @required The title heading */
+
   export let heading: string;
+  /** Sets the maximum width of the details. */
   export let maxwidth: string = "75ch";
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
+  /** Controls if details is expanded or not. */
   export let open: string = "false";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   let _isMouseOver: boolean = false;

--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -10,8 +10,7 @@
   } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
 
-  /** @required The title heading */
-
+  /** @required The title heading. */
   export let heading: string;
   /** Sets the maximum width of the details. */
   export let maxwidth: string = "75ch";

--- a/libs/web-components/src/components/divider/Divider.svelte
+++ b/libs/web-components/src/components/divider/Divider.svelte
@@ -4,12 +4,17 @@
   import { calculateMargin } from "../../common/styling";
   import type { Spacing } from "../../common/styling";
 
+  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
+
   export let testid: string = "";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 </script>
 

--- a/libs/web-components/src/components/divider/Divider.svelte
+++ b/libs/web-components/src/components/divider/Divider.svelte
@@ -4,8 +4,7 @@
   import { calculateMargin } from "../../common/styling";
   import type { Spacing } from "../../common/styling";
 
-  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
-
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   /** Top margin. */

--- a/libs/web-components/src/components/drawer/Drawer.svelte
+++ b/libs/web-components/src/components/drawer/Drawer.svelte
@@ -16,10 +16,15 @@
   // Public
   // ******
 
+  /** @required Whether the drawer is open. */
   export let open = false;
+  /** @required The position of the drawer. */
   export let position: DrawerPosition = undefined;
+  /** The heading text displayed at the top of the drawer. */
   export let heading: string = "";
-  export let maxsize: DrawerSize = undefined; // is set based on the anchor value
+  /** Sets max height on bottom position, sets width on left and right position. */
+  export let maxsize: DrawerSize = undefined;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "drawer";
   // *******
   // Private

--- a/libs/web-components/src/components/drawer/Drawer.svelte
+++ b/libs/web-components/src/components/drawer/Drawer.svelte
@@ -16,9 +16,9 @@
   // Public
   // ******
 
-  /** @required Whether the drawer is open. */
+  /** Whether the drawer is open. */
   export let open = false;
-  /** @required The position of the drawer. */
+  /** The position of the drawer. */
   export let position: DrawerPosition = undefined;
   /** The heading text displayed at the top of the drawer. */
   export let heading: string = "";

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -52,38 +52,57 @@
 
   // Props
 
+  /** @required Identifier for the dropdown. Should be unique. */
   export let name: string;
+  /** Defines how the selected value will be translated for the screen reader. If not specified it will fall back to the name. */
   export let arialabel: string = "";
+  /** The aria-labelledby attribute identifies the element(or elements) that labels the dropdown it is applied to. Normally it is the id of the label. */
   export let arialabelledby: string = "";
+  /** Stores the value of the item selected from the dropdown. */
   export let value: string | undefined = "";
+  /** When true the dropdown will have the ability to filter options by typing into the input field. */
   export let filterable: string = "false";
+  /** Show an icon to the left of the dropdown option. */
   export let leadingicon: GoAIconType | null = null;
+  /** Maximum height of the dropdown menu items popover. Non-native only. */
   export let maxheight: string = "276px";
+  /** The text displayed for the dropdown before a selection is made. Non-native only. */
   export let placeholder: string = "";
+  /** Overrides the autosized menu width. Non-native only. */
   export let width: string = "";
+  /** Sets the maximum width of the dropdown. Use a CSS unit (px, %, ch, rem, em). */
   export let maxwidth: string = "";
+  /** Disable this control. */
   export let disabled: string = "false";
+  /** Show an error state. */
   export let error: string = "false";
+  /** When true, allows multiple items to be selected. */
   export let multiselect: string = "false";
+  /** When true will render the native select HTML element. */
   export let native: string = "false";
+  /** Sets the size of the dropdown. Compact reduces height for dense layouts. */
   export let size: "default" | "compact" = "default";
+  /** The design system version for styling purposes. */
   export let version: "1" | "2" = "1";
 
-  /***
-   * @deprecated This property has no effect and will be removed in a future version
-   */
+  /** @deprecated This property has no effect and will be removed in a future version. */
   export let relative: string = "";
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
+  /** Specifies the autocomplete attribute for the dropdown input. Native only. */
   export let autocomplete: string = "";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
-  /**
-   * Exposed Privates
-   **/
+  // Exposed Privates
 
+  /** Prevents the popover from closing when clicking outside. Used for nested dropdowns or complex interactions. */
   export let disableGlobalClosePopover: boolean = false;
 
   //

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -62,9 +62,9 @@
   export let value: string | undefined = "";
   /** When true the dropdown will have the ability to filter options by typing into the input field. */
   export let filterable: string = "false";
-  /** Show an icon to the left of the dropdown option. */
+  /** Icon shown to the left of the dropdown input. */
   export let leadingicon: GoAIconType | null = null;
-  /** Maximum height of the dropdown menu items popover. Non-native only. */
+  /** Maximum height of the dropdown menu. Non-native only. */
   export let maxheight: string = "276px";
   /** The text displayed for the dropdown before a selection is made. Non-native only. */
   export let placeholder: string = "";
@@ -76,13 +76,13 @@
   export let disabled: string = "false";
   /** Show an error state. */
   export let error: string = "false";
-  /** When true, allows multiple items to be selected. */
+  /** @internal When true, allows multiple items to be selected. Not currently exposed. */
   export let multiselect: string = "false";
   /** When true will render the native select HTML element. */
   export let native: string = "false";
   /** Sets the size of the dropdown. Compact reduces height for dense layouts. */
   export let size: "default" | "compact" = "default";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
 
   /** @deprecated This property has no effect and will be removed in a future version. */

--- a/libs/web-components/src/components/dropdown/DropdownItem.svelte
+++ b/libs/web-components/src/components/dropdown/DropdownItem.svelte
@@ -33,9 +33,13 @@
 
   // Props
 
+  /** Text used to filter and match this item in typeahead search. */
   export let filter: string = "";
+  /** Display label for the dropdown item. */
   export let label: string = "";
+  /** The value submitted when this item is selected. */
   export let value: string = "";
+  /** Controls how the item is registered with the parent dropdown. */
   export let mount: DropdownItemMountType = "reset";
 
   let _rootEl: HTMLElement;

--- a/libs/web-components/src/components/file-upload-card/FileUploadCard.svelte
+++ b/libs/web-components/src/components/file-upload-card/FileUploadCard.svelte
@@ -5,11 +5,17 @@
 
   // Public
 
+  /** @required The name of the uploaded file to display. */
   export let filename: string;
+  /** @required The file size in bytes. Displayed in a human-readable format (KB, MB). */
   export let size: number;
+  /** The MIME type of the file. Used to determine the file type icon. */
   export let type: string = "";
+  /** Upload progress percentage from 0-100. Use -1 to indicate upload is complete. */
   export let progress: number = -1;
+  /** Error message to display. When set, the card shows an error state with a cancel button. */
   export let error: string = "";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   // Private

--- a/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
+++ b/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
@@ -16,7 +16,7 @@
   export let variant: Variant = "dragdrop";
   /** Accepted file types as a comma-separated list of MIME types or file extensions (e.g., "image/*,.pdf"). */
   export let accept: string = "*";
-  /** Maximum file size with unit (e.g., "5MB", "100KB", "1GB"). Files exceeding this will be rejected. */
+  /** Maximum file size with unit (e.g., "5MB", "100KB", "1GB"). Defaults to 5MB. Files exceeding this will be rejected. */
   export let maxfilesize: string = "5MB";
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";

--- a/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
+++ b/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
@@ -12,9 +12,13 @@
 
   // Public
 
+  /** The input display variant. "dragdrop" shows a drag-and-drop area, "button" shows a simple button. */
   export let variant: Variant = "dragdrop";
+  /** Accepted file types as a comma-separated list of MIME types or file extensions (e.g., "image/*,.pdf"). */
   export let accept: string = "*";
+  /** Maximum file size with unit (e.g., "5MB", "100KB", "1GB"). Files exceeding this will be rejected. */
   export let maxfilesize: string = "5MB";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   // Private

--- a/libs/web-components/src/components/filter-chip/FilterChip.svelte
+++ b/libs/web-components/src/components/filter-chip/FilterChip.svelte
@@ -29,7 +29,7 @@
   export let testid: string = "";
   /** Accessible label for the filter chip. Defaults to content with 'removable' suffix. */
   export let ariaLabel: string = "";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
 
   // Private variables

--- a/libs/web-components/src/components/filter-chip/FilterChip.svelte
+++ b/libs/web-components/src/components/filter-chip/FilterChip.svelte
@@ -7,19 +7,29 @@
   import { calculateMargin } from "../../common/styling";
   import type { GoAIconType } from "../icon/Icon.svelte";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // Props
+  /** Shows an error state. */
   export let error: string = "false";
+  /** @required Text label of the chip. */
   export let content: string;
+  /** Secondary text displayed in a smaller size before the main content. */
   export let secondarytext: string = "";
+  /** Icon displayed at the start of the chip. */
   export let leadingicon: GoAIconType | null = null;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Accessible label for the filter chip. Defaults to content with 'removable' suffix. */
   export let ariaLabel: string = "";
+  /** The design system version for styling purposes. */
   export let version: "1" | "2" = "1";
 
   // Private variables

--- a/libs/web-components/src/components/focus-trap/FocusTrap.svelte
+++ b/libs/web-components/src/components/focus-trap/FocusTrap.svelte
@@ -15,9 +15,10 @@
   import { findFirstFocusableNode } from "../../common/utils";
 
   // Public
-  // allow for outside control of whether focus trap should re-focus the first element is open/closed (see Drawer)
-  export let open: boolean = false;
 
+  /** Controls whether the focus trap is active. When true, focuses the first focusable element. */
+  export let open: boolean = false;
+  /** When true, prevents automatically scrolling focused elements into view. */
   export let preventScrollIntoView: boolean = false;
 
   // Private

--- a/libs/web-components/src/components/footer-meta-section/FooterMetaSection.svelte
+++ b/libs/web-components/src/components/footer-meta-section/FooterMetaSection.svelte
@@ -4,6 +4,7 @@
   import { onMount, tick } from "svelte";
   import { getSlottedChildren } from "../../common/utils";
 
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   let rootEl: HTMLElement;

--- a/libs/web-components/src/components/footer-nav-section/FooterNavSection.svelte
+++ b/libs/web-components/src/components/footer-nav-section/FooterNavSection.svelte
@@ -3,8 +3,11 @@
 <script lang="ts">
   import { onMount, tick } from "svelte";
 
+  /** The section heading displayed above the navigation links. */
   export let heading: string = "";
+  /** Maximum number of columns to display links in on larger screens. */
   export let maxcolumncount: number = 1;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   let rootEl: HTMLElement;

--- a/libs/web-components/src/components/footer/Footer.svelte
+++ b/libs/web-components/src/components/footer/Footer.svelte
@@ -4,8 +4,11 @@
   import { onMount, tick } from "svelte";
   import { MOBILE_BP } from "../../common/breakpoints";
 
+  /** The maximum width of the main content area */
   export let maxcontentwidth: string = "";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** URL for the Government of Alberta logo link. Set to empty string to disable the link. */
   export let url: string = "https://alberta.ca";
 
   let rootEl: HTMLElement;

--- a/libs/web-components/src/components/form-item/FormItem.svelte
+++ b/libs/web-components/src/components/form-item/FormItem.svelte
@@ -84,7 +84,7 @@
   export let requirement: RequirementType = "";
   /** Sets the maximum width of the form item. */
   export let maxwidth: string = "none";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: VersionType = "1";
   /** Specifies the input type for appropriate message spacing. Used with checkbox-list or radio-group. */
   export let type: InputType = "";

--- a/libs/web-components/src/components/form-item/FormItem.svelte
+++ b/libs/web-components/src/components/form-item/FormItem.svelte
@@ -59,26 +59,39 @@
   type VersionType = (typeof Version)[number];
   type InputType = (typeof INPUT_TYPES)[number];
 
-  // margin
+  // Margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // Optional
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Creates a label for the form item. */
   export let label: string = "";
+  /** Sets the label size. 'compact' for dense layouts, 'regular' for standard, 'large' for emphasis. */
   export let labelsize: LabelSizeType = "regular";
+  /** Help text displayed under the form field to provide additional explanation. */
   export let helptext: string = "";
+  /** Error text displayed under the form field. Leave blank to indicate a valid field. */
   export let error: string = "";
+  /** Marks the field with an optional or required label indicator. */
   export let requirement: RequirementType = "";
+  /** Sets the maximum width of the form item. */
   export let maxwidth: string = "none";
+  /** The design system version for styling purposes. */
   export let version: VersionType = "1";
+  /** Specifies the input type for appropriate message spacing. Used with checkbox-list or radio-group. */
   export let type: InputType = "";
 
-  // **For the public-form only**
-  // Overrides the label value within the form-summary to provide a shorter description of the value
+  /** Overrides the label value within the form-summary. For public-form use only. */
   export let name: string = "blank";
+  /** Sets the display order within the form summary. For public-form use only. */
   export let publicFormSummaryOrder: number = 0;
 
   let _rootEl: HTMLElement;

--- a/libs/web-components/src/components/form-step/FormStep.svelte
+++ b/libs/web-components/src/components/form-step/FormStep.svelte
@@ -21,8 +21,11 @@
   // Public
   // ======
 
+  /** @required The step label text displayed to users. */
   export let text: string;
+  /** The completion status of the step. Affects visual styling and icons. */
   export let status: FormStepStatus | undefined = undefined;
+  /** Whether this is the last step in the form stepper. Affects styling when complete. */
   export let last: string = "false";
 
   // Set by FormStepper parent component

--- a/libs/web-components/src/components/form-stepper/FormStepper.svelte
+++ b/libs/web-components/src/components/form-stepper/FormStepper.svelte
@@ -12,12 +12,17 @@
   // Public
   // ======
 
-  // this is a 1-based index, -1 is the unset value
+  /** The current step state value (1-based index). Leaving it blank (-1) will allow any step to be accessed. */
   export let step: number = -1;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // =======

--- a/libs/web-components/src/components/form/Form.svelte
+++ b/libs/web-components/src/components/form/Form.svelte
@@ -46,13 +46,14 @@
   // Required
   // ========
 
+  /** The initialization status of the form. Set to "initializing" while loading external state, then "complete" when ready. */
   export let status: "initializing" | "complete" = "complete";
 
   // ========
   // Optional
   // ========
 
-  // Helps when debugging complex forms
+  /** A name identifier for the form. Useful for debugging complex forms with multiple nested forms. */
   export let name: string = "[name] not set";
 
   // =======

--- a/libs/web-components/src/components/grid/Grid.svelte
+++ b/libs/web-components/src/components/grid/Grid.svelte
@@ -7,12 +7,11 @@
   import { validateRequired } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
 
-  /** Gap between child items */
-
+  /** Gap between child items. */
   export let gap: Spacing = "m";
   /** @required Minimum width of the child elements */
   export let minchildwidth: string = "";
-  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   /** Top margin. */

--- a/libs/web-components/src/components/grid/Grid.svelte
+++ b/libs/web-components/src/components/grid/Grid.svelte
@@ -7,14 +7,21 @@
   import { validateRequired } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
 
+  /** Gap between child items */
+
   export let gap: Spacing = "m";
+  /** @required Minimum width of the child elements */
   export let minchildwidth: string = "";
+  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
   export let testid: string = "";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   onMount(() => {

--- a/libs/web-components/src/components/hero-banner/HeroBanner.svelte
+++ b/libs/web-components/src/components/hero-banner/HeroBanner.svelte
@@ -2,12 +2,19 @@
 
 <!-- Script -->
 <script lang="ts">
+  /** Main heading text */
   export let heading: string;
+  /** Background image url */
   export let backgroundurl: string;
+  /** Minimum height of the hero banner. Defaults to 600px when a background image is provided. */
   export let minheight: string;
+  /** Maximum width of the content area */
   export let maxcontentwidth = "100%";
+  /** Hero Banner background color when no background image is provided */
   export let backgroundcolor: string = "#f8f8f8";
+  /** Text color within the hero banner */
   export let textcolor: string = "";
+  /** Test ID for the component */
   export let testid: string = "background";
 
   /* Set minheight to support old default value of 600px */

--- a/libs/web-components/src/components/hero-banner/HeroBanner.svelte
+++ b/libs/web-components/src/components/hero-banner/HeroBanner.svelte
@@ -12,9 +12,9 @@
   export let maxcontentwidth = "100%";
   /** Hero Banner background color when no background image is provided */
   export let backgroundcolor: string = "#f8f8f8";
-  /** Text color within the hero banner */
+  /** Text color within the hero banner. */
   export let textcolor: string = "";
-  /** Test ID for the component */
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "background";
 
   /* Set minheight to support old default value of 600px */

--- a/libs/web-components/src/components/icon-button/IconButton.svelte
+++ b/libs/web-components/src/components/icon-button/IconButton.svelte
@@ -23,7 +23,6 @@
 
   type Variant = (typeof Variants)[number];
 
-  // required
   /** @required Sets the icon. */
   export let icon: GoAIconType;
 
@@ -36,7 +35,7 @@
   export let variant: Variant = "color";
   /** Sets the title of the button. */
   export let title: string = "";
-  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
   /** Disables the button. */
   export let disabled: string = "false";
@@ -53,9 +52,11 @@
   export let mb: Spacing = null;
   /** Left margin. */
   export let ml: Spacing = null;
-
+  /** Action identifier passed in click events for event delegation patterns. */
   export let action: string = "";
+  /** Single argument value passed with the action in click events. */
   export let actionArg: string = "";
+  /** Multiple argument values passed with the action in click events. */
   export let actionArgs: Record<string, unknown> = {};
 
   // private

--- a/libs/web-components/src/components/icon-button/IconButton.svelte
+++ b/libs/web-components/src/components/icon-button/IconButton.svelte
@@ -24,22 +24,34 @@
   type Variant = (typeof Variants)[number];
 
   // required
+  /** @required Sets the icon. */
   export let icon: GoAIconType;
 
   // optional
+  /** Sets the size of button. */
   export let size: IconSize = "medium";
+  /** Sets the icon theme. 'outline' for stroked icons, 'filled' for solid icons. */
   export let theme: IconTheme = "outline";
+  /** Styles the button to show color, light, dark or destructive action. */
   export let variant: Variant = "color";
+  /** Sets the title of the button. */
   export let title: string = "";
+  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
   export let testid: string = "";
+  /** Disables the button. */
   export let disabled: string = "false";
+  /** When true, inverts the icon colors for use on dark backgrounds. */
   export let inverted: string = "false";
+  /** Sets the aria-label of the button. */
   export let arialabel: string = "";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   export let action: string = "";

--- a/libs/web-components/src/components/icon/Icon.svelte
+++ b/libs/web-components/src/components/icon/Icon.svelte
@@ -553,27 +553,43 @@
     | `${GoAIconType}:${IconTheme}`
     | `${GoAIconOverridesType}:${IconTheme}`;
 
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // Required
 
+  /** @required The icon type to display. See GoAIconType for available icons. */
   export let type: GoAIconType | GoAIconOverridesType | GoAIconTypeWithTheme;
 
   // Optional
 
+  /** Sets the size of the icon. Accepts numeric (1-6) or named sizes. */
   export let size: IconSize = "medium";
+  /** Sets the icon theme. 'outline' shows stroked icons, 'filled' shows solid icons. */
   export let theme: IconTheme = "outline";
+  /** When true, inverts the icon colors for use on dark backgrounds. */
   export let inverted: string = "false";
+  /** Sets a custom fill color for the icon. Accepts any valid CSS color value. */
   export let fillcolor: string = "";
+  /** Sets the opacity of the icon from 0 (transparent) to 1 (opaque). */
   export let opacity: number = 1;
+  /** Adds an accessible title to the icon SVG. Used by screen readers. */
   export let title: string = "";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Defines how the icon will be announced by screen readers. */
   export let arialabel: string = "";
+  /** Identifies the element(s) whose contents or presence are controlled by this icon. */
   export let ariacontrols: string = "";
+  /** Indicates whether the element controlled by this icon is expanded or collapsed. */
   export let ariaexpanded: string = "";
+  /** Sets the ARIA role for the icon. Defaults to 'img'. Use 'presentation' for decorative icons. */
   export let role: string = "img";
 
   let _iconType: GoAIconType | GoAIconOverridesType;

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -68,97 +68,66 @@
 
   /** Sets the type of the input field. */
   export let type: Type = "text";
-
   /** Name of input value that is received in the onChange event. */
   export let name: string = "";
-
   /** Bound to value. */
   export let value: string = "";
-
   /** Controls whether and how text input is automatically capitalized as it is entered/edited by the user. This only works on mobile devices. */
   export let autocapitalize: AutoCapitalize = "off";
-
   /** Specifies the autocomplete attribute for the input field. */
   export let autocomplete: string = "";
-
   /** Text displayed within the input when no value is set. */
   export let placeholder: string = "";
-
   /** Icon shown to the left of the text. */
   export let leadingicon: GoAIconType | null = null;
-
   /** Icon shown to the right of the text. */
   export let trailingicon: GoAIconType | null = null;
-
   /** Sets the visual style variant. 'goa' for standard GoA styling, 'bare' for minimal styling. */
   export let variant: GoAInputVariant = "goa";
-
   /** Disables this input. The input will not receive focus or events. Use [attr.disabled] with [formControl]. */
   export let disabled: string = "false";
-
   /** Flag that will result in an icon button component being rendered instead of an icon. */
   export let handletrailingiconclick: string = "false";
-
   /** Sets the cursor focus to the input. */
   export let focused: string = "false";
-
   /** Makes the input readonly. */
   export let readonly: string = "false";
-
   /** Sets the input to an error state. */
   export let error: string = "false";
-
-  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
-
   /** Sets the width of the text input area. */
   export let width: string = "30ch";
-
   /** Defines how the input will be translated for the screen reader. If not specified it will fall back to the name. */
   export let arialabel: string = "";
-
   /** The aria-labelledby attribute identifies the element (or elements) that labels the input. */
   export let arialabelledby: string = "";
-
   /** A string value that supports any number, or an ISO 8601 format if using the date or datetime type. */
   export let min: string = "";
-
   /** A string value that supports any number, or an ISO 8601 format if using the date or datetime type. */
   export let max: string = "";
-
-  /** How much a number or date should changed by. */
+  /** How much a number or date should change by. */
   export let step: number = 1;
-
   /** @deprecated Use leadingContent slot instead. */
   export let prefix: string = "";
-
   /** @deprecated Use trailingContent slot instead. */
   export let suffix: string = "";
-
   /** Debounce delay in milliseconds before firing the change event. 0 means no debounce. */
   export let debounce: number = 0;
-
   /** Defines the maximum number of characters (as UTF-16 code units) the user can enter into the input. */
   export let maxlength: number | null = null;
-
   /** Unique identifier for the input element. Used for label associations and accessibility. */
   export let id: string = "";
-
-  /** Apply margin to the top of the component. */
+  /** Top margin. */
   export let mt: Spacing = null;
-
-  /** Apply margin to the right of the component. */
+  /** Right margin. */
   export let mr: Spacing = null;
-
-  /** Apply margin to the bottom of the component. */
+  /** Bottom margin. */
   export let mb: Spacing = null;
-
-  /** Apply margin to the left of the component. */
+  /** Left margin. */
   export let ml: Spacing = null;
-
   /** Aria label for the trailing icon. Use only when the trailing icon is interactive. */
   export let trailingiconarialabel: string = "";
-
   /** Sets the text alignment within the input field. */
   export let textalign: TextAlign = "left";
 

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -66,39 +66,105 @@
   type AutoCapitalize = (typeof AutoCapitalize)[number];
   type TextAlign = (typeof TextAlign)[number];
 
+  /** Sets the type of the input field. */
   export let type: Type = "text";
+
+  /** @required Name of input value that is received in the onChange event. */
   export let name: string = "";
+
+  /** Bound to value. */
   export let value: string = "";
+
+  /** Controls whether and how text input is automatically capitalized as it is entered/edited by the user. This only works on mobile devices. */
   export let autocapitalize: AutoCapitalize = "off";
+
+  /** Specifies the autocomplete attribute for the input field. */
   export let autocomplete: string = "";
+
+  /** Text displayed within the input when no value is set. */
   export let placeholder: string = "";
+
+  /** Icon shown to the left of the text. */
   export let leadingicon: GoAIconType | null = null;
+
+  /** Icon shown to the right of the text. */
   export let trailingicon: GoAIconType | null = null;
+
+  /** Sets the visual style variant. 'goa' for standard GoA styling, 'bare' for minimal styling. */
   export let variant: GoAInputVariant = "goa";
+
+  /** Disables this input. The input will not receive focus or events. Use [attr.disabled] with [formControl]. */
   export let disabled: string = "false";
+
+  /** Flag that will result in an icon button component being rendered instead of an icon. */
   export let handletrailingiconclick: string = "false";
+
+  /** Sets the cursor focus to the input. */
   export let focused: string = "false";
+
+  /** Makes the input readonly. */
   export let readonly: string = "false";
+
+  /** Sets the input to an error state. */
   export let error: string = "false";
+
+  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
   export let testid: string = "";
+
+  /** Sets the width of the text input area. */
   export let width: string = "30ch";
+
+  /** Defines how the input will be translated for the screen reader. If not specified it will fall back to the name. */
   export let arialabel: string = "";
+
+  /** The aria-labelledby attribute identifies the element (or elements) that labels the input. */
   export let arialabelledby: string = "";
+
+  /** A string value that supports any number, or an ISO 8601 format if using the date or datetime type. */
   export let min: string = "";
+
+  /** A string value that supports any number, or an ISO 8601 format if using the date or datetime type. */
   export let max: string = "";
+
+  /** How much a number or date should changed by. */
   export let step: number = 1;
+
+  /** @deprecated Use leadingContent slot instead. */
   export let prefix: string = "";
+
+  /** @deprecated Use trailingContent slot instead. */
   export let suffix: string = "";
+
+  /** Debounce delay in milliseconds before firing the change event. 0 means no debounce. */
   export let debounce: number = 0;
+
+  /** Defines the maximum number of characters (as UTF-16 code units) the user can enter into the input. */
   export let maxlength: number | null = null;
+
+  /** Unique identifier for the input element. Used for label associations and accessibility. */
   export let id: string = "";
+
+  /** Apply margin to the top of the component. */
   export let mt: Spacing = null;
+
+  /** Apply margin to the right of the component. */
   export let mr: Spacing = null;
+
+  /** Apply margin to the bottom of the component. */
   export let mb: Spacing = null;
+
+  /** Apply margin to the left of the component. */
   export let ml: Spacing = null;
+
+  /** Aria label for the trailing icon. Use only when the trailing icon is interactive. */
   export let trailingiconarialabel: string = "";
+
+  /** Sets the text alignment within the input field. */
   export let textalign: TextAlign = "left";
+
+  /** Sets the size of the input. 'compact' reduces height for dense layouts. */
   export let size: "default" | "compact" = "default";
+  /** The design system version for styling purposes. */
   export let version: "1" | "2" = "1";
 
   let _leadingContentSlot = false;

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -130,10 +130,9 @@
   export let trailingiconarialabel: string = "";
   /** Sets the text alignment within the input field. */
   export let textalign: TextAlign = "left";
-
   /** Sets the size of the input. 'compact' reduces height for dense layouts. */
   export let size: "default" | "compact" = "default";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
 
   let _leadingContentSlot = false;

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -69,7 +69,7 @@
   /** Sets the type of the input field. */
   export let type: Type = "text";
 
-  /** @required Name of input value that is received in the onChange event. */
+  /** Name of input value that is received in the onChange event. */
   export let name: string = "";
 
   /** Bound to value. */

--- a/libs/web-components/src/components/linear-progress/LinearProgress.svelte
+++ b/libs/web-components/src/components/linear-progress/LinearProgress.svelte
@@ -12,10 +12,15 @@
 />
 
 <script lang="ts">
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string | undefined = undefined;
+  /** Progress value (0-100). When undefined, shows an indeterminate loading animation. */
   export let progress: number | undefined = undefined;
+  /** Controls visibility of the percentage text. */
   export let percentVisibility: "visible" | "hidden" = "visible";
+  /** Accessible label for the progress bar. */
   export let ariaLabel: string | undefined = undefined;
+  /** ID of the element that labels this progress bar. */
   export let ariaLabelledby: string | undefined = undefined;
 
   $: isDeterminate = progress !== undefined && progress !== null;

--- a/libs/web-components/src/components/link-button/LinkButton.svelte
+++ b/libs/web-components/src/components/link-button/LinkButton.svelte
@@ -12,12 +12,19 @@
   import { dispatch } from "../../common/utils";
   import { GoAIconType } from "../icon/Icon.svelte";
 
+  /** Sets the color theme. 'interactive' for blue, 'light' for white on dark backgrounds. */
   export let color: "interactive" | "light" = "interactive";
+  /** Icon displayed before the button text. */
   export let leadingicon: GoAIconType;
+  /** Icon displayed after the button text. */
   export let trailingicon: GoAIconType;
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   export let action: string = "";

--- a/libs/web-components/src/components/link-button/LinkButton.svelte
+++ b/libs/web-components/src/components/link-button/LinkButton.svelte
@@ -26,9 +26,11 @@
   export let mb: Spacing = null;
   /** Left margin. */
   export let ml: Spacing = null;
-
+  /** Action identifier passed in click events for event delegation patterns. */
   export let action: string = "";
+  /** Single argument value passed with the action in click events. */
   export let actionArg: string = "";
+  /** Multiple argument values passed with the action in click events. */
   export let actionArgs: Record<string, unknown> = {};
 
   let _el: HTMLButtonElement;

--- a/libs/web-components/src/components/link/Link.svelte
+++ b/libs/web-components/src/components/link/Link.svelte
@@ -13,20 +13,32 @@
   import { GoAIconType } from "../icon/Icon.svelte";
   import { onMount } from "svelte";
 
+  /** Icon displayed before the link text. */
   export let leadingicon: GoAIconType | null = null;
+  /** Icon displayed after the link text. */
   export let trailingicon: GoAIconType | null = null;
+  /** Sets the color theme. 'interactive' for blue, 'dark' for black, 'light' for white text. */
   export let color: "interactive" | "dark" | "light" = "interactive";
+  /** Sets the text size and corresponding icon size. */
   export let size: "xsmall" | "small" | "medium" | "large" = "medium";
 
+  /** Custom action event name to dispatch when the link is clicked. */
   export let action: string = "";
+  /** Single argument to pass with the action event (deprecated, use actionArgs). */
   export let actionArg: string = "";
+  /** Object of arguments to pass with the action event. */
   export let actionArgs: Record<string, unknown> = {};
 
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   let _rootEl: HTMLElement;

--- a/libs/web-components/src/components/menu-button/MenuAction.svelte
+++ b/libs/web-components/src/components/menu-button/MenuAction.svelte
@@ -21,9 +21,13 @@
   import { onMount } from "svelte";
   import { receive, relay, style, styles } from "../../common/utils";
 
+  /** Display text for the menu action. */
   export let text: string = "";
+  /** Action identifier included in the click event. */
   export let action: string = "default";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Icon displayed before the text. */
   export let icon: GoAIconType | undefined = undefined;
 
   let _el: HTMLElement;

--- a/libs/web-components/src/components/menu-button/MenuButton.svelte
+++ b/libs/web-components/src/components/menu-button/MenuButton.svelte
@@ -16,10 +16,15 @@
 
   // Public props
 
+  /** The button label text. When provided, displays as a text button with a dropdown icon. */
   export let text: string;
+  /** The button style variant. */
   export let type: "primary" | "secondary" | "tertiary" = "primary";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Icon displayed before the button text. When no text is provided, displays as an icon button. */
   export let leadingIcon: GoAIconType | undefined = undefined;
+  /** Maximum width of the dropdown menu. */
   export let maxWidth: string;
 
   // Private props

--- a/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
+++ b/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
@@ -17,13 +17,13 @@
 
   /** @required The service type which determines the badge style. "live" shows official government site text, "alpha" and "beta" show development stage badges. */
   export let type: Type;
-  /** Version number or identifier displayed in the header. */
+  /** App or service version displayed on the right side of the header. */
   export let version: string = "";
   /** Url to feedback page that will be displayed when provided. */
   export let feedbackurl: string = "";
   /** Maximum width of the content area */
   export let maxcontentwidth = "100%";
-  /** For internal header urls sets target= */
+  /** Sets the target attribute for the header link. */
   export let headerurltarget: UrlTargetType = "blank";
   /** For internal feedback urls sets target= */
   export let feedbackurltarget: UrlTargetType = "blank";

--- a/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
+++ b/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
@@ -15,13 +15,21 @@
   // Type
   type Type = (typeof Types)[number];
 
+  /** @required The service type which determines the badge style. "live" shows official government site text, "alpha" and "beta" show development stage badges. */
   export let type: Type;
+  /** Version number or identifier displayed in the header. */
   export let version: string = "";
+  /** Url to feedback page that will be displayed when provided. */
   export let feedbackurl: string = "";
+  /** Maximum width of the content area */
   export let maxcontentwidth = "100%";
+  /** For internal header urls sets target= */
   export let headerurltarget: UrlTargetType = "blank";
+  /** For internal feedback urls sets target= */
   export let feedbackurltarget: UrlTargetType = "blank";
+  /** When true, enables a custom feedback click handler via the _feedbackClick event instead of navigating to feedbackurl. */
   export let hasfeedbackhandler: string = "false";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   // Validator

--- a/libs/web-components/src/components/modal/Modal.svelte
+++ b/libs/web-components/src/components/modal/Modal.svelte
@@ -32,7 +32,7 @@
   export let maxwidth: string = "60ch";
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "modal";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: VersionType = "1";
 
   /** @deprecated Use maxwidth instead. */

--- a/libs/web-components/src/components/modal/Modal.svelte
+++ b/libs/web-components/src/components/modal/Modal.svelte
@@ -18,16 +18,24 @@
   // Public
   // ******
 
+  /** The heading text displayed at the top of the modal. */
   export let heading: string = "";
+  /** Show close icon and allow clicking the background to close the modal. */
   export let closable: string = "false";
+  /** Controls if modal is visible or not. */
   export let open: string = "false";
+  /** Sets the animation transition when opening/closing. 'fast' or 'slow' for animated, 'none' for instant. */
   export let transition: Transition = "none";
+  /** Define the context and colour of the callout modal. It is required when type is set to callout. */
   export let calloutvariant: CalloutVariant | null = null;
+  /** Set the max allowed width of the modal. */
   export let maxwidth: string = "60ch";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "modal";
+  /** The design system version for styling purposes. */
   export let version: VersionType = "1";
 
-  // @deprecated: use maxwidth
+  /** @deprecated Use maxwidth instead. */
   export let width: string = "";
 
   // *******

--- a/libs/web-components/src/components/notification/Notification.svelte
+++ b/libs/web-components/src/components/notification/Notification.svelte
@@ -28,12 +28,19 @@
   type AriaLiveType = (typeof AriaLiveTypes)[number];
   type EmphasisType = (typeof EmphasisTypes)[number];
 
+  /** Define the context and colour of the notification. */
   export let type: NotificationType = "";
+  /** Maximum width of the content area. */
   export let maxcontentwidth = "100%";
+  /** Indicates how assistive technology should handle updates to the live region. */
   export let arialive: AriaLiveType = "polite";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** The design system version for styling purposes. */
   export let version: "1" | "2" = "1";
+  /** Sets the visual prominence. 'high' for full background, 'filled' for medium. */
   export let emphasis: EmphasisType = "high";
+  /** When true, reduces padding for a more compact notification. */
   export let compact: boolean = false;
 
   let show = true;

--- a/libs/web-components/src/components/notification/Notification.svelte
+++ b/libs/web-components/src/components/notification/Notification.svelte
@@ -36,7 +36,7 @@
   export let arialive: AriaLiveType = "polite";
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
   /** Sets the visual prominence. 'high' for full background, 'filled' for medium. */
   export let emphasis: EmphasisType = "high";

--- a/libs/web-components/src/components/page-block/PageBlock.svelte
+++ b/libs/web-components/src/components/page-block/PageBlock.svelte
@@ -11,7 +11,10 @@
   };
 
   // Optional
+
+  /** Maximum width of the content area. Use "full" for 100% width or a CSS dimension like "1200px". */
   export let width: Size = "full";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   // Private

--- a/libs/web-components/src/components/pages/Pages.svelte
+++ b/libs/web-components/src/components/pages/Pages.svelte
@@ -6,11 +6,15 @@
   import type { Spacing } from "../../common/styling";
   import { getSlottedChildren } from "../../common/utils";
 
-  // Public
-  export let current: number = 1; // 1-based
+  /** The currently visible page (1-based index). */
+  export let current: number = 1;
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // Private

--- a/libs/web-components/src/components/pagination/Pagination.svelte
+++ b/libs/web-components/src/components/pagination/Pagination.svelte
@@ -16,7 +16,7 @@
 
   // public
 
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: Version = "1";
   /** @required The current page being viewed (non-zero based). */
   export let pagenumber: number;

--- a/libs/web-components/src/components/pagination/Pagination.svelte
+++ b/libs/web-components/src/components/pagination/Pagination.svelte
@@ -16,15 +16,25 @@
 
   // public
 
+  /** The design system version for styling purposes. */
   export let version: Version = "1";
+  /** @required The current page being viewed (non-zero based). */
   export let pagenumber: number;
+  /** @required Total number of data items within all pages. */
   export let itemcount: number;
+  /** Number of data items shown per page. */
   export let perpagecount: number = 10;
+  /** Controls which nav controls are visible. */
   export let variant: Variant = "all";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Top margin. */
   export let mt: Spacing = "none";
+  /** Right margin. */
   export let mr: Spacing = "none";
+  /** Bottom margin. */
   export let mb: Spacing = "m";
+  /** Left margin. */
   export let ml: Spacing = "none";
 
   // reactive

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -32,59 +32,67 @@
 
   // Public
 
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "popover";
+  /** Provides control to where the popover content is positioned. */
   export let position: "above" | "below" | "auto" = "auto";
+  /** Sets the maximum width of the popover container. */
   export let maxwidth: string | "none" = "320px";
+  /** Sets the minimum width of the popover container. */
   export let minwidth: string = "";
+  /** Sets a fixed width for the popover container. */
   export let width: string = "";
+  /** Controls the height behavior. 'full' stretches to parent height, 'wrap-content' fits content. */
   export let height: "full" | "wrap-content" = "wrap-content";
 
-  // flag passed to the FocusTrap that will prevent unwanted scrolling
+  /** Prevents scrolling into view when focus trap is activated. Passed to FocusTrap. */
   export let preventScrollIntoView: boolean = false;
 
-  // allows to override the default padding when content needs to be flush with boundries
+  /** Sets if the popover has padding. Use false when content needs to be flush with boundaries. */
   export let padded: string = "true";
 
-  // allows tabindex to be set to -1 to skip tabbing if a parent is handling events
+  /** Sets the tabindex. Use -1 to skip tabbing when a parent handles keyboard events. */
   export let tabindex: number = 0;
 
-  /***
-   * @deprecated This property has no effect and will be removed in a future version
-   */
+  /** @deprecated This property has no effect and will be removed in a future version. */
   export let relative: string = "";
 
-  // margins
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
-  // Exposed privates
-  // **Required only to allow popover position to be customized when used within
-  // other components. These props should _not_ be documented.**
+  // Exposed privates - used internally by other components
 
+  /** Prevents the popover from closing when other popovers open. Used for nested interactions. */
   export let disableGlobalClosePopover: boolean = false;
 
-  // allow for outside control of whether popover is open/closed (see AppHeaderMenu)
+  /** Controls whether the popover is open or closed. Used by parent components like AppHeaderMenu. */
   export let open: string = "false";
 
-  // allows outside control of the `open` property ex. when used within dropdown
+  /** Disables the popover interaction. Used by parent components like Dropdown. */
   export let disabled: string = "false";
 
-  // additional vertical offset that is added to popover's position
+  /** Additional vertical offset added to the popover's position. */
   export let voffset = "";
 
-  // additional horizontal offset that is added to popover's position
+  /** Additional horizontal offset added to the popover's position. */
   export let hoffset = "";
 
-  // width of outline seen when focused
+  /** Width of the focus outline border. */
   export let focusborderwidth = "var(--goa-border-width-l)";
 
-  // border radius of popover window
+  /** Border radius of the popover window. */
   export let borderradius = "var(--goa-border-radius-m)";
 
+  /** When true, clicking inside the popover will close it. */
   export let closeOnClickWithinBounds = false;
 
+  /** Indicates the popover is used within a filterable context like a combobox. */
   export let filterablecontext: string = "false";
 
   // Private

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -68,7 +68,7 @@
 
   // Exposed privates - used internally by other components
 
-  /** Prevents the popover from closing when other popovers open. Used for nested interactions. */
+  /** @internal Prevents the popover from closing when other popovers open. */
   export let disableGlobalClosePopover: boolean = false;
 
   /** Controls whether the popover is open or closed. Used by parent components like AppHeaderMenu. */
@@ -89,7 +89,7 @@
   /** Border radius of the popover window. */
   export let borderradius = "var(--goa-border-radius-m)";
 
-  /** When true, clicking inside the popover will close it. */
+  /** @internal When true, clicking inside the popover will close it. */
   export let closeOnClickWithinBounds = false;
 
   /** Indicates the popover is used within a filterable context like a combobox. */

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -50,7 +50,7 @@
   export let disabled: string = "false";
   /** Shows an error state on all radio items in the group. */
   export let error: string = "false";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: VersionType = "1";
   /** Sets the size of all radio items. 'compact' reduces spacing for dense layouts (V2 only). */
   export let size: SizeType = "default";

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -40,18 +40,31 @@
 
   // Public
 
+  /** @required The name for the radio group. Used for form submission and accessibility. */
   export let name: string;
+  /** The currently selected value in the radio group. */
   export let value: string;
+  /** Sets the layout direction. 'vertical' stacks items, 'horizontal' places them in a row. */
   export let orientation: Orientation = "vertical";
+  /** Disables all radio items in the group. */
   export let disabled: string = "false";
+  /** Shows an error state on all radio items in the group. */
   export let error: string = "false";
+  /** The design system version for styling purposes. */
   export let version: VersionType = "1";
+  /** Sets the size of all radio items. 'compact' reduces spacing for dense layouts (V2 only). */
   export let size: SizeType = "default";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Defines how the radio group will be announced by screen readers. */
   export let arialabel: string = "";
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // Private

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -40,7 +40,7 @@
 
   // Public
 
-  /** @required The name for the radio group. Used for form submission and accessibility. */
+  /** The name for the radio group. Used for accessibility and change events. */
   export let name: string;
   /** The currently selected value in the radio group. */
   export let value: string;

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -53,21 +53,34 @@
     FormFieldMountRelayDetail,
   } from "../../types/relay-types";
 
+  /** @required The value of this radio option. Will be emitted when selected. */
   export let value: string;
+  /** The name of the radio group. Inherited from the parent RadioGroup if not set. */
   export let name: string = "";
+  /** The display label for this radio option. Falls back to value if not provided. */
   export let label: string = "";
+  /** Additional description text displayed below the label. */
   export let description: string = "";
+  /** Disables this radio option. */
   export let disabled: string = "false";
+  /** Shows an error state on this radio option. */
   export let error: string = "false";
+  /** Sets this radio option as checked/selected. */
   export let checked: string = "false";
+  /** Defines how this option will be announced by screen readers. */
   export let arialabel: string = "";
-  export let revealarialabel: string = ""; // screen reader will announce this when reveal slot is displayed
+  /** Text announced by screen readers when the reveal slot content is displayed. */
+  export let revealarialabel: string = "";
+  /** Sets the maximum width of this radio item. */
   export let maxwidth: string = "none";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // private

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -61,7 +61,7 @@
   export let label: string = "";
   /** Additional description text displayed below the label. */
   export let description: string = "";
-  /** Disables this radio option. */
+  /** Disables this radio option. Also disabled if the parent RadioGroup is disabled. */
   export let disabled: string = "false";
   /** Shows an error state on this radio option. */
   export let error: string = "false";

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -53,7 +53,7 @@
     FormFieldMountRelayDetail,
   } from "../../types/relay-types";
 
-  /** @required The value of this radio option. Will be emitted when selected. */
+  /** The value of this radio option. Will be emitted when selected. */
   export let value: string;
   /** The name of the radio group. Inherited from the parent RadioGroup if not set. */
   export let name: string = "";

--- a/libs/web-components/src/components/scrollable/Scrollable.svelte
+++ b/libs/web-components/src/components/scrollable/Scrollable.svelte
@@ -4,11 +4,18 @@
   import { onMount, tick } from "svelte";
 
   // Public
+
+  /** The scroll direction. */
   export let direction: "vertical" | "horizontal" = "vertical";
+  /** Horizontal padding applied to the scrollable content. */
   export let hpadding: string = "";
+  /** Vertical padding applied to the scrollable content. */
   export let vpadding: string = "";
+  /** Maximum height of the scrollable container. Defaults to 50vh if not specified. */
   export let maxheight: string = "";
+  /** The visible height of the scrollable area. Read-only, set by the component. */
   export let offsetHeight: number;
+  /** The total scrollable height including overflow. Read-only, set by the component. */
   export let scrollHeight: number;
 
   // Private

--- a/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
+++ b/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
@@ -14,7 +14,7 @@
   import type { GoAIconType } from "../icon/Icon.svelte";
   import { calculateMargin, Spacing } from "../../common/styling";
 
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
   /** The heading text for the menu group. */
   export let heading: string;

--- a/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
+++ b/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
@@ -16,7 +16,7 @@
 
   /** The design system version for styling purposes. */
   export let version: "1" | "2" = "1";
-  /** @required The heading text for the menu group. */
+  /** The heading text for the menu group. */
   export let heading: string;
   /** Icon displayed alongside the heading. */
   export let icon: GoAIconType | null = null;

--- a/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
+++ b/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
@@ -14,13 +14,21 @@
   import type { GoAIconType } from "../icon/Icon.svelte";
   import { calculateMargin, Spacing } from "../../common/styling";
 
+  /** The design system version for styling purposes. */
   export let version: "1" | "2" = "1";
+  /** @required The heading text for the menu group. */
   export let heading: string;
+  /** Icon displayed alongside the heading. */
   export let icon: GoAIconType | null = null;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   let _open = false;

--- a/libs/web-components/src/components/side-menu-heading/SideMenuHeading.svelte
+++ b/libs/web-components/src/components/side-menu-heading/SideMenuHeading.svelte
@@ -3,8 +3,11 @@
 <script lang="ts">
   import type { GoAIconType } from "../icon/Icon.svelte";
 
+  /** The design system version for styling purposes. */
   export let version: "1" | "2" = "1";
+  /** Icon displayed before the heading text. */
   export let icon: GoAIconType | null = null;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "section-heading";
 </script>
 

--- a/libs/web-components/src/components/side-menu-heading/SideMenuHeading.svelte
+++ b/libs/web-components/src/components/side-menu-heading/SideMenuHeading.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import type { GoAIconType } from "../icon/Icon.svelte";
 
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
   /** Icon displayed before the heading text. */
   export let icon: GoAIconType | null = null;

--- a/libs/web-components/src/components/side-menu/SideMenu.svelte
+++ b/libs/web-components/src/components/side-menu/SideMenu.svelte
@@ -6,7 +6,9 @@
   import { isUrlMatch, getMatchedLink } from "../../common/urls";
   import { SideMenuGroupProps } from "../side-menu-group/SideMenuGroup.svelte";
 
+  /** The design system version for styling purposes. */
   export let version: "1" | "2" = "1";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   let _rootEl: HTMLElement;

--- a/libs/web-components/src/components/side-menu/SideMenu.svelte
+++ b/libs/web-components/src/components/side-menu/SideMenu.svelte
@@ -6,7 +6,7 @@
   import { isUrlMatch, getMatchedLink } from "../../common/urls";
   import { SideMenuGroupProps } from "../side-menu-group/SideMenuGroup.svelte";
 
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";

--- a/libs/web-components/src/components/skeleton/Skeleton.svelte
+++ b/libs/web-components/src/components/skeleton/Skeleton.svelte
@@ -44,7 +44,7 @@
   export let size: SkeletonSize = "1";
   /** Used within components that contain multiple lines. Currently only used in card skeleton type */
   export let linecount: number = 3;
-  /** @required Reset skeleton shapes to represent your content. */
+  /** Sets the skeleton shape to represent your content. */
   export let type: SkeletonType;
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";

--- a/libs/web-components/src/components/skeleton/Skeleton.svelte
+++ b/libs/web-components/src/components/skeleton/Skeleton.svelte
@@ -37,16 +37,25 @@
   type SkeletonType = (typeof Types)[number];
   type SkeletonSize = (typeof Sizes)[number];
 
+  /** Set component maximum width. Currently only used in card skeleton type */
+
   export let maxwidth: string = "300px";
+  /** Size can affect either the height, width or both for different skeleton types. */
   export let size: SkeletonSize = "1";
+  /** Used within components that contain multiple lines. Currently only used in card skeleton type */
   export let linecount: number = 3;
+  /** @required Reset skeleton shapes to represent your content. */
   export let type: SkeletonType;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
-  // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   onMount(() => {

--- a/libs/web-components/src/components/skeleton/Skeleton.svelte
+++ b/libs/web-components/src/components/skeleton/Skeleton.svelte
@@ -37,8 +37,7 @@
   type SkeletonType = (typeof Types)[number];
   type SkeletonSize = (typeof Sizes)[number];
 
-  /** Set component maximum width. Currently only used in card skeleton type */
-
+  /** Sets the maximum width. Currently only used in card skeleton type. */
   export let maxwidth: string = "300px";
   /** Size can affect either the height, width or both for different skeleton types. */
   export let size: SkeletonSize = "1";

--- a/libs/web-components/src/components/spacer/Spacer.svelte
+++ b/libs/web-components/src/components/spacer/Spacer.svelte
@@ -4,8 +4,12 @@
   import { onMount } from "svelte";
   import { injectCss, type Spacing } from "../../common/styling";
 
+  /** Horizontal spacing */
+
   export let hspacing: Spacing | "fill" = "none";
+  /** Vertical spacing */
   export let vspacing: Spacing = "none";
+  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
   export let testid: string = "";
 
   let rootEl: HTMLElement;

--- a/libs/web-components/src/components/spacer/Spacer.svelte
+++ b/libs/web-components/src/components/spacer/Spacer.svelte
@@ -4,12 +4,11 @@
   import { onMount } from "svelte";
   import { injectCss, type Spacing } from "../../common/styling";
 
-  /** Horizontal spacing */
-
+  /** Horizontal spacing. */
   export let hspacing: Spacing | "fill" = "none";
   /** Vertical spacing */
   export let vspacing: Spacing = "none";
-  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   let rootEl: HTMLElement;

--- a/libs/web-components/src/components/spinner/Spinner.svelte
+++ b/libs/web-components/src/components/spinner/Spinner.svelte
@@ -10,12 +10,14 @@
   import { tweened } from "svelte/motion";
   import { quartOut } from "svelte/easing";
 
-  // required
+  /** @required Sets the size of the spinner. */
   export let size: SpinnerSize;
 
-  // optional
+  /** When true, inverts colors for use on dark backgrounds. */
   export let invert: boolean = false;
+  /** Progress value (0-100). When >= 0, shows a progress spinner instead of infinite. */
   export let progress: number = -1;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   let type: SpinnerType = "infinite";

--- a/libs/web-components/src/components/spinner/Spinner.svelte
+++ b/libs/web-components/src/components/spinner/Spinner.svelte
@@ -10,7 +10,7 @@
   import { tweened } from "svelte/motion";
   import { quartOut } from "svelte/easing";
 
-  /** Sets the size of the spinner. */
+  /** @required Sets the size of the spinner. */
   export let size: SpinnerSize;
 
   /** When true, inverts colors for use on dark backgrounds. */

--- a/libs/web-components/src/components/spinner/Spinner.svelte
+++ b/libs/web-components/src/components/spinner/Spinner.svelte
@@ -10,7 +10,7 @@
   import { tweened } from "svelte/motion";
   import { quartOut } from "svelte/easing";
 
-  /** @required Sets the size of the spinner. */
+  /** Sets the size of the spinner. */
   export let size: SpinnerSize;
 
   /** When true, inverts colors for use on dark backgrounds. */

--- a/libs/web-components/src/components/tab/Tab.svelte
+++ b/libs/web-components/src/components/tab/Tab.svelte
@@ -22,7 +22,9 @@
   // Public
   // ======
 
+  /** The text label for this tab. Can also use the heading slot for custom content. */
   export let heading: string = "";
+  /** Whether this tab is currently selected/active. */
   export let open: boolean = false;
 
   // =======

--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -35,9 +35,9 @@
   export let striped: string = "false";
   /** A relaxed variant of the table with more vertical padding for the cells. */
   export let variant: Variant = "normal";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: VersionType = "1";
-  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
   /** Top margin. */

--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -27,16 +27,26 @@
 
   // Public
 
+  /** Width of the table. By default it will fit the enclosed content. */
   export let width: string = "";
+  /** When true, the table header sticks to the top when scrolling. */
   export let stickyheader: string = "false";
+  /** When true, alternates row background colors for improved readability. */
   export let striped: string = "false";
+  /** A relaxed variant of the table with more vertical padding for the cells. */
   export let variant: Variant = "normal";
+  /** The design system version for styling purposes. */
   export let version: VersionType = "1";
+  /** Sets the data-testid attribute. Used with ByTestId queries in tests. */
   export let testid: string = "";
 
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // Private

--- a/libs/web-components/src/components/table/TableSortHeader.svelte
+++ b/libs/web-components/src/components/table/TableSortHeader.svelte
@@ -6,6 +6,7 @@
 
 <script lang="ts">
   import { onMount } from "svelte";
+  /** Sets the sort direction indicator. */
   export let direction: GoATableSortDirection = "none";
 
   // Private

--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -9,7 +9,7 @@
   export let initialtab: number = -1;
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
-  /** The design system version for styling purposes. */
+  /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
 
   // Private

--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -5,8 +5,11 @@
   import { clamp, ensureSlotExists, fromBoolean } from "../../common/utils";
   import { GoATabProps } from "../tab/Tab.svelte";
 
-  export let initialtab: number = -1; // 1-based
+  /** The initially active tab (1-based index). If not set, the first tab is active. */
+  export let initialtab: number = -1;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** The design system version for styling purposes. */
   export let version: "1" | "2" = "1";
 
   // Private

--- a/libs/web-components/src/components/temporary-notification/TemporaryNotification.svelte
+++ b/libs/web-components/src/components/temporary-notification/TemporaryNotification.svelte
@@ -25,12 +25,20 @@
     | "progress";
 
   // Props
+
+  /** The notification message text to display. */
   export let message: string = "";
+  /** The notification type which determines the visual style and icon. */
   export let type: TemporaryNotificationType = "basic";
+  /** Progress value from 0-100. Use -1 to hide the progress bar. Only applies when type is "progress". */
   export let progress: number = -1; // -1 = hidden, 0-100 = show
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Text for the optional action button. When provided, displays a clickable link button. */
   export let actionText: string = "";
+  /** Controls whether the notification is visible. */
   export let visible: boolean = true;
+  /** Direction the notification animates from when appearing or disappearing. */
   export let animationDirection: TemporaryNotificationAnimationDirection = "down";
 
   // Icon size for success/failure icons

--- a/libs/web-components/src/components/temporary-notification/TemporaryNotificationCtrl.svelte
+++ b/libs/web-components/src/components/temporary-notification/TemporaryNotificationCtrl.svelte
@@ -32,8 +32,11 @@
   type SnackbarVerticalPosition = "top" | "bottom";
   type SnackbarHorizontalPosition = "left" | "center" | "right";
 
+  /** Vertical position of the notification container. */
   export let vPosition: SnackbarVerticalPosition = "bottom";
+  /** Horizontal position of the notification container. */
   export let hPosition: SnackbarHorizontalPosition = "center";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string;
 
   let _notificationQueue: GoabNotification[] = [];

--- a/libs/web-components/src/components/text-area/TextArea.svelte
+++ b/libs/web-components/src/components/text-area/TextArea.svelte
@@ -26,8 +26,7 @@
     FieldsetResetFieldsMsg,
   } from "../../types/relay-types";
 
-  /** Name of the input value that is received in the _change event */
-
+  /** Name of the input value that is received in the _change event. */
   export let name: string;
   /** Bound to value */
   export let value: string = "";

--- a/libs/web-components/src/components/text-area/TextArea.svelte
+++ b/libs/web-components/src/components/text-area/TextArea.svelte
@@ -26,25 +26,44 @@
     FieldsetResetFieldsMsg,
   } from "../../types/relay-types";
 
+  /** Name of the input value that is received in the _change event */
+
   export let name: string;
+  /** Bound to value */
   export let value: string = "";
+  /** Text displayed within the input when no value is set. */
   export let placeholder: string = "";
+  /** Set the number of rows. */
   export let rows: number = 3;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Width of the text area. */
   export let width: string = "100%"; // 100% is default, the lower value of width and maxwidth wins
+  /** Maximum width of the text area */
   export let maxwidth: string = "60ch"; // 60ch is default, the lower value wins b/w width and maxwidth
+  /** Sets the input to an error state */
   export let error: string = "false";
+  /** Sets the input to a read only state. */
   export let readonly: string = "false";
+  /** Sets the input to a disabled state. Use [attr.disabled] with [formControl] */
   export let disabled: string = "false";
+  /** Defines how the text will be translated for the screen reader. If not specified it will fall back to the name. */
   export let arialabel: string = "";
+  /** Counting interval for characters or words, specifying whether to count every character or word. */
   export let countby: "character" | "word" | "" = "";
+  /** Maximum number of characters or words allowed */
   export let maxcount: number = -1;
+  /** Specifies the autocomplete attribute for the textarea input. */
   export let autocomplete: string = "";
 
   // margin
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   let _error = false;

--- a/libs/web-components/src/components/text/Text.svelte
+++ b/libs/web-components/src/components/text/Text.svelte
@@ -29,14 +29,22 @@
   import { calculateMargin, Spacing } from "../../common/styling";
   import { style, styles } from "../../common/utils";
 
+  /** The HTML element to render. Use semantic elements like 'h1'-'h6' for headings. */
   export let as: TextElement | HeadingElement = "div";
+  /** Sets the max width. */
   export let maxWidth: string | "none" = "65ch";
+  /** Overrides the text size. */
   export let size: Size | undefined = undefined;
+  /** Sets the text colour. */
   export let color: "primary" | "secondary" = "primary";
 
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   let _marginBottom: Spacing = null;

--- a/libs/web-components/src/components/tooltip/Tooltip.svelte
+++ b/libs/web-components/src/components/tooltip/Tooltip.svelte
@@ -8,14 +8,23 @@
 
   // Public
 
+  /** The content of the tooltip. */
   export let content = "";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Position with respect to the child element. */
   export let position: Position = "top";
+  /** Horizontal alignment to the child element. */
   export let halign: Alignment = "center";
+  /** Sets the maximum width of the tooltip. Must use 'px' unit. */
   export let maxwidth: string = "";
+  /** Top margin. */
   export let mt: Spacing = null;
+  /** Right margin. */
   export let mr: Spacing = null;
+  /** Bottom margin. */
   export let mb: Spacing = null;
+  /** Left margin. */
   export let ml: Spacing = null;
 
   // Types

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
@@ -24,13 +24,20 @@
   // Public
   // ******
 
+  /** @required The application name displayed in the header. */
   export let heading: string;
+  /** @required URL for the header link. Clicking the logo/heading navigates to this URL. */
   export let url: string;
 
   // optional
+
+  /** Controls whether the side menu is expanded or collapsed. */
   export let open = false;
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** User's name displayed in the profile section. */
   export let userName: string = "";
+  /** Secondary text displayed below the user's name, such as role or email. */
   export let userSecondaryText: string = "";
 
   // *******

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
@@ -24,9 +24,9 @@
   // Public
   // ******
 
-  /** @required The application name displayed in the header. */
+  /** The application name displayed in the header. */
   export let heading: string;
-  /** @required URL for the header link. Clicking the logo/heading navigates to this URL. */
+  /** URL for the header link. Clicking the logo/heading navigates to this URL. */
   export let url: string;
 
   // optional

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte
@@ -10,15 +10,23 @@
   // Public
   // ******
 
+  /** @required The text label displayed for the menu item. */
   export let label: string;
+  /** @required The URL the menu item links to. */
   export let url: string;
 
   // optional
+  /** Badge text displayed alongside the menu item (e.g., notification count). */
   export let badge: string = "";
+  /** When true, indicates this is the currently active menu item. */
   export let current: boolean = false;
+  /** When true, displays a divider line above this menu item. */
   export let divider: boolean = false;
+  /** Icon displayed before the menu item label. */
   export let icon: string = "";
+  /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Sets the visual style of the badge. Use "emergency" for urgent items, "success" for positive status. */
   export let type: WorkSideMenuItemType = "normal";
 
   // *******

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte
@@ -10,9 +10,9 @@
   // Public
   // ******
 
-  /** @required The text label displayed for the menu item. */
+  /** The text label displayed for the menu item. */
   export let label: string;
-  /** @required The URL the menu item links to. */
+  /** The URL the menu item links to. */
   export let url: string;
 
   // optional


### PR DESCRIPTION
## Summary
- Adds JSDoc documentation comments to component props across 67 Svelte components
- Enables better IDE hints and autocomplete for developers using GoA components
- Supports automated documentation generation
- No functional changes - documentation only

## Changes
- 67 files modified
- ~642 lines added (comments only)
- ~60 lines removed (internal section markers replaced with JSDoc)

## Example
```javascript
/** Sets the visual style of the button. Use "primary" for main actions... */
export let type: ButtonType = "primary";
```

## Testing
- No functional changes, documentation only
- Existing tests should pass unchanged

_Created with the help of claude code_