### PR TITLE
fix(#3322): app header menu displays correctly on hover

### DIFF
--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -54,6 +54,7 @@ export function App() {
               <Link to="/bugs/3201">3201 Input Component Events</Link>
               <Link to="/bugs/3215">3215 Drawer Initial Height</Link>
               <Link to="/bugs/3248">3248 Dropdown Dynamic Children Sync</Link>
+              <Link to="/bugs/3322">3322 App Header Menu Hover</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Features">
               <Link to="/features/1383">1383 Button Filled Icons</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -38,6 +38,7 @@ import { Bug3118Route } from "./routes/bugs/bug3118";
 import { Bug3201Route } from "./routes/bugs/bug3201";
 import { Bug3215Route } from "./routes/bugs/bug3215";
 import { Bug3248Route } from "./routes/bugs/bug3248";
+import { Bug3322Route } from "./routes/bugs/bug3322";
 
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
@@ -102,6 +103,7 @@ root.render(
           <Route path="bugs/3201" element={<Bug3201Route />} />
           <Route path="bugs/3215" element={<Bug3215Route />} />
           <Route path="bugs/3248" element={<Bug3248Route />} />
+          <Route path="bugs/3322" element={<Bug3322Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3322.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3322.tsx
@@ -1,0 +1,26 @@
+import {
+  GoabAppHeader,
+  GoabAppHeaderMenu,
+  GoabPageBlock,
+} from "@abgov/react-components";
+
+export function Bug3322Route() {
+  return (
+    <>
+      <h1>Bug 3322 - App Header Menu Display</h1>
+      <p>Testing that app header menu displays correctly on hover.</p>
+
+      <GoabPageBlock width="100%">
+        <GoabAppHeader url="https://example.com" heading="Service name">
+          <GoabAppHeaderMenu heading="Search" leadingIcon="search">
+            <a href="#">Cases</a>
+            <a href="#">Payments</a>
+            <a href="#">Outstanding</a>
+          </GoabAppHeaderMenu>
+          <a href="#">Support</a>
+          <a href="#" className="interactive">Sign in</a>
+        </GoabAppHeader>
+      </GoabPageBlock>
+    </>
+  );
+}

--- a/libs/web-components/src/components/app-header/AppHeader.svelte
+++ b/libs/web-components/src/components/app-header/AppHeader.svelte
@@ -548,9 +548,7 @@
   /* Header nav item with children (app header menu) --Hover */
   .desktop :global(::slotted(goa-app-header-menu:hover)) {
     background: var(--goa-app-header-color-bg-nav-item-hover);
-    cursor: pointer;
-    color: var(--goa-app-header-color-text-nav-item-hover) !important;
-    overflow: hidden !important;
+    color: var(--goa-app-header-color-text-nav-item-hover);
   }
 
   /* Link item styling */


### PR DESCRIPTION
This PR removes `overflow: hidden` and other redundant CSS on the App Header Menu hover state.

### Before

![hover-issue](https://github.com/user-attachments/assets/64c35572-93bc-4f97-9fa0-969463ca71d1)

When I open and hover a Header Menu, the menu appears broken in latest Chrome...

<img width="355" height="104" alt="image" src="https://github.com/user-attachments/assets/d6dbfc37-5de0-4f5d-bbac-7d9e9f202079" />

and the latest FIrefox...

<img width="338" height="99" alt="image" src="https://github.com/user-attachments/assets/f3fe8643-c588-4d87-b834-52e46c65a141" />

and the latest Edge...

<img width="350" height="109" alt="image" src="https://github.com/user-attachments/assets/07f92663-9970-4b31-b806-0a7bb350f1d7" />

and the latest Safari.

<img width="341" height="109" alt="image" src="https://github.com/user-attachments/assets/6960e9b7-2e54-439e-b04c-a170c2d1a6d6" />

### After

![hover-fixed2](https://github.com/user-attachments/assets/e2cf702d-a0d0-4cc9-ba7a-54b4c6a52f8b)

When I open and hover a Header Menu, the menu works in latest in the latest Chrome...

<img width="333" height="232" alt="image" src="https://github.com/user-attachments/assets/7f488004-c786-43e6-9113-f1ff451cdc2c" />

and the latest FIrefox...

<img width="331" height="231" alt="image" src="https://github.com/user-attachments/assets/beacf421-edba-4a6d-bffd-734f6b1a6c17" />

and the latest Edge...

<img width="363" height="248" alt="image" src="https://github.com/user-attachments/assets/bd8c91b6-2eca-49ad-b311-cfe0192bd915" />

and the latest Safari.

<img width="342" height="233" alt="image" src="https://github.com/user-attachments/assets/44c90552-2ec1-4146-ae1b-a12f5cd653b5" />
