### PR TITLE
fix(checkbox): correct V2 spacing behavior

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -88,6 +88,7 @@
           <a href="/features/3396">3396 Text heading-2xs size</a>
           <a href="/features/3407-skip-on-focus-tab">3407 Skip Focus on Tab</a>
           <a href="/features/3407-stack-on-mobile">3407 Tabs Orientation</a>
+          <a href="/features/v2-checkbox">3399 V2 Checkbox Spacing</a>
         </goab-side-menu-group>
       </goab-side-menu>
     </section>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -73,6 +73,7 @@ import { Feat3407SkipOnFocusTabComponent } from "../routes/features/feat3407Skip
 import { Feat3407StackOnMobileComponent } from "../routes/features/feat3407StackOnMobile/feat3407-stack-on-mobile.component";
 import { FeatV2IconsComponent } from "../routes/features/featV2Icons/feat-v2-icons.component";
 import { Feat3396Component } from "../routes/features/feat3396/feat3396.component";
+import { FeatV2CheckboxComponent } from "../routes/features/featV2Checkbox/featV2Checkbox.component";
 
 export const appRoutes: Route[] = [
   { path: "everything", component: EverythingComponent },
@@ -149,4 +150,5 @@ export const appRoutes: Route[] = [
   { path: "features/3396", component: Feat3396Component },
   { path: "features/3407-skip-on-focus-tab", component: Feat3407SkipOnFocusTabComponent },
   { path: "features/3407-stack-on-mobile", component: Feat3407StackOnMobileComponent },
+  { path: "features/v2-checkbox", component: FeatV2CheckboxComponent },
 ];

--- a/apps/prs/angular/src/routes/features/featV2Checkbox/featV2Checkbox.component.html
+++ b/apps/prs/angular/src/routes/features/featV2Checkbox/featV2Checkbox.component.html
@@ -1,0 +1,184 @@
+<div style="padding: 20px">
+  <goab-text tag="h1" size="heading-l" mb="m">V2 Checkbox Fixes</goab-text>
+
+  <goab-text size="body-m" mb="m">
+    This page demonstrates fixes for checkbox spacing issues:
+  </goab-text>
+  <goab-block direction="column" gap="s" mb="m">
+    <goab-text size="body-s">
+      1. <strong>Checkbox auto-margin removed</strong> - Checkboxes no longer have
+      default bottom margin, fixing alignment in tables
+    </goab-text>
+    <goab-text size="body-s">
+      2. <strong>CheckboxList gap</strong> - CheckboxList now controls its own spacing
+      between items using gap: var(--goa-space-m)
+    </goab-text>
+  </goab-block>
+
+  <goab-divider></goab-divider>
+
+  <!-- Test Case 1: Checkbox in Table -->
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">
+    Test 1: Checkbox in Table
+  </goab-text>
+  <goab-text size="body-s" mb="m">
+    Previously, checkboxes in tables had unwanted bottom margin causing misalignment.
+    Now they align properly with the row content.
+  </goab-text>
+
+  <goab-table width="100%">
+    <thead>
+      <tr>
+        <th>
+          <goabx-checkbox
+            name="select-all"
+            [checked]="allSelected"
+            [indeterminate]="someSelected"
+            (onChange)="toggleSelectAll($event)"
+            ariaLabel="Select all rows"
+          ></goabx-checkbox>
+        </th>
+        <th>Name</th>
+        <th>Email</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let row of tableData">
+        <td>
+          <goabx-checkbox
+            [name]="'select-' + row.id"
+            [checked]="isRowSelected(row.id)"
+            (onChange)="toggleRow(row.id, $event)"
+            [ariaLabel]="'Select ' + row.name"
+          ></goabx-checkbox>
+        </td>
+        <td>{{ row.name }}</td>
+        <td>{{ row.email }}</td>
+        <td>{{ row.status }}</td>
+      </tr>
+    </tbody>
+  </goab-table>
+
+  <goab-text size="body-xs" mt="m">
+    Selected: {{ selectedRows.size }} of {{ tableData.length }} rows
+  </goab-text>
+
+  <goab-divider mt="xl"></goab-divider>
+
+  <!-- Test Case 2: CheckboxList Spacing -->
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">
+    Test 2: CheckboxList Spacing
+  </goab-text>
+  <goab-text size="body-s" mb="m">
+    CheckboxList now uses gap: var(--goa-space-m) for consistent spacing between items.
+    Previously relied on individual checkbox margins.
+  </goab-text>
+
+  <goabx-checkbox-list
+    name="preferences"
+    [value]="checkboxListValue"
+    (onChange)="onCheckboxListChange($event)"
+  >
+    <goabx-checkbox name="option1" text="Option 1: Email notifications"></goabx-checkbox>
+    <goabx-checkbox name="option2" text="Option 2: SMS notifications"></goabx-checkbox>
+    <goabx-checkbox name="option3" text="Option 3: Push notifications"></goabx-checkbox>
+  </goabx-checkbox-list>
+
+  <goab-text size="body-xs" mt="m">
+    Selected: {{ checkboxListValue.length > 0 ? checkboxListValue.join(', ') : 'none' }}
+  </goab-text>
+
+  <goab-divider mt="xl"></goab-divider>
+
+  <!-- Test Case 3: V2 Compact CheckboxList -->
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">
+    Test 3: V2 Compact CheckboxList
+  </goab-text>
+  <goab-text size="body-s" mb="m">
+    Compact checkbox list uses smaller gap (var(--goa-space-s)) between items.
+  </goab-text>
+
+  <goabx-checkbox-list
+    name="compact-prefs"
+    size="compact"
+    [value]="compactListValue"
+    (onChange)="onCompactListChange($event)"
+  >
+    <goabx-checkbox name="compact1" size="compact" text="Compact option 1"></goabx-checkbox>
+    <goabx-checkbox name="compact2" size="compact" text="Compact option 2"></goabx-checkbox>
+    <goabx-checkbox name="compact3" size="compact" text="Compact option 3"></goabx-checkbox>
+  </goabx-checkbox-list>
+
+  <goab-text size="body-xs" mt="m">
+    Selected: {{ compactListValue.length > 0 ? compactListValue.join(', ') : 'none' }}
+  </goab-text>
+
+  <goab-divider mt="xl"></goab-divider>
+
+  <!-- Test Case 4: V2 Standalone Checkbox -->
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">
+    Test 4: V2 Standalone Checkbox (No Auto-Margin)
+  </goab-text>
+  <goab-text size="body-s" mb="m">
+    V2 checkboxes no longer have default bottom margin.
+    Spacing should be controlled by the parent layout.
+  </goab-text>
+
+  <goab-block direction="row" gap="xl" alignment="center">
+    <goabx-checkbox name="standalone1" text="Checkbox A"></goabx-checkbox>
+    <goabx-checkbox name="standalone2" text="Checkbox B"></goabx-checkbox>
+    <goabx-checkbox name="standalone3" text="Checkbox C"></goabx-checkbox>
+  </goab-block>
+
+  <goab-text size="body-xs" mt="m">
+    Notice: No extra margin between checkboxes - spacing controlled by goab-block gap.
+  </goab-text>
+
+  <goab-divider mt="xl"></goab-divider>
+
+  <!-- V1 Regression Tests -->
+  <goab-text tag="h2" size="heading-l" mt="xl" mb="m">
+    V1 Regression Tests
+  </goab-text>
+  <goab-text size="body-s" mb="m">
+    These tests verify V1 checkboxes still behave correctly after the V2 spacing changes.
+  </goab-text>
+
+  <!-- Test Case 5: V1 Standalone Checkboxes -->
+  <goab-text tag="h3" size="heading-m" mt="l" mb="m">
+    Test 5: V1 Standalone Checkboxes (Auto-Margin)
+  </goab-text>
+  <goab-text size="body-s" mb="m">
+    V1 checkboxes should still have their default bottom margin (space-m).
+  </goab-text>
+
+  <div style="border: 1px dashed #ccc; padding: 1rem">
+    <goab-checkbox name="v1-standalone1" text="V1 Default - should have margin-bottom: space-m"></goab-checkbox>
+    <goab-checkbox name="v1-standalone2" text="V1 Default - should have margin-bottom: space-m"></goab-checkbox>
+  </div>
+
+  <goab-divider mt="xl"></goab-divider>
+
+  <!-- Test Case 6: V1 CheckboxList -->
+  <goab-text tag="h3" size="heading-m" mt="l" mb="m">
+    Test 6: V1 CheckboxList (No Gap Change)
+  </goab-text>
+  <goab-text size="body-s" mb="m">
+    V1 checkbox lists should look the same as before - individual checkbox margins control spacing, list gap is 0.
+  </goab-text>
+
+  <goab-checkbox-list
+    name="v1-list"
+    [value]="v1ListValue"
+    (onChange)="onV1ListChange($event)"
+  >
+    <goab-checkbox name="v1opt1" text="V1 list option 1"></goab-checkbox>
+    <goab-checkbox name="v1opt2" text="V1 list option 2"></goab-checkbox>
+    <goab-checkbox name="v1opt3" text="V1 list option 3"></goab-checkbox>
+  </goab-checkbox-list>
+
+  <goab-text size="body-xs" mt="m">
+    Selected: {{ v1ListValue.length > 0 ? v1ListValue.join(', ') : 'none' }}
+  </goab-text>
+</div>

--- a/apps/prs/angular/src/routes/features/featV2Checkbox/featV2Checkbox.component.ts
+++ b/apps/prs/angular/src/routes/features/featV2Checkbox/featV2Checkbox.component.ts
@@ -1,0 +1,85 @@
+import { Component } from "@angular/core";
+import {
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabxCheckbox,
+  GoabxCheckboxList,
+  GoabText,
+  GoabTable,
+  GoabBlock,
+  GoabDivider,
+  GoabCheckboxOnChangeDetail,
+  GoabCheckboxListOnChangeDetail,
+} from "@abgov/angular-components";
+import { CommonModule } from "@angular/common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat-v2-checkbox",
+  templateUrl: "./featV2Checkbox.component.html",
+  imports: [
+    CommonModule,
+    GoabCheckbox,
+    GoabCheckboxList,
+    GoabxCheckbox,
+    GoabxCheckboxList,
+    GoabText,
+    GoabTable,
+    GoabBlock,
+    GoabDivider,
+  ],
+})
+export class FeatV2CheckboxComponent {
+  selectedRows: Set<string> = new Set();
+  checkboxListValue: string[] = [];
+  compactListValue: string[] = [];
+  v1ListValue: string[] = [];
+
+  tableData = [
+    { id: "row1", name: "Alice Johnson", email: "alice@example.com", status: "Active" },
+    { id: "row2", name: "Bob Smith", email: "bob@example.com", status: "Pending" },
+    { id: "row3", name: "Carol Davis", email: "carol@example.com", status: "Active" },
+  ];
+
+  get allSelected(): boolean {
+    return this.selectedRows.size === this.tableData.length;
+  }
+
+  get someSelected(): boolean {
+    return this.selectedRows.size > 0 && this.selectedRows.size < this.tableData.length;
+  }
+
+  isRowSelected(rowId: string): boolean {
+    return this.selectedRows.has(rowId);
+  }
+
+  toggleSelectAll(event: GoabCheckboxOnChangeDetail) {
+    if (event.checked) {
+      this.selectedRows = new Set(this.tableData.map(row => row.id));
+    } else {
+      this.selectedRows = new Set();
+    }
+  }
+
+  toggleRow(rowId: string, event: GoabCheckboxOnChangeDetail) {
+    const newSelected = new Set(this.selectedRows);
+    if (event.checked) {
+      newSelected.add(rowId);
+    } else {
+      newSelected.delete(rowId);
+    }
+    this.selectedRows = newSelected;
+  }
+
+  onCheckboxListChange(event: GoabCheckboxListOnChangeDetail) {
+    this.checkboxListValue = event.value;
+  }
+
+  onCompactListChange(event: GoabCheckboxListOnChangeDetail) {
+    this.compactListValue = event.value;
+  }
+
+  onV1ListChange(event: GoabCheckboxListOnChangeDetail) {
+    this.v1ListValue = event.value;
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -98,6 +98,7 @@ export function App() {
               <Link to="/features/3306">3306 Custom slug value for tabs</Link>
               <Link to="/features/3370">3370 Clear calendar day selection</Link>
               <Link to="/features/3396">3396 Text heading-2xs size</Link>
+              <Link to="/features/v2-checkbox">3399 V2 Checkbox Spacing</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Everything">
               <Link to="/everything">A</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -78,6 +78,7 @@ import { Feat2469Route } from "./routes/features/feat2469";
 import { Feat3370Route } from "./routes/features/feat3370";
 import { Feat3396Route } from "./routes/features/feat3396";
 import { Feat3229Route } from "./routes/features/feat3229";
+import { FeatV2CheckboxRoute } from "./routes/features/featV2Checkbox";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 
@@ -163,6 +164,7 @@ root.render(
           <Route path="features/3396" element={<Feat3396Route />} />
           <Route path="features/3407-skip-on-focus-tab" element={<Feat3407SkipOnFocusTabRoute />} />
           <Route path="features/3407-stack-on-mobile" element={<Feat3407StackOnMobileRoute />} />
+          <Route path="features/v2-checkbox" element={<FeatV2CheckboxRoute />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/apps/prs/react/src/routes/features/featV2Checkbox.tsx
+++ b/apps/prs/react/src/routes/features/featV2Checkbox.tsx
@@ -1,0 +1,324 @@
+import React, { useState } from "react";
+import {
+  GoabBlock,
+  GoabText,
+  GoabOneColumnLayout,
+  GoabPageBlock,
+  GoabDivider,
+  GoabCheckbox,
+  GoabCheckboxList,
+} from "@abgov/react-components";
+import { GoabxCheckbox, GoabxCheckboxList } from "@abgov/react-components/experimental";
+import {
+  GoabCheckboxOnChangeDetail,
+  GoabCheckboxListOnChangeDetail,
+} from "@abgov/ui-components-common";
+import { Link } from "react-router-dom";
+
+export function FeatV2CheckboxRoute() {
+  const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
+  const [checkboxListValue, setCheckboxListValue] = useState<string[]>([]);
+  const [v2CompactListValue, setV2CompactListValue] = useState<string[]>([]);
+  const [v1ListValue, setV1ListValue] = useState<string[]>([]);
+  const [descListValue, setDescListValue] = useState<string[]>([]);
+  const [v1DescListValue, setV1DescListValue] = useState<string[]>([]);
+
+  const tableData = [
+    { id: "row1", name: "Alice Johnson", email: "alice@example.com", status: "Active" },
+    { id: "row2", name: "Bob Smith", email: "bob@example.com", status: "Pending" },
+    { id: "row3", name: "Carol Davis", email: "carol@example.com", status: "Active" },
+  ];
+
+  const handleRowSelect = (rowId: string, detail: GoabCheckboxOnChangeDetail) => {
+    const newSelected = new Set(selectedRows);
+    if (detail.checked) {
+      newSelected.add(rowId);
+    } else {
+      newSelected.delete(rowId);
+    }
+    setSelectedRows(newSelected);
+  };
+
+  return (
+    <GoabPageBlock width="full">
+      <GoabOneColumnLayout>
+        <GoabBlock direction="column" gap="l">
+          <goa-link mt={"xl"} leadingicon={"arrow-back"}>
+            <Link to="/">Back</Link>
+          </goa-link>
+          <GoabText tag="h1" size="heading-l" mb={"m"}>
+            V2 Checkbox Fixes
+          </GoabText>
+
+          <GoabText size="body-m">
+            This page demonstrates fixes for checkbox spacing issues:
+          </GoabText>
+          <GoabBlock direction="column" gap="s" mb="m">
+            <GoabText size="body-s">
+              1. <strong>Checkbox auto-margin removed</strong> - Checkboxes no longer have
+              default bottom margin, fixing alignment in tables
+            </GoabText>
+            <GoabText size="body-s">
+              2. <strong>CheckboxList gap</strong> - CheckboxList now controls its own spacing
+              between items using gap: var(--goa-space-m)
+            </GoabText>
+          </GoabBlock>
+
+          <GoabDivider />
+
+          {/* Test Case 1: Checkbox in Table */}
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Test 1: Checkbox in Table
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            Previously, checkboxes in tables had unwanted bottom margin causing misalignment.
+            Now they align properly with the row content.
+          </GoabText>
+
+          <goa-table width="100%">
+            <thead>
+              <tr>
+                <th>
+                  <GoabxCheckbox
+                    name="select-all"
+                    checked={selectedRows.size === tableData.length}
+                    indeterminate={selectedRows.size > 0 && selectedRows.size < tableData.length}
+                    onChange={(detail: GoabCheckboxOnChangeDetail) => {
+                      if (detail.checked) {
+                        setSelectedRows(new Set(tableData.map(row => row.id)));
+                      } else {
+                        setSelectedRows(new Set());
+                      }
+                    }}
+                    ariaLabel="Select all rows"
+                  />
+                </th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tableData.map((row) => (
+                <tr key={row.id}>
+                  <td>
+                    <GoabxCheckbox
+                      name={`select-${row.id}`}
+                      checked={selectedRows.has(row.id)}
+                      onChange={(detail: GoabCheckboxOnChangeDetail) => handleRowSelect(row.id, detail)}
+                      ariaLabel={`Select ${row.name}`}
+                    />
+                  </td>
+                  <td>{row.name}</td>
+                  <td>{row.email}</td>
+                  <td>{row.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </goa-table>
+
+          <GoabText size="body-xs" mt="m">
+            Selected: {selectedRows.size} of {tableData.length} rows
+          </GoabText>
+
+          <GoabDivider mt="xl" />
+
+          {/* Test Case 2: CheckboxList Spacing */}
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Test 2: CheckboxList Spacing
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            CheckboxList now uses gap: var(--goa-space-m) for consistent spacing between items.
+            Previously relied on individual checkbox margins.
+          </GoabText>
+
+          <GoabxCheckboxList
+            name="preferences"
+            value={checkboxListValue}
+            onChange={(detail: GoabCheckboxListOnChangeDetail) => setCheckboxListValue(detail.value)}
+          >
+            <GoabxCheckbox name="option1" text="Option 1: Email notifications" />
+            <GoabxCheckbox name="option2" text="Option 2: SMS notifications" />
+            <GoabxCheckbox name="option3" text="Option 3: Push notifications" />
+          </GoabxCheckboxList>
+
+          <GoabText size="body-xs" mt="m">
+            Selected: {checkboxListValue.join(", ") || "none"}
+          </GoabText>
+
+          <GoabDivider mt="xl" />
+
+          {/* Test Case 2b: CheckboxList with Descriptions */}
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Test 2b: V2 CheckboxList with Descriptions
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            Testing checkbox description alignment when descriptions are set per option.
+          </GoabText>
+
+          <GoabxCheckboxList
+            name="with-descriptions"
+            value={descListValue}
+            onChange={(detail: GoabCheckboxListOnChangeDetail) => setDescListValue(detail.value)}
+          >
+            <GoabxCheckbox
+              name="desc1"
+              text="Email notifications"
+              description="Receive updates about your account via email"
+            />
+            <GoabxCheckbox
+              name="desc2"
+              text="SMS notifications"
+              description="Get text messages for urgent alerts only"
+            />
+            <GoabxCheckbox
+              name="desc3"
+              text="Push notifications"
+              description="Browser notifications when you're online"
+            />
+          </GoabxCheckboxList>
+
+          <GoabDivider mt="xl" />
+
+          {/* Test Case 2c: V1 CheckboxList with Descriptions (comparison) */}
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Test 2c: V1 CheckboxList with Descriptions (comparison)
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            V1 version for comparison.
+          </GoabText>
+
+          <GoabCheckboxList
+            name="v1-with-descriptions"
+            value={v1DescListValue}
+            onChange={(detail: GoabCheckboxListOnChangeDetail) => setV1DescListValue(detail.value)}
+          >
+            <GoabCheckbox
+              name="v1desc1"
+              text="Email notifications"
+              description="Receive updates about your account via email"
+            />
+            <GoabCheckbox
+              name="v1desc2"
+              text="SMS notifications"
+              description="Get text messages for urgent alerts only"
+            />
+            <GoabCheckbox
+              name="v1desc3"
+              text="Push notifications"
+              description="Browser notifications when you're online"
+            />
+          </GoabCheckboxList>
+
+          <GoabDivider mt="xl" />
+
+          {/* Test Case 3: V2 Compact CheckboxList */}
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Test 3: V2 Compact CheckboxList
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            Compact checkbox list uses smaller gap (var(--goa-space-s)) between items.
+          </GoabText>
+
+          <GoabxCheckboxList
+            name="compact-prefs"
+            size="compact"
+            value={v2CompactListValue}
+            onChange={(detail: GoabCheckboxListOnChangeDetail) => setV2CompactListValue(detail.value)}
+          >
+            <GoabxCheckbox
+              name="compact1"
+              size="compact"
+              text="Compact option 1"
+              description="Description for compact option 1"
+            />
+            <GoabxCheckbox
+              name="compact2"
+              size="compact"
+              text="Compact option 2"
+              description="Description for compact option 2"
+            />
+            <GoabxCheckbox
+              name="compact3"
+              size="compact"
+              text="Compact option 3"
+              description="Description for compact option 3"
+            />
+          </GoabxCheckboxList>
+
+          <GoabText size="body-xs" mt="m">
+            Selected: {v2CompactListValue.join(", ") || "none"}
+          </GoabText>
+
+          <GoabDivider mt="xl" />
+
+          {/* Test Case 4: Standalone Checkbox */}
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Test 4: V2 Standalone Checkbox (No Auto-Margin)
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            V2 checkboxes no longer have default bottom margin.
+            Spacing should be controlled by the parent layout.
+          </GoabText>
+
+          <GoabBlock direction="row" gap="xl" alignment="center">
+            <GoabxCheckbox name="standalone1" text="Checkbox A" />
+            <GoabxCheckbox name="standalone2" text="Checkbox B" />
+            <GoabxCheckbox name="standalone3" text="Checkbox C" />
+          </GoabBlock>
+
+          <GoabText size="body-xs" mt="m">
+            Notice: No extra margin between checkboxes - spacing controlled by GoabBlock gap.
+          </GoabText>
+
+          <GoabDivider mt="xl" />
+
+          {/* V1 Regression Tests */}
+          <GoabText tag="h2" size="heading-l" mt="xl" mb="m">
+            V1 Regression Tests
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            These tests verify V1 checkboxes still behave correctly after the V2 spacing changes.
+          </GoabText>
+
+          {/* Test Case 5: V1 Standalone Checkboxes */}
+          <GoabText tag="h3" size="heading-m" mt="l" mb="m">
+            Test 5: V1 Standalone Checkboxes (Auto-Margin)
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            V1 checkboxes should still have their default bottom margin (space-m).
+          </GoabText>
+
+          <div style={{ border: "1px dashed #ccc", padding: "1rem" }}>
+            <GoabCheckbox name="v1-standalone1" text="V1 Default - should have margin-bottom: space-m" />
+            <GoabCheckbox name="v1-standalone2" text="V1 Default - should have margin-bottom: space-m" />
+          </div>
+
+          <GoabDivider mt="xl" />
+
+          {/* Test Case 6: V1 CheckboxList */}
+          <GoabText tag="h3" size="heading-m" mt="l" mb="m">
+            Test 6: V1 CheckboxList (No Gap Change)
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            V1 checkbox lists should look the same as before - individual checkbox margins control spacing, list gap is 0.
+          </GoabText>
+
+          <GoabCheckboxList
+            name="v1-list"
+            value={v1ListValue}
+            onChange={(detail: GoabCheckboxListOnChangeDetail) => setV1ListValue(detail.value)}
+          >
+            <GoabCheckbox name="v1opt1" text="V1 list option 1" />
+            <GoabCheckbox name="v1opt2" text="V1 list option 2" />
+            <GoabCheckbox name="v1opt3" text="V1 list option 3" />
+          </GoabCheckboxList>
+
+          <GoabText size="body-xs" mt="m">
+            Selected: {v1ListValue.join(", ") || "none"}
+          </GoabText>
+        </GoabBlock>
+      </GoabOneColumnLayout>
+    </GoabPageBlock>
+  );
+}

--- a/libs/angular-components/src/experimental/checkbox-list/checkbox-list.spec.ts
+++ b/libs/angular-components/src/experimental/checkbox-list/checkbox-list.spec.ts
@@ -1,0 +1,115 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { GoabxCheckboxList } from "./checkbox-list";
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { ReactiveFormsModule } from "@angular/forms";
+import { fireEvent } from "@testing-library/dom";
+import { By } from "@angular/platform-browser";
+import { Spacing } from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  imports: [GoabxCheckboxList],
+  template: `
+    <goabx-checkbox-list
+      [name]="name"
+      [value]="value"
+      [disabled]="disabled"
+      [error]="error"
+      [testId]="testId"
+      [maxWidth]="maxWidth"
+      [size]="size"
+      [mt]="mt"
+      [mb]="mb"
+      [ml]="ml"
+      [mr]="mr"
+      (onChange)="onChange()"
+    >
+    </goabx-checkbox-list>
+  `,
+})
+class TestCheckboxListComponent {
+  name?: string;
+  value?: string[];
+  disabled?: boolean;
+  error?: boolean;
+  testId?: string;
+  maxWidth?: string;
+  size?: "default" | "compact";
+  mt?: Spacing;
+  mb?: Spacing;
+  ml?: Spacing;
+  mr?: Spacing;
+
+  onChange() {
+    /* do nothing */
+  }
+}
+
+describe("GoabxCheckboxList", () => {
+  let fixture: ComponentFixture<TestCheckboxListComponent>;
+  let component: TestCheckboxListComponent;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestCheckboxListComponent, GoabxCheckboxList, ReactiveFormsModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestCheckboxListComponent);
+    component = fixture.componentInstance;
+
+    component.name = "foo";
+    component.value = ["option1"];
+    component.disabled = false;
+    component.error = false;
+    component.testId = "testId";
+    component.maxWidth = "480px";
+    component.size = "compact";
+    component.mt = "s";
+    component.mr = "m";
+    component.mb = "l";
+    component.ml = "xl";
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+  }));
+
+  it("should render properties", () => {
+    const el = fixture.debugElement.query(
+      By.css("goa-checkbox-list"),
+    ).nativeElement;
+    expect(el.getAttribute("name")).toBe(component.name);
+    expect(el.getAttribute("version")).toBe("2");
+    expect(el.getAttribute("size")).toBe("compact");
+    expect(el.getAttribute("testid")).toBe(component.testId);
+    expect(el.getAttribute("maxwidth")).toBe(component.maxWidth);
+    expect(el.getAttribute("mt")).toBe(component.mt);
+    expect(el.getAttribute("mr")).toBe(component.mr);
+    expect(el.getAttribute("mb")).toBe(component.mb);
+    expect(el.getAttribute("ml")).toBe(component.ml);
+  });
+
+  it("should default version to 2", () => {
+    const el = fixture.debugElement.query(
+      By.css("goa-checkbox-list"),
+    ).nativeElement;
+    expect(el.getAttribute("version")).toBe("2");
+  });
+
+  it("should handle onChange event", async () => {
+    const onChange = jest.spyOn(component, "onChange");
+
+    const el = fixture.debugElement.query(
+      By.css("goa-checkbox-list"),
+    ).nativeElement;
+
+    fireEvent(
+      el,
+      new CustomEvent("_change", {
+        detail: { name: "foo", value: ["option1", "option2"] },
+      }),
+    );
+
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/libs/angular-components/src/experimental/checkbox-list/checkbox-list.ts
+++ b/libs/angular-components/src/experimental/checkbox-list/checkbox-list.ts
@@ -1,0 +1,92 @@
+import { GoabCheckboxListOnChangeDetail } from "@abgov/ui-components-common";
+import {
+  CUSTOM_ELEMENTS_SCHEMA,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  forwardRef,
+  OnInit,
+  ChangeDetectorRef,
+  Renderer2,
+} from "@angular/core";
+import { NG_VALUE_ACCESSOR } from "@angular/forms";
+import { CommonModule } from "@angular/common";
+import { GoabControlValueAccessor } from "../base.component";
+
+@Component({
+  standalone: true,
+  selector: "goabx-checkbox-list",
+  template: ` <goa-checkbox-list
+    *ngIf="isReady"
+    [attr.name]="name"
+    [value]="value"
+    [disabled]="disabled"
+    [attr.error]="error"
+    [attr.testid]="testId"
+    [id]="id"
+    [attr.maxwidth]="maxWidth"
+    [attr.version]="version"
+    [attr.size]="size"
+    [attr.mt]="mt"
+    [attr.mb]="mb"
+    [attr.ml]="ml"
+    [attr.mr]="mr"
+    (_change)="_onChange($event)"
+  >
+    <ng-content />
+  </goa-checkbox-list>`,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [CommonModule],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      multi: true,
+      useExisting: forwardRef(() => GoabxCheckboxList),
+    },
+  ],
+})
+export class GoabxCheckboxList extends GoabControlValueAccessor implements OnInit {
+  isReady = false;
+  version = "2";
+  @Input() name!: string;
+  @Input() maxWidth?: string;
+  @Input() size?: "default" | "compact" = "default";
+
+  // Override value to handle string arrays consistently
+  @Input() override value?: string[];
+
+  constructor(
+    private cdr: ChangeDetectorRef,
+    renderer: Renderer2,
+  ) {
+    super(renderer);
+  }
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.isReady = true;
+      this.cdr.detectChanges();
+    });
+  }
+
+  @Output() onChange = new EventEmitter<GoabCheckboxListOnChangeDetail>();
+
+  _onChange(e: Event) {
+    const detail = { ...(e as CustomEvent<GoabCheckboxListOnChangeDetail>).detail, event: e };
+    this.onChange.emit(detail);
+    this.markAsTouched();
+
+    // Update the form control with the selected values
+    const selectedValues = detail.value || [];
+    // clone to ensure a new reference so the underlying web component updates
+    this.value = [...selectedValues];
+    this.fcChange?.([...selectedValues]);
+  }
+
+  // Simplified writeValue - expects array input directly
+  override writeValue(value: string[] | null): void {
+    // clone to ensure a new reference and trigger downstream updates
+    this.value = Array.isArray(value) ? [...value] : [];
+  }
+}

--- a/libs/angular-components/src/experimental/index.ts
+++ b/libs/angular-components/src/experimental/index.ts
@@ -3,6 +3,7 @@ export * from "./button/button";
 export * from "./calendar/calendar";
 export * from "./callout/callout";
 export * from "./checkbox/checkbox";
+export * from "./checkbox-list/checkbox-list";
 export * from "./date-picker/date-picker";
 export * from "./drawer/drawer";
 export * from "./dropdown/dropdown";

--- a/libs/react-components/specs/checkbox-list-v2.browser.spec.tsx
+++ b/libs/react-components/specs/checkbox-list-v2.browser.spec.tsx
@@ -1,0 +1,303 @@
+import { render } from "vitest-browser-react";
+import { GoabxCheckboxList, GoabxCheckbox } from "../src/experimental";
+import { expect, describe, it, vi } from "vitest";
+import { useState } from "react";
+import { userEvent } from "@vitest/browser/context";
+
+describe("CheckboxList V2", () => {
+  it("should render with version 2 set on the web component", async () => {
+    const Component = () => {
+      return (
+        <div data-testid="container">
+          <GoabxCheckboxList name="test-list" testId="checkbox-list">
+            <GoabxCheckbox name="option1" text="Option 1" testId="checkbox-1" />
+            <GoabxCheckbox name="option2" text="Option 2" testId="checkbox-2" />
+          </GoabxCheckboxList>
+        </div>
+      );
+    };
+
+    const result = render(<Component />);
+
+    const container = result.getByTestId("container");
+    const checkboxList = result.getByTestId("checkbox-list");
+
+    expect(container).toBeTruthy();
+    expect(checkboxList).toBeTruthy();
+
+    // V2 wrapper should set version="2" on the web component
+    const wcElement = container.element().querySelector("goa-checkbox-list") as any;
+    expect(wcElement).toBeTruthy();
+    expect(wcElement.version).toBe("2");
+  });
+
+  it("should handle checkbox selection and state management", async () => {
+    const Component = () => {
+      const [selectedValues, setSelectedValues] = useState<string[]>([]);
+
+      return (
+        <div data-testid="container">
+          <span data-testid="selected-values">{selectedValues.join(",")}</span>
+          <GoabxCheckboxList
+            name="test-list"
+            testId="checkbox-list"
+            value={selectedValues}
+            onChange={(detail) => setSelectedValues(detail.value)}
+          >
+            <GoabxCheckbox name="option1" text="Option 1" testId="checkbox-1" />
+            <GoabxCheckbox name="option2" text="Option 2" testId="checkbox-2" />
+            <GoabxCheckbox name="option3" text="Option 3" testId="checkbox-3" />
+          </GoabxCheckboxList>
+        </div>
+      );
+    };
+
+    const result = render(<Component />);
+
+    const selectedValues = result.getByTestId("selected-values");
+    const checkbox1 = result.getByTestId("checkbox-1");
+    const checkbox2 = result.getByTestId("checkbox-2");
+
+    // Initial state should be empty
+    await vi.waitFor(() => {
+      expect(selectedValues.element().textContent).toBe("");
+    });
+
+    // Click first checkbox
+    await checkbox1.click();
+    await vi.waitFor(() => {
+      expect(selectedValues.element().textContent).toBe("option1");
+    });
+
+    // Click second checkbox
+    await checkbox2.click();
+    await vi.waitFor(() => {
+      const text = selectedValues.element().textContent || "";
+      expect(text.split(",")).toEqual(expect.arrayContaining(["option1", "option2"]));
+      expect(text.split(",").length).toBe(2);
+    });
+
+    // Unclick first checkbox
+    await checkbox1.click();
+    await vi.waitFor(() => {
+      expect(selectedValues.element().textContent).toBe("option2");
+    });
+  });
+
+  it("should handle programmatic value changes", async () => {
+    const Component = () => {
+      const [selectedValues, setSelectedValues] = useState<string[]>([]);
+
+      return (
+        <div data-testid="container">
+          <span data-testid="selected-values">{selectedValues.join(",")}</span>
+          <button
+            data-testid="set-values-btn"
+            onClick={() => setSelectedValues(["option1", "option3"])}
+          >
+            Set Values
+          </button>
+          <button data-testid="clear-values-btn" onClick={() => setSelectedValues([])}>
+            Clear Values
+          </button>
+          <GoabxCheckboxList
+            name="test-list"
+            testId="checkbox-list"
+            value={selectedValues}
+            onChange={(detail) => setSelectedValues(detail.value)}
+          >
+            <GoabxCheckbox name="option1" text="Option 1" testId="checkbox-1" />
+            <GoabxCheckbox name="option2" text="Option 2" testId="checkbox-2" />
+            <GoabxCheckbox name="option3" text="Option 3" testId="checkbox-3" />
+          </GoabxCheckboxList>
+        </div>
+      );
+    };
+
+    const result = render(<Component />);
+
+    const selectedValues = result.getByTestId("selected-values");
+    const setValuesBtn = result.getByTestId("set-values-btn");
+    const clearValuesBtn = result.getByTestId("clear-values-btn");
+
+    // Initial state should be empty
+    await vi.waitFor(() => {
+      expect(selectedValues.element().textContent).toBe("");
+    });
+
+    // Set values programmatically
+    await setValuesBtn.click();
+    await vi.waitFor(
+      () => {
+        const text = selectedValues.element().textContent || "";
+        if (text === "") return false;
+        const values = text.split(",").filter((v) => v.trim() !== "");
+        return (
+          values.length === 2 && values.includes("option1") && values.includes("option3")
+        );
+      },
+      { timeout: 2000 },
+    );
+
+    // Clear values programmatically
+    await clearValuesBtn.click();
+    await vi.waitFor(() => {
+      expect(selectedValues.element().textContent).toBe("");
+    });
+  });
+
+  it("should handle disabled state", async () => {
+    const Component = () => {
+      const [isDisabled, setIsDisabled] = useState(false);
+      const [selectedValues, setSelectedValues] = useState<string[]>([]);
+
+      return (
+        <div data-testid="container">
+          <span data-testid="selected-values">{selectedValues.join(",")}</span>
+          <span data-testid="disabled-state">{isDisabled ? "disabled" : "enabled"}</span>
+          <button
+            data-testid="toggle-disabled-btn"
+            onClick={() => setIsDisabled(!isDisabled)}
+          >
+            Toggle Disabled
+          </button>
+          <GoabxCheckboxList
+            name="test-list"
+            testId="checkbox-list"
+            disabled={isDisabled}
+            value={selectedValues}
+            onChange={(detail) => setSelectedValues(detail.value)}
+          >
+            <GoabxCheckbox name="option1" text="Option 1" testId="checkbox-1" />
+            <GoabxCheckbox name="option2" text="Option 2" testId="checkbox-2" />
+          </GoabxCheckboxList>
+        </div>
+      );
+    };
+
+    const result = render(<Component />);
+
+    const selectedValues = result.getByTestId("selected-values");
+    const disabledState = result.getByTestId("disabled-state");
+    const toggleBtn = result.getByTestId("toggle-disabled-btn");
+    const checkbox1 = result.getByTestId("checkbox-1");
+
+    // Initially not disabled - should be able to click
+    await vi.waitFor(() => {
+      expect(disabledState.element().textContent).toBe("enabled");
+    });
+
+    await checkbox1.click();
+    await vi.waitFor(() => {
+      expect(selectedValues.element().textContent).toBe("option1");
+    });
+
+    // Disable the checkbox list
+    await toggleBtn.click();
+    await vi.waitFor(() => {
+      expect(disabledState.element().textContent).toBe("disabled");
+    });
+
+    // disabled state is applied
+    expect(disabledState.element().textContent).toBe("disabled");
+  });
+
+  it("should propagate disabled state to child checkboxes on mount", async () => {
+    const Component = () => (
+      <GoabxCheckboxList
+        name="test-list"
+        testId="checkbox-list"
+        disabled={true}
+      >
+        <GoabxCheckbox name="option1" text="Option 1" testId="checkbox-1" />
+        <GoabxCheckbox name="option2" text="Option 2" testId="checkbox-2" />
+      </GoabxCheckboxList>
+    );
+
+    const result = render(<Component />);
+
+    // Verify child checkboxes are disabled (label gets 'disabled' class)
+    const checkbox1 = result.getByTestId("checkbox-1");
+    const checkbox2 = result.getByTestId("checkbox-2");
+    await vi.waitFor(() => {
+      const checkbox1El = checkbox1.element() as HTMLElement;
+      const checkbox2El = checkbox2.element() as HTMLElement;
+      expect(checkbox1El.classList.contains("disabled")).toBe(true);
+      expect(checkbox2El.classList.contains("disabled")).toBe(true);
+    });
+  });
+
+  it("should propagate error state to child checkboxes on mount", async () => {
+    const Component = () => (
+      <GoabxCheckboxList
+        name="test-list"
+        testId="checkbox-list"
+        error={true}
+      >
+        <GoabxCheckbox name="option1" text="Option 1" testId="checkbox-1" />
+        <GoabxCheckbox name="option2" text="Option 2" testId="checkbox-2" />
+      </GoabxCheckboxList>
+    );
+
+    const result = render(<Component />);
+
+    // Verify child checkboxes have error state (label gets 'error' class)
+    const checkbox1 = result.getByTestId("checkbox-1");
+    const checkbox2 = result.getByTestId("checkbox-2");
+    await vi.waitFor(() => {
+      const checkbox1El = checkbox1.element() as HTMLElement;
+      const checkbox2El = checkbox2.element() as HTMLElement;
+      expect(checkbox1El.classList.contains("error")).toBe(true);
+      expect(checkbox2El.classList.contains("error")).toBe(true);
+    });
+  });
+
+  it("passes the browser event in change detail", async () => {
+    const onChange = vi.fn();
+
+    const Component = () => (
+      <GoabxCheckboxList
+        name="event-list"
+        testId="event-checkbox-list"
+        onChange={onChange}
+      >
+        <GoabxCheckbox name="event-option1" text="Option 1" testId="event-checkbox-1" />
+      </GoabxCheckboxList>
+    );
+
+    const result = render(<Component />);
+    const checkbox = result.getByTestId("event-checkbox-1");
+
+    await userEvent.click(checkbox);
+
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const detail = onChange.mock.calls[0][0];
+      expect(detail.name).toBe("event-list");
+      expect(detail.value).toEqual(["event-option1"]);
+      expect(detail.event).toBeInstanceOf(Event);
+    });
+  });
+
+  it("should support compact size", async () => {
+    const Component = () => {
+      return (
+        <div data-testid="container">
+          <GoabxCheckboxList name="compact-list" testId="compact-checkbox-list" size="compact">
+            <GoabxCheckbox name="option1" text="Option 1" size="compact" testId="compact-checkbox-1" />
+            <GoabxCheckbox name="option2" text="Option 2" size="compact" testId="compact-checkbox-2" />
+          </GoabxCheckboxList>
+        </div>
+      );
+    };
+
+    const result = render(<Component />);
+
+    const container = result.getByTestId("container");
+    expect(container).toBeTruthy();
+
+    const wcElement = container.element().querySelector("goa-checkbox-list") as any;
+    expect(wcElement).toBeTruthy();
+    expect(wcElement.size).toBe("compact");
+  });
+});

--- a/libs/react-components/src/experimental/checkbox-list/checkbox-list.spec.tsx
+++ b/libs/react-components/src/experimental/checkbox-list/checkbox-list.spec.tsx
@@ -1,0 +1,98 @@
+import { render } from "@testing-library/react";
+import { fireEvent } from "@testing-library/dom";
+import GoabxCheckboxList, { GoabxCheckboxListProps as CheckboxListProps } from "./checkbox-list";
+import { describe, it, expect, vi } from "vitest";
+import { GoabCheckboxListOnChangeDetail } from "@abgov/ui-components-common";
+
+const testId = "test-id";
+
+describe("GoabxCheckboxList", () => {
+  it("should render", () => {
+    render(<GoabxCheckboxList name="foo" />);
+
+    const checkboxList = document.querySelector("goa-checkbox-list");
+    expect(checkboxList?.getAttribute("name")).toBe("foo");
+    expect(checkboxList?.getAttribute("version")).toBe("2");
+    expect(checkboxList?.getAttribute("disabled")).toBeNull();
+    expect(checkboxList?.getAttribute("error")).toBeNull();
+  });
+
+  it("should render with props", () => {
+    const props: CheckboxListProps = {
+      name: "foo",
+      value: ["option1", "option2"],
+      maxWidth: "480px",
+      size: "compact",
+      disabled: true,
+      error: true,
+      testId: testId,
+      mt: "s",
+      mr: "m",
+      mb: "l",
+      ml: "xl",
+    };
+
+    render(<GoabxCheckboxList {...props} />);
+
+    const checkboxList = document.querySelector("goa-checkbox-list");
+    expect(checkboxList?.getAttribute("name")).toBe("foo");
+    expect(checkboxList?.getAttribute("maxwidth")).toBe("480px");
+    expect(checkboxList?.getAttribute("size")).toBe("compact");
+    expect(checkboxList?.getAttribute("version")).toBe("2");
+    expect(checkboxList?.getAttribute("disabled")).toBe("true");
+    expect(checkboxList?.getAttribute("error")).toBe("true");
+    expect(checkboxList?.getAttribute("testid")).toBe(testId);
+    expect(checkboxList?.getAttribute("mt")).toBe("s");
+    expect(checkboxList?.getAttribute("mr")).toBe("m");
+    expect(checkboxList?.getAttribute("mb")).toBe("l");
+    expect(checkboxList?.getAttribute("ml")).toBe("xl");
+  });
+
+  it("should default version to 2", () => {
+    render(<GoabxCheckboxList name="foo" />);
+
+    const checkboxList = document.querySelector("goa-checkbox-list");
+    expect(checkboxList?.getAttribute("version")).toBe("2");
+  });
+
+  it("should handle the onChange event", async function () {
+    const onChangeStub = vi.fn();
+
+    function onChange({ name, value }: GoabCheckboxListOnChangeDetail) {
+      expect(name).toBe("foo");
+      expect(value).toEqual(["option1"]);
+      onChangeStub();
+    }
+
+    const props: CheckboxListProps = {
+      name: "foo",
+      value: [],
+      onChange: onChange,
+      testId: testId,
+    };
+
+    render(<GoabxCheckboxList {...props} />);
+    const checkboxList = document.querySelector("goa-checkbox-list");
+
+    checkboxList &&
+      fireEvent(
+        checkboxList,
+        new CustomEvent("_change", {
+          detail: { name: "foo", value: ["option1"] },
+        }),
+      );
+    expect(onChangeStub).toBeCalled();
+  });
+
+  it("should render children", () => {
+    render(
+      <GoabxCheckboxList name="foo">
+        <div data-testid="child">Child content</div>
+      </GoabxCheckboxList>
+    );
+
+    const child = document.querySelector("[data-testid='child']");
+    expect(child).toBeTruthy();
+    expect(child?.textContent).toBe("Child content");
+  });
+});

--- a/libs/react-components/src/experimental/checkbox-list/checkbox-list.tsx
+++ b/libs/react-components/src/experimental/checkbox-list/checkbox-list.tsx
@@ -1,34 +1,57 @@
 import {
   GoabCheckboxListOnChangeDetail,
-  Margins
+  Margins,
 } from "@abgov/ui-components-common";
 import { useEffect, useRef, type JSX } from "react";
 
-export interface GoabCheckboxListProps extends Margins {
+interface WCProps extends Margins {
+  ref: React.RefObject<HTMLElement | null>;
+  name: string;
+  value?: string[];
+  disabled?: string;
+  error?: string;
+  testid?: string;
+  maxwidth?: string;
+  version?: string;
+  size?: string;
+}
+
+declare module "react" {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      "goa-checkbox-list": WCProps & React.HTMLAttributes<HTMLElement>;
+    }
+  }
+}
+
+export interface GoabxCheckboxListProps extends Margins {
   name: string;
   value?: string[];
   disabled?: boolean;
   error?: boolean;
   testId?: string;
   maxWidth?: string;
+  size?: "default" | "compact";
   children?: React.ReactNode;
   onChange?: (detail: GoabCheckboxListOnChangeDetail) => void;
 }
 
-export function GoabCheckboxList({
+export function GoabxCheckboxList({
   name,
   value = [],
   disabled,
   error,
   testId,
   maxWidth,
+  size = "default",
   children,
   onChange,
   mt,
   mr,
   mb,
   ml,
-}: GoabCheckboxListProps): JSX.Element {
+}: GoabxCheckboxListProps): JSX.Element {
   const el = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -36,26 +59,14 @@ export function GoabCheckboxList({
 
     const current = el.current;
     const listener = (e: Event) => {
-      try {
-        const detail = (e as CustomEvent<GoabCheckboxListOnChangeDetail>).detail;
-        onChange?.({ ...detail, event: e });
-      } catch (error) {
-        console.error("Error handling checkbox list change:", error);
-      }
+      const detail = (e as CustomEvent<GoabCheckboxListOnChangeDetail>).detail;
+      onChange?.({ ...detail, event: e });
     };
 
-    try {
-      current.addEventListener("_change", listener);
-    } catch (error) {
-      console.error("Failed to attach checkbox list listener:", error);
-    }
+    current.addEventListener("_change", listener);
 
     return () => {
-      try {
-        current.removeEventListener("_change", listener);
-      } catch (error) {
-        console.error("Failed to remove checkbox list listener:", error);
-      }
+      current.removeEventListener("_change", listener);
     };
   }, [onChange]);
 
@@ -68,6 +79,8 @@ export function GoabCheckboxList({
       error={error ? "true" : undefined}
       testid={testId}
       maxwidth={maxWidth}
+      version="2"
+      size={size}
       mt={mt}
       mr={mr}
       mb={mb}
@@ -78,4 +91,4 @@ export function GoabCheckboxList({
   );
 }
 
-export default GoabCheckboxList;
+export default GoabxCheckboxList;

--- a/libs/react-components/src/experimental/index.ts
+++ b/libs/react-components/src/experimental/index.ts
@@ -3,6 +3,7 @@ export * from "./button/button";
 export * from "./calendar/calendar";
 export * from "./callout/callout";
 export * from "./checkbox/checkbox";
+export * from "./checkbox-list/checkbox-list";
 export * from "./date-picker/date-picker";
 export * from "./drawer/drawer";
 export * from "./dropdown/dropdown";

--- a/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
+++ b/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
@@ -38,6 +38,10 @@
   export let testid: string = "";
   /** Sets the maximum width of the checkbox list container. */
   export let maxwidth: string = "none";
+  /** @internal Design system version for styling. */
+  export let version: "1" | "2" = "1";
+  /** Sets the size of the checkbox list. 'compact' reduces spacing between items. */
+  export let size: "default" | "compact" = "default";
 
   /** Top margin. */
   export let mt: Spacing = null;
@@ -426,7 +430,7 @@
   data-testid={testid}
   on:focus={onFocus}
 >
-  <div bind:this={_slotEl} class="checkbox-container">
+  <div bind:this={_slotEl} class="checkbox-container" class:v2={version === "2"} class:compact={size === "compact"}>
     <slot />
   </div>
 </div>
@@ -448,5 +452,13 @@
     display: flex;
     flex-direction: column;
     gap: 0;
+  }
+
+  .checkbox-container.v2 {
+    gap: var(--goa-space-m);
+  }
+
+  .checkbox-container.v2.compact {
+    gap: var(--goa-space-s);
   }
 </style>

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -103,7 +103,10 @@
     // hold on to the initial value to prevent losing it on check changes
     _value = value;
     _descriptionId = `description_${name}`;
-    mb ??= size === "compact" ? "s" : "m";
+
+    // V1: preserve backwards-compatible auto-margin
+    // V2: parent controls spacing, no auto-margin
+    if (version === "1") mb ??= size === "compact" ? "s" : "m";
 
     addRelayListener();
     addRevealSlotListener();
@@ -420,7 +423,7 @@ max-width: ${maxwidth};
 
   .description {
     font: var(--goa-checkbox-description-font-size);
-    margin-left: var(--goa-space-xl);
+    margin-left: calc(var(--goa-checkbox-size) + var(--goa-checkbox-gap));
     margin-top: var(--goa-space-2xs); /* Space between text and description */
   }
 
@@ -646,5 +649,9 @@ max-width: ${maxwidth};
   .v2.compact .text {
     padding-left: var(--goa-checkbox-gap-compact);
     font: var(--goa-checkbox-label-font-size-compact);
+  }
+
+  .compact .description {
+    margin-left: calc(var(--goa-checkbox-size) + var(--goa-checkbox-gap-compact));
   }
 </style>


### PR DESCRIPTION
## Summary
- Remove automatic margin-bottom from Checkbox in V2 mode
- Let CheckboxList control spacing via gap property
- Add playground test pages for visual verification

## Changes
- `Checkbox.svelte`: Removed auto-margin (`mb ??= size === "compact" ? "s" : "m"`)
- `CheckboxList.svelte`: Changed `gap: 0` to `gap: var(--goa-space-m)`
- `featV2Checkbox.tsx`: Test page at `/features/v2-checkbox`

### Before
<img width="1310" height="658" alt="image" src="https://github.com/user-attachments/assets/b54ce2de-0d3d-4687-b7ac-0149329d71a7" />
<img width="1268" height="486" alt="image" src="https://github.com/user-attachments/assets/807e9b3b-c6c8-4056-82f7-fe77075c2ef5" />


### After
<img width="1374" height="718" alt="image" src="https://github.com/user-attachments/assets/5228b505-e4ad-4635-b853-210cf4a6b089" />

(^^ no unwanted bottom margin)

<img width="1244" height="528" alt="image" src="https://github.com/user-attachments/assets/b95e8166-2bf4-47db-bdb6-f945bb7c1a87" />

(^^ should look the same)

Added GoabxCheckboxList experimental wrappers for React and Angular — there wasn't one for checkbox-list yet, only for checkbox. Follows the Goabx pattern from #3357, auto-defaults version="2" and accepts a size prop.

## Testing
- [ ] Visit `/features/v2-checkbox` in React playground
- [ ] Verify checkboxes in a list have consistent spacing
- [ ] Verify standalone checkboxes no longer have unwanted bottom margin

## Related
- Spacing fix for V2 checkbox styling to match design specs