### PR TITLE
fix(#3373): fix v2 filter chip click event

### DIFF
--- a/apps/prs/web/src/app/App.svelte
+++ b/apps/prs/web/src/app/App.svelte
@@ -1,13 +1,15 @@
+<script lang="ts">
+  import "@abgov/style";
+  import { Router, Route } from "svelte-routing";
+  import Issue2333 from "../routes/2333.svelte";
+  import Issue3279 from "../routes/3279.svelte";
+</script>
+
 <svelte:head>
   <title>Goab Component Playground</title>
 </svelte:head>
 
-<script lang="ts">
-  import "@abgov/style";
-  import { Router, Route } from 'svelte-routing';
-  import Issue2333 from '../routes/2333.svelte';
-</script>
-
 <Router>
   <Route path="/issues/2333" component={Issue2333} />
+  <Route path="/issues/3279" component={Issue3279} />
 </Router>

--- a/apps/prs/web/src/routes/3279.svelte
+++ b/apps/prs/web/src/routes/3279.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  // Route component for /issues/3279
+  let v1Clicks = 0;
+  let v2Clicks = 0;
+
+  function incV1() {
+    v1Clicks += 1;
+  }
+
+  function incV2() {
+    v2Clicks += 1;
+  }
+</script>
+
+<div class="page">
+  <h1>Issue 3279</h1>
+  <p>Two filter chips (v1 + v2) with click counts.</p>
+
+  <div class="row">
+    <goa-filter-chip content={`v1 clicks: ${v1Clicks}`} version="1" on:_click={incV1} />
+  </div>
+
+  <div class="row">
+    <goa-filter-chip content={`v2 clicks: ${v2Clicks}`} version="2" on:_click={incV2} />
+  </div>
+</div>
+
+<style>
+  .page {
+    padding: 2rem;
+  }
+
+  .row {
+    margin-top: 1rem;
+  }
+</style>

--- a/libs/web-components/src/components/filter-chip/FilterChip.svelte
+++ b/libs/web-components/src/components/filter-chip/FilterChip.svelte
@@ -36,9 +36,7 @@
 
   // Event handlers
   function onDelete(e: Event) {
-    el.dispatchEvent(
-      new CustomEvent("_click", { composed: true, bubbles: true }),
-    );
+    el.dispatchEvent(new CustomEvent("_click", { composed: true, bubbles: true }));
     e.stopPropagation();
   }
 
@@ -84,7 +82,7 @@
     <goa-icon-button
       size="3"
       icon="close"
-      onclick={onDelete}
+      on:_click={onDelete}
       arialabel="Remove filter"
       variant={_error ? "destructive" : "dark"}
       testid="delete-button"
@@ -130,10 +128,7 @@
   .chip {
     display: inline-flex;
     align-items: center;
-    background-color: var(
-      --goa-filter-chip-bg-color,
-      var(--goa-color-greyscale-white)
-    );
+    background-color: var(--goa-filter-chip-bg-color, var(--goa-color-greyscale-white));
     border-radius: var(--goa-filter-chip-border-radius, 1rem);
     border: var(
       --goa-filter-chip-border,
@@ -170,10 +165,7 @@
       --goa-filter-chip-border-color-error,
       var(--goa-color-emergency-default)
     );
-    color: var(
-      --goa-filter-chip-text-color-error,
-      var(--goa-color-emergency-default)
-    );
+    color: var(--goa-filter-chip-text-color-error, var(--goa-color-emergency-default));
   }
 
   .chip:not(.v2).error:hover {
@@ -193,10 +185,7 @@
   }
 
   .text {
-    line-height: var(
-      --goa-filter-chip-line-height,
-      var(--goa-line-height-2)
-    ); /* 24px */
+    line-height: var(--goa-filter-chip-line-height, var(--goa-line-height-2)); /* 24px */
     padding-top: 0;
     display: flex;
     align-items: center;


### PR DESCRIPTION
# Before (the change)

Selecting the close button on a v2 Filter Chip fires two "_click" events.

![3279-broken](https://github.com/user-attachments/assets/2998c937-a374-4ea0-825c-a4a91a8f41d1)

# After (the change)

Selecting the close button on a v2 Filter Chip fires one "_click" event.

![3279-fixed](https://github.com/user-attachments/assets/8360fc5f-d64d-4668-94ba-5a06637f342b)
