### PR TITLE
feat(#3370): Date Picker and and Calendar improvements

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -81,6 +81,7 @@
           <a href="/features/3137">3137</a>
           <a href="/features/3241">3241</a>
           <a href="/features/3306">3306</a>
+          <a href="/features/3370">3370</a>
           <a href="/features/v2-icons">v2 header icons</a>
         </goab-side-menu-group>
       </goab-side-menu>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -62,11 +62,12 @@ import { Feat2722Component } from "../routes/features/feat2722/feat2722.componen
 import { Feat2730Component } from "../routes/features/feat2730/feat2730.component";
 import { Feat2829Component } from "../routes/features/feat2829/feat2829.component";
 import { Feat3102Component } from "../routes/features/feat3102/feat3102.component";
-import { FeatV2IconsComponent } from "../routes/features/featV2Icons/feat-v2-icons.component";
 import { Feat3137Component } from "../routes/features/feat3137/feat3137.component";
 import { Feat3241Component } from "../routes/features/feat3241/feat3241.component";
 import { Feat3306Component } from "../routes/features/feat3306/feat3306.component";
 import { Feat2469Component } from "../routes/features/feat2469/feat2469.component";
+import { Feat3370Component } from "../routes/features/feat3370/feat3370.component";
+import { FeatV2IconsComponent } from "../routes/features/featV2Icons/feat-v2-icons.component";
 
 export const appRoutes: Route[] = [
   { path: "everything", component: EverythingComponent },
@@ -135,5 +136,7 @@ export const appRoutes: Route[] = [
   { path: "features/3137", component: Feat3137Component },
   { path: "features/3241", component: Feat3241Component },
   { path: "features/v2-icons", component: FeatV2IconsComponent },
+  { path: "features/3137", component: Feat3137Component },
   { path: "features/3306", component: Feat3306Component },
+  { path: "features/3370", component: Feat3370Component },
 ];

--- a/apps/prs/angular/src/routes/features/feat3370/feat3370.component.html
+++ b/apps/prs/angular/src/routes/features/feat3370/feat3370.component.html
@@ -1,0 +1,29 @@
+<div>
+  <h1>
+    <a
+      href="https://github.com/GovAlta/ui-components/issues/3370"
+      target="_blank"
+      rel="noreferrer"
+    >
+      Feature 3370
+    </a>
+  </h1>
+  <div>
+    <h2>Clear calendar day selection when year and/or month changes</h2>
+    <goab-calendar (onChange)="handleOnChange($event)" [value]="calendarValue" />
+    <p>Selected Date: {{ calendarValue || "none" }}</p>
+    <goab-button (onClick)="clearCalendarValue()">Clear Selection</goab-button>
+  </div>
+  <div>
+    <goab-date-picker
+      (onChange)="handleDatePickerChange($event)"
+      [value]="datePickerValue"
+    />
+    <p>Selected Date: {{ datePickerValue || "none" }}</p>
+    <goab-button-group>
+      <goab-button (onClick)="clearDatePickerValue()">Clear Selection</goab-button>
+      <goab-button (onClick)="toCalendarDateValue()">To Calendar as Date</goab-button>
+      <goab-button (onClick)="toCalendarStringValue()">To Calendar as String</goab-button>
+    </goab-button-group>
+  </div>
+</div>

--- a/apps/prs/angular/src/routes/features/feat3370/feat3370.component.ts
+++ b/apps/prs/angular/src/routes/features/feat3370/feat3370.component.ts
@@ -1,0 +1,51 @@
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+import {
+  GoabButton,
+  GoabButtonGroup,
+  GoabCalendar,
+  GoabDatePicker,
+} from "@abgov/angular-components";
+import {
+  GoabCalendarOnChangeDetail,
+  GoabDatePickerOnChangeDetail,
+} from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat3370",
+  templateUrl: "./feat3370.component.html",
+  imports: [CommonModule, GoabButton, GoabButtonGroup, GoabCalendar, GoabDatePicker],
+})
+export class Feat3370Component {
+  calendarValue: Date | string = "";
+  datePickerValue = "";
+
+  handleOnChange(details: GoabCalendarOnChangeDetail): void {
+    this.calendarValue = details.value;
+  }
+
+  handleDatePickerChange(details: GoabDatePickerOnChangeDetail): void {
+    this.datePickerValue = details.valueStr;
+  }
+
+  clearCalendarValue(): void {
+    this.calendarValue = "";
+  }
+
+  clearDatePickerValue(): void {
+    this.datePickerValue = "";
+  }
+
+  toCalendarDateValue(): void {
+    if (this.datePickerValue) {
+      this.calendarValue = new Date(`${this.datePickerValue}T00:00:00`);
+    }
+  }
+
+  toCalendarStringValue(): void {
+    if (this.datePickerValue) {
+      this.calendarValue = this.datePickerValue;
+    }
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -92,6 +92,7 @@ export function App() {
               <Link to="/features/3241">3241 V2 Experimental Wrappers</Link>
               <Link to="/features/v2-icons">v2 header icons</Link>
               <Link to="/features/3306">3306 Custom slug value for tabs</Link>
+              <Link to="/features/3370">3370 Clear calendar day selection</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Everything">
               <Link to="/everything">A</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -72,6 +72,7 @@ import { FeatV2IconsRoute } from "./routes/features/featV2Icons";
 import { Feat3137Route } from "./routes/features/feat3137";
 import { Feat3306Route } from "./routes/features/feat3306";
 import { Feat2469Route } from "./routes/features/feat2469";
+import { Feat3370Route } from "./routes/features/feat3370";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 
@@ -149,7 +150,9 @@ root.render(
           <Route path="features/3137" element={<Feat3137Route />} />
           <Route path="features/3241" element={<Feat3241Route />} />
           <Route path="features/v2-icons" element={<FeatV2IconsRoute />} />
+          <Route path="features/3137" element={<Feat3137Route />} />
           <Route path="features/3306" element={<Feat3306Route />} />
+          <Route path="features/3370" element={<Feat3370Route />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/apps/prs/react/src/routes/features/feat3370.tsx
+++ b/apps/prs/react/src/routes/features/feat3370.tsx
@@ -1,0 +1,44 @@
+import { GoabButton, GoabCalendar, GoabDatePicker } from "@abgov/react-components";
+import {
+  GoabCalendarOnChangeDetail,
+  GoabDatePickerOnChangeDetail,
+} from "@abgov/ui-components-common";
+import React, { useState } from "react";
+
+export function Feat3370Route() {
+  const [calendarValue, setCalendarValue] = useState("");
+  const [datePickerValue, setDatePickerValue] = useState("");
+
+  function handleOnChange(details: GoabCalendarOnChangeDetail) {
+    setCalendarValue(details.value);
+  }
+
+  function handleDatePickerChange(details: GoabDatePickerOnChangeDetail) {
+    setDatePickerValue(details.valueStr);
+  }
+
+  return (
+    <div>
+      <h1>
+        <a
+          href="https://github.com/GovAlta/ui-components/issues/3370"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Feature 3370
+        </a>
+      </h1>
+      <div>
+        <h2>Clear calendar day selection when year and/or month changes</h2>
+        <GoabCalendar onChange={handleOnChange} value={calendarValue} />
+        <p>Selected Date: {calendarValue || "none"}</p>
+        <GoabButton onClick={() => setCalendarValue("")}>Clear Selection</GoabButton>
+      </div>
+      <div>
+        <GoabDatePicker onChange={handleDatePickerChange} value={datePickerValue} />
+        <p>Selected Date: {datePickerValue || "none"}</p>
+        <GoabButton onClick={() => setDatePickerValue("")}>Clear Selection</GoabButton>
+      </div>
+    </div>
+  );
+}

--- a/libs/angular-components/src/experimental/calendar/calendar.ts
+++ b/libs/angular-components/src/experimental/calendar/calendar.ts
@@ -39,7 +39,7 @@ export class GoabxCalendar extends GoabBaseComponent implements OnInit {
   version = 2;
 
   @Input() name?: string;
-  @Input() value?: Date;
+  @Input() value?: Date | string;
   @Input() min?: Date;
   @Input() max?: Date;
 

--- a/libs/angular-components/src/lib/components/calendar/calendar.ts
+++ b/libs/angular-components/src/lib/components/calendar/calendar.ts
@@ -36,7 +36,7 @@ import { GoabBaseComponent } from "../base.component";
 })
 export class GoabCalendar extends GoabBaseComponent implements OnInit {
   @Input() name?: string;
-  @Input() value?: Date;
+  @Input() value?: Date | string;
   @Input() min?: Date;
   @Input() max?: Date;
 

--- a/libs/react-components/specs/calendar.browser.spec.tsx
+++ b/libs/react-components/specs/calendar.browser.spec.tsx
@@ -1,5 +1,4 @@
-import { render } from "vitest-browser-react";
-
+import { render, RenderResult } from "vitest-browser-react";
 import { GoabCalendar } from "../src";
 import { expect, describe, it, vi } from "vitest";
 import { userEvent } from "@vitest/browser/context";
@@ -599,6 +598,109 @@ describe("Calendar", () => {
     });
   });
 
+  describe("Given a date is selected", () => {
+    const currentValue = "2026-01-31";
+    const handleChange = vi.fn();
+
+    let result: RenderResult;
+
+    beforeEach(async () => {
+      const Component = () => {
+        return (
+          <GoabCalendar
+            testId="test-calendar"
+            value={currentValue}
+            onChange={handleChange}
+          />
+        );
+      };
+      result = render(<Component />);
+    });
+
+    it("focuses the value selected date", async () => {
+      await vi.waitFor(() => {
+        const selected = result.getByTestId(currentValue);
+        expect(selected.element().classList.contains("selected")).toBe(true);
+      });
+    });
+
+    it("does not select a day in the next month when another month is selected", async () => {
+      // Move from January to February 2026
+      const monthsDropdown = result.getByTestId("months");
+      const februaryItem = result.getByTestId("dropdown-item-2");
+
+      // select February
+      await monthsDropdown.click();
+      await februaryItem.click();
+
+      await vi.waitFor(() => {
+        const firstDayOfFeb = result.getByTestId("2026-02-01");
+        expect(firstDayOfFeb).toBeVisible();
+      });
+
+      await vi.waitFor(() => {
+        // Feb 2026 is four weeks that fit perfectly in the calendar view. Jan 31
+        // should not be visible or in the calendar at all.
+        expect(result.container.getElementsByClassName("selected").length).toBe(0);
+        // Value didn't change
+        expect(handleChange).not.toHaveBeenCalled();
+      });
+    });
+
+    it("does not select a day in the next year when another year is selected", async () => {
+      // Move from 2026 to January 2027
+      const yearsDropdown = result.getByTestId("years");
+      const jan2027Item = result.getByTestId("dropdown-item-2027");
+      const firstDayOfJan2027 = result.getByTestId("2027-01-01");
+
+      // select 2027
+      await yearsDropdown.click();
+      await jan2027Item.click();
+
+      // Wait for dropdown to be interactive
+      await vi.waitFor(() => {
+        expect(firstDayOfJan2027).toBeVisible();
+      });
+
+      await vi.waitFor(() => {
+        expect(result.container.getElementsByClassName("selected").length).toBe(0);
+        // Value didn't change
+        expect(handleChange).not.toHaveBeenCalled();
+      });
+    });
+
+    it("will keep the selection when navigating back to the original month", async () => {
+      // Move from January to February 2026
+      const monthsDropdown = result.getByTestId("months");
+      const februaryItem = result.getByTestId("dropdown-item-2");
+      const firstDayOfFeb = result.getByTestId("2026-02-01");
+
+      // select February
+      await monthsDropdown.click();
+      await februaryItem.click();
+
+      await vi.waitFor(() => {
+        expect(firstDayOfFeb).toBeVisible();
+      });
+
+      const januaryItem = result.getByTestId("dropdown-item-1");
+      const firstDayOfJan = result.getByTestId("2026-01-01");
+
+      // select January again
+      await monthsDropdown.click();
+      await januaryItem.click();
+
+      await vi.waitFor(() => {
+        expect(firstDayOfJan).toBeVisible();
+      });
+
+      await vi.waitFor(() => {
+        const selected = result.getByTestId(currentValue);
+        expect(selected.element().classList.contains("selected")).toBe(true);
+      });
+    });
+  });
+
   describe("Visual states", () => {
     it("highlights today's date", async () => {
       const handleChange = vi.fn();
@@ -714,6 +816,71 @@ describe("Calendar", () => {
 
         await vi.waitFor(() => {
           expect(falseyOption.element()).toBeTruthy();
+        });
+      });
+    });
+
+    // #3305: If you selected a date that didn't exist in the next month
+    // (e.g., Jan 31 to Feb), the calendar would not render February at all.
+    describe("3305", async () => {
+      const handleChange = vi.fn();
+      let result: RenderResult;
+
+      beforeEach(async () => {
+        const Component = () => {
+          return <GoabCalendar testId="test-calendar" onChange={handleChange} />;
+        };
+
+        result = render(<Component />);
+      });
+
+      it("can show February after selecting Jan 31", async () => {
+        // Move from January to February 2026
+        const yearsDropdown = result.getByTestId("years");
+        const year2027Item = result.getByTestId("dropdown-item-2027");
+
+        // Select 2027
+        await yearsDropdown.click();
+        await year2027Item.click();
+
+        // Select January (2027)
+        const monthsDropdown = result.getByTestId("months");
+        const januaryItem = result.getByTestId("dropdown-item-1");
+        const lastDayOfJan = result.getByTestId("2027-01-31");
+
+        // Select January
+        await monthsDropdown.click();
+        await januaryItem.click();
+
+        // Wait for dropdown to be interactive
+        await vi.waitFor(() => {
+          expect(lastDayOfJan).toBeVisible();
+        });
+
+        await lastDayOfJan.click();
+        await vi.waitFor(() => {
+          expect(handleChange).toHaveBeenCalledWith({
+            name: "",
+            value: "2027-01-31",
+          });
+        });
+
+        handleChange.mockReset();
+
+        // Select February
+        const februaryItem = result.getByTestId("dropdown-item-2");
+
+        await monthsDropdown.click();
+        await februaryItem.click();
+
+        const firstDayOfFeb = result.getByTestId("2027-02-01");
+        const lastDayOfFeb = result.getByTestId("2027-02-28");
+
+        // Wait for calendar to be interactive at February, which means a pass.
+        await vi.waitFor(() => {
+          expect(firstDayOfFeb).toBeVisible();
+          expect(lastDayOfFeb).toBeVisible();
+          expect(handleChange).not.toHaveBeenCalled();
         });
       });
     });

--- a/libs/react-components/specs/datepicker.browser.spec.tsx
+++ b/libs/react-components/specs/datepicker.browser.spec.tsx
@@ -4,6 +4,11 @@ import { expect, describe, it, vi } from "vitest";
 import { userEvent } from "@vitest/browser/context";
 import { format } from "date-fns";
 
+function getTodayDate(): Date {
+  const today = new Date();
+  return new Date(today.getFullYear(), today.getMonth(), today.getDate());
+}
+
 describe("DatePicker", () => {
   it("renders", async () => {
     const Component = () => {
@@ -34,7 +39,7 @@ describe("DatePicker", () => {
   });
 
   it("shows an error state", async () => {
-    const value = new Date();
+    const value = getTodayDate();
 
     const Component = () => {
       return <GoabDatePicker testId="date-picker" value={value} error={true} />;

--- a/libs/web-components/src/components/calendar/Calendar.svelte
+++ b/libs/web-components/src/components/calendar/Calendar.svelte
@@ -73,8 +73,8 @@
       const newDate = new CalendarDate(value);
       if (newDate.isValid()) {
         renderCalendar({ type: "date", value: newDate });
-        _selectedDate = newDate;
-        _calendarDate = newDate;
+        _selectedDate = newDate.clone();
+        _calendarDate = newDate.clone();
       }
     }
   }
@@ -99,7 +99,10 @@
     }
 
     // Re-render with updated values
-    renderCalendar({ type: "date", value: _calendarDate || new CalendarDate() });
+    renderCalendar({
+      type: "date",
+      value: _calendarDate || new CalendarDate(),
+    });
   }
 
   // *****
@@ -108,9 +111,12 @@
 
   onMount(() => {
     if (value) {
-      _calendarDate = _selectedDate = new CalendarDate(value);
+      _calendarDate = new CalendarDate(value);
+      _selectedDate = _calendarDate.clone();
     } else {
-      _calendarDate = new CalendarDate();
+      // Bug3305: by default _calendarDate defaults to today. To prevent issues
+      // initialize calendarDate to the 1st of the month.
+      _calendarDate = new CalendarDate().setDay(1);
       _selectedDate = new CalendarDate(0);
     }
 
@@ -132,9 +138,18 @@
         _calendarDate = change.value;
         break;
       case "month":
+        // Bug3305: when the month changes we need to reset the day to the 1st
+        // to prevent _calendarDate from becoming invalid.
+        // For example if January 31 is selected, February would not show
+        // because February 31 is not a date.
+        _calendarDate.setDay(1);
         _calendarDate.setMonth(change.value);
         break;
       case "year":
+        // Bug3305: As with "month", when the "year" changes we need to reset
+        // the day to the 1st to prevent _calendarDate from becoming invalid in
+        // edge cases like a leap year, i.e. Feb 29, 2024 is valid, but not 2025
+        _calendarDate.setDay(1);
         _calendarDate.setYear(change.value);
         break;
     }
@@ -148,8 +163,12 @@
     _monthDays = [];
     for (let i = 0; i < dayCount; i++) {
       _monthDays.push(
-          new CalendarDate({year: _calendarDate.year, month: _calendarDate.month, day: i+1})
-      )
+        new CalendarDate({
+          year: _calendarDate.year,
+          month: _calendarDate.month,
+          day: i + 1,
+        }),
+      );
     }
 
     // previous month days to fill the start of the calendar
@@ -164,7 +183,8 @@
 
     // next month days to fill the end of the calendar
     _nextMonthDays = [];
-    _nextMonthDayCount = 7 - ((_previousMonthDays.length + _monthDays.length) % 7);
+    _nextMonthDayCount =
+      7 - ((_previousMonthDays.length + _monthDays.length) % 7);
 
     // ensure a full week is not appended to the end
     if (_nextMonthDayCount < 7) {
@@ -180,8 +200,8 @@
       e.stopPropagation();
       e.preventDefault();
 
-      // prevent selection outsite min/max boundies
-      if ( newDate.isBefore(_min) || newDate.isAfter(_max) ) {
+      // prevent selection outside min/max boundaries
+      if (newDate.isBefore(_min) || newDate.isAfter(_max)) {
         return;
       }
 
@@ -241,7 +261,7 @@
           }
           break;
         case "Enter":
-          _selectedDate = _calendarDate;
+          _selectedDate = _calendarDate.clone();
           dispatchValue();
           e.stopPropagation();
           e.preventDefault();
@@ -296,7 +316,8 @@
       renderCalendar({ type: "date", value: d });
     }
 
-    _selectedDate = _calendarDate = d;
+    _calendarDate = d.clone();
+    _selectedDate = d.clone();
     dispatchValue();
   }
 </script>
@@ -307,8 +328,13 @@
   data-testid={testid}
   tabindex="-1"
 >
-   <goa-block gap="s" mb="s">
-    <goa-form-item label="Month" mt="0" {version} labelsize={version === "2" ? "compact" : "regular"}>
+  <goa-block gap="s" mb="s">
+    <goa-form-item
+      label="Month"
+      mt="0"
+      {version}
+      labelsize={version === "2" ? "compact" : "regular"}
+    >
       <goa-dropdown
         name="month"
         disable-global-close-popover="yes"
@@ -322,12 +348,17 @@
         size={version === "2" ? "compact" : "default"}
       >
         {#each _months as month, i}
-          <goa-dropdown-item value={i+1+""} label={month} />
+          <goa-dropdown-item value={i + 1 + ""} label={month} />
         {/each}
       </goa-dropdown>
     </goa-form-item>
 
-    <goa-form-item label="Year" mt="0" {version} labelsize={version === "2" ? "compact" : "regular"}>
+    <goa-form-item
+      label="Year"
+      mt="0"
+      {version}
+      labelsize={version === "2" ? "compact" : "regular"}
+    >
       <goa-dropdown
         name="year"
         disable-global-close-popover="yes"
@@ -405,7 +436,10 @@
 <style>
   .bordered {
     display: inline-block;
-    border: var(--goa-date-input-calendar-border, 1px solid var(--goa-color-greyscale-700));
+    border: var(
+      --goa-date-input-calendar-border,
+      1px solid var(--goa-color-greyscale-700)
+    );
     border-radius: var(--goa-date-input-calendar-border-radius);
     padding: 1rem;
   }

--- a/libs/web-components/src/components/calendar/calendar.spec.ts
+++ b/libs/web-components/src/components/calendar/calendar.spec.ts
@@ -5,7 +5,7 @@ import {
   render,
   waitFor,
 } from "@testing-library/svelte";
-import { addDays, lastDayOfMonth, startOfDay } from "date-fns";
+import { addDays, lastDayOfMonth, startOfDay, addMonths } from "date-fns";
 import { tick } from "svelte";
 import { it, expect, vi } from "vitest";
 
@@ -166,6 +166,9 @@ it("updates the calendar when a new month is selected", async () => {
   const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   const monthsEl = queryByTestId("months");
 
+  const today = toDayStart(new Date());
+  today.setDate(1);
+
   // validate the day of the first day for the current month
   {
     const dayOfWeek = date.getDay();
@@ -177,27 +180,29 @@ it("updates the calendar when a new month is selected", async () => {
     expect((buttonEl as HTMLElement).dataset.day).toBe(dayNames[dayOfWeek]);
   }
 
+  // The date should be selected
+  expect(container.querySelector(".selected")).toBeTruthy();
+
   // change month
+  const nextMonth = addMonths(today, 1);
   monthsEl?.dispatchEvent(
     new CustomEvent("_change", {
-      detail: { value: month + 1 },
+      detail: { type: "month", value: nextMonth.getMonth() + 1 },
     }),
   );
 
   await waitFor(() => {
-    const date = new Date(year, month + 1, day);
-    const dayOfWeek = date.getDay();
-    const buttonEl = queryByTestId(getDateStamp(date));
+    const date = toDayStart(nextMonth);
+    date.setMonth(nextMonth.getMonth() - 1); // revert to 0-index value
+    date.setDate(1);
 
-    expect(buttonEl).toBeTruthy();
-    const dayEl = buttonEl?.querySelector("[data-testid=date]");
-    expect(dayEl?.innerHTML).toBe("1");
-    expect((buttonEl as HTMLElement).dataset.day).toBe(dayNames[dayOfWeek]);
+    // 3370: After changing the month a day in the new month should not be selected
+    expect(container.querySelector(".selected")).toBeFalsy();
   });
 });
 
 it("updates the calendar when a new year is selected", async () => {
-  const { container, queryByTestId } = render(Calendar);
+  const { queryByTestId } = render(Calendar);
   await tick();
 
   const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];


### PR DESCRIPTION
# Before (the change)

Lots of issues that are fixed in this PR:

- After you selected January 31 you could not change the calendar to February, or any month with <31 days in it. There was a bug where the day selected would be kept, making it invalid and preventing the calendar redrawing (February 31 is not valid).

- For the Calendar and DatePicker a new value is never propagated unless a date is clicked on.

- When a date _is_ selected in the Calendar that is the only day that is selected. Before, in some situations, if you selected a date like February 15, changing the month to March would show March 15 selected.

- When a date _is_ selected the Calendar might not show that day as selected if you changed the month or year, and then returned the calendar to the month of the selected date. For example if you selected February 15, 2026 and changed the month to March, changing it back might not show February 15, 2026 as selected anymore.

# After (the change)

These things are all fixed!

There are a lot of changes that involve using `.clone()` with `_currentDate` and `_selectedDate`. This is because most of the  errors were caused by using the same object references, so changes to one changed the other.

Unfortunately there are a few changes caused by Prettier also.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

- Given a date is selected, when the user navigates to a different **month**, then **no day** is visually selected in the calendar grid.
- Given a date is selected, when the user navigates to a different **year**, then **no day** is visually selected in the calendar grid.
- Given a date is selected, when the user navigates back to the selected date’s **month/year**, then the originally selected day is visually selected again in the calendar grid.
- (DatePicker only) Given a date is selected, when the user navigates months/years, and closes the picker then the **input value does not change**
- Given the calendar is showing a month/year that does not match the selected date, when the user selects a day, then:
	- that new date becomes selected
	- the calendar grid shows it as selected
	- the input updates accordingly
	- the calendar closes
- For bug #3305: if you select January 31 you can still select a date in February (28 days) or April (30 days)