### PR TITLE
Docs: Migrate to V2 styling and other fixes

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -52,10 +52,10 @@ export default defineConfig({
           find: "@abgov/style",
           replacement: path.resolve(workspaceRoot, "dist/libs/web-components/index.css"),
         },
-        // Design tokens from npm (V2 at root)
+        // Design tokens V2 for docs styling (via npm alias)
         {
           find: "@design-tokens",
-          replacement: path.resolve(workspaceRoot, "node_modules/@abgov/design-tokens/dist"),
+          replacement: path.resolve(workspaceRoot, "node_modules/@abgov/design-tokens-v2/dist"),
         },
       ],
       dedupe: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,56 +1,78 @@
-import { defineConfig } from 'astro/config';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
+import { defineConfig } from "astro/config";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
-import react from '@astrojs/react';
-import mdx from '@astrojs/mdx';
+import react from "@astrojs/react";
+import mdx from "@astrojs/mdx";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const workspaceRoot = path.resolve(__dirname, '..');
+const workspaceRoot = path.resolve(__dirname, "..");
 
 // https://astro.build/config
 export default defineConfig({
-  root: '.',
-  outDir: '../dist/docs',
+  root: ".",
+  outDir: "../dist/docs",
   build: {
-    chunkSizeWarningLimit: 1000
+    chunkSizeWarningLimit: 1000,
   },
   server: {
     port: 4203,
-    host: '0.0.0.0',
+    host: "0.0.0.0",
   },
 
   preview: {
     port: 4304,
-    host: '0.0.0.0'
+    host: "0.0.0.0",
   },
 
   vite: {
     resolve: {
       alias: [
         // More specific aliases must come first
-        { find: '@abgov/react-components/experimental', replacement: path.resolve(workspaceRoot, 'libs/react-components/src/experimental/index.ts') },
-        { find: '@abgov/react-components', replacement: path.resolve(workspaceRoot, 'libs/react-components/src/index.ts') },
-        { find: '@abgov/web-components', replacement: path.resolve(workspaceRoot, 'dist/libs/web-components/') },
-        { find: '@abgov/ui-components-common', replacement: path.resolve(workspaceRoot, 'libs/common/src/index.ts') },
-        { find: '@abgov/style', replacement: path.resolve(workspaceRoot, 'dist/libs/web-components/index.css') },
-        { find: '@design-tokens', replacement: path.resolve(workspaceRoot, 'node_modules/@abgov/design-tokens/dist') },
+        {
+          find: "@abgov/react-components/experimental",
+          replacement: path.resolve(
+            workspaceRoot,
+            "libs/react-components/src/experimental/index.ts",
+          ),
+        },
+        {
+          find: "@abgov/react-components",
+          replacement: path.resolve(workspaceRoot, "libs/react-components/src/index.ts"),
+        },
+        {
+          find: "@abgov/web-components",
+          replacement: path.resolve(workspaceRoot, "dist/libs/web-components/"),
+        },
+        {
+          find: "@abgov/ui-components-common",
+          replacement: path.resolve(workspaceRoot, "libs/common/src/index.ts"),
+        },
+        {
+          find: "@abgov/style",
+          replacement: path.resolve(workspaceRoot, "dist/libs/web-components/index.css"),
+        },
+        // Design tokens from npm (V2 at root)
+        {
+          find: "@design-tokens",
+          replacement: path.resolve(workspaceRoot, "node_modules/@abgov/design-tokens/dist"),
+        },
       ],
-      dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
+      dedupe: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
     },
     optimizeDeps: {
-      include: ['react', 'react-dom'],
+      include: ["react", "react-dom"],
       force: true,
     },
     server: {
       fs: {
-        allow: [workspaceRoot]
-      }
+        allow: [workspaceRoot],
+      },
     },
     ssr: {
-      noExternal: ['@astrojs/react', '@astrojs/mdx']
-    }
+      noExternal: ["@astrojs/react", "@astrojs/mdx"],
+    },
   },
 
-  integrations: [react(), mdx()]
+  integrations: [react(), mdx()],
 });

--- a/docs/generated/component-apis/accordion.json
+++ b/docs/generated/component-apis/accordion.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "accordion",
   "extractedFrom": "libs/web-components/src/components/accordion/Accordion.svelte",
-  "extractedAt": "2026-01-05T23:10:27.416Z",
+  "extractedAt": "2026-02-04T08:10:50.390Z",
   "props": [
     {
       "name": "open",
@@ -41,7 +41,7 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Unique identifier for the accordion. Auto-generated if not provided."
+      "description": "Unique identifier for the accordion."
     },
     {
       "name": "maxWidth",

--- a/docs/generated/component-apis/app-header-menu.json
+++ b/docs/generated/component-apis/app-header-menu.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "app-header-menu",
   "extractedFrom": "libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte",
-  "extractedAt": "2026-01-05T23:10:27.420Z",
+  "extractedAt": "2026-02-04T08:10:50.392Z",
   "props": [
     {
       "name": "heading",

--- a/docs/generated/component-apis/app-header.json
+++ b/docs/generated/component-apis/app-header.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "app-header",
   "extractedFrom": "libs/web-components/src/components/app-header/AppHeader.svelte",
-  "extractedAt": "2026-01-05T23:10:27.419Z",
+  "extractedAt": "2026-02-04T08:10:50.392Z",
   "props": [
     {
       "name": "heading",

--- a/docs/generated/component-apis/badge.json
+++ b/docs/generated/component-apis/badge.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "badge",
   "extractedFrom": "libs/web-components/src/components/badge/Badge.svelte",
-  "extractedAt": "2026-01-05T23:10:27.421Z",
+  "extractedAt": "2026-02-04T08:10:50.393Z",
   "props": [
     {
       "name": "type",
@@ -52,7 +52,7 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Sets the data-testid attribute. Used with ByTestId queries in tests."
+      "description": "Sets a data-testid attribute for automated testing."
     },
     {
       "name": "content",
@@ -66,7 +66,8 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "@deprecated Use icontype instead. Includes an icon in the badge."
+      "description": "@deprecated Use icontype instead. Includes an icon in the badge.",
+      "deprecated": true
     },
     {
       "name": "icontype",
@@ -101,18 +102,6 @@
       "required": false,
       "default": "strong",
       "description": "Sets the visual emphasis. 'subtle' for less prominent, 'strong' for more emphasis."
-    },
-    {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "typeLabel": "GoabBadgeVersion",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/block.json
+++ b/docs/generated/component-apis/block.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "block",
   "extractedFrom": "libs/web-components/src/components/block/Block.svelte",
-  "extractedAt": "2026-01-05T23:10:27.421Z",
+  "extractedAt": "2026-02-04T08:10:50.394Z",
   "props": [
     {
       "name": "gap",

--- a/docs/generated/component-apis/button-group.json
+++ b/docs/generated/component-apis/button-group.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "button-group",
   "extractedFrom": "libs/web-components/src/components/button-group/ButtonGroup.svelte",
-  "extractedAt": "2026-01-05T23:10:27.423Z",
+  "extractedAt": "2026-02-04T08:10:50.394Z",
   "props": [
     {
       "name": "alignment",
@@ -12,7 +12,7 @@
         "end",
         "center"
       ],
-      "required": true,
+      "required": false,
       "default": "start",
       "description": "Positions the button group in the page layout."
     },
@@ -33,7 +33,7 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Sets the data-testid attribute. Used with ByTestId queries in tests."
+      "description": "Sets a data-testid attribute for automated testing."
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/button.json
+++ b/docs/generated/component-apis/button.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "button",
   "extractedFrom": "libs/web-components/src/components/button/Button.svelte",
-  "extractedAt": "2026-01-05T23:10:27.422Z",
+  "extractedAt": "2026-02-04T08:10:50.394Z",
   "props": [
     {
       "name": "type",
@@ -79,18 +79,6 @@
       "required": false,
       "default": "",
       "description": "Sets a custom width for the button (e.g., \"200px\" or \"100%\")."
-    },
-    {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "typeLabel": "GoabButtonVersion",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "2",
-      "description": "Design system version. Version 2 includes updated styling and accessibility improvements."
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/calendar.json
+++ b/docs/generated/component-apis/calendar.json
@@ -1,14 +1,14 @@
 {
   "componentSlug": "calendar",
   "extractedFrom": "libs/web-components/src/components/calendar/Calendar.svelte",
-  "extractedAt": "2026-01-05T23:10:27.423Z",
+  "extractedAt": "2026-02-04T08:10:50.395Z",
   "props": [
     {
       "name": "name",
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Name identifier for the calendar, used in form submission and change events."
+      "description": "Name identifier for the calendar, included in change events."
     },
     {
       "name": "value",

--- a/docs/generated/component-apis/callout.json
+++ b/docs/generated/component-apis/callout.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "callout",
   "extractedFrom": "libs/web-components/src/components/callout/Callout.svelte",
-  "extractedAt": "2026-01-05T23:10:27.425Z",
+  "extractedAt": "2026-02-04T08:10:50.395Z",
   "props": [
     {
       "name": "mt",
@@ -45,7 +45,7 @@
       ],
       "required": false,
       "default": "large",
-      "description": "The medium callout has reduced padding and type size to adjust for a compact area and smaller viewport width when a smaller size is required."
+      "description": "Sets the size of the callout. 'medium' has reduced padding and type size for compact areas."
     },
     {
       "name": "type",
@@ -115,18 +115,6 @@
       "required": false,
       "default": "outline",
       "description": "Sets the icon theme. 'outline' for stroked icons, 'filled' for solid icons."
-    },
-    {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "typeLabel": "GoabCalloutVersionType",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
     }
   ],
   "events": [],

--- a/docs/generated/component-apis/card-actions.json
+++ b/docs/generated/component-apis/card-actions.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "card-actions",
   "extractedFrom": "libs/web-components/src/components/card-actions/CardActions.svelte",
-  "extractedAt": "2026-01-05T23:10:27.425Z",
+  "extractedAt": "2026-02-04T08:10:50.396Z",
   "props": [],
   "events": [],
   "slots": [

--- a/docs/generated/component-apis/card-content.json
+++ b/docs/generated/component-apis/card-content.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "card-content",
   "extractedFrom": "libs/web-components/src/components/card-content/CardContent.svelte",
-  "extractedAt": "2026-01-05T23:10:27.426Z",
+  "extractedAt": "2026-02-04T08:10:50.396Z",
   "props": [],
   "events": [],
   "slots": [

--- a/docs/generated/component-apis/card-group.json
+++ b/docs/generated/component-apis/card-group.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "card-group",
   "extractedFrom": "libs/web-components/src/components/card-group/CardGroup.svelte",
-  "extractedAt": "2026-01-05T23:10:27.426Z",
+  "extractedAt": "2026-02-04T08:10:50.396Z",
   "props": [],
   "events": [],
   "slots": [

--- a/docs/generated/component-apis/card-image.json
+++ b/docs/generated/component-apis/card-image.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "card-image",
   "extractedFrom": "libs/web-components/src/components/card-image/CardImage.svelte",
-  "extractedAt": "2026-01-05T23:10:27.426Z",
+  "extractedAt": "2026-02-04T08:10:50.396Z",
   "props": [
     {
       "name": "src",

--- a/docs/generated/component-apis/card.json
+++ b/docs/generated/component-apis/card.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "card",
   "extractedFrom": "libs/web-components/src/components/card/Card.svelte",
-  "extractedAt": "2026-01-05T23:10:27.425Z",
+  "extractedAt": "2026-02-04T08:10:50.395Z",
   "props": [
     {
       "name": "elevation",

--- a/docs/generated/component-apis/checkbox-list.json
+++ b/docs/generated/component-apis/checkbox-list.json
@@ -1,14 +1,14 @@
 {
   "componentSlug": "checkbox-list",
   "extractedFrom": "libs/web-components/src/components/checkbox-list/CheckboxList.svelte",
-  "extractedAt": "2026-01-05T23:10:27.431Z",
+  "extractedAt": "2026-02-04T19:24:42.584Z",
   "props": [
     {
       "name": "name",
       "type": "string",
       "required": true,
       "default": null,
-      "description": "- Manages a selected values array and synchronizes state down to child checkboxes. - Relays form-related events (mount, set value, set/reset error, reset fields) to and from children. Approach - Children register themselves via a FormFieldMount event; we track them in _childRecords. - All value and error changes flow through a small relay bus (receive/relay helpers). - Support both slotted goa-checkbox elements and direct child component instances. / import { onMount, tick } from \"svelte\"; import type { Spacing } from \"../../common/styling\"; import { calculateMargin } from \"../../common/styling\"; import { receive, relay, toBoolean } from \"../../common/utils\"; import { FieldsetSetValueMsg, FieldsetSetValueRelayDetail, FieldsetSetErrorMsg, FieldsetResetErrorsMsg, FormFieldMountRelayDetail, FormFieldMountMsg, FieldsetResetFieldsMsg, FieldsetErrorRelayDetail, } from \"../../types/relay-types\"; /** The name for the checkbox list group. Used for form submission."
+      "description": "The name for the checkbox list group. Used as group identifier in change events."
     },
     {
       "name": "value",

--- a/docs/generated/component-apis/checkbox.json
+++ b/docs/generated/component-apis/checkbox.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "checkbox",
   "extractedFrom": "libs/web-components/src/components/checkbox/Checkbox.svelte",
-  "extractedAt": "2026-01-05T23:10:27.427Z",
+  "extractedAt": "2026-02-04T08:10:50.397Z",
   "props": [
     {
       "name": "name",
@@ -97,17 +97,6 @@
       "required": false,
       "default": "default",
       "description": "Sets the size of the checkbox. 'compact' reduces spacing for dense layouts."
-    },
-    {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/chip.json
+++ b/docs/generated/component-apis/chip.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "chip",
   "extractedFrom": "libs/web-components/src/components/chip/Chip.svelte",
-  "extractedAt": "2026-01-05T23:10:27.431Z",
+  "extractedAt": "2026-02-04T08:10:50.398Z",
   "props": [
     {
       "name": "mt",
@@ -41,49 +41,56 @@
       "typeLabel": "GoAIconType",
       "required": false,
       "default": null,
-      "description": "@deprecated Use GoAFilterChip instead. Icon displayed at the start of the chip."
+      "description": "@deprecated Use GoAFilterChip instead. Icon displayed at the start of the chip.",
+      "deprecated": true
     },
     {
       "name": "icontheme",
       "type": "IconTheme",
       "required": false,
       "default": "outline",
-      "description": "@deprecated Use GoAFilterChip instead. The icon theme - outline or filled."
+      "description": "@deprecated Use GoAFilterChip instead. The icon theme - outline or filled.",
+      "deprecated": true
     },
     {
       "name": "error",
       "type": "boolean",
       "required": false,
       "default": "false",
-      "description": "@deprecated Use GoAFilterChip instead. Shows an error state on the chip."
+      "description": "@deprecated Use GoAFilterChip instead. Shows an error state on the chip.",
+      "deprecated": true
     },
     {
       "name": "deletable",
       "type": "boolean",
       "required": false,
       "default": "false",
-      "description": "@deprecated Use GoAFilterChip instead. When true, shows a delete icon and makes chip clickable."
+      "description": "@deprecated Use GoAFilterChip instead. When true, shows a delete icon and makes chip clickable.",
+      "deprecated": true
     },
     {
       "name": "content",
       "type": "string",
       "required": true,
       "default": null,
-      "description": "@deprecated Use GoAFilterChip instead. The text content displayed in the chip."
+      "description": "@deprecated Use GoAFilterChip instead. The text content displayed in the chip.",
+      "deprecated": true
     },
     {
       "name": "variant",
       "type": "ChipVariant",
       "required": true,
       "default": null,
-      "description": "@deprecated Use GoAFilterChip instead. The chip variant style."
+      "description": "@deprecated Use GoAFilterChip instead. The chip variant style.",
+      "deprecated": true
     },
     {
       "name": "testId",
       "type": "string",
       "required": false,
       "default": "",
-      "description": "@deprecated Use GoAFilterChip instead. Sets a data-testid attribute for automated testing."
+      "description": "@deprecated Use GoAFilterChip instead. Sets a data-testid attribute for automated testing.",
+      "deprecated": true
     }
   ],
   "events": [

--- a/docs/generated/component-apis/circular-progress.json
+++ b/docs/generated/component-apis/circular-progress.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "circular-progress",
   "extractedFrom": "libs/web-components/src/components/circular-progress/CircularProgress.svelte",
-  "extractedAt": "2026-01-05T23:10:27.432Z",
+  "extractedAt": "2026-02-04T08:10:50.399Z",
   "props": [
     {
       "name": "variant",

--- a/docs/generated/component-apis/container.json
+++ b/docs/generated/component-apis/container.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "container",
   "extractedFrom": "libs/web-components/src/components/container/Container.svelte",
-  "extractedAt": "2026-01-05T23:10:27.432Z",
+  "extractedAt": "2026-02-04T08:10:50.399Z",
   "props": [
     {
       "name": "type",
@@ -64,11 +64,25 @@
       "description": "Sets the maximum width of the container."
     },
     {
+      "name": "minHeight",
+      "type": "any",
+      "required": false,
+      "default": "",
+      "description": "Sets the minimum height of the container."
+    },
+    {
+      "name": "maxHeight",
+      "type": "any",
+      "required": false,
+      "default": "",
+      "description": "Sets the maximum height of the container."
+    },
+    {
       "name": "testId",
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Sets the data-testid attribute. Used with ByTestId queries in tests."
+      "description": "Sets a data-testid attribute for automated testing."
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/data-grid.json
+++ b/docs/generated/component-apis/data-grid.json
@@ -1,29 +1,18 @@
 {
   "componentSlug": "data-grid",
   "extractedFrom": "libs/web-components/src/components/data-grid/DataGrid.svelte",
-  "extractedAt": "2026-01-05T23:10:27.433Z",
+  "extractedAt": "2026-02-04T08:10:50.400Z",
   "props": [
     {
-      "name": "keyboardIcon",
-      "type": "string | boolean",
+      "name": "keyboardIconVisibility",
+      "type": "\"visible\" | \"hidden\"",
       "values": [
-        "string",
-        "boolean"
+        "visible",
+        "hidden"
       ],
       "required": false,
-      "default": "true",
-      "description": "Whether to show the keyboard navigation indicator icon when navigating with arrow keys."
-    },
-    {
-      "name": "keyboardIconPosition",
-      "type": "\"left\" | \"right\"",
-      "values": [
-        "left",
-        "right"
-      ],
-      "required": false,
-      "default": "left",
-      "description": "Position of the keyboard navigation indicator icon."
+      "default": "visible",
+      "description": "Controls visibility of the keyboard navigation indicator icon. Use \"visible\" to show or \"hidden\" to hide."
     },
     {
       "name": "keyboardNav",
@@ -35,6 +24,17 @@
       "required": false,
       "default": "table",
       "description": "Navigation mode. \"table\" navigates like a table (up/down between rows), \"layout\" allows wrapping between rows with left/right arrows."
+    },
+    {
+      "name": "keyboardIconPosition",
+      "type": "\"left\" | \"right\"",
+      "values": [
+        "left",
+        "right"
+      ],
+      "required": false,
+      "default": "left",
+      "description": "Position of the keyboard navigation indicator icon."
     }
   ],
   "events": [],

--- a/docs/generated/component-apis/date-picker.json
+++ b/docs/generated/component-apis/date-picker.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "date-picker",
   "extractedFrom": "libs/web-components/src/components/date-picker/DatePicker.svelte",
-  "extractedAt": "2026-01-05T23:10:27.434Z",
+  "extractedAt": "2026-02-04T08:10:50.400Z",
   "props": [
     {
       "name": "type",
@@ -54,7 +54,8 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "@deprecated This property has no effect and will be removed in a future version."
+      "description": "@deprecated This property has no effect and will be removed in a future version.",
+      "deprecated": true
     },
     {
       "name": "disabled",
@@ -76,6 +77,17 @@
       "required": false,
       "default": "",
       "description": "Sets the width of the date picker input."
+    },
+    {
+      "name": "size",
+      "type": "\"default\" | \"compact\"",
+      "values": [
+        "default",
+        "compact"
+      ],
+      "required": false,
+      "default": "default",
+      "description": "Sets the size of the date picker. 'compact' reduces height for dense layouts."
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/details.json
+++ b/docs/generated/component-apis/details.json
@@ -1,14 +1,14 @@
 {
   "componentSlug": "details",
   "extractedFrom": "libs/web-components/src/components/details/Details.svelte",
-  "extractedAt": "2026-01-05T23:10:27.434Z",
+  "extractedAt": "2026-02-04T08:10:50.401Z",
   "props": [
     {
       "name": "heading",
       "type": "string",
       "required": true,
       "default": null,
-      "description": "The title heading"
+      "description": "The title heading."
     },
     {
       "name": "maxWidth",

--- a/docs/generated/component-apis/divider.json
+++ b/docs/generated/component-apis/divider.json
@@ -1,14 +1,14 @@
 {
   "componentSlug": "divider",
   "extractedFrom": "libs/web-components/src/components/divider/Divider.svelte",
-  "extractedAt": "2026-01-05T23:10:27.435Z",
+  "extractedAt": "2026-02-04T08:10:50.401Z",
   "props": [
     {
       "name": "testId",
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Sets the data-testid attribute. Used with ByTestId queries in tests."
+      "description": "Sets a data-testid attribute for automated testing."
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/drawer.json
+++ b/docs/generated/component-apis/drawer.json
@@ -1,19 +1,19 @@
 {
   "componentSlug": "drawer",
   "extractedFrom": "libs/web-components/src/components/drawer/Drawer.svelte",
-  "extractedAt": "2026-01-05T23:10:27.435Z",
+  "extractedAt": "2026-02-04T08:10:50.401Z",
   "props": [
     {
       "name": "open",
       "type": "any",
-      "required": true,
+      "required": false,
       "default": "false",
       "description": "Whether the drawer is open."
     },
     {
       "name": "position",
       "type": "DrawerPosition",
-      "required": true,
+      "required": false,
       "default": null,
       "description": "The position of the drawer."
     },
@@ -42,8 +42,8 @@
       "name": "version",
       "type": "VersionType",
       "required": false,
-      "default": "2",
-      "description": "The design system version for styling purposes."
+      "default": "1",
+      "description": ""
     }
   ],
   "events": [

--- a/docs/generated/component-apis/dropdown.json
+++ b/docs/generated/component-apis/dropdown.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "dropdown",
   "extractedFrom": "libs/web-components/src/components/dropdown/Dropdown.svelte",
-  "extractedAt": "2026-01-05T23:10:27.438Z",
+  "extractedAt": "2026-02-04T08:10:50.403Z",
   "props": [
     {
       "name": "name",
@@ -48,14 +48,14 @@
       "typeLabel": "GoAIconType",
       "required": false,
       "default": null,
-      "description": "Show an icon to the left of the dropdown option."
+      "description": "Icon shown to the left of the dropdown input."
     },
     {
       "name": "maxHeight",
       "type": "string",
       "required": false,
       "default": "276px",
-      "description": "Maximum height of the dropdown menu items popover. Non-native only."
+      "description": "Maximum height of the dropdown menu. Non-native only."
     },
     {
       "name": "placeholder",
@@ -93,13 +93,6 @@
       "description": "Show an error state."
     },
     {
-      "name": "multiselect",
-      "type": "boolean",
-      "required": false,
-      "default": "false",
-      "description": "When true, allows multiple items to be selected."
-    },
-    {
       "name": "native",
       "type": "boolean",
       "required": false,
@@ -118,22 +111,12 @@
       "description": "Sets the size of the dropdown. Compact reduces height for dense layouts."
     },
     {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
-    },
-    {
       "name": "relative",
       "type": "string",
       "required": false,
       "default": "",
-      "description": "@deprecated This property has no effect and will be removed in a future version."
+      "description": "@deprecated This property has no effect and will be removed in a future version.",
+      "deprecated": true
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/file-upload-card.json
+++ b/docs/generated/component-apis/file-upload-card.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "file-upload-card",
   "extractedFrom": "libs/web-components/src/components/file-upload-card/FileUploadCard.svelte",
-  "extractedAt": "2026-01-05T23:10:27.439Z",
+  "extractedAt": "2026-02-04T08:10:50.404Z",
   "props": [
     {
       "name": "filename",
@@ -44,6 +44,17 @@
       "required": false,
       "default": "",
       "description": "Sets a data-testid attribute for automated testing."
+    },
+    {
+      "name": "version",
+      "type": "\"1\" | \"2\"",
+      "values": [
+        "1",
+        "2"
+      ],
+      "required": false,
+      "default": "1",
+      "description": ""
     }
   ],
   "events": [],

--- a/docs/generated/component-apis/file-upload-input.json
+++ b/docs/generated/component-apis/file-upload-input.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "file-upload-input",
   "extractedFrom": "libs/web-components/src/components/file-upload-input/FileUploadInput.svelte",
-  "extractedAt": "2026-01-05T23:10:27.440Z",
+  "extractedAt": "2026-02-04T08:10:50.404Z",
   "props": [
     {
       "name": "variant",
@@ -22,7 +22,7 @@
       "type": "string",
       "required": false,
       "default": "5MB",
-      "description": "Maximum file size with unit (e.g., \"5MB\", \"100KB\", \"1GB\"). Files exceeding this will be rejected."
+      "description": "Maximum file size with unit (e.g., \"5MB\", \"100KB\", \"1GB\"). Defaults to 5MB. Files exceeding this will be rejected."
     },
     {
       "name": "testId",
@@ -30,6 +30,17 @@
       "required": false,
       "default": "",
       "description": "Sets a data-testid attribute for automated testing."
+    },
+    {
+      "name": "version",
+      "type": "\"1\" | \"2\"",
+      "values": [
+        "1",
+        "2"
+      ],
+      "required": false,
+      "default": "1",
+      "description": ""
     }
   ],
   "events": [

--- a/docs/generated/component-apis/filter-chip.json
+++ b/docs/generated/component-apis/filter-chip.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "filter-chip",
   "extractedFrom": "libs/web-components/src/components/filter-chip/FilterChip.svelte",
-  "extractedAt": "2026-01-05T23:10:27.440Z",
+  "extractedAt": "2026-02-04T08:10:50.404Z",
   "props": [
     {
       "name": "mt",
@@ -77,17 +77,6 @@
       "required": false,
       "default": "",
       "description": "Accessible label for the filter chip. Defaults to content with 'removable' suffix."
-    },
-    {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
     }
   ],
   "events": [

--- a/docs/generated/component-apis/focus-trap.json
+++ b/docs/generated/component-apis/focus-trap.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "focus-trap",
   "extractedFrom": "libs/web-components/src/components/focus-trap/FocusTrap.svelte",
-  "extractedAt": "2026-01-05T23:10:27.441Z",
+  "extractedAt": "2026-02-04T08:10:50.405Z",
   "props": [
     {
       "name": "open",

--- a/docs/generated/component-apis/footer-meta-section.json
+++ b/docs/generated/component-apis/footer-meta-section.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "footer-meta-section",
   "extractedFrom": "libs/web-components/src/components/footer-meta-section/FooterMetaSection.svelte",
-  "extractedAt": "2026-01-05T23:10:27.442Z",
+  "extractedAt": "2026-02-04T08:10:50.405Z",
   "props": [
     {
       "name": "testId",

--- a/docs/generated/component-apis/footer-nav-section.json
+++ b/docs/generated/component-apis/footer-nav-section.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "footer-nav-section",
   "extractedFrom": "libs/web-components/src/components/footer-nav-section/FooterNavSection.svelte",
-  "extractedAt": "2026-01-05T23:10:27.442Z",
+  "extractedAt": "2026-02-04T08:10:50.406Z",
   "props": [
     {
       "name": "heading",

--- a/docs/generated/component-apis/footer.json
+++ b/docs/generated/component-apis/footer.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "footer",
   "extractedFrom": "libs/web-components/src/components/footer/Footer.svelte",
-  "extractedAt": "2026-01-05T23:10:27.441Z",
+  "extractedAt": "2026-02-04T08:10:50.405Z",
   "props": [
     {
       "name": "maxcontentwidth",
@@ -23,6 +23,17 @@
       "required": false,
       "default": "https://alberta.ca",
       "description": "URL for the Government of Alberta logo link. Set to empty string to disable the link."
+    },
+    {
+      "name": "version",
+      "type": "\"1\" | \"2\"",
+      "values": [
+        "1",
+        "2"
+      ],
+      "required": false,
+      "default": "1",
+      "description": ""
     }
   ],
   "events": [],

--- a/docs/generated/component-apis/form-item.json
+++ b/docs/generated/component-apis/form-item.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "form-item",
   "extractedFrom": "libs/web-components/src/components/form-item/FormItem.svelte",
-  "extractedAt": "2026-01-05T23:10:27.445Z",
+  "extractedAt": "2026-02-04T08:10:50.407Z",
   "props": [
     {
       "name": "mt",
@@ -94,18 +94,6 @@
       "required": false,
       "default": "none",
       "description": "Sets the maximum width of the form item."
-    },
-    {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "typeLabel": "GoabFormItemVersionType",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
     },
     {
       "name": "type",

--- a/docs/generated/component-apis/form-step.json
+++ b/docs/generated/component-apis/form-step.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "form-step",
   "extractedFrom": "libs/web-components/src/components/form-step/FormStep.svelte",
-  "extractedAt": "2026-01-05T23:10:27.446Z",
+  "extractedAt": "2026-02-04T08:10:50.408Z",
   "props": [
     {
       "name": "text",

--- a/docs/generated/component-apis/form-stepper.json
+++ b/docs/generated/component-apis/form-stepper.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "form-stepper",
   "extractedFrom": "libs/web-components/src/components/form-stepper/FormStepper.svelte",
-  "extractedAt": "2026-01-05T23:10:27.446Z",
+  "extractedAt": "2026-02-04T08:10:50.408Z",
   "props": [
     {
       "name": "step",

--- a/docs/generated/component-apis/form.json
+++ b/docs/generated/component-apis/form.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "form",
   "extractedFrom": "libs/web-components/src/components/form/Form.svelte",
-  "extractedAt": "2026-01-05T23:10:27.444Z",
+  "extractedAt": "2026-02-04T08:10:50.407Z",
   "props": [
     {
       "name": "status",

--- a/docs/generated/component-apis/grid.json
+++ b/docs/generated/component-apis/grid.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "grid",
   "extractedFrom": "libs/web-components/src/components/grid/Grid.svelte",
-  "extractedAt": "2026-01-05T23:10:27.447Z",
+  "extractedAt": "2026-02-04T08:10:50.408Z",
   "props": [
     {
       "name": "gap",
@@ -9,7 +9,7 @@
       "typeLabel": "Spacing",
       "required": false,
       "default": "m",
-      "description": "Gap between child items"
+      "description": "Gap between child items."
     },
     {
       "name": "minchildwidth",
@@ -23,7 +23,7 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Sets the data-testid attribute. Used with ByTestId queries in tests."
+      "description": "Sets a data-testid attribute for automated testing."
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/hero-banner.json
+++ b/docs/generated/component-apis/hero-banner.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "hero-banner",
   "extractedFrom": "libs/web-components/src/components/hero-banner/HeroBanner.svelte",
-  "extractedAt": "2026-01-05T23:10:27.447Z",
+  "extractedAt": "2026-02-04T08:10:50.408Z",
   "props": [
     {
       "name": "heading",
@@ -43,14 +43,14 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Text color within the hero banner"
+      "description": "Text color within the hero banner."
     },
     {
       "name": "testId",
       "type": "string",
       "required": false,
       "default": "background",
-      "description": "Test ID for the component"
+      "description": "Sets a data-testid attribute for automated testing."
     }
   ],
   "events": [],

--- a/docs/generated/component-apis/icon-button.json
+++ b/docs/generated/component-apis/icon-button.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "icon-button",
   "extractedFrom": "libs/web-components/src/components/icon-button/IconButton.svelte",
-  "extractedAt": "2026-01-05T23:10:27.448Z",
+  "extractedAt": "2026-02-04T08:10:50.410Z",
   "props": [
     {
       "name": "icon",
@@ -52,7 +52,7 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Sets the data-testid attribute. Used with ByTestId queries in tests."
+      "description": "Sets a data-testid attribute for automated testing."
     },
     {
       "name": "disabled",

--- a/docs/generated/component-apis/icon.json
+++ b/docs/generated/component-apis/icon.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "icon",
   "extractedFrom": "libs/web-components/src/components/icon/Icon.svelte",
-  "extractedAt": "2026-01-05T23:10:27.448Z",
+  "extractedAt": "2026-02-04T08:10:50.410Z",
   "props": [
     {
       "name": "mt",

--- a/docs/generated/component-apis/input.json
+++ b/docs/generated/component-apis/input.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "input",
   "extractedFrom": "libs/web-components/src/components/input/Input.svelte",
-  "extractedAt": "2026-01-05T23:10:27.449Z",
+  "extractedAt": "2026-02-04T08:10:50.410Z",
   "props": [
     {
       "name": "type",
@@ -29,7 +29,7 @@
     {
       "name": "name",
       "type": "string",
-      "required": true,
+      "required": false,
       "default": "",
       "description": "Name of input value that is received in the onChange event."
     },
@@ -133,7 +133,7 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Sets the data-testid attribute. Used with ByTestId queries in tests."
+      "description": "Sets a data-testid attribute for automated testing."
     },
     {
       "name": "width",
@@ -175,21 +175,23 @@
       "type": "number",
       "required": false,
       "default": "1",
-      "description": "How much a number or date should changed by."
+      "description": "How much a number or date should change by."
     },
     {
       "name": "prefix",
       "type": "string",
       "required": false,
       "default": "",
-      "description": "@deprecated Use leadingContent slot instead."
+      "description": "@deprecated Use leadingContent slot instead.",
+      "deprecated": true
     },
     {
       "name": "suffix",
       "type": "string",
       "required": false,
       "default": "",
-      "description": "@deprecated Use trailingContent slot instead."
+      "description": "@deprecated Use trailingContent slot instead.",
+      "deprecated": true
     },
     {
       "name": "debounce",
@@ -222,7 +224,7 @@
       "typeLabel": "Spacing",
       "required": false,
       "default": null,
-      "description": "Apply margin to the top of the component."
+      "description": "Top margin."
     },
     {
       "name": "mr",
@@ -230,7 +232,7 @@
       "typeLabel": "Spacing",
       "required": false,
       "default": null,
-      "description": "Apply margin to the right of the component."
+      "description": "Right margin."
     },
     {
       "name": "mb",
@@ -238,7 +240,7 @@
       "typeLabel": "Spacing",
       "required": false,
       "default": null,
-      "description": "Apply margin to the bottom of the component."
+      "description": "Bottom margin."
     },
     {
       "name": "ml",
@@ -246,7 +248,7 @@
       "typeLabel": "Spacing",
       "required": false,
       "default": null,
-      "description": "Apply margin to the left of the component."
+      "description": "Left margin."
     },
     {
       "name": "trailingIconAriaLabel",
@@ -277,17 +279,6 @@
       "required": false,
       "default": "default",
       "description": "Sets the size of the input. 'compact' reduces height for dense layouts."
-    },
-    {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
     }
   ],
   "events": [

--- a/docs/generated/component-apis/linear-progress.json
+++ b/docs/generated/component-apis/linear-progress.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "linear-progress",
   "extractedFrom": "libs/web-components/src/components/linear-progress/LinearProgress.svelte",
-  "extractedAt": "2026-01-05T23:10:27.450Z",
+  "extractedAt": "2026-02-04T08:10:50.411Z",
   "props": [
     {
       "name": "testId",

--- a/docs/generated/component-apis/link-button.json
+++ b/docs/generated/component-apis/link-button.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "link-button",
   "extractedFrom": "libs/web-components/src/components/link-button/LinkButton.svelte",
-  "extractedAt": "2026-01-05T23:10:27.451Z",
+  "extractedAt": "2026-02-04T08:10:50.411Z",
   "props": [
     {
       "name": "color",

--- a/docs/generated/component-apis/link.json
+++ b/docs/generated/component-apis/link.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "link",
   "extractedFrom": "libs/web-components/src/components/link/Link.svelte",
-  "extractedAt": "2026-01-05T23:10:27.450Z",
+  "extractedAt": "2026-02-04T08:10:50.411Z",
   "props": [
     {
       "name": "leadingIcon",
@@ -50,17 +50,6 @@
       "required": false,
       "default": "",
       "description": "Sets a data-testid attribute for automated testing."
-    },
-    {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes. V2 shows underline on hover only."
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/menu-button.json
+++ b/docs/generated/component-apis/menu-button.json
@@ -1,16 +1,12 @@
 {
   "componentSlug": "menu-button",
   "extractedFrom": "libs/web-components/src/components/menu-button/MenuButton.svelte",
-  "extractedAt": "2026-01-05T23:10:27.451Z",
+  "extractedAt": "2026-02-04T08:10:50.411Z",
   "props": [
     {
       "name": "text",
-      "type": "string | undefined",
-      "values": [
-        "string",
-        "undefined"
-      ],
-      "required": false,
+      "type": "string",
+      "required": true,
       "default": null,
       "description": "The button label text. When provided, displays as a text button with a dropdown icon."
     },
@@ -42,25 +38,11 @@
       "description": "Icon displayed before the button text. When no text is provided, displays as an icon button."
     },
     {
-      "name": "leadingIconTheme",
-      "type": "IconTheme",
-      "required": false,
-      "default": "outline",
-      "description": "Theme for the leading icon."
-    },
-    {
       "name": "maxWidth",
       "type": "string",
       "required": true,
       "default": null,
       "description": "Maximum width of the dropdown menu."
-    },
-    {
-      "name": "size",
-      "type": "MenuActionSize",
-      "required": false,
-      "default": "normal",
-      "description": "Size of the button and menu items."
     }
   ],
   "events": [

--- a/docs/generated/component-apis/microsite-header.json
+++ b/docs/generated/component-apis/microsite-header.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "microsite-header",
   "extractedFrom": "libs/web-components/src/components/microsite-header/MicrositeHeader.svelte",
-  "extractedAt": "2026-01-05T23:10:27.452Z",
+  "extractedAt": "2026-02-04T08:10:50.412Z",
   "props": [
     {
       "name": "type",
@@ -21,7 +21,7 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Version number or identifier displayed in the header."
+      "description": "App or service version displayed on the right side of the header."
     },
     {
       "name": "feedbackurl",
@@ -47,7 +47,7 @@
       ],
       "required": false,
       "default": "blank",
-      "description": "For internal header urls sets target="
+      "description": "Sets the target attribute for the header link."
     },
     {
       "name": "feedbackurltarget",

--- a/docs/generated/component-apis/modal.json
+++ b/docs/generated/component-apis/modal.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "modal",
   "extractedFrom": "libs/web-components/src/components/modal/Modal.svelte",
-  "extractedAt": "2026-01-05T23:10:27.452Z",
+  "extractedAt": "2026-02-04T08:10:50.412Z",
   "props": [
     {
       "name": "heading",
@@ -63,23 +63,12 @@
       "description": "Sets a data-testid attribute for automated testing."
     },
     {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "typeLabel": "GoabModalVersionType",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
-    },
-    {
       "name": "width",
       "type": "string",
       "required": false,
       "default": "",
-      "description": "@deprecated Use maxwidth instead."
+      "description": "@deprecated Use maxwidth instead.",
+      "deprecated": true
     }
   ],
   "events": [

--- a/docs/generated/component-apis/notification.json
+++ b/docs/generated/component-apis/notification.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "notification",
   "extractedFrom": "libs/web-components/src/components/notification/Notification.svelte",
-  "extractedAt": "2026-01-05T23:10:27.453Z",
+  "extractedAt": "2026-02-04T08:10:50.413Z",
   "props": [
     {
       "name": "type",
@@ -43,17 +43,6 @@
       "required": false,
       "default": "",
       "description": "Sets a data-testid attribute for automated testing."
-    },
-    {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
     },
     {
       "name": "emphasis",

--- a/docs/generated/component-apis/page-block.json
+++ b/docs/generated/component-apis/page-block.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "page-block",
   "extractedFrom": "libs/web-components/src/components/page-block/PageBlock.svelte",
-  "extractedAt": "2026-01-05T23:10:27.455Z",
+  "extractedAt": "2026-02-04T08:10:50.413Z",
   "props": [
     {
       "name": "width",

--- a/docs/generated/component-apis/pages.json
+++ b/docs/generated/component-apis/pages.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "pages",
   "extractedFrom": "libs/web-components/src/components/pages/Pages.svelte",
-  "extractedAt": "2026-01-05T23:10:27.455Z",
+  "extractedAt": "2026-02-04T08:10:50.413Z",
   "props": [
     {
       "name": "current",

--- a/docs/generated/component-apis/pagination.json
+++ b/docs/generated/component-apis/pagination.json
@@ -1,15 +1,8 @@
 {
   "componentSlug": "pagination",
   "extractedFrom": "libs/web-components/src/components/pagination/Pagination.svelte",
-  "extractedAt": "2026-01-05T23:10:27.456Z",
+  "extractedAt": "2026-02-04T08:10:50.414Z",
   "props": [
-    {
-      "name": "version",
-      "type": "Version",
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
-    },
     {
       "name": "pagenumber",
       "type": "number",

--- a/docs/generated/component-apis/popover.json
+++ b/docs/generated/component-apis/popover.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "popover",
   "extractedFrom": "libs/web-components/src/components/popover/Popover.svelte",
-  "extractedAt": "2026-01-05T23:10:27.456Z",
+  "extractedAt": "2026-02-04T08:10:50.414Z",
   "props": [
     {
       "name": "testId",
@@ -12,11 +12,10 @@
     },
     {
       "name": "position",
-      "type": "\"above\" | \"below\" | \"right\" | \"auto\"",
+      "type": "\"above\" | \"below\" | \"auto\"",
       "values": [
         "above",
         "below",
-        "right",
         "auto"
       ],
       "required": false,
@@ -85,7 +84,8 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "@deprecated This property has no effect and will be removed in a future version."
+      "description": "@deprecated This property has no effect and will be removed in a future version.",
+      "deprecated": true
     },
     {
       "name": "mt",
@@ -118,13 +118,6 @@
       "required": false,
       "default": null,
       "description": "Left margin."
-    },
-    {
-      "name": "disableGlobalClosePopover",
-      "type": "boolean",
-      "required": false,
-      "default": "false",
-      "description": "Prevents the popover from closing when other popovers open. Used for nested interactions."
     },
     {
       "name": "open",
@@ -169,29 +162,11 @@
       "description": "Border radius of the popover window."
     },
     {
-      "name": "closeOnClickWithinBounds",
-      "type": "any",
-      "required": false,
-      "default": "false",
-      "description": "When true, clicking inside the popover will close it."
-    },
-    {
       "name": "filterablecontext",
       "type": "boolean",
       "required": false,
       "default": "false",
       "description": "Indicates the popover is used within a filterable context like a combobox."
-    },
-    {
-      "name": "externalTarget",
-      "type": "HTMLElement | null",
-      "values": [
-        "HTMLElement",
-        "null"
-      ],
-      "required": false,
-      "default": null,
-      "description": "An external element to use as the popover target instead of the slotted target."
     }
   ],
   "events": [

--- a/docs/generated/component-apis/radio-group.json
+++ b/docs/generated/component-apis/radio-group.json
@@ -1,14 +1,14 @@
 {
   "componentSlug": "radio-group",
   "extractedFrom": "libs/web-components/src/components/radio-group/RadioGroup.svelte",
-  "extractedAt": "2026-01-05T23:10:27.457Z",
+  "extractedAt": "2026-02-04T08:10:50.414Z",
   "props": [
     {
       "name": "name",
       "type": "string",
       "required": true,
       "default": null,
-      "description": "The name for the radio group. Used for form submission and accessibility."
+      "description": "The name for the radio group. Used for accessibility and change events."
     },
     {
       "name": "value",
@@ -42,18 +42,6 @@
       "required": false,
       "default": "false",
       "description": "Shows an error state on all radio items in the group."
-    },
-    {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "typeLabel": "GoabRadioGroupVersionType",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
     },
     {
       "name": "size",

--- a/docs/generated/component-apis/radio-item.json
+++ b/docs/generated/component-apis/radio-item.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "radio-item",
   "extractedFrom": "libs/web-components/src/components/radio-item/RadioItem.svelte",
-  "extractedAt": "2026-01-05T23:10:27.457Z",
+  "extractedAt": "2026-02-04T08:10:50.415Z",
   "props": [
     {
       "name": "value",
@@ -36,7 +36,7 @@
       "type": "boolean",
       "required": false,
       "default": "false",
-      "description": "Disables this radio option."
+      "description": "Disables this radio option. Also disabled if the parent RadioGroup is disabled."
     },
     {
       "name": "error",

--- a/docs/generated/component-apis/scrollable.json
+++ b/docs/generated/component-apis/scrollable.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "scrollable",
   "extractedFrom": "libs/web-components/src/components/scrollable/Scrollable.svelte",
-  "extractedAt": "2026-01-05T23:10:27.458Z",
+  "extractedAt": "2026-02-04T08:10:50.415Z",
   "props": [
     {
       "name": "direction",

--- a/docs/generated/component-apis/side-menu-group.json
+++ b/docs/generated/component-apis/side-menu-group.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "side-menu-group",
   "extractedFrom": "libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte",
-  "extractedAt": "2026-01-05T23:10:27.458Z",
+  "extractedAt": "2026-02-04T08:10:50.416Z",
   "props": [
     {
       "name": "heading",

--- a/docs/generated/component-apis/side-menu-heading.json
+++ b/docs/generated/component-apis/side-menu-heading.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "side-menu-heading",
   "extractedFrom": "libs/web-components/src/components/side-menu-heading/SideMenuHeading.svelte",
-  "extractedAt": "2026-01-05T23:10:27.459Z",
+  "extractedAt": "2026-02-04T08:10:50.416Z",
   "props": [
     {
       "name": "icon",

--- a/docs/generated/component-apis/side-menu.json
+++ b/docs/generated/component-apis/side-menu.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "side-menu",
   "extractedFrom": "libs/web-components/src/components/side-menu/SideMenu.svelte",
-  "extractedAt": "2026-01-05T23:10:27.458Z",
+  "extractedAt": "2026-02-04T08:10:50.415Z",
   "props": [
     {
       "name": "testId",

--- a/docs/generated/component-apis/skeleton.json
+++ b/docs/generated/component-apis/skeleton.json
@@ -1,14 +1,14 @@
 {
   "componentSlug": "skeleton",
   "extractedFrom": "libs/web-components/src/components/skeleton/Skeleton.svelte",
-  "extractedAt": "2026-01-05T23:10:27.459Z",
+  "extractedAt": "2026-02-04T08:10:50.416Z",
   "props": [
     {
       "name": "maxWidth",
       "type": "string",
       "required": false,
       "default": "300px",
-      "description": "Set component maximum width. Currently only used in card skeleton type"
+      "description": "Sets the maximum width. Currently only used in card skeleton type."
     },
     {
       "name": "size",
@@ -51,7 +51,7 @@
       ],
       "required": true,
       "default": null,
-      "description": "Reset skeleton shapes to represent your content."
+      "description": "Sets the skeleton shape to represent your content."
     },
     {
       "name": "testId",

--- a/docs/generated/component-apis/spacer.json
+++ b/docs/generated/component-apis/spacer.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "spacer",
   "extractedFrom": "libs/web-components/src/components/spacer/Spacer.svelte",
-  "extractedAt": "2026-01-05T23:10:27.460Z",
+  "extractedAt": "2026-02-04T08:10:50.416Z",
   "props": [
     {
       "name": "hspacing",
@@ -9,7 +9,7 @@
       "typeLabel": "Spacing",
       "required": false,
       "default": "none",
-      "description": "Horizontal spacing"
+      "description": "Horizontal spacing."
     },
     {
       "name": "vspacing",
@@ -24,7 +24,7 @@
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Sets the data-testid attribute. Used with ByTestId queries in tests."
+      "description": "Sets a data-testid attribute for automated testing."
     }
   ],
   "events": [],

--- a/docs/generated/component-apis/spinner.json
+++ b/docs/generated/component-apis/spinner.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "spinner",
   "extractedFrom": "libs/web-components/src/components/spinner/Spinner.svelte",
-  "extractedAt": "2026-01-05T23:10:27.460Z",
+  "extractedAt": "2026-02-04T08:10:50.416Z",
   "props": [
     {
       "name": "size",

--- a/docs/generated/component-apis/tab.json
+++ b/docs/generated/component-apis/tab.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "tab",
   "extractedFrom": "libs/web-components/src/components/tab/Tab.svelte",
-  "extractedAt": "2026-01-05T23:10:27.460Z",
+  "extractedAt": "2026-02-04T08:10:50.417Z",
   "props": [
     {
       "name": "heading",
@@ -16,6 +16,20 @@
       "required": false,
       "default": "false",
       "description": "Whether this tab is currently selected/active."
+    },
+    {
+      "name": "disabled",
+      "type": "boolean",
+      "required": false,
+      "default": "false",
+      "description": ""
+    },
+    {
+      "name": "slug",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": ""
     }
   ],
   "events": [],

--- a/docs/generated/component-apis/table.json
+++ b/docs/generated/component-apis/table.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "table",
   "extractedFrom": "libs/web-components/src/components/table/Table.svelte",
-  "extractedAt": "2026-01-05T23:10:27.461Z",
+  "extractedAt": "2026-02-04T08:10:50.417Z",
   "props": [
     {
       "name": "width",
@@ -37,23 +37,11 @@
       "description": "A relaxed variant of the table with more vertical padding for the cells."
     },
     {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "typeLabel": "GoabTableVersionType",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "1",
-      "description": "The design system version for styling purposes."
-    },
-    {
       "name": "testId",
       "type": "string",
       "required": false,
       "default": "",
-      "description": "Sets the data-testid attribute. Used with ByTestId queries in tests."
+      "description": "Sets a data-testid attribute for automated testing."
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/tabs.json
+++ b/docs/generated/component-apis/tabs.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "tabs",
   "extractedFrom": "libs/web-components/src/components/tabs/Tabs.svelte",
-  "extractedAt": "2026-01-05T23:10:27.461Z",
+  "extractedAt": "2026-02-04T08:10:50.418Z",
   "props": [
     {
       "name": "initialtab",
@@ -18,17 +18,6 @@
       "description": "Sets a data-testid attribute for automated testing."
     },
     {
-      "name": "version",
-      "type": "\"1\" | \"2\"",
-      "values": [
-        "1",
-        "2"
-      ],
-      "required": false,
-      "default": "2",
-      "description": "The design system version for styling purposes."
-    },
-    {
       "name": "variant",
       "type": "\"default\" | \"segmented\"",
       "values": [
@@ -37,53 +26,7 @@
       ],
       "required": false,
       "default": "default",
-      "description": "Sets the visual style of tabs. 'segmented' shows pill/button style tabs."
-    },
-    {
-      "name": "updateurl",
-      "type": "boolean",
-      "required": false,
-      "default": "true",
-      "description": "When true, appends the tab ID as a URL hash when a tab is clicked."
-    },
-    {
-      "name": "stackonmobile",
-      "type": "boolean",
-      "required": false,
-      "default": "true",
-      "description": "When true, tabs stack vertically on mobile. When false, tabs stay horizontal."
-    },
-    {
-      "name": "mt",
-      "type": "Spacing",
-      "typeLabel": "Spacing",
-      "required": false,
-      "default": null,
-      "description": "Top margin (applied to tab header)."
-    },
-    {
-      "name": "mr",
-      "type": "Spacing",
-      "typeLabel": "Spacing",
-      "required": false,
-      "default": null,
-      "description": "Right margin (applied to tab header)."
-    },
-    {
-      "name": "mb",
-      "type": "Spacing",
-      "typeLabel": "Spacing",
-      "required": false,
-      "default": null,
-      "description": "Bottom margin (applied to tab header)."
-    },
-    {
-      "name": "ml",
-      "type": "Spacing",
-      "typeLabel": "Spacing",
-      "required": false,
-      "default": null,
-      "description": "Left margin (applied to tab header)."
+      "description": ""
     }
   ],
   "events": [

--- a/docs/generated/component-apis/temporary-notification.json
+++ b/docs/generated/component-apis/temporary-notification.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "temporary-notification",
   "extractedFrom": "libs/web-components/src/components/temporary-notification/TemporaryNotification.svelte",
-  "extractedAt": "2026-01-05T23:10:27.462Z",
+  "extractedAt": "2026-02-04T08:10:50.418Z",
   "props": [
     {
       "name": "message",

--- a/docs/generated/component-apis/text-area.json
+++ b/docs/generated/component-apis/text-area.json
@@ -1,14 +1,14 @@
 {
   "componentSlug": "text-area",
   "extractedFrom": "libs/web-components/src/components/text-area/TextArea.svelte",
-  "extractedAt": "2026-01-05T23:10:27.463Z",
+  "extractedAt": "2026-02-04T08:10:50.419Z",
   "props": [
     {
       "name": "name",
       "type": "string",
       "required": true,
       "default": null,
-      "description": "Name of the input value that is received in the _change event"
+      "description": "Name of the input value that is received in the _change event."
     },
     {
       "name": "value",
@@ -110,14 +110,14 @@
       "type": "VersionType",
       "required": false,
       "default": "1",
-      "description": "The design system version for styling purposes."
+      "description": ""
     },
     {
       "name": "size",
       "type": "SizeType",
       "required": false,
       "default": "default",
-      "description": "Sets the size of the text area. 'compact' reduces height for dense layouts."
+      "description": ""
     },
     {
       "name": "mt",

--- a/docs/generated/component-apis/text.json
+++ b/docs/generated/component-apis/text.json
@@ -1,14 +1,20 @@
 {
   "componentSlug": "text",
   "extractedFrom": "libs/web-components/src/components/text/Text.svelte",
-  "extractedAt": "2026-01-05T23:10:27.462Z",
+  "extractedAt": "2026-02-04T19:50:01.587Z",
   "props": [
     {
       "name": "as",
-      "type": "TextElement | HeadingElement",
+      "type": "\"span\" | \"div\" | \"p\" | \"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\"",
       "values": [
-        "TextElement",
-        "HeadingElement"
+        "span",
+        "div",
+        "p",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5"
       ],
       "required": false,
       "default": "div",
@@ -27,7 +33,7 @@
     },
     {
       "name": "size",
-      "type": "Size",
+      "type": "\"heading-xl\" | \"heading-l\" | \"heading-m\" | \"heading-s\" | \"heading-xs\" | \"body-l\" | \"body-m\" | \"body-s\" | \"body-xs\"",
       "values": [
         "heading-xl",
         "heading-l",

--- a/docs/generated/component-apis/tooltip.json
+++ b/docs/generated/component-apis/tooltip.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "tooltip",
   "extractedFrom": "libs/web-components/src/components/tooltip/Tooltip.svelte",
-  "extractedAt": "2026-01-05T23:10:27.463Z",
+  "extractedAt": "2026-02-04T08:10:50.419Z",
   "props": [
     {
       "name": "content",

--- a/docs/generated/component-apis/work-side-menu.json
+++ b/docs/generated/component-apis/work-side-menu.json
@@ -1,7 +1,7 @@
 {
   "componentSlug": "work-side-menu",
   "extractedFrom": "libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte",
-  "extractedAt": "2026-01-05T23:10:27.464Z",
+  "extractedAt": "2026-02-04T08:10:50.420Z",
   "props": [
     {
       "name": "heading",

--- a/docs/src/components/CodeSnippet.tsx
+++ b/docs/src/components/CodeSnippet.tsx
@@ -88,14 +88,30 @@ function SingleCodeBlock({
 
   const cleanedCode = cleanCode(code);
 
+  // Syntax highlighting
   useEffect(() => {
     if (codeRef.current) {
       codeRef.current.removeAttribute("data-highlighted");
       hljs.highlightElement(codeRef.current);
     }
-    if (containerRef.current && maxHeight) {
-      setNeedsExpand(containerRef.current.scrollHeight > maxHeight);
-    }
+  }, [cleanedCode]);
+
+  // Detect whether expand button is needed using ResizeObserver.
+  // A one-shot useEffect fails here because inside GoabxTabs, inactive tab
+  // content is hidden (scrollHeight = 0). ResizeObserver fires when the
+  // container becomes visible after a tab switch, so the measurement is reliable.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !maxHeight) return;
+
+    const check = () => {
+      setNeedsExpand(container.scrollHeight > maxHeight);
+    };
+
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(container);
+    return () => observer.disconnect();
   }, [cleanedCode, maxHeight]);
 
   const handleCopy = async () => {
@@ -205,17 +221,50 @@ export function CodeSnippet({
       ) as Framework[])
     : [];
 
-  // Subscribe to global framework preference changes from other components
+  // Subscribe to global framework preference changes from other components.
+  // Directly manipulate the tab DOM state without triggering focus or hash changes.
   useEffect(() => {
     return subscribeToFrameworkPreference((framework) => {
-      // Only update if the framework is available in this snippet
       if (availableFrameworks.length === 0 || availableFrameworks.includes(framework)) {
         setSelectedFramework(framework);
+
+        // Directly switch goa-tabs without triggering focus
+        if (tabsRef.current) {
+          const goaTabs = tabsRef.current.querySelector("goa-tabs");
+          if (goaTabs) {
+            const targetIndex = availableFrameworks.indexOf(framework);
+            const tabs = goaTabs.querySelectorAll('[role="tab"]');
+
+            // Check if already on the correct tab
+            const targetTab = tabs[targetIndex] as HTMLElement;
+            if (targetTab && targetTab.getAttribute("aria-selected") === "true") {
+              return; // Already selected, nothing to do
+            }
+
+            // Update tab button states (aria-selected, tabindex)
+            tabs.forEach((tab, i) => {
+              tab.setAttribute("aria-selected", i === targetIndex ? "true" : "false");
+              tab.setAttribute("tabindex", i === targetIndex ? "0" : "-1");
+            });
+
+            // Tell each goa-tab content whether it should be open
+            const tabContents = goaTabs.querySelectorAll("goa-tab");
+            tabContents.forEach((content, i) => {
+              content.dispatchEvent(
+                new CustomEvent("tabs:set-open", {
+                  composed: true,
+                  detail: { open: i === targetIndex },
+                })
+              );
+            });
+          }
+        }
       }
     });
   }, [availableFrameworks]);
 
-  // Listen for native tab change events (more reliable than React wrapper onChange)
+  // Listen for native tab change events (user clicking a tab in THIS component).
+  // Broadcasts the change to all other CodeSnippet instances on the page.
   // Note: GoA tabs are 1-indexed, so we subtract 1 to get the array index
   useEffect(() => {
     if (!tabsRef.current || availableFrameworks.length <= 1) return;
@@ -420,7 +469,6 @@ export function CodeSnippet({
         // Multiple frameworks - use tabs with content inside
         <div className="framework-switcher" ref={tabsRef}>
           <GoabxTabs
-            key={selectedFramework}
             variant="segmented"
             initialTab={availableFrameworks.indexOf(selectedFramework) + 1}
           >

--- a/docs/src/components/CodeSnippet.tsx
+++ b/docs/src/components/CodeSnippet.tsx
@@ -387,10 +387,37 @@ export function CodeSnippet({
     );
   };
 
+  // Helper to render code blocks for a specific framework
+  const renderBlocksForFramework = (fw: Framework) => {
+    if (!extractParts) {
+      const rawCode = getFrameworkRawCode(frameworkCode, fw);
+      const lang = fw === 'react' ? 'tsx' : 'html';
+      return (
+        <SingleCodeBlock
+          code={rawCode}
+          language={lang}
+          showCopy={showCopy}
+          maxHeight={maxHeight}
+        />
+      );
+    }
+
+    switch (fw) {
+      case 'react':
+        return renderReactBlocks(frameworkCode.react);
+      case 'angular':
+        return renderAngularBlocks(frameworkCode.angular);
+      case 'webComponents':
+        return renderWebComponentsBlocks(frameworkCode.webComponents);
+      default:
+        return null;
+    }
+  };
+
   return (
     <div className="code-snippet-wrapper">
-      {/* Framework Switcher - outside the code container */}
-      {availableFrameworks.length > 1 && (
+      {availableFrameworks.length > 1 ? (
+        // Multiple frameworks - use tabs with content inside
         <div className="framework-switcher" ref={tabsRef}>
           <GoabxTabs
             key={selectedFramework}
@@ -399,17 +426,23 @@ export function CodeSnippet({
           >
             {availableFrameworks.map((fw) => (
               <GoabTab key={fw} heading={FRAMEWORK_LABELS[fw]}>
-                {/* Empty - content rendered separately below */}
+                <div className="code-snippet">
+                  <div className="code-blocks">
+                    {renderBlocksForFramework(fw)}
+                  </div>
+                </div>
               </GoabTab>
             ))}
           </GoabxTabs>
         </div>
+      ) : (
+        // Single framework - no tabs needed
+        <div className="code-snippet">
+          <div className="code-blocks">
+            {renderFrameworkBlocks()}
+          </div>
+        </div>
       )}
-
-      <div className="code-snippet">
-        {/* Code Blocks */}
-        <div className="code-blocks">{renderFrameworkBlocks()}</div>
-      </div>
 
       <CodeSnippetStyles />
     </div>
@@ -465,8 +498,8 @@ function CodeSnippetStyles() {
         font-size: 0.875rem;
       }
 
-      .framework-switcher {
-        margin-bottom: -24px; /* Compensate for 32px margin inside goa-tabs to get 8px gap */
+      .framework-switcher .code-snippet {
+        margin-top: calc(-2rem + 12px);
       }
 
       .code-blocks {
@@ -485,7 +518,6 @@ function CodeSnippetStyles() {
         position: absolute;
         top: var(--goa-space-xs, 0.25rem);
         right: var(--goa-space-s, 0.5rem);
-        z-index: 1;
       }
 
       .code-block-title {
@@ -558,7 +590,6 @@ function CodeSnippetStyles() {
         justify-content: center;
         padding: var(--goa-space-s, 0.5rem) 0;
         position: relative;
-        z-index: 2;
         margin-top: -2rem;
       }
 

--- a/docs/src/components/CodeSnippet.tsx
+++ b/docs/src/components/CodeSnippet.tsx
@@ -1,31 +1,32 @@
-import { useState, useEffect, useRef } from 'react';
-import { GoabTabs, GoabTab } from '@abgov/react-components';
-import hljs from 'highlight.js/lib/core';
-import typescript from 'highlight.js/lib/languages/typescript';
-import xml from 'highlight.js/lib/languages/xml';
-import css from 'highlight.js/lib/languages/css';
-import javascript from 'highlight.js/lib/languages/javascript';
+import { useState, useEffect, useRef } from "react";
+import { GoabxTabs, GoabxButton } from "@abgov/react-components/experimental";
+import { GoabTab } from "@abgov/react-components";
+import hljs from "highlight.js/lib/core";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import css from "highlight.js/lib/languages/css";
+import javascript from "highlight.js/lib/languages/javascript";
 import {
   extractReactCode,
   extractAngularCode,
   extractWebComponentsCode,
   type ExtractedReactCode,
   type ExtractedAngularCode,
-  type ExtractedWebComponentsCode
-} from '../lib/extract-code-parts';
+  type ExtractedWebComponentsCode,
+} from "../lib/extract-code-parts";
 import {
   getFrameworkPreference,
   setFrameworkPreference,
   subscribeToFrameworkPreference,
-  type Framework
-} from '../lib/framework-preference';
+  type Framework,
+} from "../lib/framework-preference";
 
 // Register languages
-hljs.registerLanguage('typescript', typescript);
-hljs.registerLanguage('tsx', typescript);
-hljs.registerLanguage('html', xml);
-hljs.registerLanguage('css', css);
-hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("tsx", typescript);
+hljs.registerLanguage("html", xml);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("javascript", javascript);
 
 interface AngularCode {
   ts?: string;
@@ -45,7 +46,7 @@ interface CodeSnippetProps {
   frameworkCode?: FrameworkCode;
   /** Initial framework when using frameworkCode */
   initialFramework?: Framework;
-  language?: 'tsx' | 'typescript' | 'html' | 'css' | 'javascript';
+  language?: "tsx" | "typescript" | "html" | "css" | "javascript";
   showCopy?: boolean;
   showLineNumbers?: boolean;
   maxHeight?: number;
@@ -55,9 +56,9 @@ interface CodeSnippetProps {
 }
 
 const FRAMEWORK_LABELS: Record<Framework, string> = {
-  react: 'React',
-  angular: 'Angular',
-  webComponents: 'Web Components',
+  react: "React",
+  angular: "Angular",
+  webComponents: "Web Components",
 };
 
 // ============================================================================
@@ -72,7 +73,13 @@ interface SingleCodeBlockProps {
   maxHeight?: number;
 }
 
-function SingleCodeBlock({ code, language, title, showCopy = true, maxHeight }: SingleCodeBlockProps) {
+function SingleCodeBlock({
+  code,
+  language,
+  title,
+  showCopy = true,
+  maxHeight,
+}: SingleCodeBlockProps) {
   const [copied, setCopied] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [needsExpand, setNeedsExpand] = useState(false);
@@ -83,7 +90,7 @@ function SingleCodeBlock({ code, language, title, showCopy = true, maxHeight }: 
 
   useEffect(() => {
     if (codeRef.current) {
-      codeRef.current.removeAttribute('data-highlighted');
+      codeRef.current.removeAttribute("data-highlighted");
       hljs.highlightElement(codeRef.current);
     }
     if (containerRef.current && maxHeight) {
@@ -97,27 +104,39 @@ function SingleCodeBlock({ code, language, title, showCopy = true, maxHeight }: 
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      console.error('Failed to copy:', err);
+      console.error("Failed to copy:", err);
     }
   };
 
   return (
-    <div className={`code-block ${needsExpand && !isExpanded ? 'has-gradient' : ''}`}>
+    <div className={`code-block ${needsExpand && !isExpanded ? "has-gradient" : ""}`}>
       <div className="code-block-header">
         {title && <span className="code-block-title">{title}</span>}
         {showCopy && (
           <button
-            className={`copy-button ${copied ? 'copied' : ''}`}
+            className={`copy-button ${copied ? "copied" : ""}`}
             onClick={handleCopy}
-            aria-label={copied ? 'Copied!' : 'Copy code'}
-            title={copied ? 'Copied!' : 'Copy code'}
+            aria-label={copied ? "Copied!" : "Copy code"}
+            title={copied ? "Copied!" : "Copy code"}
           >
             {copied ? (
-              <svg className="copy-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg
+                className="copy-icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
                 <polyline points="20 6 9 17 4 12"></polyline>
               </svg>
             ) : (
-              <svg className="copy-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg
+                className="copy-icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
               </svg>
@@ -127,8 +146,8 @@ function SingleCodeBlock({ code, language, title, showCopy = true, maxHeight }: 
       </div>
       <div
         ref={containerRef}
-        className={`code-container ${isExpanded ? 'expanded' : ''}`}
-        style={{ maxHeight: isExpanded ? 'none' : maxHeight ? `${maxHeight}px` : 'none' }}
+        className={`code-container ${isExpanded ? "expanded" : ""}`}
+        style={{ maxHeight: isExpanded ? "none" : maxHeight ? `${maxHeight}px` : "none" }}
       >
         <pre>
           <code ref={codeRef} className={`language-${language}`}>
@@ -139,15 +158,14 @@ function SingleCodeBlock({ code, language, title, showCopy = true, maxHeight }: 
       {needsExpand && (
         <div className="expand-wrapper">
           <span className="expand-button-bg">
-            <goa-button
-              version="2"
+            <GoabxButton
               type="tertiary"
               size="compact"
-              trailingicon={isExpanded ? 'chevron-up' : 'chevron-down'}
+              trailingIcon={isExpanded ? "chevron-up" : "chevron-down"}
               onClick={() => setIsExpanded(!isExpanded)}
             >
-              {isExpanded ? 'Show less' : 'Show more'}
-            </goa-button>
+              {isExpanded ? "Show less" : "Show more"}
+            </GoabxButton>
           </span>
         </div>
       )}
@@ -162,13 +180,13 @@ function SingleCodeBlock({ code, language, title, showCopy = true, maxHeight }: 
 export function CodeSnippet({
   code,
   frameworkCode,
-  initialFramework = 'react',
-  language = 'tsx',
+  initialFramework = "react",
+  language = "tsx",
   showCopy = true,
   showLineNumbers = false,
   maxHeight,
   title,
-  extractParts = true
+  extractParts = true,
 }: CodeSnippetProps) {
   // Initialize from global preference (falls back to initialFramework prop if not set)
   const [selectedFramework, setSelectedFramework] = useState<Framework>(() => {
@@ -182,7 +200,9 @@ export function CodeSnippet({
 
   // Get available frameworks
   const availableFrameworks = hasFrameworkSwitcher
-    ? (Object.keys(frameworkCode).filter(k => frameworkCode[k as Framework]) as Framework[])
+    ? (Object.keys(frameworkCode).filter(
+        (k) => frameworkCode[k as Framework],
+      ) as Framework[])
     : [];
 
   // Subscribe to global framework preference changes from other components
@@ -203,7 +223,7 @@ export function CodeSnippet({
     const handleTabChange = (e: Event) => {
       const customEvent = e as CustomEvent<{ tab: number }>;
       const tabIndex = customEvent.detail?.tab;
-      if (typeof tabIndex === 'number') {
+      if (typeof tabIndex === "number") {
         const frameworkIndex = tabIndex - 1; // GoA tabs are 1-indexed
         if (availableFrameworks[frameworkIndex]) {
           // Broadcast to all other components and persist to localStorage
@@ -212,10 +232,10 @@ export function CodeSnippet({
       }
     };
 
-    const tabsElement = tabsRef.current.querySelector('goa-tabs');
+    const tabsElement = tabsRef.current.querySelector("goa-tabs");
     if (tabsElement) {
-      tabsElement.addEventListener('_change', handleTabChange);
-      return () => tabsElement.removeEventListener('_change', handleTabChange);
+      tabsElement.addEventListener("_change", handleTabChange);
+      return () => tabsElement.removeEventListener("_change", handleTabChange);
     }
   }, [availableFrameworks]);
 
@@ -225,7 +245,7 @@ export function CodeSnippet({
       <div className="code-snippet-wrapper">
         <div className="code-snippet">
           <SingleCodeBlock
-            code={code || ''}
+            code={code || ""}
             language={language}
             title={title}
             showCopy={showCopy}
@@ -242,7 +262,7 @@ export function CodeSnippet({
     if (!extractParts) {
       // Simple mode - just show the raw code for selected framework
       const rawCode = getFrameworkRawCode(frameworkCode, selectedFramework);
-      const lang = selectedFramework === 'react' ? 'tsx' : 'html';
+      const lang = selectedFramework === "react" ? "tsx" : "html";
       return (
         <SingleCodeBlock
           code={rawCode}
@@ -255,11 +275,11 @@ export function CodeSnippet({
 
     // Extract and render multiple blocks based on framework
     switch (selectedFramework) {
-      case 'react':
+      case "react":
         return renderReactBlocks(frameworkCode.react);
-      case 'angular':
+      case "angular":
         return renderAngularBlocks(frameworkCode.angular);
-      case 'webComponents':
+      case "webComponents":
         return renderWebComponentsBlocks(frameworkCode.webComponents);
       default:
         return null;
@@ -273,12 +293,27 @@ export function CodeSnippet({
     return (
       <>
         {extracted.css && (
-          <SingleCodeBlock code={extracted.css} language="css" showCopy={showCopy} maxHeight={maxHeight} />
+          <SingleCodeBlock
+            code={extracted.css}
+            language="css"
+            showCopy={showCopy}
+            maxHeight={maxHeight}
+          />
         )}
         {extracted.setup && (
-          <SingleCodeBlock code={extracted.setup} language="tsx" showCopy={showCopy} maxHeight={maxHeight} />
+          <SingleCodeBlock
+            code={extracted.setup}
+            language="tsx"
+            showCopy={showCopy}
+            maxHeight={maxHeight}
+          />
         )}
-        <SingleCodeBlock code={extracted.jsx} language="tsx" showCopy={showCopy} maxHeight={maxHeight} />
+        <SingleCodeBlock
+          code={extracted.jsx}
+          language="tsx"
+          showCopy={showCopy}
+          maxHeight={maxHeight}
+        />
       </>
     );
   };
@@ -287,37 +322,67 @@ export function CodeSnippet({
     if (!angular) return <div className="no-code">No Angular code available</div>;
 
     // Handle both string (legacy) and object format
-    const angularObj: AngularCode = typeof angular === 'string'
-      ? { template: angular }
-      : angular;
+    const angularObj: AngularCode =
+      typeof angular === "string" ? { template: angular } : angular;
 
     const extracted = extractAngularCode(angularObj.ts, angularObj.template);
     return (
       <>
         {extracted.css && (
-          <SingleCodeBlock code={extracted.css} language="css" showCopy={showCopy} maxHeight={maxHeight} />
+          <SingleCodeBlock
+            code={extracted.css}
+            language="css"
+            showCopy={showCopy}
+            maxHeight={maxHeight}
+          />
         )}
         {extracted.typescript && (
-          <SingleCodeBlock code={extracted.typescript} language="typescript" showCopy={showCopy} maxHeight={maxHeight} />
+          <SingleCodeBlock
+            code={extracted.typescript}
+            language="typescript"
+            showCopy={showCopy}
+            maxHeight={maxHeight}
+          />
         )}
-        <SingleCodeBlock code={extracted.template} language="html" showCopy={showCopy} maxHeight={maxHeight} />
+        <SingleCodeBlock
+          code={extracted.template}
+          language="html"
+          showCopy={showCopy}
+          maxHeight={maxHeight}
+        />
       </>
     );
   };
 
   const renderWebComponentsBlocks = (webComponentsCode?: string) => {
-    if (!webComponentsCode) return <div className="no-code">No Web Components code available</div>;
+    if (!webComponentsCode)
+      return <div className="no-code">No Web Components code available</div>;
 
     const extracted = extractWebComponentsCode(webComponentsCode);
     return (
       <>
         {extracted.css && (
-          <SingleCodeBlock code={extracted.css} language="css" showCopy={showCopy} maxHeight={maxHeight} />
+          <SingleCodeBlock
+            code={extracted.css}
+            language="css"
+            showCopy={showCopy}
+            maxHeight={maxHeight}
+          />
         )}
         {extracted.javascript && (
-          <SingleCodeBlock code={extracted.javascript} language="javascript" showCopy={showCopy} maxHeight={maxHeight} />
+          <SingleCodeBlock
+            code={extracted.javascript}
+            language="javascript"
+            showCopy={showCopy}
+            maxHeight={maxHeight}
+          />
         )}
-        <SingleCodeBlock code={extracted.html} language="html" showCopy={showCopy} maxHeight={maxHeight} />
+        <SingleCodeBlock
+          code={extracted.html}
+          language="html"
+          showCopy={showCopy}
+          maxHeight={maxHeight}
+        />
       </>
     );
   };
@@ -327,27 +392,23 @@ export function CodeSnippet({
       {/* Framework Switcher - outside the code container */}
       {availableFrameworks.length > 1 && (
         <div className="framework-switcher" ref={tabsRef}>
-          <GoabTabs
+          <GoabxTabs
             key={selectedFramework}
             variant="segmented"
             initialTab={availableFrameworks.indexOf(selectedFramework) + 1}
-            updateUrl={false}
-            stackOnMobile={false}
           >
             {availableFrameworks.map((fw) => (
               <GoabTab key={fw} heading={FRAMEWORK_LABELS[fw]}>
                 {/* Empty - content rendered separately below */}
               </GoabTab>
             ))}
-          </GoabTabs>
+          </GoabxTabs>
         </div>
       )}
 
       <div className="code-snippet">
         {/* Code Blocks */}
-        <div className="code-blocks">
-          {renderFrameworkBlocks()}
-        </div>
+        <div className="code-blocks">{renderFrameworkBlocks()}</div>
       </div>
 
       <CodeSnippetStyles />
@@ -360,32 +421,32 @@ export function CodeSnippet({
 // ============================================================================
 
 function cleanCode(raw: string): string {
-  const lines = raw.split('\n');
+  const lines = raw.split("\n");
   while (lines.length && !lines[0].trim()) lines.shift();
   while (lines.length && !lines[lines.length - 1].trim()) lines.pop();
   const minIndent = lines
-    .filter(line => line.trim())
+    .filter((line) => line.trim())
     .reduce((min, line) => {
       const match = line.match(/^(\s*)/);
       return match ? Math.min(min, match[1].length) : min;
     }, Infinity);
   return lines
-    .map(line => line.slice(minIndent === Infinity ? 0 : minIndent))
-    .join('\n');
+    .map((line) => line.slice(minIndent === Infinity ? 0 : minIndent))
+    .join("\n");
 }
 
 function getFrameworkRawCode(frameworkCode: FrameworkCode, framework: Framework): string {
   switch (framework) {
-    case 'react':
-      return frameworkCode.react || '';
-    case 'angular':
+    case "react":
+      return frameworkCode.react || "";
+    case "angular":
       const angular = frameworkCode.angular;
-      if (typeof angular === 'string') return angular;
-      return angular?.template || '';
-    case 'webComponents':
-      return frameworkCode.webComponents || '';
+      if (typeof angular === "string") return angular;
+      return angular?.template || "";
+    case "webComponents":
+      return frameworkCode.webComponents || "";
     default:
-      return '';
+      return "";
   }
 }
 

--- a/docs/src/components/ComponentTabs.tsx
+++ b/docs/src/components/ComponentTabs.tsx
@@ -1,5 +1,6 @@
-import { useState, type ReactNode } from 'react';
-import { GoabTabs, GoabTab } from '@abgov/react-components';
+import { useState, type ReactNode } from "react";
+import { GoabxTabs } from "@abgov/react-components/experimental";
+import { GoabTab } from "@abgov/react-components";
 
 interface TabConfig {
   id: string;
@@ -21,13 +22,13 @@ interface ComponentTabsProps {
 export function ComponentTabs({ tabs, children }: ComponentTabsProps) {
   const [activeTab, setActiveTab] = useState(0);
 
-  const handleTabChange = (event: CustomEvent<{ tab: number }>) => {
-    setActiveTab(event.detail.tab);
+  const handleTabChange = (detail: { tab: number }) => {
+    setActiveTab(detail.tab);
   };
 
   return (
     <div className="component-tabs">
-      <GoabTabs initialTab={0} onChange={handleTabChange}>
+      <GoabxTabs initialTab={0} onChange={handleTabChange}>
         {tabs.map((tab, index) => (
           <GoabTab
             key={tab.id}
@@ -38,7 +39,7 @@ export function ComponentTabs({ tabs, children }: ComponentTabsProps) {
             </div>
           </GoabTab>
         ))}
-      </GoabTabs>
+      </GoabxTabs>
 
       <style>{`
         .component-tabs {

--- a/docs/src/components/ComponentsGrid.tsx
+++ b/docs/src/components/ComponentsGrid.tsx
@@ -10,26 +10,26 @@
  * Design pattern based on ExamplesGrid - Figma + workspace demo hybrid approach.
  */
 
-import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import {
-  GoabTable,
-  GoabTableSortHeader,
-  GoabButton,
-  GoabInput,
-  GoabFormItem,
-  GoabFilterChip,
-  GoabBadge,
+  GoabxButton,
+  GoabxInput,
+  GoabxFormItem,
+  GoabxFilterChip,
+  GoabxDrawer,
+  GoabxCheckbox,
+} from "@abgov/react-components/experimental";
+import {
   GoabIcon,
-  GoabDrawer,
-  GoabCheckbox,
   GoabDivider,
   GoabButtonGroup,
-  GoabTabs,
+  GoabCheckboxList,
   GoabTab,
-} from '@abgov/react-components';
-import { useTwoLevelSort } from '../hooks/useTwoLevelSort';
-import { useMobile } from '../hooks/useCompactToolbar';
-import { useViewSettings } from '../hooks/useViewSettings';
+  type GoabCheckboxListOnChangeDetail,
+} from "@abgov/react-components";
+import { useTwoLevelSort } from "../hooks/useTwoLevelSort";
+import { useMobile } from "../hooks/useCompactToolbar";
+import { useViewSettings } from "../hooks/useViewSettings";
 
 // Type for component data (matches Astro content collection)
 export interface Component {
@@ -37,8 +37,13 @@ export interface Component {
   data: {
     name: string;
     description?: string;
-    status: 'stable' | 'beta' | 'deprecated' | 'experimental';
-    category: 'inputs-and-actions' | 'content-layout' | 'structure-and-navigation' | 'feedback-and-alerts' | 'utilities';
+    status: "stable" | "beta" | "deprecated" | "experimental";
+    category:
+      | "inputs-and-actions"
+      | "content-layout"
+      | "structure-and-navigation"
+      | "feedback-and-alerts"
+      | "utilities";
     tags?: string[];
     relatedComponents?: string[];
     webComponentTag?: string;
@@ -51,58 +56,77 @@ interface ComponentsGridProps {
   components: Component[];
 }
 
-const DEFAULT_VISIBLE_COLUMNS = ['name', 'description', 'category', 'status'];
+const DEFAULT_VISIBLE_COLUMNS = ["name", "description", "category", "status"];
 
 // Badge type mapping for status (semantic)
-function getStatusBadgeType(status: string): 'success' | 'warning' | 'emergency' | 'information' {
+function getStatusBadgeType(
+  status: string,
+): "success" | "warning" | "emergency" | "information" {
   switch (status) {
-    case 'stable': return 'success';
-    case 'beta': return 'information';
-    case 'experimental': return 'warning';
-    case 'deprecated': return 'emergency';
-    default: return 'information';
+    case "stable":
+      return "success";
+    case "beta":
+      return "information";
+    case "experimental":
+      return "warning";
+    case "deprecated":
+      return "emergency";
+    default:
+      return "information";
   }
 }
 
 // Badge type mapping for categories (using V2 extended colors)
-function getCategoryBadgeType(category: string): 'sky' | 'pasture' | 'dawn' | 'lilac' | 'prairie' | 'default' {
+function getCategoryBadgeType(
+  category: string,
+): "sky" | "pasture" | "dawn" | "lilac" | "prairie" | "default" {
   switch (category) {
-    case 'content-layout': return 'sky';
-    case 'feedback-and-alerts': return 'prairie';
-    case 'structure-and-navigation': return 'lilac';
-    case 'inputs-and-actions': return 'dawn';
-    case 'forms': return 'pasture';
-    case 'technical': return 'default';
-    case 'utilities': return 'default';
-    default: return 'default';
+    case "content-layout":
+      return "sky";
+    case "feedback-and-alerts":
+      return "prairie";
+    case "structure-and-navigation":
+      return "lilac";
+    case "inputs-and-actions":
+      return "dawn";
+    case "forms":
+      return "pasture";
+    case "technical":
+      return "default";
+    case "utilities":
+      return "default";
+    default:
+      return "default";
   }
 }
 
 // Format category for display
 function formatCategory(category: string): string {
   return category
-    .split('-')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }
 
 // Format status for display
 function formatStatus(status: string): string {
-  if (status === 'stable') return 'Available';
+  if (status === "stable") return "Available";
   return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
 export function ComponentsGrid({ components }: ComponentsGridProps) {
   // State
-  const [searchValue, setSearchValue] = useState('');
+  const [searchValue, setSearchValue] = useState("");
   const [searchChips, setSearchChips] = useState<string[]>([]);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [isSticky, setIsSticky] = useState(false);
 
   // Ref for sticky detection sentinel
   const sentinelRef = useRef<HTMLDivElement>(null);
-  // Ref for view toggle tabs
-  const viewToggleRef = useRef<HTMLDivElement>(null);
+  // Ref for table (to handle sort events from web component)
+  const tableRef = useRef<HTMLElement>(null);
+  // TODO: Remove tabsRef when GoabxTabs wrapper exposes updateUrl and stackOnMobile props
+  const tabsRef = useRef<HTMLElement>(null);
 
   // Detect when toolbar becomes sticky using IntersectionObserver
   useEffect(() => {
@@ -114,7 +138,7 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
         // When sentinel is not intersecting (scrolled out of view), toolbar is sticky
         setIsSticky(!entry.isIntersecting);
       },
-      { threshold: 0 }
+      { threshold: 0 },
     );
 
     observer.observe(sentinel);
@@ -132,33 +156,52 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
   }>({ category: [], status: [] });
 
   // Hooks
-  const { sortConfig, setSortConfig, sortByKey, clearSort, handleTableSort } = useTwoLevelSort();
+  const { sortConfig, setSortConfig, sortByKey, clearSort, handleTableSort } =
+    useTwoLevelSort();
   const isMobile = useMobile();
   const { viewSettings, setLayout } = useViewSettings({
-    pageKey: 'components',
-    defaultLayout: 'card', // 'card' = grid view
+    pageKey: "components",
+    defaultLayout: "card", // 'card' = grid view
     defaultColumns: DEFAULT_VISIBLE_COLUMNS,
   });
 
-  // Listen for view toggle tab changes (native event - GoA tabs are 1-indexed)
-  useEffect(() => {
-    if (!viewToggleRef.current) return;
 
-    const handleViewChange = (e: Event) => {
-      const customEvent = e as CustomEvent<{ tab: number }>;
-      const tabIndex = customEvent.detail?.tab;
-      if (tabIndex === 1) {
-        setLayout('card'); // Grid view
-      } else if (tabIndex === 2) {
-        setLayout('list'); // List view
+  // Listen for table sort events (from goa-table web component)
+  // Also explicitly set version="2" attribute since React may not set it correctly on custom elements
+  useEffect(() => {
+    const table = tableRef.current;
+    if (!table) return;
+
+    // Explicitly set version attribute for V2 styling (React doesn't always set attributes on custom elements)
+    table.setAttribute("version", "2");
+
+    const handleSort = (e: Event) => {
+      const detail = (e as CustomEvent<{ sortBy: string; sortDir: "asc" | "desc" }>)
+        .detail;
+      handleTableSort(detail);
+    };
+
+    table.addEventListener("_sort", handleSort);
+    return () => table.removeEventListener("_sort", handleSort);
+  }, [handleTableSort]);
+
+  // TODO: Remove this useEffect when GoabxTabs wrapper exposes updateUrl and stackOnMobile props
+  // Using goa-tabs web component directly because GoabxTabs wrapper is missing these props
+  useEffect(() => {
+    const tabs = tabsRef.current;
+    if (!tabs) return;
+
+    const handleChange = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab: number }>).detail;
+      if (detail.tab === 1) {
+        setLayout("card"); // Grid view
+      } else if (detail.tab === 2) {
+        setLayout("list"); // List view
       }
     };
 
-    const tabsElement = viewToggleRef.current.querySelector('goa-tabs');
-    if (tabsElement) {
-      tabsElement.addEventListener('_change', handleViewChange);
-      return () => tabsElement.removeEventListener('_change', handleViewChange);
-    }
+    tabs.addEventListener("_change", handleChange);
+    return () => tabs.removeEventListener("_change", handleChange);
   }, [setLayout]);
 
   // Expanded groups state
@@ -166,16 +209,16 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
 
   // Extract unique filter values
   const filterOptions = useMemo(() => {
-    const categories = [...new Set(components.map(c => c.data.category))].sort();
-    const statuses = [...new Set(components.map(c => c.data.status))].sort();
+    const categories = [...new Set(components.map((c) => c.data.category))].sort();
+    const statuses = [...new Set(components.map((c) => c.data.status))].sort();
     return { categories, statuses };
   }, [components]);
 
   // View mode: 'card' = grid view, 'list' = list view (table)
   // On mobile, always use card view
-  const viewMode = useMemo((): 'card' | 'list' => {
-    if (isMobile) return 'card';
-    return viewSettings.layout === 'list' ? 'list' : 'card';
+  const viewMode = useMemo((): "card" | "list" => {
+    if (isMobile) return "card";
+    return viewSettings.layout === "list" ? "list" : "card";
   }, [isMobile, viewSettings.layout]);
 
   // Filter and sort components
@@ -188,22 +231,32 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
         searchChips.every(
           (chip) =>
             component.data.name.toLowerCase().includes(chip.toLowerCase()) ||
-            (component.data.description || '').toLowerCase().includes(chip.toLowerCase()) ||
+            (component.data.description || "")
+              .toLowerCase()
+              .includes(chip.toLowerCase()) ||
             component.data.category.toLowerCase().includes(chip.toLowerCase()) ||
-            (component.data.tags || []).some(tag => tag.toLowerCase().includes(chip.toLowerCase())) ||
-            (component.data.webComponentTag || '').toLowerCase().includes(chip.toLowerCase())
-        )
+            (component.data.tags || []).some((tag) =>
+              tag.toLowerCase().includes(chip.toLowerCase()),
+            ) ||
+            (component.data.webComponentTag || "")
+              .toLowerCase()
+              .includes(chip.toLowerCase()),
+        ),
       );
     }
 
     // Apply category filters
     if (appliedFilters.category.length > 0) {
-      result = result.filter((component) => appliedFilters.category.includes(component.data.category));
+      result = result.filter((component) =>
+        appliedFilters.category.includes(component.data.category),
+      );
     }
 
     // Apply status filters
     if (appliedFilters.status.length > 0) {
-      result = result.filter((component) => appliedFilters.status.includes(component.data.status));
+      result = result.filter((component) =>
+        appliedFilters.status.includes(component.data.status),
+      );
     }
 
     // Apply sorting
@@ -214,25 +267,25 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
         let bVal: string;
 
         switch (key) {
-          case 'name':
+          case "name":
             aVal = a.data.name;
             bVal = b.data.name;
             break;
-          case 'category':
+          case "category":
             aVal = a.data.category;
             bVal = b.data.category;
             break;
-          case 'status':
+          case "status":
             aVal = a.data.status;
             bVal = b.data.status;
             break;
           default:
-            aVal = '';
-            bVal = '';
+            aVal = "";
+            bVal = "";
         }
 
         const cmp = aVal.localeCompare(bVal);
-        const dir = sortConfig.primary!.direction === 'asc' ? 1 : -1;
+        const dir = sortConfig.primary!.direction === "asc" ? 1 : -1;
 
         if (cmp !== 0) return cmp * dir;
 
@@ -242,24 +295,24 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
           let secBVal: string;
 
           switch (secKey) {
-            case 'name':
+            case "name":
               secAVal = a.data.name;
               secBVal = b.data.name;
               break;
-            case 'category':
+            case "category":
               secAVal = a.data.category;
               secBVal = b.data.category;
               break;
-            case 'status':
+            case "status":
               secAVal = a.data.status;
               secBVal = b.data.status;
               break;
             default:
-              secAVal = '';
-              secBVal = '';
+              secAVal = "";
+              secBVal = "";
           }
 
-          const secDir = sortConfig.secondary.direction === 'asc' ? 1 : -1;
+          const secDir = sortConfig.secondary.direction === "asc" ? 1 : -1;
           return secAVal.localeCompare(secBVal) * secDir;
         }
 
@@ -280,14 +333,14 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
     filteredComponents.forEach((component) => {
       let groupKey: string;
       switch (viewSettings.groupBy) {
-        case 'category':
+        case "category":
           groupKey = component.data.category;
           break;
-        case 'status':
+        case "status":
           groupKey = component.data.status;
           break;
         default:
-          groupKey = 'Unknown';
+          groupKey = "Unknown";
       }
 
       if (!groupMap.has(groupKey)) {
@@ -300,10 +353,10 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
     sortedKeys.forEach((key) => {
       let label: string;
       switch (viewSettings.groupBy) {
-        case 'category':
+        case "category":
           label = formatCategory(key);
           break;
-        case 'status':
+        case "status":
           label = formatStatus(key);
           break;
         default:
@@ -339,7 +392,7 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
     const trimmed = searchValue.trim();
     if (trimmed && !searchChips.includes(trimmed)) {
       setSearchChips((prev) => [...prev, trimmed]);
-      setSearchValue('');
+      setSearchValue("");
     }
   }, [searchValue, searchChips]);
 
@@ -348,14 +401,17 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
   }, []);
 
   // Filter handlers
-  const togglePendingFilter = useCallback((filterType: 'category' | 'status', value: string) => {
-    setPendingFilters((prev) => ({
-      ...prev,
-      [filterType]: prev[filterType].includes(value)
-        ? prev[filterType].filter((v) => v !== value)
-        : [...prev[filterType], value],
-    }));
-  }, []);
+  const togglePendingFilter = useCallback(
+    (filterType: "category" | "status", value: string) => {
+      setPendingFilters((prev) => ({
+        ...prev,
+        [filterType]: prev[filterType].includes(value)
+          ? prev[filterType].filter((v) => v !== value)
+          : [...prev[filterType], value],
+      }));
+    },
+    [],
+  );
 
   const applyFilters = useCallback(() => {
     setAppliedFilters(pendingFilters);
@@ -368,12 +424,15 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
     setAppliedFilters(empty);
   }, []);
 
-  const removeAppliedFilter = useCallback((filterType: 'category' | 'status', value: string) => {
-    setAppliedFilters((prev) => ({
-      ...prev,
-      [filterType]: prev[filterType].filter((v) => v !== value),
-    }));
-  }, []);
+  const removeAppliedFilter = useCallback(
+    (filterType: "category" | "status", value: string) => {
+      setAppliedFilters((prev) => ({
+        ...prev,
+        [filterType]: prev[filterType].filter((v) => v !== value),
+      }));
+    },
+    [],
+  );
 
   // Clear all filters, search, and sort
   const clearAll = useCallback(() => {
@@ -383,30 +442,36 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
   }, [clearAllFilters, clearSort]);
 
   // Get sort direction for column headers
-  const getColumnSortDirection = useCallback((columnKey: string): 'asc' | 'desc' | 'none' => {
-    if (sortConfig.primary?.key === columnKey) {
-      return sortConfig.primary.direction;
-    }
-    if (sortConfig.secondary?.key === columnKey) {
-      return sortConfig.secondary.direction;
-    }
-    return 'none';
-  }, [sortConfig]);
+  const getColumnSortDirection = useCallback(
+    (columnKey: string): "asc" | "desc" | "none" => {
+      if (sortConfig.primary?.key === columnKey) {
+        return sortConfig.primary.direction;
+      }
+      if (sortConfig.secondary?.key === columnKey) {
+        return sortConfig.secondary.direction;
+      }
+      return "none";
+    },
+    [sortConfig],
+  );
 
   // Get sort order indicator ("1" or "2") for column headers
-  const getColumnSortOrder = useCallback((columnKey: string): string | undefined => {
-    // Only show numbers if there are two sorts active
-    if (!sortConfig.primary || !sortConfig.secondary) {
+  const getColumnSortOrder = useCallback(
+    (columnKey: string): string | undefined => {
+      // Only show numbers if there are two sorts active
+      if (!sortConfig.primary || !sortConfig.secondary) {
+        return undefined;
+      }
+      if (sortConfig.primary.key === columnKey) {
+        return "1";
+      }
+      if (sortConfig.secondary.key === columnKey) {
+        return "2";
+      }
       return undefined;
-    }
-    if (sortConfig.primary.key === columnKey) {
-      return "1";
-    }
-    if (sortConfig.secondary.key === columnKey) {
-      return "2";
-    }
-    return undefined;
-  }, [sortConfig]);
+    },
+    [sortConfig],
+  );
 
   // Render component card (grid view) - matches ExamplesGrid pattern
   const renderComponentCard = useCallback(
@@ -425,14 +490,12 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
 
           {/* Description */}
           {component.data.description && (
-            <p className="component-card-description">
-              {component.data.description}
-            </p>
+            <p className="component-card-description">{component.data.description}</p>
           )}
 
           {/* Category badge only - status shown in table view */}
           <div className="component-card-badges">
-            <GoabBadge
+            <goa-badge
               version="2"
               type={getCategoryBadgeType(component.data.category)}
               content={formatCategory(component.data.category)}
@@ -442,7 +505,7 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
         </div>
       </a>
     ),
-    []
+    [],
   );
 
   // Render table row (list view)
@@ -455,10 +518,10 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
           </a>
         </td>
         <td className="component-description-cell">
-          {component.data.description || '—'}
+          {component.data.description || "—"}
         </td>
         <td>
-          <GoabBadge
+          <goa-badge
             version="2"
             type={getCategoryBadgeType(component.data.category)}
             content={formatCategory(component.data.category)}
@@ -466,7 +529,7 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
           />
         </td>
         <td>
-          <GoabBadge
+          <goa-badge
             version="2"
             type={getStatusBadgeType(component.data.status)}
             content={formatStatus(component.data.status)}
@@ -475,10 +538,11 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
         </td>
       </tr>
     ),
-    []
+    [],
   );
 
-  const hasActiveFilters = searchChips.length > 0 ||
+  const hasActiveFilters =
+    searchChips.length > 0 ||
     appliedFilters.category.length > 0 ||
     appliedFilters.status.length > 0 ||
     sortConfig.primary;
@@ -489,40 +553,56 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
       <div ref={sentinelRef} className="components-sentinel" aria-hidden="true" />
 
       {/* Toolbar */}
-      <div className={`components-toolbar ${isSticky ? 'components-toolbar--sticky' : ''}`}>
+      <div
+        className={`components-toolbar ${isSticky ? "components-toolbar--sticky" : ""}`}
+      >
         {/* Search input */}
         <div className="components-search-section">
-          <GoabFormItem
-            helpText={!isSticky ? 'Search by name, category, or tag' : undefined}
+          <GoabxFormItem
+            helpText={!isSticky ? "Search by name, category, or tag" : undefined}
           >
-            <GoabInput
+            <GoabxInput
               name="componentSearch"
               value={searchValue}
               leadingIcon="search"
               width="100%"
               size="compact"
               onChange={(e) => setSearchValue(e.value)}
-              onKeyPress={(e) => e.key === 'Enter' && applySearch()}
+              onKeyPress={(e) => e.key === "Enter" && applySearch()}
             />
-          </GoabFormItem>
+          </GoabxFormItem>
         </div>
 
         {/* View toggle + Filters */}
         <div className="components-toolbar-actions">
-          {/* View toggle - segmented tabs */}
-          <div className="view-toggle-wrapper" ref={viewToggleRef}>
-            <GoabTabs
+          {/*
+           * TODO: Replace <goa-tabs> with GoabxTabs when wrapper exposes these props
+           *
+           * Using web component directly because GoabxTabs wrapper is missing:
+           * - updateUrl prop (we need false to avoid polluting browser history)
+           * - stackOnMobile prop (we need false for compact view toggle)
+           *
+           * When fixed, remove: tabsRef, useEffect for _change event, goa-tabs from global.d.ts
+           */}
+          <div className="view-toggle-wrapper">
+            <goa-tabs
+              ref={tabsRef}
+              version="2"
               variant="segmented"
-              initialTab={viewMode === 'card' ? 1 : 2}
-              updateUrl={false}
-              stackOnMobile={false}
+              initialtab={viewMode === "card" ? 1 : 2}
+              updateurl="false"
+              stackonmobile="false"
             >
-              <GoabTab heading="Grid"><span /></GoabTab>
-              <GoabTab heading="List"><span /></GoabTab>
-            </GoabTabs>
+              <goa-tab heading="Grid">
+                <span />
+              </goa-tab>
+              <goa-tab heading="List">
+                <span />
+              </goa-tab>
+            </goa-tabs>
           </div>
 
-          <GoabButton
+          <GoabxButton
             type="secondary"
             leadingIcon="filter-lines"
             size="compact"
@@ -532,28 +612,38 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
             }}
           >
             Filters
-          </GoabButton>
+          </GoabxButton>
         </div>
       </div>
 
       {/* Active filters chips */}
       {hasActiveFilters && (
         <div className="components-chips">
-          <GoabIcon type="filter-lines" size="small" fillColor="var(--goa-color-text-secondary)" />
+          <GoabIcon
+            type="filter-lines"
+            size="small"
+            fillColor="var(--goa-color-text-secondary)"
+          />
 
           {/* Sort chips */}
           {sortConfig.primary && (
-            <GoabFilterChip
+            <GoabxFilterChip
               content={sortConfig.primary.key}
-              leadingIcon={sortConfig.primary.direction === 'asc' ? 'arrow-up' : 'arrow-down'}
-              secondaryText={sortConfig.secondary ? '1st' : undefined}
-              onClick={() => setSortConfig({ primary: sortConfig.secondary, secondary: null })}
+              leadingIcon={
+                sortConfig.primary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
+              secondaryText={sortConfig.secondary ? "1st" : undefined}
+              onClick={() =>
+                setSortConfig({ primary: sortConfig.secondary, secondary: null })
+              }
             />
           )}
           {sortConfig.secondary && (
-            <GoabFilterChip
+            <GoabxFilterChip
               content={sortConfig.secondary.key}
-              leadingIcon={sortConfig.secondary.direction === 'asc' ? 'arrow-up' : 'arrow-down'}
+              leadingIcon={
+                sortConfig.secondary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
               secondaryText="2nd"
               onClick={() => setSortConfig((prev) => ({ ...prev, secondary: null }))}
             />
@@ -561,20 +651,39 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
 
           {/* Search chips */}
           {searchChips.map((chip) => (
-            <GoabFilterChip key={chip} content={chip} onClick={() => removeSearchChip(chip)} />
+            <GoabxFilterChip
+              key={chip}
+              content={chip}
+              onClick={() => removeSearchChip(chip)}
+            />
           ))}
 
           {/* Category filter chips */}
           {appliedFilters.category.map((cat) => (
-            <GoabFilterChip key={`cat-${cat}`} content={formatCategory(cat)} onClick={() => removeAppliedFilter('category', cat)} />
+            <GoabxFilterChip
+              key={`cat-${cat}`}
+              content={formatCategory(cat)}
+              onClick={() => removeAppliedFilter("category", cat)}
+            />
           ))}
 
           {/* Status filter chips */}
           {appliedFilters.status.map((status) => (
-            <GoabFilterChip key={`status-${status}`} content={formatStatus(status)} onClick={() => removeAppliedFilter('status', status)} />
+            <GoabxFilterChip
+              key={`status-${status}`}
+              content={formatStatus(status)}
+              onClick={() => removeAppliedFilter("status", status)}
+            />
           ))}
 
-          <a href="#" className="clear-all-link" onClick={(e) => { e.preventDefault(); clearAll(); }}>
+          <a
+            href="#"
+            className="clear-all-link"
+            onClick={(e) => {
+              e.preventDefault();
+              clearAll();
+            }}
+          >
             Clear all
           </a>
         </div>
@@ -582,101 +691,127 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
 
       {/* Results count */}
       <p className="components-count">
-        {filteredComponents.length} component{filteredComponents.length !== 1 ? 's' : ''}
+        {filteredComponents.length} component{filteredComponents.length !== 1 ? "s" : ""}
       </p>
 
       {/* List View (table) */}
-      {viewMode === 'list' && (
+      {viewMode === "list" && (
         <div className="components-table-wrapper">
-          <GoabTable width="100%" variant="normal" onSort={handleTableSort}>
-            <thead>
-              <tr>
-                <th>
-                  <GoabTableSortHeader
-                    name="name"
-                    direction={getColumnSortDirection('name')}
-                    sortOrder={getColumnSortOrder('name')}
-                  >
-                    Name
-                  </GoabTableSortHeader>
-                </th>
-                <th>Description</th>
-                <th>
-                  <GoabTableSortHeader
-                    name="category"
-                    direction={getColumnSortDirection('category')}
-                    sortOrder={getColumnSortOrder('category')}
-                  >
-                    Category
-                  </GoabTableSortHeader>
-                </th>
-                <th>
-                  <GoabTableSortHeader
-                    name="status"
-                    direction={getColumnSortDirection('status')}
-                    sortOrder={getColumnSortOrder('status')}
-                  >
-                    Status
-                  </GoabTableSortHeader>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {groupedComponents
-                ? groupedComponents.map((group) => (
-                    <React.Fragment key={group.key}>
-                      <tr className="components-group-row" onClick={() => toggleGroup(group.key)}>
-                        <td colSpan={4}>
-                          <div className="components-group-header">
-                            <GoabIcon
-                              type={expandedGroups.has(group.key) ? 'chevron-down' : 'chevron-forward'}
-                              size="small"
-                            />
-                            <strong>{group.label}</strong>
-                            <GoabBadge version="2" type="default" content={String(group.components.length)} emphasis="subtle" />
-                          </div>
-                        </td>
-                      </tr>
-                      {expandedGroups.has(group.key) && group.components.map(renderTableRow)}
-                    </React.Fragment>
-                  ))
-                : filteredComponents.map(renderTableRow)}
-            </tbody>
-          </GoabTable>
+          {/* Using web components directly for V2 styling - React wrappers don't pass version prop */}
+          <goa-table ref={tableRef} version="2" width="100%" variant="normal">
+            <table style={{ width: "100%" }}>
+              <thead>
+                <tr>
+                  <th>
+                    <goa-table-sort-header
+                      version="2"
+                      name="name"
+                      direction={getColumnSortDirection("name")}
+                    >
+                      Name
+                    </goa-table-sort-header>
+                  </th>
+                  <th>Description</th>
+                  <th>
+                    <goa-table-sort-header
+                      version="2"
+                      name="category"
+                      direction={getColumnSortDirection("category")}
+                    >
+                      Category
+                    </goa-table-sort-header>
+                  </th>
+                  <th>
+                    <goa-table-sort-header
+                      version="2"
+                      name="status"
+                      direction={getColumnSortDirection("status")}
+                    >
+                      Status
+                    </goa-table-sort-header>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {groupedComponents
+                  ? groupedComponents.map((group) => (
+                      <React.Fragment key={group.key}>
+                        <tr
+                          className="components-group-row"
+                          onClick={() => toggleGroup(group.key)}
+                        >
+                          <td colSpan={4}>
+                            <div className="components-group-header">
+                              <GoabIcon
+                                type={
+                                  expandedGroups.has(group.key)
+                                    ? "chevron-down"
+                                    : "chevron-forward"
+                                }
+                                size="small"
+                              />
+                              <strong>{group.label}</strong>
+                              <goa-badge
+                                version="2"
+                                type="default"
+                                content={String(group.components.length)}
+                                emphasis="subtle"
+                              />
+                            </div>
+                          </td>
+                        </tr>
+                        {expandedGroups.has(group.key) &&
+                          group.components.map(renderTableRow)}
+                      </React.Fragment>
+                    ))
+                  : filteredComponents.map(renderTableRow)}
+              </tbody>
+            </table>
+          </goa-table>
         </div>
       )}
 
       {/* Card View */}
-      {viewMode === 'card' && (
+      {viewMode === "card" && (
         <div className="components-card-view">
-          {groupedComponents
-            ? groupedComponents.map((group) => (
-                <div key={group.key} className="components-group">
-                  <button className="components-group-btn" onClick={() => toggleGroup(group.key)}>
-                    <GoabIcon
-                      type={expandedGroups.has(group.key) ? 'chevron-down' : 'chevron-forward'}
-                      size="small"
-                    />
-                    <strong>{group.label}</strong>
-                    <GoabBadge version="2" type="dark" content={String(group.components.length)} emphasis="subtle" />
-                  </button>
-                  {expandedGroups.has(group.key) && (
-                    <div className="components-card-grid">
-                      {group.components.map(renderComponentCard)}
-                    </div>
-                  )}
-                </div>
-              ))
-            : (
-              <div className="components-card-grid">
-                {filteredComponents.map(renderComponentCard)}
+          {groupedComponents ? (
+            groupedComponents.map((group) => (
+              <div key={group.key} className="components-group">
+                <button
+                  className="components-group-btn"
+                  onClick={() => toggleGroup(group.key)}
+                >
+                  <GoabIcon
+                    type={
+                      expandedGroups.has(group.key) ? "chevron-down" : "chevron-forward"
+                    }
+                    size="small"
+                  />
+                  <strong>{group.label}</strong>
+                  <goa-badge
+                    version="2"
+                    type="dark"
+                    content={String(group.components.length)}
+                    emphasis="subtle"
+                  />
+                </button>
+                {expandedGroups.has(group.key) && (
+                  <div className="components-card-grid">
+                    {group.components.map(renderComponentCard)}
+                  </div>
+                )}
               </div>
-            )}
+            ))
+          ) : (
+            <div className="components-card-grid">
+              {filteredComponents.map(renderComponentCard)}
+            </div>
+          )}
         </div>
       )}
 
       {/* Filter Drawer */}
-      <GoabDrawer
+      <GoabxDrawer
         heading="Filter components"
         position="right"
         open={filterDrawerOpen}
@@ -684,56 +819,76 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
         onClose={() => setFilterDrawerOpen(false)}
         actions={
           <GoabButtonGroup alignment="start" gap="compact">
-            <GoabButton type="primary" size="compact" onClick={applyFilters}>
+            <GoabxButton type="primary" size="compact" onClick={applyFilters}>
               Apply filters
-            </GoabButton>
-            <GoabButton type="tertiary" size="compact" onClick={() => setFilterDrawerOpen(false)}>
+            </GoabxButton>
+            <GoabxButton
+              type="tertiary"
+              size="compact"
+              onClick={() => setFilterDrawerOpen(false)}
+            >
               Cancel
-            </GoabButton>
+            </GoabxButton>
           </GoabButtonGroup>
         }
       >
         <div className="filter-drawer-content">
           {/* Category filter */}
-          <GoabFormItem label="Category">
-            <div className="filter-checkboxes">
+          <GoabxFormItem label="Category">
+            <GoabCheckboxList
+              name="category"
+              value={pendingFilters.category}
+              onChange={(detail: GoabCheckboxListOnChangeDetail) =>
+                setPendingFilters((prev) => ({ ...prev, category: detail.value }))
+              }
+            >
               {filterOptions.categories.map((category) => (
-                <GoabCheckbox
+                <GoabxCheckbox
                   key={category}
-                  name={`category-${category}`}
+                  name={category}
+                  value={category}
                   text={formatCategory(category)}
-                  checked={pendingFilters.category.includes(category)}
-                  onChange={() => togglePendingFilter('category', category)}
+                  size="compact"
                 />
               ))}
-            </div>
-          </GoabFormItem>
+            </GoabCheckboxList>
+          </GoabxFormItem>
 
           {/* Status filter */}
-          <GoabFormItem label="Status">
-            <div className="filter-checkboxes">
+          <GoabxFormItem label="Status">
+            <GoabCheckboxList
+              name="status"
+              value={pendingFilters.status}
+              onChange={(detail: GoabCheckboxListOnChangeDetail) =>
+                setPendingFilters((prev) => ({ ...prev, status: detail.value }))
+              }
+            >
               {filterOptions.statuses.map((status) => (
-                <GoabCheckbox
+                <GoabxCheckbox
                   key={status}
-                  name={`status-${status}`}
+                  name={status}
+                  value={status}
                   text={formatStatus(status)}
-                  checked={pendingFilters.status.includes(status)}
-                  onChange={() => togglePendingFilter('status', status)}
+                  size="compact"
                 />
               ))}
-            </div>
-          </GoabFormItem>
+            </GoabCheckboxList>
+          </GoabxFormItem>
 
           {(pendingFilters.category.length > 0 || pendingFilters.status.length > 0) && (
             <>
               <GoabDivider />
-              <GoabButton type="tertiary" size="compact" onClick={() => setPendingFilters({ category: [], status: [] })}>
+              <GoabxButton
+                type="tertiary"
+                size="compact"
+                onClick={() => setPendingFilters({ category: [], status: [] })}
+              >
                 Clear all filters
-              </GoabButton>
+              </GoabxButton>
             </>
           )}
         </div>
-      </GoabDrawer>
+      </GoabxDrawer>
 
       <style>{`
         .components-grid {

--- a/docs/src/components/ComponentsGrid.tsx
+++ b/docs/src/components/ComponentsGrid.tsx
@@ -1024,9 +1024,13 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
           }
         }
 
-        @media (max-width: 600px) {
+        @media (max-width: 623px) {
           .components-card-grid {
             grid-template-columns: 1fr;
+          }
+
+          .view-toggle-wrapper {
+            display: none;
           }
         }
 

--- a/docs/src/components/ConfigurationPreview.tsx
+++ b/docs/src/components/ConfigurationPreview.tsx
@@ -184,7 +184,6 @@ export function ConfigurationPreview({
           gap: var(--goa-space-m, 1rem);
           margin-bottom: var(--goa-space-m, 1rem);
           position: relative;
-          z-index: 2;
         }
 
         .config-dropdown {
@@ -225,7 +224,7 @@ export function ConfigurationPreview({
           min-height: 120px;
           margin-bottom: var(--goa-space-m, 1rem);
           position: relative;
-          z-index: 1;
+          z-index: 1; /* Allow dropdowns to appear above code snippets */
           isolation: isolate;
         }
 

--- a/docs/src/components/DocumentationTabs.tsx
+++ b/docs/src/components/DocumentationTabs.tsx
@@ -4,8 +4,9 @@
  * This component tests and implements GoA tabs for the docs site dogfooding effort.
  * Uses actual GoA React components instead of custom CSS tabs.
  */
-import { GoabTabs, GoabTab } from '@abgov/react-components';
-import type { ReactNode } from 'react';
+import { GoabxTabs } from "@abgov/react-components/experimental";
+import { GoabTab } from "@abgov/react-components";
+import type { ReactNode } from "react";
 
 interface TabConfig {
   heading: string;
@@ -20,16 +21,18 @@ interface DocumentationTabsProps {
 
 export function DocumentationTabs({ tabs, initialTab = 0 }: DocumentationTabsProps) {
   return (
-    <GoabTabs initialTab={initialTab}>
+    <GoabxTabs initialTab={initialTab}>
       {tabs.map((tab, index) => (
         <GoabTab
           key={index}
-          heading={tab.count !== undefined ? `${tab.heading} (${tab.count})` : tab.heading}
+          heading={
+            tab.count !== undefined ? `${tab.heading} (${tab.count})` : tab.heading
+          }
         >
           {tab.content}
         </GoabTab>
       ))}
-    </GoabTabs>
+    </GoabxTabs>
   );
 }
 

--- a/docs/src/components/ExamplesGrid.tsx
+++ b/docs/src/components/ExamplesGrid.tsx
@@ -11,26 +11,26 @@
  * Design pattern based on Figma + workspace demo hybrid approach.
  */
 
-import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import {
-  GoabTable,
-  GoabTableSortHeader,
-  GoabButton,
-  GoabInput,
-  GoabFormItem,
-  GoabFilterChip,
-  GoabBadge,
+  GoabxButton,
+  GoabxInput,
+  GoabxFormItem,
+  GoabxFilterChip,
+  GoabxDrawer,
+  GoabxCheckbox,
+} from "@abgov/react-components/experimental";
+import {
   GoabIcon,
-  GoabDrawer,
-  GoabCheckbox,
   GoabDivider,
   GoabButtonGroup,
-  GoabTabs,
+  GoabCheckboxList,
   GoabTab,
-} from '@abgov/react-components';
-import { useTwoLevelSort } from '../hooks/useTwoLevelSort';
-import { useMobile } from '../hooks/useCompactToolbar';
-import { useViewSettings, type LayoutType } from '../hooks/useViewSettings';
+  type GoabCheckboxListOnChangeDetail,
+} from "@abgov/react-components";
+import { useTwoLevelSort } from "../hooks/useTwoLevelSort";
+import { useMobile } from "../hooks/useCompactToolbar";
+import { useViewSettings, type LayoutType } from "../hooks/useViewSettings";
 
 // Type for example data (matches Astro content collection)
 export interface Example {
@@ -38,12 +38,19 @@ export interface Example {
   data: {
     id: string;
     title: string;
-    categories: ('content-layout' | 'feedback-and-alerts' | 'inputs-and-actions' | 'forms' | 'structure-and-navigation' | 'technical')[];
-    scale: 'interaction' | 'task' | 'page' | 'service';
-    userType: 'citizen' | 'worker' | 'both';
+    categories: (
+      | "content-layout"
+      | "feedback-and-alerts"
+      | "inputs-and-actions"
+      | "forms"
+      | "structure-and-navigation"
+      | "technical"
+    )[];
+    scale: "interaction" | "task" | "page" | "service";
+    userType: "citizen" | "worker" | "both";
     tags?: string[];
     components: string[];
-    status: 'published' | 'draft' | 'deprecated';
+    status: "published" | "draft" | "deprecated";
   };
   body?: string;
 }
@@ -52,40 +59,58 @@ interface ExamplesGridProps {
   examples: Example[];
 }
 
-const DEFAULT_VISIBLE_COLUMNS = ['title', 'scale', 'category', 'userType', 'status'];
+const DEFAULT_VISIBLE_COLUMNS = ["title", "scale", "category", "userType", "status"];
 
 // Badge type mapping for scales (using V2 extended colors)
-function getScaleBadgeType(scale: string): 'sky' | 'sunset' | 'pasture' | 'lilac' | 'prairie' | 'dawn' {
+function getScaleBadgeType(
+  scale: string,
+): "sky" | "sunset" | "pasture" | "lilac" | "prairie" | "dawn" {
   switch (scale) {
-    case 'interaction': return 'sky';
-    case 'task': return 'sunset';
-    case 'page': return 'pasture';
-    case 'flow': return 'lilac';
-    case 'service': return 'prairie';
-    default: return 'dawn';
+    case "interaction":
+      return "sky";
+    case "task":
+      return "sunset";
+    case "page":
+      return "pasture";
+    case "flow":
+      return "lilac";
+    case "service":
+      return "prairie";
+    default:
+      return "dawn";
   }
 }
 
 // Badge type mapping for categories (using V2 extended colors)
-function getCategoryBadgeType(category: string): 'sky' | 'pasture' | 'dawn' | 'lilac' | 'prairie' | 'default' {
+function getCategoryBadgeType(
+  category: string,
+): "sky" | "pasture" | "dawn" | "lilac" | "prairie" | "default" {
   switch (category) {
-    case 'content-layout': return 'sky';
-    case 'feedback-and-alerts': return 'prairie';
-    case 'structure-and-navigation': return 'lilac';
-    case 'inputs-and-actions': return 'dawn';
-    case 'forms': return 'pasture';
-    case 'technical': return 'default';
-    case 'utilities': return 'default';
-    default: return 'default';
+    case "content-layout":
+      return "sky";
+    case "feedback-and-alerts":
+      return "prairie";
+    case "structure-and-navigation":
+      return "lilac";
+    case "inputs-and-actions":
+      return "dawn";
+    case "forms":
+      return "pasture";
+    case "technical":
+      return "default";
+    case "utilities":
+      return "default";
+    default:
+      return "default";
   }
 }
 
 // Format category for display
 function formatCategory(category: string): string {
   return category
-    .split('-')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }
 
 // Format scale for display
@@ -95,21 +120,23 @@ function formatScale(scale: string): string {
 
 // Format user type for display
 function formatUserType(userType: string): string {
-  if (userType === 'both') return 'Both';
+  if (userType === "both") return "Both";
   return userType.charAt(0).toUpperCase() + userType.slice(1);
 }
 
 export function ExamplesGrid({ examples }: ExamplesGridProps) {
   // State
-  const [searchValue, setSearchValue] = useState('');
+  const [searchValue, setSearchValue] = useState("");
   const [searchChips, setSearchChips] = useState<string[]>([]);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [isSticky, setIsSticky] = useState(false);
 
   // Ref for sticky detection sentinel
   const sentinelRef = useRef<HTMLDivElement>(null);
-  // Ref for view toggle tabs
-  const viewToggleRef = useRef<HTMLDivElement>(null);
+  // Ref for table (to handle sort events from web component)
+  const tableRef = useRef<HTMLElement>(null);
+  // TODO: Remove tabsRef when GoabxTabs wrapper exposes updateUrl and stackOnMobile props
+  const tabsRef = useRef<HTMLElement>(null);
 
   // Detect when toolbar becomes sticky using IntersectionObserver
   useEffect(() => {
@@ -121,7 +148,7 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
         // When sentinel is not intersecting (scrolled out of view), toolbar is sticky
         setIsSticky(!entry.isIntersecting);
       },
-      { threshold: 0 }
+      { threshold: 0 },
     );
 
     observer.observe(sentinel);
@@ -141,33 +168,51 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
   }>({ category: [], scale: [], userType: [] });
 
   // Hooks
-  const { sortConfig, setSortConfig, sortByKey, clearSort, handleTableSort } = useTwoLevelSort();
+  const { sortConfig, setSortConfig, sortByKey, clearSort, handleTableSort } =
+    useTwoLevelSort();
   const isMobile = useMobile();
   const { viewSettings, setLayout } = useViewSettings({
-    pageKey: 'examples',
-    defaultLayout: 'card', // 'card' = grid view
+    pageKey: "examples",
+    defaultLayout: "card", // 'card' = grid view
     defaultColumns: DEFAULT_VISIBLE_COLUMNS,
   });
 
-  // Listen for view toggle tab changes (native event - GoA tabs are 1-indexed)
+  // Listen for table sort events (from goa-table web component)
+  // Also explicitly set version="2" attribute since React may not set it correctly on custom elements
   useEffect(() => {
-    if (!viewToggleRef.current) return;
+    const table = tableRef.current;
+    if (!table) return;
 
-    const handleViewChange = (e: Event) => {
-      const customEvent = e as CustomEvent<{ tab: number }>;
-      const tabIndex = customEvent.detail?.tab;
-      if (tabIndex === 1) {
-        setLayout('card'); // Grid view
-      } else if (tabIndex === 2) {
-        setLayout('list'); // List view
+    // Explicitly set version attribute for V2 styling (React doesn't always set attributes on custom elements)
+    table.setAttribute("version", "2");
+
+    const handleSort = (e: Event) => {
+      const detail = (e as CustomEvent<{ sortBy: string; sortDir: "asc" | "desc" }>)
+        .detail;
+      handleTableSort(detail);
+    };
+
+    table.addEventListener("_sort", handleSort);
+    return () => table.removeEventListener("_sort", handleSort);
+  }, [handleTableSort]);
+
+  // TODO: Remove this useEffect when GoabxTabs wrapper exposes updateUrl and stackOnMobile props
+  // Using goa-tabs web component directly because GoabxTabs wrapper is missing these props
+  useEffect(() => {
+    const tabs = tabsRef.current;
+    if (!tabs) return;
+
+    const handleChange = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab: number }>).detail;
+      if (detail.tab === 1) {
+        setLayout("card"); // Grid view
+      } else if (detail.tab === 2) {
+        setLayout("list"); // List view
       }
     };
 
-    const tabsElement = viewToggleRef.current.querySelector('goa-tabs');
-    if (tabsElement) {
-      tabsElement.addEventListener('_change', handleViewChange);
-      return () => tabsElement.removeEventListener('_change', handleViewChange);
-    }
+    tabs.addEventListener("_change", handleChange);
+    return () => tabs.removeEventListener("_change", handleChange);
   }, [setLayout]);
 
   // Expanded groups state
@@ -175,17 +220,17 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
 
   // Extract unique filter values
   const filterOptions = useMemo(() => {
-    const categories = [...new Set(examples.flatMap(e => e.data.categories))].sort();
-    const scales = [...new Set(examples.map(e => e.data.scale))].sort();
-    const userTypes = [...new Set(examples.map(e => e.data.userType))].sort();
+    const categories = [...new Set(examples.flatMap((e) => e.data.categories))].sort();
+    const scales = [...new Set(examples.map((e) => e.data.scale))].sort();
+    const userTypes = [...new Set(examples.map((e) => e.data.userType))].sort();
     return { categories, scales, userTypes };
   }, [examples]);
 
   // View mode: 'card' = grid view, 'list' = list view
   // On mobile, always use grid view (cards)
-  const viewMode = useMemo((): 'card' | 'list' => {
-    if (isMobile) return 'card';
-    return viewSettings.layout === 'list' ? 'list' : 'card';
+  const viewMode = useMemo((): "card" | "list" => {
+    if (isMobile) return "card";
+    return viewSettings.layout === "list" ? "list" : "card";
   }, [isMobile, viewSettings.layout]);
 
   // Filter and sort examples
@@ -198,60 +243,70 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
         searchChips.every(
           (chip) =>
             example.data.title.toLowerCase().includes(chip.toLowerCase()) ||
-            example.data.categories.some(cat => cat.toLowerCase().includes(chip.toLowerCase())) ||
+            example.data.categories.some((cat) =>
+              cat.toLowerCase().includes(chip.toLowerCase()),
+            ) ||
             example.data.scale.toLowerCase().includes(chip.toLowerCase()) ||
-            (example.data.tags || []).some(tag => tag.toLowerCase().includes(chip.toLowerCase())) ||
-            example.data.components.some(comp => comp.toLowerCase().includes(chip.toLowerCase()))
-        )
+            (example.data.tags || []).some((tag) =>
+              tag.toLowerCase().includes(chip.toLowerCase()),
+            ) ||
+            example.data.components.some((comp) =>
+              comp.toLowerCase().includes(chip.toLowerCase()),
+            ),
+        ),
       );
     }
 
     // Apply category filters (OR logic - show if example has ANY of the selected categories)
     if (appliedFilters.category.length > 0) {
       result = result.filter((example) =>
-        example.data.categories.some(cat => appliedFilters.category.includes(cat))
+        example.data.categories.some((cat) => appliedFilters.category.includes(cat)),
       );
     }
 
     // Apply scale filters
     if (appliedFilters.scale.length > 0) {
-      result = result.filter((example) => appliedFilters.scale.includes(example.data.scale));
+      result = result.filter((example) =>
+        appliedFilters.scale.includes(example.data.scale),
+      );
     }
 
     // Apply userType filters
     if (appliedFilters.userType.length > 0) {
-      result = result.filter((example) => appliedFilters.userType.includes(example.data.userType));
+      result = result.filter((example) =>
+        appliedFilters.userType.includes(example.data.userType),
+      );
     }
 
     // Apply sorting
     if (sortConfig.primary) {
       result = [...result].sort((a, b) => {
         const key = sortConfig.primary!.key;
-        const dir = sortConfig.primary!.direction === 'asc' ? 1 : -1;
+        const dir = sortConfig.primary!.direction === "asc" ? 1 : -1;
 
         let aVal: string;
         let bVal: string;
 
         switch (key) {
-          case 'title':
+          case "title":
             aVal = a.data.title;
             bVal = b.data.title;
             break;
-          case 'category':
-            aVal = a.data.categories[0] || '';
-            bVal = b.data.categories[0] || '';
+          case "category":
+            aVal = a.data.categories[0] || "";
+            bVal = b.data.categories[0] || "";
             break;
-          case 'scale':
+          case "scale":
             aVal = a.data.scale;
             bVal = b.data.scale;
             break;
-          case 'userType':
+          case "userType":
             aVal = a.data.userType;
             bVal = b.data.userType;
             break;
           default:
-            aVal = '';
-            bVal = '';
+            aVal = "";
+            bVal = "";
         }
 
         const cmp = aVal.localeCompare(bVal);
@@ -259,31 +314,31 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
 
         if (sortConfig.secondary) {
           const secKey = sortConfig.secondary.key;
-          const secDir = sortConfig.secondary.direction === 'asc' ? 1 : -1;
+          const secDir = sortConfig.secondary.direction === "asc" ? 1 : -1;
 
           let secAVal: string;
           let secBVal: string;
 
           switch (secKey) {
-            case 'title':
+            case "title":
               secAVal = a.data.title;
               secBVal = b.data.title;
               break;
-            case 'category':
-              secAVal = a.data.categories[0] || '';
-              secBVal = b.data.categories[0] || '';
+            case "category":
+              secAVal = a.data.categories[0] || "";
+              secBVal = b.data.categories[0] || "";
               break;
-            case 'scale':
+            case "scale":
               secAVal = a.data.scale;
               secBVal = b.data.scale;
               break;
-            case 'userType':
+            case "userType":
               secAVal = a.data.userType;
               secBVal = b.data.userType;
               break;
             default:
-              secAVal = '';
-              secBVal = '';
+              secAVal = "";
+              secBVal = "";
           }
 
           return secAVal.localeCompare(secBVal) * secDir;
@@ -306,17 +361,17 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
     filteredExamples.forEach((example) => {
       let groupKey: string;
       switch (viewSettings.groupBy) {
-        case 'category':
-          groupKey = example.data.categories[0] || 'Uncategorized';
+        case "category":
+          groupKey = example.data.categories[0] || "Uncategorized";
           break;
-        case 'scale':
+        case "scale":
           groupKey = example.data.scale;
           break;
-        case 'userType':
+        case "userType":
           groupKey = example.data.userType;
           break;
         default:
-          groupKey = 'Unknown';
+          groupKey = "Unknown";
       }
 
       if (!groupMap.has(groupKey)) {
@@ -329,13 +384,13 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
     sortedKeys.forEach((key) => {
       let label: string;
       switch (viewSettings.groupBy) {
-        case 'category':
+        case "category":
           label = formatCategory(key);
           break;
-        case 'scale':
+        case "scale":
           label = formatScale(key);
           break;
-        case 'userType':
+        case "userType":
           label = formatUserType(key);
           break;
         default:
@@ -371,7 +426,7 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
     const trimmed = searchValue.trim();
     if (trimmed && !searchChips.includes(trimmed)) {
       setSearchChips((prev) => [...prev, trimmed]);
-      setSearchValue('');
+      setSearchValue("");
     }
   }, [searchValue, searchChips]);
 
@@ -380,14 +435,17 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
   }, []);
 
   // Filter handlers
-  const togglePendingFilter = useCallback((filterType: 'category' | 'scale' | 'userType', value: string) => {
-    setPendingFilters((prev) => ({
-      ...prev,
-      [filterType]: prev[filterType].includes(value)
-        ? prev[filterType].filter((v) => v !== value)
-        : [...prev[filterType], value],
-    }));
-  }, []);
+  const togglePendingFilter = useCallback(
+    (filterType: "category" | "scale" | "userType", value: string) => {
+      setPendingFilters((prev) => ({
+        ...prev,
+        [filterType]: prev[filterType].includes(value)
+          ? prev[filterType].filter((v) => v !== value)
+          : [...prev[filterType], value],
+      }));
+    },
+    [],
+  );
 
   const applyFilters = useCallback(() => {
     setAppliedFilters(pendingFilters);
@@ -400,12 +458,15 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
     setAppliedFilters(empty);
   }, []);
 
-  const removeAppliedFilter = useCallback((filterType: 'category' | 'scale' | 'userType', value: string) => {
-    setAppliedFilters((prev) => ({
-      ...prev,
-      [filterType]: prev[filterType].filter((v) => v !== value),
-    }));
-  }, []);
+  const removeAppliedFilter = useCallback(
+    (filterType: "category" | "scale" | "userType", value: string) => {
+      setAppliedFilters((prev) => ({
+        ...prev,
+        [filterType]: prev[filterType].filter((v) => v !== value),
+      }));
+    },
+    [],
+  );
 
   // Clear all filters and search
   const clearAll = useCallback(() => {
@@ -432,21 +493,30 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
           {/* Description */}
           {example.body && (
             <p className="example-card-description">
-              {example.body.split('\n')[0].replace(/^#+\s*/, '').substring(0, 120)}
-              {example.body.length > 120 ? '...' : ''}
+              {example.body
+                .split("\n")[0]
+                .replace(/^#+\s*/, "")
+                .substring(0, 120)}
+              {example.body.length > 120 ? "..." : ""}
             </p>
           )}
 
           {/* Category badges */}
           <div className="example-card-badges">
             {example.data.tags?.slice(0, 3).map((tag) => (
-              <GoabBadge key={tag} type={getScaleBadgeType(example.data.scale)} content={tag} emphasis="subtle" />
+              <goa-badge
+                key={tag}
+                version="2"
+                type={getScaleBadgeType(example.data.scale)}
+                content={tag}
+                emphasis="subtle"
+              />
             ))}
           </div>
         </div>
       </a>
     ),
-    []
+    [],
   );
 
   // Render table row (for list view)
@@ -461,53 +531,77 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
         <td>
           <div className="example-categories">
             {example.data.categories.map((cat) => (
-              <GoabBadge key={cat} type={getCategoryBadgeType(cat)} content={formatCategory(cat)} emphasis="subtle" />
+              <goa-badge
+                key={cat}
+                version="2"
+                type={getCategoryBadgeType(cat)}
+                content={formatCategory(cat)}
+                emphasis="subtle"
+              />
             ))}
           </div>
         </td>
         <td>
-          <GoabBadge type={getScaleBadgeType(example.data.scale)} content={formatScale(example.data.scale)} emphasis="subtle" />
+          <goa-badge
+            version="2"
+            type={getScaleBadgeType(example.data.scale)}
+            content={formatScale(example.data.scale)}
+            emphasis="subtle"
+          />
         </td>
         <td>{formatUserType(example.data.userType)}</td>
         <td>
           <div className="example-tags">
             {example.data.tags?.slice(0, 3).map((tag) => (
-              <GoabBadge key={tag} type="information" content={tag} emphasis="subtle" />
+              <goa-badge
+                key={tag}
+                version="2"
+                type="information"
+                content={tag}
+                emphasis="subtle"
+              />
             ))}
           </div>
         </td>
       </tr>
     ),
-    []
+    [],
   );
 
   // Get sort direction for column headers
-  const getColumnSortDirection = useCallback((columnKey: string): 'asc' | 'desc' | 'none' => {
-    if (sortConfig.primary?.key === columnKey) {
-      return sortConfig.primary.direction;
-    }
-    if (sortConfig.secondary?.key === columnKey) {
-      return sortConfig.secondary.direction;
-    }
-    return 'none';
-  }, [sortConfig]);
+  const getColumnSortDirection = useCallback(
+    (columnKey: string): "asc" | "desc" | "none" => {
+      if (sortConfig.primary?.key === columnKey) {
+        return sortConfig.primary.direction;
+      }
+      if (sortConfig.secondary?.key === columnKey) {
+        return sortConfig.secondary.direction;
+      }
+      return "none";
+    },
+    [sortConfig],
+  );
 
   // Get sort order indicator ("1" or "2") for column headers
-  const getColumnSortOrder = useCallback((columnKey: string): string | undefined => {
-    // Only show numbers if there are two sorts active
-    if (!sortConfig.primary || !sortConfig.secondary) {
+  const getColumnSortOrder = useCallback(
+    (columnKey: string): string | undefined => {
+      // Only show numbers if there are two sorts active
+      if (!sortConfig.primary || !sortConfig.secondary) {
+        return undefined;
+      }
+      if (sortConfig.primary.key === columnKey) {
+        return "1";
+      }
+      if (sortConfig.secondary.key === columnKey) {
+        return "2";
+      }
       return undefined;
-    }
-    if (sortConfig.primary.key === columnKey) {
-      return "1";
-    }
-    if (sortConfig.secondary.key === columnKey) {
-      return "2";
-    }
-    return undefined;
-  }, [sortConfig]);
+    },
+    [sortConfig],
+  );
 
-  const hasActiveFilters = searchChips.length > 0 ||
+  const hasActiveFilters =
+    searchChips.length > 0 ||
     appliedFilters.category.length > 0 ||
     appliedFilters.scale.length > 0 ||
     appliedFilters.userType.length > 0 ||
@@ -519,40 +613,54 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
       <div ref={sentinelRef} className="examples-sentinel" aria-hidden="true" />
 
       {/* Toolbar */}
-      <div className={`examples-toolbar ${isSticky ? 'examples-toolbar--sticky' : ''}`}>
+      <div className={`examples-toolbar ${isSticky ? "examples-toolbar--sticky" : ""}`}>
         {/* Search input */}
         <div className="examples-search-section">
-          <GoabFormItem
-            helpText={!isSticky ? 'Search by keyword, category, or name' : undefined}
+          <GoabxFormItem
+            helpText={!isSticky ? "Search by keyword, category, or name" : undefined}
           >
-            <GoabInput
+            <GoabxInput
               name="exampleSearch"
               value={searchValue}
               leadingIcon="search"
               width="100%"
               size="compact"
               onChange={(e) => setSearchValue(e.value)}
-              onKeyPress={(e) => e.key === 'Enter' && applySearch()}
+              onKeyPress={(e) => e.key === "Enter" && applySearch()}
             />
-          </GoabFormItem>
+          </GoabxFormItem>
         </div>
 
         {/* View toggle + Filters */}
         <div className="examples-toolbar-actions">
-          {/* View toggle - segmented tabs */}
-          <div className="view-toggle-wrapper" ref={viewToggleRef}>
-            <GoabTabs
+          {/*
+           * TODO: Replace <goa-tabs> with GoabxTabs when wrapper exposes these props
+           *
+           * Using web component directly because GoabxTabs wrapper is missing:
+           * - updateUrl prop (we need false to avoid polluting browser history)
+           * - stackOnMobile prop (we need false for compact view toggle)
+           *
+           * When fixed, remove: tabsRef, useEffect for _change event, goa-tabs from global.d.ts
+           */}
+          <div className="view-toggle-wrapper">
+            <goa-tabs
+              ref={tabsRef}
+              version="2"
               variant="segmented"
-              initialTab={viewMode === 'card' ? 1 : 2}
-              updateUrl={false}
-              stackOnMobile={false}
+              initialtab={viewMode === "card" ? 1 : 2}
+              updateurl="false"
+              stackonmobile="false"
             >
-              <GoabTab heading="Grid"><span /></GoabTab>
-              <GoabTab heading="List"><span /></GoabTab>
-            </GoabTabs>
+              <goa-tab heading="Grid">
+                <span />
+              </goa-tab>
+              <goa-tab heading="List">
+                <span />
+              </goa-tab>
+            </goa-tabs>
           </div>
 
-          <GoabButton
+          <GoabxButton
             type="secondary"
             leadingIcon="filter-lines"
             size="compact"
@@ -562,28 +670,38 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
             }}
           >
             Filters
-          </GoabButton>
+          </GoabxButton>
         </div>
       </div>
 
       {/* Active filters chips */}
       {hasActiveFilters && (
         <div className="examples-chips">
-          <GoabIcon type="filter-lines" size="small" fillColor="var(--goa-color-text-secondary)" />
+          <GoabIcon
+            type="filter-lines"
+            size="small"
+            fillColor="var(--goa-color-text-secondary)"
+          />
 
           {/* Sort chips */}
           {sortConfig.primary && (
-            <GoabFilterChip
+            <GoabxFilterChip
               content={sortConfig.primary.key}
-              leadingIcon={sortConfig.primary.direction === 'asc' ? 'arrow-up' : 'arrow-down'}
-              secondaryText={sortConfig.secondary ? '1st' : undefined}
-              onClick={() => setSortConfig({ primary: sortConfig.secondary, secondary: null })}
+              leadingIcon={
+                sortConfig.primary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
+              secondaryText={sortConfig.secondary ? "1st" : undefined}
+              onClick={() =>
+                setSortConfig({ primary: sortConfig.secondary, secondary: null })
+              }
             />
           )}
           {sortConfig.secondary && (
-            <GoabFilterChip
+            <GoabxFilterChip
               content={sortConfig.secondary.key}
-              leadingIcon={sortConfig.secondary.direction === 'asc' ? 'arrow-up' : 'arrow-down'}
+              leadingIcon={
+                sortConfig.secondary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
               secondaryText="2nd"
               onClick={() => setSortConfig((prev) => ({ ...prev, secondary: null }))}
             />
@@ -591,25 +709,48 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
 
           {/* Search chips */}
           {searchChips.map((chip) => (
-            <GoabFilterChip key={chip} content={chip} onClick={() => removeSearchChip(chip)} />
+            <GoabxFilterChip
+              key={chip}
+              content={chip}
+              onClick={() => removeSearchChip(chip)}
+            />
           ))}
 
           {/* Category filter chips */}
           {appliedFilters.category.map((cat) => (
-            <GoabFilterChip key={`cat-${cat}`} content={formatCategory(cat)} onClick={() => removeAppliedFilter('category', cat)} />
+            <GoabxFilterChip
+              key={`cat-${cat}`}
+              content={formatCategory(cat)}
+              onClick={() => removeAppliedFilter("category", cat)}
+            />
           ))}
 
           {/* Scale filter chips */}
           {appliedFilters.scale.map((scale) => (
-            <GoabFilterChip key={`scale-${scale}`} content={formatScale(scale)} onClick={() => removeAppliedFilter('scale', scale)} />
+            <GoabxFilterChip
+              key={`scale-${scale}`}
+              content={formatScale(scale)}
+              onClick={() => removeAppliedFilter("scale", scale)}
+            />
           ))}
 
           {/* User type filter chips */}
           {appliedFilters.userType.map((ut) => (
-            <GoabFilterChip key={`ut-${ut}`} content={formatUserType(ut)} onClick={() => removeAppliedFilter('userType', ut)} />
+            <GoabxFilterChip
+              key={`ut-${ut}`}
+              content={formatUserType(ut)}
+              onClick={() => removeAppliedFilter("userType", ut)}
+            />
           ))}
 
-          <a href="#" className="clear-all-link" onClick={(e) => { e.preventDefault(); clearAll(); }}>
+          <a
+            href="#"
+            className="clear-all-link"
+            onClick={(e) => {
+              e.preventDefault();
+              clearAll();
+            }}
+          >
             Clear all
           </a>
         </div>
@@ -617,110 +758,136 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
 
       {/* Results count */}
       <p className="examples-count">
-        {filteredExamples.length} example{filteredExamples.length !== 1 ? 's' : ''}
+        {filteredExamples.length} example{filteredExamples.length !== 1 ? "s" : ""}
       </p>
 
       {/* List View (table) */}
-      {viewMode === 'list' && (
+      {viewMode === "list" && (
         <div className="examples-table-wrapper">
-          <GoabTable width="100%" variant="normal" onSort={handleTableSort}>
-            <thead>
-              <tr>
-                <th>
-                  <GoabTableSortHeader
-                    name="title"
-                    direction={getColumnSortDirection('title')}
-                    sortOrder={getColumnSortOrder('title')}
-                  >
-                    Name
-                  </GoabTableSortHeader>
-                </th>
-                <th>
-                  <GoabTableSortHeader
-                    name="category"
-                    direction={getColumnSortDirection('category')}
-                    sortOrder={getColumnSortOrder('category')}
-                  >
-                    Category
-                  </GoabTableSortHeader>
-                </th>
-                <th>
-                  <GoabTableSortHeader
-                    name="scale"
-                    direction={getColumnSortDirection('scale')}
-                    sortOrder={getColumnSortOrder('scale')}
-                  >
-                    Scale
-                  </GoabTableSortHeader>
-                </th>
-                <th style={{ minWidth: '140px' }}>
-                  <GoabTableSortHeader
-                    name="userType"
-                    direction={getColumnSortDirection('userType')}
-                    sortOrder={getColumnSortOrder('userType')}
-                  >
-                    User Type
-                  </GoabTableSortHeader>
-                </th>
-                <th>Tags</th>
-              </tr>
-            </thead>
-            <tbody>
-              {groupedExamples
-                ? groupedExamples.map((group) => (
-                    <React.Fragment key={group.key}>
-                      <tr className="examples-group-row" onClick={() => toggleGroup(group.key)}>
-                        <td colSpan={5}>
-                          <div className="examples-group-header">
-                            <GoabIcon
-                              type={expandedGroups.has(group.key) ? 'chevron-down' : 'chevron-forward'}
-                              size="small"
-                            />
-                            <strong>{group.label}</strong>
-                            <GoabBadge type="default" content={String(group.examples.length)} emphasis="subtle" />
-                          </div>
-                        </td>
-                      </tr>
-                      {expandedGroups.has(group.key) && group.examples.map(renderTableRow)}
-                    </React.Fragment>
-                  ))
-                : filteredExamples.map(renderTableRow)}
-            </tbody>
-          </GoabTable>
+          {/* Using web components directly for V2 styling - React wrappers don't pass version prop */}
+          <goa-table ref={tableRef} version="2" width="100%" variant="normal">
+            <table style={{ width: "100%" }}>
+              <thead>
+                <tr>
+                  <th>
+                    <goa-table-sort-header
+                      version="2"
+                      name="title"
+                      direction={getColumnSortDirection("title")}
+                    >
+                      Name
+                    </goa-table-sort-header>
+                  </th>
+                  <th>
+                    <goa-table-sort-header
+                      version="2"
+                      name="category"
+                      direction={getColumnSortDirection("category")}
+                    >
+                      Category
+                    </goa-table-sort-header>
+                  </th>
+                  <th>
+                    <goa-table-sort-header
+                      version="2"
+                      name="scale"
+                      direction={getColumnSortDirection("scale")}
+                    >
+                      Scale
+                    </goa-table-sort-header>
+                  </th>
+                  <th style={{ minWidth: "140px" }}>
+                    <goa-table-sort-header
+                      version="2"
+                      name="userType"
+                      direction={getColumnSortDirection("userType")}
+                    >
+                      User Type
+                    </goa-table-sort-header>
+                  </th>
+                  <th>Tags</th>
+                </tr>
+              </thead>
+              <tbody>
+                {groupedExamples
+                  ? groupedExamples.map((group) => (
+                      <React.Fragment key={group.key}>
+                        <tr
+                          className="examples-group-row"
+                          onClick={() => toggleGroup(group.key)}
+                        >
+                          <td colSpan={5}>
+                            <div className="examples-group-header">
+                              <GoabIcon
+                                type={
+                                  expandedGroups.has(group.key)
+                                    ? "chevron-down"
+                                    : "chevron-forward"
+                                }
+                                size="small"
+                              />
+                              <strong>{group.label}</strong>
+                              <goa-badge
+                                version="2"
+                                type="default"
+                                content={String(group.examples.length)}
+                                emphasis="subtle"
+                              />
+                            </div>
+                          </td>
+                        </tr>
+                        {expandedGroups.has(group.key) &&
+                          group.examples.map(renderTableRow)}
+                      </React.Fragment>
+                    ))
+                  : filteredExamples.map(renderTableRow)}
+              </tbody>
+            </table>
+          </goa-table>
         </div>
       )}
 
       {/* Card View */}
-      {viewMode === 'card' && (
+      {viewMode === "card" && (
         <div className="examples-card-view">
-          {groupedExamples
-            ? groupedExamples.map((group) => (
-                <div key={group.key} className="examples-group">
-                  <button className="examples-group-btn" onClick={() => toggleGroup(group.key)}>
-                    <GoabIcon
-                      type={expandedGroups.has(group.key) ? 'chevron-down' : 'chevron-forward'}
-                      size="small"
-                    />
-                    <strong>{group.label}</strong>
-                    <GoabBadge type="dark" content={String(group.examples.length)} emphasis="subtle" />
-                  </button>
-                  {expandedGroups.has(group.key) && (
-                    <div className="examples-card-grid">
-                      {group.examples.map(renderExampleCard)}
-                    </div>
-                  )}
-                </div>
-              ))
-            : (
-              <div className="examples-card-grid">
-                {filteredExamples.map(renderExampleCard)}
+          {groupedExamples ? (
+            groupedExamples.map((group) => (
+              <div key={group.key} className="examples-group">
+                <button
+                  className="examples-group-btn"
+                  onClick={() => toggleGroup(group.key)}
+                >
+                  <GoabIcon
+                    type={
+                      expandedGroups.has(group.key) ? "chevron-down" : "chevron-forward"
+                    }
+                    size="small"
+                  />
+                  <strong>{group.label}</strong>
+                  <goa-badge
+                    version="2"
+                    type="dark"
+                    content={String(group.examples.length)}
+                    emphasis="subtle"
+                  />
+                </button>
+                {expandedGroups.has(group.key) && (
+                  <div className="examples-card-grid">
+                    {group.examples.map(renderExampleCard)}
+                  </div>
+                )}
               </div>
-            )}
+            ))
+          ) : (
+            <div className="examples-card-grid">
+              {filteredExamples.map(renderExampleCard)}
+            </div>
+          )}
         </div>
       )}
 
       {/* Filter Drawer */}
-      <GoabDrawer
+      <GoabxDrawer
         heading="Filter examples"
         position="right"
         open={filterDrawerOpen}
@@ -728,71 +895,101 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
         onClose={() => setFilterDrawerOpen(false)}
         actions={
           <GoabButtonGroup alignment="start" gap="compact">
-            <GoabButton type="primary" size="compact" onClick={applyFilters}>
+            <GoabxButton type="primary" size="compact" onClick={applyFilters}>
               Apply filters
-            </GoabButton>
-            <GoabButton type="tertiary" size="compact" onClick={() => setFilterDrawerOpen(false)}>
+            </GoabxButton>
+            <GoabxButton
+              type="tertiary"
+              size="compact"
+              onClick={() => setFilterDrawerOpen(false)}
+            >
               Cancel
-            </GoabButton>
+            </GoabxButton>
           </GoabButtonGroup>
         }
       >
         <div className="filter-drawer-content">
           {/* Scale filter */}
-          <GoabFormItem label="Scale">
-            <div className="filter-checkboxes">
+          <GoabxFormItem label="Scale">
+            <GoabCheckboxList
+              name="scale"
+              value={pendingFilters.scale}
+              onChange={(detail: GoabCheckboxListOnChangeDetail) =>
+                setPendingFilters((prev) => ({ ...prev, scale: detail.value }))
+              }
+            >
               {filterOptions.scales.map((scale) => (
-                <GoabCheckbox
+                <GoabxCheckbox
                   key={scale}
-                  name={`scale-${scale}`}
+                  name={scale}
+                  value={scale}
                   text={formatScale(scale)}
-                  checked={pendingFilters.scale.includes(scale)}
-                  onChange={() => togglePendingFilter('scale', scale)}
+                  size="compact"
                 />
               ))}
-            </div>
-          </GoabFormItem>
+            </GoabCheckboxList>
+          </GoabxFormItem>
 
           {/* Category filter */}
-          <GoabFormItem label="Category">
-            <div className="filter-checkboxes">
+          <GoabxFormItem label="Category">
+            <GoabCheckboxList
+              name="category"
+              value={pendingFilters.category}
+              onChange={(detail: GoabCheckboxListOnChangeDetail) =>
+                setPendingFilters((prev) => ({ ...prev, category: detail.value }))
+              }
+            >
               {filterOptions.categories.map((category) => (
-                <GoabCheckbox
+                <GoabxCheckbox
                   key={category}
-                  name={`category-${category}`}
+                  name={category}
+                  value={category}
                   text={formatCategory(category)}
-                  checked={pendingFilters.category.includes(category)}
-                  onChange={() => togglePendingFilter('category', category)}
+                  size="compact"
                 />
               ))}
-            </div>
-          </GoabFormItem>
+            </GoabCheckboxList>
+          </GoabxFormItem>
 
           {/* User Type filter */}
-          <GoabFormItem label="User Type">
-            <div className="filter-checkboxes">
+          <GoabxFormItem label="User Type">
+            <GoabCheckboxList
+              name="userType"
+              value={pendingFilters.userType}
+              onChange={(detail: GoabCheckboxListOnChangeDetail) =>
+                setPendingFilters((prev) => ({ ...prev, userType: detail.value }))
+              }
+            >
               {filterOptions.userTypes.map((userType) => (
-                <GoabCheckbox
+                <GoabxCheckbox
                   key={userType}
-                  name={`userType-${userType}`}
+                  name={userType}
+                  value={userType}
                   text={formatUserType(userType)}
-                  checked={pendingFilters.userType.includes(userType)}
-                  onChange={() => togglePendingFilter('userType', userType)}
+                  size="compact"
                 />
               ))}
-            </div>
-          </GoabFormItem>
+            </GoabCheckboxList>
+          </GoabxFormItem>
 
-          {(pendingFilters.category.length > 0 || pendingFilters.scale.length > 0 || pendingFilters.userType.length > 0) && (
+          {(pendingFilters.category.length > 0 ||
+            pendingFilters.scale.length > 0 ||
+            pendingFilters.userType.length > 0) && (
             <>
               <GoabDivider />
-              <GoabButton type="tertiary" size="compact" onClick={() => setPendingFilters({ category: [], scale: [], userType: [] })}>
+              <GoabxButton
+                type="tertiary"
+                size="compact"
+                onClick={() =>
+                  setPendingFilters({ category: [], scale: [], userType: [] })
+                }
+              >
                 Clear all filters
-              </GoabButton>
+              </GoabxButton>
             </>
           )}
         </div>
-      </GoabDrawer>
+      </GoabxDrawer>
 
       <style>{`
         .examples-grid {

--- a/docs/src/components/ExamplesGrid.tsx
+++ b/docs/src/components/ExamplesGrid.tsx
@@ -1132,9 +1132,13 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
           }
         }
 
-        @media (max-width: 600px) {
+        @media (max-width: 623px) {
           .examples-card-grid {
             grid-template-columns: 1fr;
+          }
+
+          .view-toggle-wrapper {
+            display: none;
           }
         }
 

--- a/docs/src/components/SiteNav.tsx
+++ b/docs/src/components/SiteNav.tsx
@@ -122,15 +122,17 @@ export function SiteNav({ currentSlug, currentCategory, initialSection }: SiteNa
     }
   }, [isOpen]);
 
-  // Close menu when viewport shrinks (gives more room for content)
+  // Close menu on viewport changes to prevent state desync
   useEffect(() => {
     let previousWidth = window.innerWidth;
 
     const handleResize = () => {
       const width = window.innerWidth;
+      const crossedToDesktop = previousWidth < MOBILE_BREAKPOINT && width >= MOBILE_BREAKPOINT;
 
-      // Close menu when window shrinks
-      if (width < previousWidth) {
+      // Close menu when window shrinks (gives more room for content)
+      // OR when crossing from mobile to desktop (prevents floating menu bug)
+      if (width < previousWidth || crossedToDesktop) {
         setIsOpen(false);
       }
 

--- a/docs/src/components/TokensGrid.tsx
+++ b/docs/src/components/TokensGrid.tsx
@@ -331,7 +331,7 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
   const renderTokenCard = useCallback(
     (token: FlatToken) => (
       <div key={token.name} className="token-card">
-        <GoabContainer type="non-interactive" accent="thin" padding="compact">
+        <GoabContainer type="interactive" padding="compact" mb="none">
           <div className="token-card-content">
             <div className="token-card-main">
               {renderPreview(token)}
@@ -741,9 +741,6 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
           gap: var(--goa-space-m);
         }
 
-        .token-card {
-          margin-bottom: var(--goa-space-s);
-        }
 
         .token-card-content {
           display: flex;

--- a/docs/src/components/TokensGrid.tsx
+++ b/docs/src/components/TokensGrid.tsx
@@ -11,28 +11,28 @@
  * Design pattern based on ExamplesGrid - Figma + workspace demo hybrid approach.
  */
 
-import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import {
-  GoabTable,
-  GoabTableSortHeader,
-  GoabButton,
+  GoabxButton,
+  GoabxInput,
+  GoabxFormItem,
+  GoabxFilterChip,
+  GoabxDrawer,
+  GoabxCheckbox,
+} from "@abgov/react-components/experimental";
+import {
   GoabIconButton,
-  GoabInput,
-  GoabFormItem,
-  GoabFilterChip,
-  GoabBadge,
   GoabIcon,
-  GoabDrawer,
-  GoabCheckbox,
   GoabDivider,
   GoabButtonGroup,
   GoabContainer,
-  GoabTabs,
+  GoabCheckboxList,
   GoabTab,
-} from '@abgov/react-components';
-import { useTwoLevelSort } from '../hooks/useTwoLevelSort';
-import { useMobile } from '../hooks/useCompactToolbar';
-import type { FlatToken } from '../lib/tokens';
+  type GoabCheckboxListOnChangeDetail,
+} from "@abgov/react-components";
+import { useTwoLevelSort } from "../hooks/useTwoLevelSort";
+import { useMobile } from "../hooks/useCompactToolbar";
+import type { FlatToken } from "../lib/tokens";
 
 interface FilterGroup {
   name: string;
@@ -45,14 +45,22 @@ interface TokensGridProps {
 }
 
 // Badge type mapping for categories (using V2 extended colors)
-function getCategoryBadgeType(category: string): 'sky' | 'pasture' | 'sunset' | 'lilac' | 'prairie' | 'dawn' {
+function getCategoryBadgeType(
+  category: string,
+): "sky" | "pasture" | "sunset" | "lilac" | "prairie" | "dawn" {
   switch (category) {
-    case 'color': return 'sky';
-    case 'spacing': return 'pasture';
-    case 'typography': return 'sunset';
-    case 'border': return 'lilac';
-    case 'shadow': return 'prairie';
-    default: return 'dawn';
+    case "color":
+      return "sky";
+    case "spacing":
+      return "pasture";
+    case "typography":
+      return "sunset";
+    case "border":
+      return "lilac";
+    case "shadow":
+      return "prairie";
+    default:
+      return "dawn";
   }
 }
 
@@ -62,27 +70,29 @@ function formatCategory(category: string): string {
 }
 
 // Token syntax types
-type TokenSyntax = 'css' | 'scss';
+type TokenSyntax = "css" | "scss";
 
 // Convert CSS variable name to SCSS variable name
 function toScssSyntax(cssName: string): string {
   // --goa-color-primary → $goa-color-primary
-  return cssName.replace(/^--/, '$');
+  return cssName.replace(/^--/, "$");
 }
 
 export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
   // State
-  const [searchValue, setSearchValue] = useState('');
+  const [searchValue, setSearchValue] = useState("");
   const [searchChips, setSearchChips] = useState<string[]>([]);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [isSticky, setIsSticky] = useState(false);
   const [copiedToken, setCopiedToken] = useState<string | null>(null);
-  const [tokenSyntax, setTokenSyntax] = useState<TokenSyntax>('css');
+  const [tokenSyntax, setTokenSyntax] = useState<TokenSyntax>("css");
 
   // Ref for sticky detection sentinel
   const sentinelRef = useRef<HTMLDivElement>(null);
-  // Ref for syntax toggle tabs
-  const syntaxToggleRef = useRef<HTMLDivElement>(null);
+  // Ref for table (to handle sort events from web component)
+  const tableRef = useRef<HTMLElement>(null);
+  // TODO: Remove tabsRef when GoabxTabs wrapper exposes updateUrl and stackOnMobile props
+  const tabsRef = useRef<HTMLElement>(null);
 
   // Detect when toolbar becomes sticky using IntersectionObserver
   useEffect(() => {
@@ -94,32 +104,11 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
         // When sentinel is not intersecting (scrolled out of view), toolbar is sticky
         setIsSticky(!entry.isIntersecting);
       },
-      { threshold: 0 }
+      { threshold: 0 },
     );
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, []);
-
-  // Listen for syntax toggle tab changes (native event - GoA tabs are 1-indexed)
-  useEffect(() => {
-    if (!syntaxToggleRef.current) return;
-
-    const handleSyntaxChange = (e: Event) => {
-      const customEvent = e as CustomEvent<{ tab: number }>;
-      const tabIndex = customEvent.detail?.tab;
-      if (tabIndex === 1) {
-        setTokenSyntax('css');
-      } else if (tabIndex === 2) {
-        setTokenSyntax('scss');
-      }
-    };
-
-    const tabsElement = syntaxToggleRef.current.querySelector('goa-tabs');
-    if (tabsElement) {
-      tabsElement.addEventListener('_change', handleSyntaxChange);
-      return () => tabsElement.removeEventListener('_change', handleSyntaxChange);
-    }
   }, []);
 
   // Filter state
@@ -127,13 +116,48 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
   const [appliedFilters, setAppliedFilters] = useState<string[]>([]);
 
   // Hooks
-  const { sortConfig, setSortConfig, sortByKey, clearSort, handleTableSort } = useTwoLevelSort();
+  const { sortConfig, setSortConfig, sortByKey, clearSort, handleTableSort } =
+    useTwoLevelSort();
   const isMobile = useMobile();
+
+  // Listen for table sort events (from goa-table web component)
+  useEffect(() => {
+    const table = tableRef.current;
+    if (!table) return;
+
+    const handleSort = (e: Event) => {
+      const detail = (e as CustomEvent<{ sortBy: string; sortDir: "asc" | "desc" }>)
+        .detail;
+      handleTableSort(detail);
+    };
+
+    table.addEventListener("_sort", handleSort);
+    return () => table.removeEventListener("_sort", handleSort);
+  }, [handleTableSort]);
+
+  // TODO: Remove this useEffect when GoabxTabs wrapper exposes updateUrl and stackOnMobile props
+  // Using goa-tabs web component directly because GoabxTabs wrapper is missing these props
+  useEffect(() => {
+    const tabs = tabsRef.current;
+    if (!tabs) return;
+
+    const handleChange = (e: Event) => {
+      const detail = (e as CustomEvent<{ tab: number }>).detail;
+      if (detail.tab === 1) {
+        setTokenSyntax("css");
+      } else if (detail.tab === 2) {
+        setTokenSyntax("scss");
+      }
+    };
+
+    tabs.addEventListener("_change", handleChange);
+    return () => tabs.removeEventListener("_change", handleChange);
+  }, []);
 
   // View mode: 'list' (table) on desktop, 'card' on mobile
   // No user toggle - automatically switches based on viewport
-  const viewMode = useMemo((): 'card' | 'list' => {
-    return isMobile ? 'card' : 'list';
+  const viewMode = useMemo((): "card" | "list" => {
+    return isMobile ? "card" : "list";
   }, [isMobile]);
 
   // Filter and sort tokens
@@ -147,8 +171,8 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
           (chip) =>
             token.name.toLowerCase().includes(chip.toLowerCase()) ||
             token.value.toLowerCase().includes(chip.toLowerCase()) ||
-            token.category.toLowerCase().includes(chip.toLowerCase())
-        )
+            token.category.toLowerCase().includes(chip.toLowerCase()),
+        ),
       );
     }
 
@@ -165,18 +189,18 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
     if (sortConfig.primary) {
       result = [...result].sort((a, b) => {
         const key = sortConfig.primary!.key as keyof FlatToken;
-        const aVal = String(a[key] || '');
-        const bVal = String(b[key] || '');
+        const aVal = String(a[key] || "");
+        const bVal = String(b[key] || "");
         const cmp = aVal.localeCompare(bVal);
-        const dir = sortConfig.primary!.direction === 'asc' ? 1 : -1;
+        const dir = sortConfig.primary!.direction === "asc" ? 1 : -1;
 
         if (cmp !== 0) return cmp * dir;
 
         if (sortConfig.secondary) {
           const secKey = sortConfig.secondary.key as keyof FlatToken;
-          const secAVal = String(a[secKey] || '');
-          const secBVal = String(b[secKey] || '');
-          const secDir = sortConfig.secondary.direction === 'asc' ? 1 : -1;
+          const secAVal = String(a[secKey] || "");
+          const secBVal = String(b[secKey] || "");
+          const secDir = sortConfig.secondary.direction === "asc" ? 1 : -1;
           return secAVal.localeCompare(secBVal) * secDir;
         }
 
@@ -187,13 +211,12 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
     return result;
   }, [tokens, searchChips, appliedFilters, sortConfig, filterGroups]);
 
-
   // Search handlers
   const applySearch = useCallback(() => {
     const trimmed = searchValue.trim();
     if (trimmed && !searchChips.includes(trimmed)) {
       setSearchChips((prev) => [...prev, trimmed]);
-      setSearchValue('');
+      setSearchValue("");
     }
   }, [searchValue, searchChips]);
 
@@ -204,7 +227,7 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
   // Filter handlers
   const togglePendingFilter = useCallback((category: string) => {
     setPendingFilters((prev) =>
-      prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category]
+      prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category],
     );
   }, []);
 
@@ -223,21 +246,27 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
   }, []);
 
   // Get formatted token name based on current syntax
-  const getFormattedTokenName = useCallback((cssName: string): string => {
-    return tokenSyntax === 'scss' ? toScssSyntax(cssName) : cssName;
-  }, [tokenSyntax]);
+  const getFormattedTokenName = useCallback(
+    (cssName: string): string => {
+      return tokenSyntax === "scss" ? toScssSyntax(cssName) : cssName;
+    },
+    [tokenSyntax],
+  );
 
   // Copy to clipboard (copies the formatted name)
-  const copyToClipboard = useCallback(async (tokenName: string) => {
-    try {
-      const formattedName = getFormattedTokenName(tokenName);
-      await navigator.clipboard.writeText(formattedName);
-      setCopiedToken(tokenName);
-      setTimeout(() => setCopiedToken(null), 2000);
-    } catch (err) {
-      console.error('Failed to copy:', err);
-    }
-  }, [getFormattedTokenName]);
+  const copyToClipboard = useCallback(
+    async (tokenName: string) => {
+      try {
+        const formattedName = getFormattedTokenName(tokenName);
+        await navigator.clipboard.writeText(formattedName);
+        setCopiedToken(tokenName);
+        setTimeout(() => setCopiedToken(null), 2000);
+      } catch (err) {
+        console.error("Failed to copy:", err);
+      }
+    },
+    [getFormattedTokenName],
+  );
 
   // Clear all filters, search, and sort
   const clearAll = useCallback(() => {
@@ -247,30 +276,36 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
   }, [clearAllFilters, clearSort]);
 
   // Get sort direction for column headers
-  const getColumnSortDirection = useCallback((columnKey: string): 'asc' | 'desc' | 'none' => {
-    if (sortConfig.primary?.key === columnKey) {
-      return sortConfig.primary.direction;
-    }
-    if (sortConfig.secondary?.key === columnKey) {
-      return sortConfig.secondary.direction;
-    }
-    return 'none';
-  }, [sortConfig]);
+  const getColumnSortDirection = useCallback(
+    (columnKey: string): "asc" | "desc" | "none" => {
+      if (sortConfig.primary?.key === columnKey) {
+        return sortConfig.primary.direction;
+      }
+      if (sortConfig.secondary?.key === columnKey) {
+        return sortConfig.secondary.direction;
+      }
+      return "none";
+    },
+    [sortConfig],
+  );
 
   // Get sort order indicator ("1" or "2") for column headers
-  const getColumnSortOrder = useCallback((columnKey: string): string | undefined => {
-    // Only show numbers if there are two sorts active
-    if (!sortConfig.primary || !sortConfig.secondary) {
+  const getColumnSortOrder = useCallback(
+    (columnKey: string): string | undefined => {
+      // Only show numbers if there are two sorts active
+      if (!sortConfig.primary || !sortConfig.secondary) {
+        return undefined;
+      }
+      if (sortConfig.primary.key === columnKey) {
+        return "1";
+      }
+      if (sortConfig.secondary.key === columnKey) {
+        return "2";
+      }
       return undefined;
-    }
-    if (sortConfig.primary.key === columnKey) {
-      return "1";
-    }
-    if (sortConfig.secondary.key === columnKey) {
-      return "2";
-    }
-    return undefined;
-  }, [sortConfig]);
+    },
+    [sortConfig],
+  );
 
   // Render color preview
   const renderPreview = (token: FlatToken) => {
@@ -283,7 +318,7 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
             height: 24,
             borderRadius: 4,
             backgroundColor: token.value,
-            border: '1px solid var(--goa-color-greyscale-200)',
+            border: "1px solid var(--goa-color-greyscale-200)",
           }}
           title={token.value}
         />
@@ -305,19 +340,24 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
                 <span className="token-value">{token.value}</span>
               </div>
               <GoabIconButton
-                icon={copiedToken === token.name ? 'checkmark' : 'copy'}
+                icon={copiedToken === token.name ? "checkmark" : "copy"}
                 size="small"
                 variant="dark"
                 ariaLabel={`Copy ${getFormattedTokenName(token.name)}`}
                 onClick={() => copyToClipboard(token.name)}
               />
             </div>
-            <GoabBadge type={getCategoryBadgeType(token.category)} content={formatCategory(token.category)} emphasis="subtle" />
+            <goa-badge
+              version="2"
+              type={getCategoryBadgeType(token.category)}
+              content={formatCategory(token.category)}
+              emphasis="subtle"
+            />
           </div>
         </GoabContainer>
       </div>
     ),
-    [copiedToken, copyToClipboard, getFormattedTokenName]
+    [copiedToken, copyToClipboard, getFormattedTokenName],
   );
 
   // Render table row (list view)
@@ -332,11 +372,16 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
           <code className="token-value">{token.value}</code>
         </td>
         <td>
-          <GoabBadge type={getCategoryBadgeType(token.category)} content={formatCategory(token.category)} emphasis="subtle" />
+          <goa-badge
+            version="2"
+            type={getCategoryBadgeType(token.category)}
+            content={formatCategory(token.category)}
+            emphasis="subtle"
+          />
         </td>
         <td>
           <GoabIconButton
-            icon={copiedToken === token.name ? 'checkmark' : 'copy'}
+            icon={copiedToken === token.name ? "checkmark" : "copy"}
             size="small"
             variant="dark"
             ariaLabel={`Copy ${getFormattedTokenName(token.name)}`}
@@ -345,10 +390,11 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
         </td>
       </tr>
     ),
-    [copiedToken, copyToClipboard, getFormattedTokenName]
+    [copiedToken, copyToClipboard, getFormattedTokenName],
   );
 
-  const hasActiveFilters = searchChips.length > 0 || appliedFilters.length > 0 || sortConfig.primary;
+  const hasActiveFilters =
+    searchChips.length > 0 || appliedFilters.length > 0 || sortConfig.primary;
 
   return (
     <div className="tokens-grid">
@@ -356,40 +402,54 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
       <div ref={sentinelRef} className="tokens-sentinel" aria-hidden="true" />
 
       {/* Toolbar */}
-      <div className={`tokens-toolbar ${isSticky ? 'tokens-toolbar--sticky' : ''}`}>
+      <div className={`tokens-toolbar ${isSticky ? "tokens-toolbar--sticky" : ""}`}>
         {/* Search input */}
         <div className="tokens-search-section">
-          <GoabFormItem
-            helpText={!isSticky ? 'Search by name, value, or category' : undefined}
+          <GoabxFormItem
+            helpText={!isSticky ? "Search by name, value, or category" : undefined}
           >
-            <GoabInput
+            <GoabxInput
               name="tokenSearch"
               value={searchValue}
               leadingIcon="search"
               width="100%"
               size="compact"
               onChange={(e) => setSearchValue(e.value)}
-              onKeyPress={(e) => e.key === 'Enter' && applySearch()}
+              onKeyPress={(e) => e.key === "Enter" && applySearch()}
             />
-          </GoabFormItem>
+          </GoabxFormItem>
         </div>
 
         {/* Syntax toggle + Filters */}
         <div className="tokens-toolbar-actions">
-          {/* CSS/SCSS syntax toggle - segmented tabs */}
-          <div className="syntax-toggle-wrapper" ref={syntaxToggleRef}>
-            <GoabTabs
+          {/*
+           * TODO: Replace <goa-tabs> with GoabxTabs when wrapper exposes these props
+           *
+           * Using web component directly because GoabxTabs wrapper is missing:
+           * - updateUrl prop (we need false to avoid polluting browser history)
+           * - stackOnMobile prop (we need false for compact toggle)
+           *
+           * When fixed, remove: tabsRef, useEffect for _change event, goa-tabs from global.d.ts
+           */}
+          <div className="syntax-toggle-wrapper">
+            <goa-tabs
+              ref={tabsRef}
+              version="2"
               variant="segmented"
-              initialTab={tokenSyntax === 'css' ? 1 : 2}
-              updateUrl={false}
-              stackOnMobile={false}
+              initialtab={tokenSyntax === "css" ? 1 : 2}
+              updateurl="false"
+              stackonmobile="false"
             >
-              <GoabTab heading="CSS"><span /></GoabTab>
-              <GoabTab heading="SCSS"><span /></GoabTab>
-            </GoabTabs>
+              <goa-tab heading="CSS">
+                <span />
+              </goa-tab>
+              <goa-tab heading="SCSS">
+                <span />
+              </goa-tab>
+            </goa-tabs>
           </div>
 
-          <GoabButton
+          <GoabxButton
             type="secondary"
             leadingIcon="filter-lines"
             size="compact"
@@ -399,28 +459,38 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
             }}
           >
             Filters
-          </GoabButton>
+          </GoabxButton>
         </div>
       </div>
 
       {/* Active filters chips */}
       {hasActiveFilters && (
         <div className="tokens-chips">
-          <GoabIcon type="filter-lines" size="small" fillColor="var(--goa-color-text-secondary)" />
+          <GoabIcon
+            type="filter-lines"
+            size="small"
+            fillColor="var(--goa-color-text-secondary)"
+          />
 
           {/* Sort chips */}
           {sortConfig.primary && (
-            <GoabFilterChip
+            <GoabxFilterChip
               content={sortConfig.primary.key}
-              leadingIcon={sortConfig.primary.direction === 'asc' ? 'arrow-up' : 'arrow-down'}
-              secondaryText={sortConfig.secondary ? '1st' : undefined}
-              onClick={() => setSortConfig({ primary: sortConfig.secondary, secondary: null })}
+              leadingIcon={
+                sortConfig.primary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
+              secondaryText={sortConfig.secondary ? "1st" : undefined}
+              onClick={() =>
+                setSortConfig({ primary: sortConfig.secondary, secondary: null })
+              }
             />
           )}
           {sortConfig.secondary && (
-            <GoabFilterChip
+            <GoabxFilterChip
               content={sortConfig.secondary.key}
-              leadingIcon={sortConfig.secondary.direction === 'asc' ? 'arrow-up' : 'arrow-down'}
+              leadingIcon={
+                sortConfig.secondary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
               secondaryText="2nd"
               onClick={() => setSortConfig((prev) => ({ ...prev, secondary: null }))}
             />
@@ -428,15 +498,30 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
 
           {/* Search chips */}
           {searchChips.map((chip) => (
-            <GoabFilterChip key={chip} content={chip} onClick={() => removeSearchChip(chip)} />
+            <GoabxFilterChip
+              key={chip}
+              content={chip}
+              onClick={() => removeSearchChip(chip)}
+            />
           ))}
 
           {/* Filter group chips */}
           {appliedFilters.map((filterName) => (
-            <GoabFilterChip key={filterName} content={filterName} onClick={() => removeAppliedFilter(filterName)} />
+            <GoabxFilterChip
+              key={filterName}
+              content={filterName}
+              onClick={() => removeAppliedFilter(filterName)}
+            />
           ))}
 
-          <a href="#" className="clear-all-link" onClick={(e) => { e.preventDefault(); clearAll(); }}>
+          <a
+            href="#"
+            className="clear-all-link"
+            onClick={(e) => {
+              e.preventDefault();
+              clearAll();
+            }}
+          >
             Clear all
           </a>
         </div>
@@ -444,56 +529,55 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
 
       {/* Results count */}
       <p className="tokens-count">
-        {filteredTokens.length} token{filteredTokens.length !== 1 ? 's' : ''}
+        {filteredTokens.length} token{filteredTokens.length !== 1 ? "s" : ""}
       </p>
 
       {/* List View (table) */}
-      {viewMode === 'list' && (
+      {viewMode === "list" && (
         <div className="tokens-table-wrapper">
-          <GoabTable width="100%" variant="normal" onSort={handleTableSort}>
-            <thead>
-              <tr>
-                <th style={{ width: 60 }}>Preview</th>
-                <th style={{ minWidth: 320 }}>
-                  <GoabTableSortHeader
-                    name="name"
-                    direction={getColumnSortDirection('name')}
-                    sortOrder={getColumnSortOrder('name')}
-                  >
-                    Token
-                  </GoabTableSortHeader>
-                </th>
-                <th>Value</th>
-                <th>
-                  <GoabTableSortHeader
-                    name="category"
-                    direction={getColumnSortDirection('category')}
-                    sortOrder={getColumnSortOrder('category')}
-                  >
-                    Category
-                  </GoabTableSortHeader>
-                </th>
-                <th style={{ width: 60 }}></th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredTokens.map(renderTableRow)}
-            </tbody>
-          </GoabTable>
+          {/* Using web components directly for V2 styling - React wrappers don't pass version prop */}
+          <goa-table ref={tableRef} version="2" width="100%" variant="normal">
+            <table style={{ width: "100%" }}>
+              <thead>
+                <tr>
+                  <th style={{ width: 60 }}>Preview</th>
+                  <th style={{ minWidth: 320 }}>
+                    <goa-table-sort-header
+                      version="2"
+                      name="name"
+                      direction={getColumnSortDirection("name")}
+                    >
+                      Token
+                    </goa-table-sort-header>
+                  </th>
+                  <th>Value</th>
+                  <th>
+                    <goa-table-sort-header
+                      version="2"
+                      name="category"
+                      direction={getColumnSortDirection("category")}
+                    >
+                      Category
+                    </goa-table-sort-header>
+                  </th>
+                  <th style={{ width: 60 }}></th>
+                </tr>
+              </thead>
+              <tbody>{filteredTokens.map(renderTableRow)}</tbody>
+            </table>
+          </goa-table>
         </div>
       )}
 
       {/* Card View (mobile only) */}
-      {viewMode === 'card' && (
+      {viewMode === "card" && (
         <div className="tokens-card-view">
-          <div className="tokens-card-grid">
-            {filteredTokens.map(renderTokenCard)}
-          </div>
+          <div className="tokens-card-grid">{filteredTokens.map(renderTokenCard)}</div>
         </div>
       )}
 
       {/* Filter Drawer */}
-      <GoabDrawer
+      <GoabxDrawer
         heading="Filter tokens"
         position="right"
         open={filterDrawerOpen}
@@ -501,40 +585,54 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
         onClose={() => setFilterDrawerOpen(false)}
         actions={
           <GoabButtonGroup alignment="start" gap="compact">
-            <GoabButton type="primary" size="compact" onClick={applyFilters}>
+            <GoabxButton type="primary" size="compact" onClick={applyFilters}>
               Apply filters
-            </GoabButton>
-            <GoabButton type="tertiary" size="compact" onClick={() => setFilterDrawerOpen(false)}>
+            </GoabxButton>
+            <GoabxButton
+              type="tertiary"
+              size="compact"
+              onClick={() => setFilterDrawerOpen(false)}
+            >
               Cancel
-            </GoabButton>
+            </GoabxButton>
           </GoabButtonGroup>
         }
       >
         <div className="filter-drawer-content">
-          <GoabFormItem label="Category">
-            <div className="filter-checkboxes">
+          <GoabxFormItem label="Category">
+            <GoabCheckboxList
+              name="category"
+              value={pendingFilters}
+              onChange={(detail: GoabCheckboxListOnChangeDetail) =>
+                setPendingFilters(detail.value)
+              }
+            >
               {filterGroups.map((group) => (
-                <GoabCheckbox
+                <GoabxCheckbox
                   key={group.name}
-                  name={`filter-${group.name}`}
+                  name={group.name}
+                  value={group.name}
                   text={group.name}
-                  checked={pendingFilters.includes(group.name)}
-                  onChange={() => togglePendingFilter(group.name)}
+                  size="compact"
                 />
               ))}
-            </div>
-          </GoabFormItem>
+            </GoabCheckboxList>
+          </GoabxFormItem>
 
           {pendingFilters.length > 0 && (
             <>
               <GoabDivider />
-              <GoabButton type="tertiary" size="compact" onClick={() => setPendingFilters([])}>
+              <GoabxButton
+                type="tertiary"
+                size="compact"
+                onClick={() => setPendingFilters([])}
+              >
                 Clear all filters
-              </GoabButton>
+              </GoabxButton>
             </>
           )}
         </div>
-      </GoabDrawer>
+      </GoabxDrawer>
 
       <style>{`
         .tokens-grid {

--- a/docs/src/components/nav/ComponentsSubMenu.tsx
+++ b/docs/src/components/nav/ComponentsSubMenu.tsx
@@ -5,6 +5,7 @@
  * Uses GoabxWorkSideMenuGroup for expandable category sections.
  */
 
+import type { MouseEvent } from 'react';
 import {
   GoabxWorkSideMenu,
   GoabxWorkSideMenuItem,
@@ -118,19 +119,35 @@ export function ComponentsSubMenu({
   // We're on the All Components page if there's no currentSlug
   const isAllComponentsPage = !currentSlug;
 
+  // Handle back button click - wrap prevents navigation, triggers state change
+  const handleBackClick = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onBack();
+  };
+
+  // Handle All Components click on detail pages - navigate without URL auto-matching
+  const handleAllComponentsClick = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    window.location.href = '/components';
+  };
+
   // Primary content: Back button + All Components link + component categories
   const primaryContent = (
     <>
-      {/* Back to parent menu */}
-      <GoabxWorkSideMenuItem
-        label="All"
-        icon="arrow-back"
-        onClick={onBack}
-      />
+      {/* Back to parent menu - wrapped div captures click since component doesn't expose onClick */}
+      <div onClick={handleBackClick} style={{ cursor: 'pointer' }}>
+        <GoabxWorkSideMenuItem
+          label="All"
+          icon="arrow-back"
+          url="/__back__"
+        />
+      </div>
 
       {/* All Components page link
           - On All Components page: use url so auto-matching highlights it
-          - On component detail pages: use onClick to prevent auto-matching */}
+          - On component detail pages: wrap in div to prevent auto-matching */}
       {isAllComponentsPage ? (
         <GoabxWorkSideMenuItem
           label="All Components"
@@ -138,11 +155,13 @@ export function ComponentsSubMenu({
           url="/components"
         />
       ) : (
-        <GoabxWorkSideMenuItem
-          label="All Components"
-          icon="apps"
-          onClick={() => window.location.href = '/components'}
-        />
+        <div onClick={handleAllComponentsClick} style={{ cursor: 'pointer' }}>
+          <GoabxWorkSideMenuItem
+            label="All Components"
+            icon="apps"
+            url="/__all_components__"
+          />
+        </div>
       )}
 
       {/* Component categories - using GoabxWorkSideMenuGroup for expandable sections */}

--- a/docs/src/components/nav/ParentMenu.tsx
+++ b/docs/src/components/nav/ParentMenu.tsx
@@ -10,6 +10,7 @@
 import {
   GoabxWorkSideMenu,
   GoabxWorkSideMenuItem,
+  GoabxWorkSideMenuGroup,
 } from '@abgov/react-components/experimental';
 import { GoabSpacer } from '@abgov/react-components';
 
@@ -33,12 +34,20 @@ interface ParentMenuProps {
 const DIRECT_NAV_SECTIONS: Record<string, string> = {
   'tokens': '/tokens',
   'examples': '/examples',
-  'get-started': '/get-started',
   'foundations': '/foundations',
 };
 
 // Sections that open a submenu
 const SUBMENU_SECTIONS = ['components'];
+
+// Sections that render as expandable groups with sub-items
+const GROUP_SECTIONS: Record<string, Array<{ label: string; url: string }>> = {
+  'get-started': [
+    { label: 'Early Adopters', url: '/get-started' },
+    { label: 'Designers', url: '/get-started/designers' },
+    { label: 'Developers', url: '/get-started/developers' },
+  ],
+};
 
 // Main navigation sections
 const SECTIONS = [
@@ -63,9 +72,27 @@ export function ParentMenu({ isOpen, onToggle, onSelectSection, currentSection }
       {SECTIONS.map((section) => {
         const directUrl = DIRECT_NAV_SECTIONS[section.id];
         const hasSubmenu = SUBMENU_SECTIONS.includes(section.id);
+        const groupItems = GROUP_SECTIONS[section.id];
         const isActive = currentSection === section.id;
 
-        if (directUrl) {
+        if (groupItems) {
+          // Expandable group with sub-items
+          return (
+            <GoabxWorkSideMenuGroup
+              key={section.id}
+              heading={section.label}
+              icon={section.icon}
+            >
+              {groupItems.map((item) => (
+                <GoabxWorkSideMenuItem
+                  key={item.url}
+                  label={item.label}
+                  url={item.url}
+                />
+              ))}
+            </GoabxWorkSideMenuGroup>
+          );
+        } else if (directUrl) {
           // Direct navigation - use url prop
           return (
             <GoabxWorkSideMenuItem
@@ -91,7 +118,7 @@ export function ParentMenu({ isOpen, onToggle, onSelectSection, currentSection }
             </div>
           );
         } else {
-          // Placeholder sections (get-started, foundations) - disabled for now
+          // Placeholder sections - disabled for now
           return (
             <GoabxWorkSideMenuItem
               key={section.id}

--- a/docs/src/content/examples/add-a-filter-chip/angular.html
+++ b/docs/src/content/examples/add-a-filter-chip/angular.html
@@ -1,11 +1,11 @@
 <div>
-  <goab-filter-chip
+  <goabx-filter-chip
     *ngFor="let filter of activeFilters"
     [content]="filter"
     (onClick)="removeFilter(filter)"
     mr="s"
     mb="s"
     mt="s">
-  </goab-filter-chip>
+  </goabx-filter-chip>
 </div>
-<goab-button mt="l" (onClick)="addFilter()">Add Random Filter</goab-button>
+<goabx-button mt="l" (onClick)="addFilter()">Add Random Filter</goabx-button>

--- a/docs/src/content/examples/add-a-filter-chip/react.tsx
+++ b/docs/src/content/examples/add-a-filter-chip/react.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { GoabButton, GoabFilterChip } from "@abgov/react-components";
+import { GoabxButton, GoabxFilterChip } from "@abgov/react-components/experimental";
 
 export function AddAFilterChip() {
   const [activeFilters, setActiveFilters] = useState<string[]>([]);
@@ -19,7 +19,7 @@ export function AddAFilterChip() {
     <>
       <div>
         {activeFilters.map((filter) => (
-          <GoabFilterChip
+          <GoabxFilterChip
             key={filter}
             content={filter}
             onClick={() => removeFilter(filter)}
@@ -29,7 +29,7 @@ export function AddAFilterChip() {
           />
         ))}
       </div>
-      <GoabButton mt="l" onClick={addFilter}>Add Random Filter</GoabButton>
+      <GoabxButton mt="l" onClick={addFilter}>Add Random Filter</GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/add-a-filter-chip/web-components.html
+++ b/docs/src/content/examples/add-a-filter-chip/web-components.html
@@ -1,5 +1,5 @@
 <div id="filter-container"></div>
-<goa-button mt="l" id="add-filter-btn">Add Random Filter</goa-button>
+<goa-button version="2" mt="l" id="add-filter-btn">Add Random Filter</goa-button>
 
 <script>
   const activeFilters = [];
@@ -10,6 +10,7 @@
     container.innerHTML = "";
     activeFilters.forEach((filter) => {
       const chip = document.createElement("goa-filter-chip");
+      chip.setAttribute("version", "2");
       chip.setAttribute("content", filter);
       chip.setAttribute("mr", "s");
       chip.setAttribute("mb", "s");

--- a/docs/src/content/examples/add-a-record-using-a-drawer/angular.html
+++ b/docs/src/content/examples/add-a-record-using-a-drawer/angular.html
@@ -1,40 +1,40 @@
-<goab-button leadingIcon="add" (onClick)="onClick()">Add Record</goab-button>
-<goab-drawer maxSize="492px" [open]="open" heading="Add Record" position="right" (onClose)="onClose()" [actions]="actions">
-  <goab-form-item label="Level of education">
-    <goab-dropdown (onChange)="dropdownOnChange($event)" name="education" value="university">
-      <goab-dropdown-item value="high-school" label="High School Diploma"></goab-dropdown-item>
-      <goab-dropdown-item value="college" label="College Diploma"></goab-dropdown-item>
-      <goab-dropdown-item value="university" label="University Degree"></goab-dropdown-item>
-      <goab-dropdown-item value="masters" label="Master's Degree"></goab-dropdown-item>
-      <goab-dropdown-item value="doctorate" label="Doctorate"></goab-dropdown-item>
-    </goab-dropdown>
-  </goab-form-item>
-  <goab-form-item label="Educational institution" mt="l">
-    <goab-input name="education" type="text" (onChange)="inputOnChange($event)"></goab-input>
-  </goab-form-item>
-  <goab-form-item label="Field of study" requirement="optional" mt="l">
-    <goab-input name="fieldOfStudy" type="text" (onChange)="inputOnChange($event)"></goab-input>
-  </goab-form-item>
-  <goab-form-item label="Is the person currently attending?" mt="l">
-    <goab-radio-group name="attendTraining" orientation="horizontal" (onChange)="radioOnChange($event)">
-      <goab-radio-item value="yes" label="Yes"></goab-radio-item>
-      <goab-radio-item value="no" label="No"></goab-radio-item>
-    </goab-radio-group>
-  </goab-form-item>
-  <goab-form-item label="Start date" mt="l">
-    <goab-date-picker (onChange)="dateOnChange($event)"></goab-date-picker>
-    <goab-checkbox name="startDateApproximate" text="Approximate date" value="y" mt="s"></goab-checkbox>
-  </goab-form-item>
-  <goab-form-item label="Credential received?" mt="l">
-    <goab-radio-group name="credentialReceived" orientation="horizontal" (onChange)="radioOnChange($event)">
-      <goab-radio-item value="yes" label="Yes"></goab-radio-item>
-      <goab-radio-item value="no" label="No"></goab-radio-item>
-    </goab-radio-group>
-  </goab-form-item>
+<goabx-button leadingIcon="add" (onClick)="onClick()">Add Record</goabx-button>
+<goabx-drawer maxSize="492px" [open]="open" heading="Add Record" position="right" (onClose)="onClose()" [actions]="actions">
+  <goabx-form-item label="Level of education">
+    <goabx-dropdown (onChange)="dropdownOnChange($event)" name="education" value="university">
+      <goabx-dropdown-item value="high-school" label="High School Diploma"></goabx-dropdown-item>
+      <goabx-dropdown-item value="college" label="College Diploma"></goabx-dropdown-item>
+      <goabx-dropdown-item value="university" label="University Degree"></goabx-dropdown-item>
+      <goabx-dropdown-item value="masters" label="Master's Degree"></goabx-dropdown-item>
+      <goabx-dropdown-item value="doctorate" label="Doctorate"></goabx-dropdown-item>
+    </goabx-dropdown>
+  </goabx-form-item>
+  <goabx-form-item label="Educational institution" mt="l">
+    <goabx-input name="education" type="text" (onChange)="inputOnChange($event)"></goabx-input>
+  </goabx-form-item>
+  <goabx-form-item label="Field of study" requirement="optional" mt="l">
+    <goabx-input name="fieldOfStudy" type="text" (onChange)="inputOnChange($event)"></goabx-input>
+  </goabx-form-item>
+  <goabx-form-item label="Is the person currently attending?" mt="l">
+    <goabx-radio-group name="attendTraining" orientation="horizontal" (onChange)="radioOnChange($event)">
+      <goabx-radio-item value="yes" label="Yes"></goabx-radio-item>
+      <goabx-radio-item value="no" label="No"></goabx-radio-item>
+    </goabx-radio-group>
+  </goabx-form-item>
+  <goabx-form-item label="Start date" mt="l">
+    <goabx-date-picker (onChange)="dateOnChange($event)"></goabx-date-picker>
+    <goabx-checkbox name="startDateApproximate" text="Approximate date" value="y" mt="s"></goabx-checkbox>
+  </goabx-form-item>
+  <goabx-form-item label="Credential received?" mt="l">
+    <goabx-radio-group name="credentialReceived" orientation="horizontal" (onChange)="radioOnChange($event)">
+      <goabx-radio-item value="yes" label="Yes"></goabx-radio-item>
+      <goabx-radio-item value="no" label="No"></goabx-radio-item>
+    </goabx-radio-group>
+  </goabx-form-item>
   <ng-template #actions>
     <goab-button-group>
-      <goab-button type="primary" size="compact" (onClick)="closeDrawer()">Add record</goab-button>
-      <goab-button type="tertiary" size="compact" (onClick)="closeDrawer()">Cancel</goab-button>
+      <goabx-button type="primary" size="compact" (onClick)="closeDrawer()">Add record</goabx-button>
+      <goabx-button type="tertiary" size="compact" (onClick)="closeDrawer()">Cancel</goabx-button>
     </goab-button-group>
   </ng-template>
-</goab-drawer>
+</goabx-drawer>

--- a/docs/src/content/examples/add-a-record-using-a-drawer/react.tsx
+++ b/docs/src/content/examples/add-a-record-using-a-drawer/react.tsx
@@ -1,28 +1,27 @@
 import { useState } from "react";
 import {
-  GoabBlock,
-  GoabButton,
-  GoabButtonGroup,
-  GoabCheckbox,
-  GoabDatePicker,
-  GoabDrawer,
-  GoabDropdown,
-  GoabDropdownItem,
-  GoabFormItem,
-  GoabInput,
-  GoabRadioGroup,
-  GoabRadioItem,
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxCheckbox,
+  GoabxDatePicker,
+  GoabxDrawer,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
+import { GoabBlock, GoabButtonGroup } from "@abgov/react-components";
 
 export function AddARecordUsingADrawer() {
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      <GoabButton leadingIcon="add" onClick={() => setOpen(true)}>
+      <GoabxButton leadingIcon="add" onClick={() => setOpen(true)}>
         Add Record
-      </GoabButton>
-      <GoabDrawer
+      </GoabxButton>
+      <GoabxDrawer
         maxSize="492px"
         open={open}
         heading="Add Record"
@@ -30,47 +29,47 @@ export function AddARecordUsingADrawer() {
         onClose={() => setOpen(false)}
         actions={
           <GoabButtonGroup>
-            <GoabButton type="primary" size="compact" onClick={() => setOpen(false)}>
+            <GoabxButton type="primary" size="compact" onClick={() => setOpen(false)}>
               Add record
-            </GoabButton>
-            <GoabButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
+            </GoabxButton>
+            <GoabxButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
               Cancel
-            </GoabButton>
+            </GoabxButton>
           </GoabButtonGroup>
         }
       >
-        <GoabFormItem label="Level of education">
-          <GoabDropdown onChange={() => {}} name="education" value="university">
-            <GoabDropdownItem value="high-school" label="High School Diploma" />
-            <GoabDropdownItem value="college" label="College Diploma" />
-            <GoabDropdownItem value="university" label="University Degree" />
-            <GoabDropdownItem value="masters" label="Master's Degree" />
-            <GoabDropdownItem value="doctorate" label="Doctorate" />
-          </GoabDropdown>
-        </GoabFormItem>
-        <GoabFormItem label="Educational institution" mt="l">
-          <GoabInput name="education" type="text" onChange={() => {}} />
-        </GoabFormItem>
-        <GoabFormItem label="Field of study" requirement="optional" mt="l">
-          <GoabInput name="fieldOfStudy" type="text" onChange={() => {}} />
-        </GoabFormItem>
-        <GoabFormItem label="Is the person currently attending?" mt="l">
-          <GoabRadioGroup name="attendTraining" orientation="horizontal" onChange={() => {}}>
-            <GoabRadioItem value="yes" label="Yes" />
-            <GoabRadioItem value="no" label="No" />
-          </GoabRadioGroup>
-        </GoabFormItem>
-        <GoabFormItem label="Start date" mt="l">
-          <GoabDatePicker onChange={() => {}} value={new Date("2022-09-01")} />
-          <GoabCheckbox name="startDateApproximate" text="Approximate date" value="y" mt="s" />
-        </GoabFormItem>
-        <GoabFormItem label="Credential received?" mt="l">
-          <GoabRadioGroup name="credentialReceived" orientation="horizontal" onChange={() => {}}>
-            <GoabRadioItem value="yes" label="Yes" />
-            <GoabRadioItem value="no" label="No" />
-          </GoabRadioGroup>
-        </GoabFormItem>
-      </GoabDrawer>
+        <GoabxFormItem label="Level of education">
+          <GoabxDropdown onChange={() => {}} name="education" value="university">
+            <GoabxDropdownItem value="high-school" label="High School Diploma" />
+            <GoabxDropdownItem value="college" label="College Diploma" />
+            <GoabxDropdownItem value="university" label="University Degree" />
+            <GoabxDropdownItem value="masters" label="Master's Degree" />
+            <GoabxDropdownItem value="doctorate" label="Doctorate" />
+          </GoabxDropdown>
+        </GoabxFormItem>
+        <GoabxFormItem label="Educational institution" mt="l">
+          <GoabxInput name="education" type="text" onChange={() => {}} />
+        </GoabxFormItem>
+        <GoabxFormItem label="Field of study" requirement="optional" mt="l">
+          <GoabxInput name="fieldOfStudy" type="text" onChange={() => {}} />
+        </GoabxFormItem>
+        <GoabxFormItem label="Is the person currently attending?" mt="l">
+          <GoabxRadioGroup name="attendTraining" orientation="horizontal" onChange={() => {}}>
+            <GoabxRadioItem value="yes" label="Yes" />
+            <GoabxRadioItem value="no" label="No" />
+          </GoabxRadioGroup>
+        </GoabxFormItem>
+        <GoabxFormItem label="Start date" mt="l">
+          <GoabxDatePicker onChange={() => {}} value={new Date("2022-09-01")} />
+          <GoabxCheckbox name="startDateApproximate" text="Approximate date" value="y" mt="s" />
+        </GoabxFormItem>
+        <GoabxFormItem label="Credential received?" mt="l">
+          <GoabxRadioGroup name="credentialReceived" orientation="horizontal" onChange={() => {}}>
+            <GoabxRadioItem value="yes" label="Yes" />
+            <GoabxRadioItem value="no" label="No" />
+          </GoabxRadioGroup>
+        </GoabxFormItem>
+      </GoabxDrawer>
     </>
   );
 }

--- a/docs/src/content/examples/add-a-record-using-a-drawer/web-components.html
+++ b/docs/src/content/examples/add-a-record-using-a-drawer/web-components.html
@@ -1,7 +1,7 @@
-<goa-button id="open-drawer-btn" leadingicon="add">Add Record</goa-button>
-<goa-drawer id="record-drawer" max-size="492px" heading="Add Record" position="right">
-  <goa-form-item label="Level of education">
-    <goa-dropdown name="education" value="university">
+<goa-button version="2" id="open-drawer-btn" leadingicon="add">Add Record</goa-button>
+<goa-drawer version="2" id="record-drawer" max-size="492px" heading="Add Record" position="right">
+  <goa-form-item version="2" label="Level of education">
+    <goa-dropdown version="2" name="education" value="university">
       <goa-dropdown-item value="high-school" label="High School Diploma"></goa-dropdown-item>
       <goa-dropdown-item value="college" label="College Diploma"></goa-dropdown-item>
       <goa-dropdown-item value="university" label="University Degree"></goa-dropdown-item>
@@ -9,32 +9,32 @@
       <goa-dropdown-item value="doctorate" label="Doctorate"></goa-dropdown-item>
     </goa-dropdown>
   </goa-form-item>
-  <goa-form-item label="Educational institution" mt="l">
-    <goa-input name="education" type="text"></goa-input>
+  <goa-form-item version="2" label="Educational institution" mt="l">
+    <goa-input version="2" name="education" type="text"></goa-input>
   </goa-form-item>
-  <goa-form-item label="Field of study" requirement="optional" mt="l">
-    <goa-input name="fieldOfStudy" type="text"></goa-input>
+  <goa-form-item version="2" label="Field of study" requirement="optional" mt="l">
+    <goa-input version="2" name="fieldOfStudy" type="text"></goa-input>
   </goa-form-item>
-  <goa-form-item label="Is the person currently attending?" mt="l">
-    <goa-radio-group name="attendTraining" orientation="horizontal">
+  <goa-form-item version="2" label="Is the person currently attending?" mt="l">
+    <goa-radio-group version="2" name="attendTraining" orientation="horizontal">
       <goa-radio-item value="yes" label="Yes"></goa-radio-item>
       <goa-radio-item value="no" label="No"></goa-radio-item>
     </goa-radio-group>
   </goa-form-item>
-  <goa-form-item label="Start date" mt="l">
-    <goa-date-picker></goa-date-picker>
-    <goa-checkbox name="startDateApproximate" text="Approximate date" value="y" mt="s"></goa-checkbox>
+  <goa-form-item version="2" label="Start date" mt="l">
+    <goa-date-picker version="2"></goa-date-picker>
+    <goa-checkbox version="2" name="startDateApproximate" text="Approximate date" value="y" mt="s"></goa-checkbox>
   </goa-form-item>
-  <goa-form-item label="Credential received?" mt="l">
-    <goa-radio-group name="credentialReceived" orientation="horizontal">
+  <goa-form-item version="2" label="Credential received?" mt="l">
+    <goa-radio-group version="2" name="credentialReceived" orientation="horizontal">
       <goa-radio-item value="yes" label="Yes"></goa-radio-item>
       <goa-radio-item value="no" label="No"></goa-radio-item>
     </goa-radio-group>
   </goa-form-item>
   <div slot="actions">
     <goa-button-group>
-      <goa-button id="add-record-btn" type="primary" size="compact">Add record</goa-button>
-      <goa-button id="cancel-btn" type="tertiary" size="compact">Cancel</goa-button>
+      <goa-button version="2" id="add-record-btn" type="primary" size="compact">Add record</goa-button>
+      <goa-button version="2" id="cancel-btn" type="tertiary" size="compact">Cancel</goa-button>
     </goa-button-group>
   </div>
 </goa-drawer>

--- a/docs/src/content/examples/add-and-edit-lots-of-filters/angular.html
+++ b/docs/src/content/examples/add-and-edit-lots-of-filters/angular.html
@@ -1,36 +1,36 @@
-<goab-button (onClick)="onClick()">Filters</goab-button>
-<goab-drawer heading="Filters" [open]="open" (onClose)="onClose()" position="right" [actions]="actions">
-  <goab-form-item label="Entry status">
+<goabx-button (onClick)="onClick()">Filters</goabx-button>
+<goabx-drawer heading="Filters" [open]="open" (onClose)="onClose()" position="right" [actions]="actions">
+  <goabx-form-item label="Entry status">
     <goab-checkbox-list name="entryStatus" (onChange)="onCheckboxChange($event)">
-      <goab-checkbox name="draft" text="Draft" value="draft"></goab-checkbox>
-      <goab-checkbox name="published" text="Published" value="published"></goab-checkbox>
+      <goabx-checkbox name="draft" text="Draft" value="draft"></goabx-checkbox>
+      <goabx-checkbox name="published" text="Published" value="published"></goabx-checkbox>
     </goab-checkbox-list>
-  </goab-form-item>
-  <goab-form-item label="Assigned to - Region" mt="l">
+  </goabx-form-item>
+  <goabx-form-item label="Assigned to - Region" mt="l">
     <goab-checkbox-list name="region" (onChange)="onCheckboxChange($event)">
-      <goab-checkbox name="calgary" text="Calgary" value="calgary"></goab-checkbox>
-      <goab-checkbox name="central" text="Central" value="central"></goab-checkbox>
-      <goab-checkbox name="edmonton" text="Edmonton" value="edmonton"></goab-checkbox>
-      <goab-checkbox name="north" text="North" value="north"></goab-checkbox>
-      <goab-checkbox name="south" text="South" value="south"></goab-checkbox>
+      <goabx-checkbox name="calgary" text="Calgary" value="calgary"></goabx-checkbox>
+      <goabx-checkbox name="central" text="Central" value="central"></goabx-checkbox>
+      <goabx-checkbox name="edmonton" text="Edmonton" value="edmonton"></goabx-checkbox>
+      <goabx-checkbox name="north" text="North" value="north"></goabx-checkbox>
+      <goabx-checkbox name="south" text="South" value="south"></goabx-checkbox>
     </goab-checkbox-list>
-  </goab-form-item>
-  <goab-form-item label="Assigned to" mt="l">
-    <goab-dropdown [value]="assignedTo" name="assignedToData" (onChange)="onChangeAssignedTo($event)">
-      <goab-dropdown-item value="1" label="Person 1"></goab-dropdown-item>
-      <goab-dropdown-item value="2" label="Person 2"></goab-dropdown-item>
-    </goab-dropdown>
-  </goab-form-item>
-  <goab-form-item label="Date taken" mt="l">
-    <goab-radio-group name="dateTaken" (onChange)="radioOnChange($event)">
-      <goab-radio-item value="24" label="Last 24 hours"></goab-radio-item>
-      <goab-radio-item value="72" label="Last 72 hours"></goab-radio-item>
-    </goab-radio-group>
-  </goab-form-item>
+  </goabx-form-item>
+  <goabx-form-item label="Assigned to" mt="l">
+    <goabx-dropdown [value]="assignedTo" name="assignedToData" (onChange)="onChangeAssignedTo($event)">
+      <goabx-dropdown-item value="1" label="Person 1"></goabx-dropdown-item>
+      <goabx-dropdown-item value="2" label="Person 2"></goabx-dropdown-item>
+    </goabx-dropdown>
+  </goabx-form-item>
+  <goabx-form-item label="Date taken" mt="l">
+    <goabx-radio-group name="dateTaken" (onChange)="radioOnChange($event)">
+      <goabx-radio-item value="24" label="Last 24 hours"></goabx-radio-item>
+      <goabx-radio-item value="72" label="Last 72 hours"></goabx-radio-item>
+    </goabx-radio-group>
+  </goabx-form-item>
   <ng-template #actions>
     <goab-button-group>
-      <goab-button type="primary" size="compact" (onClick)="closeDrawer()">Apply filters</goab-button>
-      <goab-button type="tertiary" size="compact" (onClick)="closeDrawer()">Cancel</goab-button>
+      <goabx-button type="primary" size="compact" (onClick)="closeDrawer()">Apply filters</goabx-button>
+      <goabx-button type="tertiary" size="compact" (onClick)="closeDrawer()">Cancel</goabx-button>
     </goab-button-group>
   </ng-template>
-</goab-drawer>
+</goabx-drawer>

--- a/docs/src/content/examples/add-and-edit-lots-of-filters/react.tsx
+++ b/docs/src/content/examples/add-and-edit-lots-of-filters/react.tsx
@@ -1,67 +1,66 @@
 import { useState } from "react";
 import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabCheckbox,
-  GoabCheckboxList,
-  GoabDrawer,
-  GoabDropdown,
-  GoabDropdownItem,
-  GoabFormItem,
-  GoabRadioGroup,
-  GoabRadioItem,
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxCheckbox,
+  GoabxDrawer,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxFormItem,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
+import { GoabButtonGroup, GoabCheckboxList } from "@abgov/react-components";
 
 export function AddAndEditLotsOfFilters() {
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      <GoabButton onClick={() => setOpen(true)}>Filters</GoabButton>
-      <GoabDrawer
+      <GoabxButton onClick={() => setOpen(true)}>Filters</GoabxButton>
+      <GoabxDrawer
           heading="Filters"
           open={open}
           onClose={() => setOpen(false)}
           position="right"
           actions={
             <GoabButtonGroup>
-              <GoabButton type="primary" size="compact" onClick={() => setOpen(false)}>
+              <GoabxButton type="primary" size="compact" onClick={() => setOpen(false)}>
                 Apply filters
-              </GoabButton>
-              <GoabButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
+              </GoabxButton>
+              <GoabxButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
                 Cancel
-              </GoabButton>
+              </GoabxButton>
             </GoabButtonGroup>
           }
         >
-          <GoabFormItem label="Entry status">
+          <GoabxFormItem label="Entry status">
             <GoabCheckboxList name="entryStatus" onChange={() => {}}>
-              <GoabCheckbox name="draft" text="Draft" value="draft" />
-              <GoabCheckbox name="published" text="Published" value="published" />
+              <GoabxCheckbox name="draft" text="Draft" value="draft" />
+              <GoabxCheckbox name="published" text="Published" value="published" />
             </GoabCheckboxList>
-          </GoabFormItem>
-          <GoabFormItem label="Assigned to - Region" mt="l">
+          </GoabxFormItem>
+          <GoabxFormItem label="Assigned to - Region" mt="l">
             <GoabCheckboxList name="region" onChange={() => {}}>
-              <GoabCheckbox name="calgary" text="Calgary" value="calgary" />
-              <GoabCheckbox name="central" text="Central" value="central" />
-              <GoabCheckbox name="edmonton" text="Edmonton" value="edmonton" />
-              <GoabCheckbox name="north" text="North" value="north" />
-              <GoabCheckbox name="south" text="South" value="south" />
+              <GoabxCheckbox name="calgary" text="Calgary" value="calgary" />
+              <GoabxCheckbox name="central" text="Central" value="central" />
+              <GoabxCheckbox name="edmonton" text="Edmonton" value="edmonton" />
+              <GoabxCheckbox name="north" text="North" value="north" />
+              <GoabxCheckbox name="south" text="South" value="south" />
             </GoabCheckboxList>
-          </GoabFormItem>
-          <GoabFormItem label="Assigned to" mt="l">
-            <GoabDropdown name="assignedTo" onChange={() => {}}>
-              <GoabDropdownItem value="1" label="Person 1" />
-              <GoabDropdownItem value="2" label="Person 2" />
-            </GoabDropdown>
-          </GoabFormItem>
-          <GoabFormItem label="Date taken" mt="l">
-            <GoabRadioGroup name="dateTaken" onChange={() => {}}>
-              <GoabRadioItem value="24" label="Last 24 hours" />
-              <GoabRadioItem value="72" label="Last 72 hours" />
-            </GoabRadioGroup>
-          </GoabFormItem>
-      </GoabDrawer>
+          </GoabxFormItem>
+          <GoabxFormItem label="Assigned to" mt="l">
+            <GoabxDropdown name="assignedTo" onChange={() => {}}>
+              <GoabxDropdownItem value="1" label="Person 1" />
+              <GoabxDropdownItem value="2" label="Person 2" />
+            </GoabxDropdown>
+          </GoabxFormItem>
+          <GoabxFormItem label="Date taken" mt="l">
+            <GoabxRadioGroup name="dateTaken" onChange={() => {}}>
+              <GoabxRadioItem value="24" label="Last 24 hours" />
+              <GoabxRadioItem value="72" label="Last 72 hours" />
+            </GoabxRadioGroup>
+          </GoabxFormItem>
+      </GoabxDrawer>
     </>
   );
 }

--- a/docs/src/content/examples/add-and-edit-lots-of-filters/web-components.html
+++ b/docs/src/content/examples/add-and-edit-lots-of-filters/web-components.html
@@ -1,36 +1,36 @@
-<goa-button id="open-filters-btn">Filters</goa-button>
-<goa-drawer id="filters-drawer" heading="Filters" position="right">
-  <goa-form-item label="Entry status">
+<goa-button version="2" id="open-filters-btn">Filters</goa-button>
+<goa-drawer version="2" id="filters-drawer" heading="Filters" position="right">
+  <goa-form-item version="2" label="Entry status">
     <goa-checkbox-list name="entryStatus">
-      <goa-checkbox name="draft" text="Draft" value="draft"></goa-checkbox>
-      <goa-checkbox name="published" text="Published" value="published"></goa-checkbox>
+      <goa-checkbox version="2" name="draft" text="Draft" value="draft"></goa-checkbox>
+      <goa-checkbox version="2" name="published" text="Published" value="published"></goa-checkbox>
     </goa-checkbox-list>
   </goa-form-item>
-  <goa-form-item label="Assigned to - Region" mt="l">
+  <goa-form-item version="2" label="Assigned to - Region" mt="l">
     <goa-checkbox-list name="region">
-      <goa-checkbox name="calgary" text="Calgary" value="calgary"></goa-checkbox>
-      <goa-checkbox name="central" text="Central" value="central"></goa-checkbox>
-      <goa-checkbox name="edmonton" text="Edmonton" value="edmonton"></goa-checkbox>
-      <goa-checkbox name="north" text="North" value="north"></goa-checkbox>
-      <goa-checkbox name="south" text="South" value="south"></goa-checkbox>
+      <goa-checkbox version="2" name="calgary" text="Calgary" value="calgary"></goa-checkbox>
+      <goa-checkbox version="2" name="central" text="Central" value="central"></goa-checkbox>
+      <goa-checkbox version="2" name="edmonton" text="Edmonton" value="edmonton"></goa-checkbox>
+      <goa-checkbox version="2" name="north" text="North" value="north"></goa-checkbox>
+      <goa-checkbox version="2" name="south" text="South" value="south"></goa-checkbox>
     </goa-checkbox-list>
   </goa-form-item>
-  <goa-form-item label="Assigned to" mt="l">
-    <goa-dropdown name="assignedTo">
+  <goa-form-item version="2" label="Assigned to" mt="l">
+    <goa-dropdown version="2" name="assignedTo">
       <goa-dropdown-item value="1" label="Person 1"></goa-dropdown-item>
       <goa-dropdown-item value="2" label="Person 2"></goa-dropdown-item>
     </goa-dropdown>
   </goa-form-item>
-  <goa-form-item label="Date taken" mt="l">
-    <goa-radio-group name="dateTaken">
+  <goa-form-item version="2" label="Date taken" mt="l">
+    <goa-radio-group version="2" name="dateTaken">
       <goa-radio-item value="24" label="Last 24 hours"></goa-radio-item>
       <goa-radio-item value="72" label="Last 72 hours"></goa-radio-item>
     </goa-radio-group>
   </goa-form-item>
   <div slot="actions">
     <goa-button-group>
-      <goa-button id="apply-filters-btn" type="primary" size="compact">Apply filters</goa-button>
-      <goa-button id="cancel-btn" type="tertiary" size="compact">Cancel</goa-button>
+      <goa-button version="2" id="apply-filters-btn" type="primary" size="compact">Apply filters</goa-button>
+      <goa-button version="2" id="cancel-btn" type="tertiary" size="compact">Cancel</goa-button>
     </goa-button-group>
   </div>
 </goa-drawer>

--- a/docs/src/content/examples/add-another-item-in-a-modal/angular.html
+++ b/docs/src/content/examples/add-another-item-in-a-modal/angular.html
@@ -1,22 +1,22 @@
-<goab-button type="tertiary" leadingIcon="add" (onClick)="toggleModal()">Add another item</goab-button>
-<goab-modal [open]="open" (onClose)="toggleModal()" heading="Add a new item" [actions]="actions">
+<goabx-button type="tertiary" leadingIcon="add" (onClick)="toggleModal()">Add another item</goabx-button>
+<goabx-modal [open]="open" (onClose)="toggleModal()" heading="Add a new item" [actions]="actions">
   <p>Fill in the information to create a new item</p>
-  <goab-form-item label="Type" mt="l">
-    <goab-dropdown (onChange)="updateType($event)" [value]="type">
-      <goab-dropdown-item value="1" label="Option 1"></goab-dropdown-item>
-      <goab-dropdown-item value="2" label="Option 2"></goab-dropdown-item>
-    </goab-dropdown>
-  </goab-form-item>
-  <goab-form-item label="Name" mt="l">
-    <goab-input name="name" width="100%" (onChange)="updateName($event)" [value]="name"></goab-input>
-  </goab-form-item>
-  <goab-form-item label="Description" mt="l">
-    <goab-textarea name="description" width="100%" [rows]="3" (onChange)="updateDescription($event)" [value]="description"></goab-textarea>
-  </goab-form-item>
+  <goabx-form-item label="Type" mt="l">
+    <goabx-dropdown (onChange)="updateType($event)" [value]="type">
+      <goabx-dropdown-item value="1" label="Option 1"></goabx-dropdown-item>
+      <goabx-dropdown-item value="2" label="Option 2"></goabx-dropdown-item>
+    </goabx-dropdown>
+  </goabx-form-item>
+  <goabx-form-item label="Name" mt="l">
+    <goabx-input name="name" width="100%" (onChange)="updateName($event)" [value]="name"></goabx-input>
+  </goabx-form-item>
+  <goabx-form-item label="Description" mt="l">
+    <goabx-textarea name="description" width="100%" [rows]="3" (onChange)="updateDescription($event)" [value]="description"></goabx-textarea>
+  </goabx-form-item>
   <ng-template #actions>
     <goab-button-group alignment="end">
-      <goab-button type="tertiary" size="compact" (onClick)="toggleModal()">Cancel</goab-button>
-      <goab-button type="primary" size="compact" (onClick)="toggleModal()">Save new item</goab-button>
+      <goabx-button type="tertiary" size="compact" (onClick)="toggleModal()">Cancel</goabx-button>
+      <goabx-button type="primary" size="compact" (onClick)="toggleModal()">Save new item</goabx-button>
     </goab-button-group>
   </ng-template>
-</goab-modal>
+</goabx-modal>

--- a/docs/src/content/examples/add-another-item-in-a-modal/react.tsx
+++ b/docs/src/content/examples/add-another-item-in-a-modal/react.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabDropdown,
-  GoabDropdownItem,
-  GoabFormItem,
-  GoabInput,
-  GoabModal,
-  GoabTextarea,
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxModal,
+  GoabxTextArea,
+} from "@abgov/react-components/experimental";
+import { GoabButtonGroup } from "@abgov/react-components";
 
 export function AddAnotherItemInAModal() {
   const [open, setOpen] = useState(false);
@@ -18,48 +18,48 @@ export function AddAnotherItemInAModal() {
 
   return (
     <>
-      <GoabButton type="tertiary" leadingIcon="add" onClick={() => setOpen(true)}>
+      <GoabxButton type="tertiary" leadingIcon="add" onClick={() => setOpen(true)}>
         Add another item
-      </GoabButton>
-      <GoabModal
+      </GoabxButton>
+      <GoabxModal
           heading="Add a new item"
           open={open}
           actions={
             <GoabButtonGroup alignment="end">
-              <GoabButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
+              <GoabxButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
                 Cancel
-              </GoabButton>
-              <GoabButton type="primary" size="compact" onClick={() => setOpen(false)}>
+              </GoabxButton>
+              <GoabxButton type="primary" size="compact" onClick={() => setOpen(false)}>
                 Save new item
-              </GoabButton>
+              </GoabxButton>
             </GoabButtonGroup>
           }
         >
           <p>Fill in the information to create a new item</p>
-          <GoabFormItem label="Type" mt="l">
-            <GoabDropdown onChange={(e) => setType(e.value)} value={type}>
-              <GoabDropdownItem value="1" label="Option 1" />
-              <GoabDropdownItem value="2" label="Option 2" />
-            </GoabDropdown>
-          </GoabFormItem>
-          <GoabFormItem label="Name" mt="l">
-            <GoabInput
+          <GoabxFormItem label="Type" mt="l">
+            <GoabxDropdown onChange={(e) => setType(e.value)} value={type}>
+              <GoabxDropdownItem value="1" label="Option 1" />
+              <GoabxDropdownItem value="2" label="Option 2" />
+            </GoabxDropdown>
+          </GoabxFormItem>
+          <GoabxFormItem label="Name" mt="l">
+            <GoabxInput
               onChange={(e) => setName(e.value)}
               value={name}
               name="name"
               width="100%"
             />
-          </GoabFormItem>
-          <GoabFormItem label="Description" mt="l">
-            <GoabTextarea
+          </GoabxFormItem>
+          <GoabxFormItem label="Description" mt="l">
+            <GoabxTextArea
               name="description"
               rows={3}
               width="100%"
               onChange={(e) => setDescription(e.value)}
               value={description}
             />
-          </GoabFormItem>
-      </GoabModal>
+          </GoabxFormItem>
+      </GoabxModal>
     </>
   );
 }

--- a/docs/src/content/examples/add-another-item-in-a-modal/web-components.html
+++ b/docs/src/content/examples/add-another-item-in-a-modal/web-components.html
@@ -1,22 +1,22 @@
-<goa-button id="open-modal-btn" type="tertiary" leadingicon="add">Add another item</goa-button>
-<goa-modal id="add-item-modal" heading="Add a new item">
+<goa-button version="2" id="open-modal-btn" type="tertiary" leadingicon="add">Add another item</goa-button>
+<goa-modal version="2" id="add-item-modal" heading="Add a new item">
   <p>Fill in the information to create a new item</p>
-  <goa-form-item label="Type" mt="l">
-    <goa-dropdown id="type-dropdown">
+  <goa-form-item version="2" label="Type" mt="l">
+    <goa-dropdown version="2" id="type-dropdown">
       <goa-dropdown-item value="1" label="Option 1"></goa-dropdown-item>
       <goa-dropdown-item value="2" label="Option 2"></goa-dropdown-item>
     </goa-dropdown>
   </goa-form-item>
-  <goa-form-item label="Name" mt="l">
-    <goa-input name="name" width="100%" id="name-input"></goa-input>
+  <goa-form-item version="2" label="Name" mt="l">
+    <goa-input version="2" name="name" width="100%" id="name-input"></goa-input>
   </goa-form-item>
-  <goa-form-item label="Description" mt="l">
-    <goa-textarea name="description" width="100%" rows="3" id="description-textarea"></goa-textarea>
+  <goa-form-item version="2" label="Description" mt="l">
+    <goa-textarea version="2" name="description" width="100%" rows="3" id="description-textarea"></goa-textarea>
   </goa-form-item>
   <div slot="actions">
     <goa-button-group alignment="end">
-      <goa-button id="cancel-btn" type="tertiary" size="compact">Cancel</goa-button>
-      <goa-button id="save-btn" type="primary" size="compact">Save new item</goa-button>
+      <goa-button version="2" id="cancel-btn" type="tertiary" size="compact">Cancel</goa-button>
+      <goa-button version="2" id="save-btn" type="primary" size="compact">Save new item</goa-button>
     </goa-button-group>
   </div>
 </goa-modal>

--- a/docs/src/content/examples/ask-a-long-answer-question-with-a-maximum-word-count/angular.html
+++ b/docs/src/content/examples/ask-a-long-answer-question-with-a-maximum-word-count/angular.html
@@ -1,12 +1,12 @@
-<goab-form-item
+<goabx-form-item
   label="Provide more detail"
   helpText="Maximum 500 words. Do not include personal or financial information.">
-  <goab-textarea
+  <goabx-textarea
     name="program"
     [formControl]="form.controls.program"
     width="100%"
     [rows]="6"
     [maxCount]="500"
     countBy="word">
-  </goab-textarea>
-</goab-form-item>
+  </goabx-textarea>
+</goabx-form-item>

--- a/docs/src/content/examples/ask-a-long-answer-question-with-a-maximum-word-count/react.tsx
+++ b/docs/src/content/examples/ask-a-long-answer-question-with-a-maximum-word-count/react.tsx
@@ -1,15 +1,15 @@
 import { useState } from "react";
-import { GoabFormItem, GoabTextarea } from "@abgov/react-components";
+import { GoabxFormItem, GoabxTextArea } from "@abgov/react-components/experimental";
 
 export function AskALongAnswerQuestionWithAMaximumWordCount() {
   const [value, setValue] = useState("");
 
   return (
-    <GoabFormItem
+    <GoabxFormItem
       label="Provide more detail"
       helpText="Maximum 500 words. Do not include personal or financial information."
     >
-      <GoabTextarea
+      <GoabxTextArea
         name="program"
         onChange={(e) => setValue(e.value)}
         value={value}
@@ -18,6 +18,6 @@ export function AskALongAnswerQuestionWithAMaximumWordCount() {
         maxCount={500}
         countBy="word"
       />
-    </GoabFormItem>
+    </GoabxFormItem>
   );
 }

--- a/docs/src/content/examples/ask-a-long-answer-question-with-a-maximum-word-count/web-components.html
+++ b/docs/src/content/examples/ask-a-long-answer-question-with-a-maximum-word-count/web-components.html
@@ -1,7 +1,7 @@
-<goa-form-item
+<goa-form-item version="2"
   label="Provide more detail"
   helptext="Maximum 500 words. Do not include personal or financial information.">
-  <goa-textarea
+  <goa-textarea version="2"
     name="program"
     id="program-textarea"
     width="100%"

--- a/docs/src/content/examples/ask-a-user-for-a-birthday/angular.html
+++ b/docs/src/content/examples/ask-a-user-for-a-birthday/angular.html
@@ -1,8 +1,8 @@
-<goab-form-item label="What is your date of birth?">
-  <goab-date-picker
+<goabx-form-item label="What is your date of birth?">
+  <goabx-date-picker
     name="birthdate"
     type="input"
     [value]="birthdate"
     (onChange)="onDateChange($event)">
-  </goab-date-picker>
-</goab-form-item>
+  </goabx-date-picker>
+</goabx-form-item>

--- a/docs/src/content/examples/ask-a-user-for-a-birthday/react.tsx
+++ b/docs/src/content/examples/ask-a-user-for-a-birthday/react.tsx
@@ -1,17 +1,17 @@
 import { useState } from "react";
-import { GoabDatePicker, GoabFormItem } from "@abgov/react-components";
+import { GoabxDatePicker, GoabxFormItem } from "@abgov/react-components/experimental";
 
 export function AskForBirthday() {
   const [birthdate, setBirthdate] = useState<Date | undefined>(undefined);
 
   return (
-    <GoabFormItem label="What is your date of birth?">
-      <GoabDatePicker
+    <GoabxFormItem label="What is your date of birth?">
+      <GoabxDatePicker
         name="birthdate"
         type="input"
         value={birthdate}
         onChange={(e) => setBirthdate(e.value)}
       />
-    </GoabFormItem>
+    </GoabxFormItem>
   );
 }

--- a/docs/src/content/examples/ask-a-user-for-a-birthday/web-components.html
+++ b/docs/src/content/examples/ask-a-user-for-a-birthday/web-components.html
@@ -1,5 +1,5 @@
-<goa-form-item label="What is your date of birth?">
-  <goa-date-picker name="birthdate" type="input" id="birthdate"></goa-date-picker>
+<goa-form-item version="2" label="What is your date of birth?">
+  <goa-date-picker version="2" name="birthdate" type="input" id="birthdate"></goa-date-picker>
 </goa-form-item>
 
 <script>

--- a/docs/src/content/examples/ask-a-user-for-an-address/angular.html
+++ b/docs/src/content/examples/ask-a-user-for-an-address/angular.html
@@ -1,36 +1,36 @@
 <goab-text size="heading-l" mt="none" mb="xl">What is your address?</goab-text>
-<goab-form-item label="Street Address">
-  <goab-input name="address" type="text" [formControl]="form.controls.address" width="100%"></goab-input>
-</goab-form-item>
-<goab-form-item label="Suite or unit #" mt="l">
-  <goab-input name="suite" type="text" [formControl]="form.controls.suite" width="100%"></goab-input>
-</goab-form-item>
-<goab-form-item label="City or town" mt="l">
-  <goab-input name="city" type="text" [formControl]="form.controls.city" width="100%"></goab-input>
-</goab-form-item>
+<goabx-form-item label="Street Address">
+  <goabx-input name="address" type="text" [formControl]="form.controls.address" width="100%"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Suite or unit #" mt="l">
+  <goabx-input name="suite" type="text" [formControl]="form.controls.suite" width="100%"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="City or town" mt="l">
+  <goabx-input name="city" type="text" [formControl]="form.controls.city" width="100%"></goabx-input>
+</goabx-form-item>
 <goab-block direction="row" gap="l" mt="l">
-  <goab-form-item label="Province or territory">
-    <goab-dropdown name="province" [formControl]="form.controls.province">
-      <goab-dropdown-item label="Alberta" value="AB"></goab-dropdown-item>
-      <goab-dropdown-item label="British Columbia" value="BC"></goab-dropdown-item>
-      <goab-dropdown-item label="Manitoba" value="MB"></goab-dropdown-item>
-      <goab-dropdown-item label="New Brunswick" value="NB"></goab-dropdown-item>
-      <goab-dropdown-item label="Newfoundland and Labrador" value="NL"></goab-dropdown-item>
-      <goab-dropdown-item label="Northwest Territories" value="NT"></goab-dropdown-item>
-      <goab-dropdown-item label="Nova Scotia" value="NS"></goab-dropdown-item>
-      <goab-dropdown-item label="Nunavut" value="NU"></goab-dropdown-item>
-      <goab-dropdown-item label="Ontario" value="ON"></goab-dropdown-item>
-      <goab-dropdown-item label="Prince Edward Island" value="PE"></goab-dropdown-item>
-      <goab-dropdown-item label="Quebec" value="QC"></goab-dropdown-item>
-      <goab-dropdown-item label="Saskatchewan" value="SK"></goab-dropdown-item>
-      <goab-dropdown-item label="Yukon" value="YT"></goab-dropdown-item>
-    </goab-dropdown>
-  </goab-form-item>
-  <goab-form-item label="Postal Code">
-    <goab-input name="postalCode" type="text" [formControl]="form.controls.postalCode" width="7ch"></goab-input>
-  </goab-form-item>
+  <goabx-form-item label="Province or territory">
+    <goabx-dropdown name="province" [formControl]="form.controls.province">
+      <goabx-dropdown-item label="Alberta" value="AB"></goabx-dropdown-item>
+      <goabx-dropdown-item label="British Columbia" value="BC"></goabx-dropdown-item>
+      <goabx-dropdown-item label="Manitoba" value="MB"></goabx-dropdown-item>
+      <goabx-dropdown-item label="New Brunswick" value="NB"></goabx-dropdown-item>
+      <goabx-dropdown-item label="Newfoundland and Labrador" value="NL"></goabx-dropdown-item>
+      <goabx-dropdown-item label="Northwest Territories" value="NT"></goabx-dropdown-item>
+      <goabx-dropdown-item label="Nova Scotia" value="NS"></goabx-dropdown-item>
+      <goabx-dropdown-item label="Nunavut" value="NU"></goabx-dropdown-item>
+      <goabx-dropdown-item label="Ontario" value="ON"></goabx-dropdown-item>
+      <goabx-dropdown-item label="Prince Edward Island" value="PE"></goabx-dropdown-item>
+      <goabx-dropdown-item label="Quebec" value="QC"></goabx-dropdown-item>
+      <goabx-dropdown-item label="Saskatchewan" value="SK"></goabx-dropdown-item>
+      <goabx-dropdown-item label="Yukon" value="YT"></goabx-dropdown-item>
+    </goabx-dropdown>
+  </goabx-form-item>
+  <goabx-form-item label="Postal Code">
+    <goabx-input name="postalCode" type="text" [formControl]="form.controls.postalCode" width="7ch"></goabx-input>
+  </goabx-form-item>
 </goab-block>
 <goab-button-group alignment="start" mt="2xl">
-  <goab-button type="primary" (onClick)="onClick()">Save and continue</goab-button>
-  <goab-button type="secondary" (onClick)="onClick()">Cancel</goab-button>
+  <goabx-button type="primary" (onClick)="onClick()">Save and continue</goabx-button>
+  <goabx-button type="secondary" (onClick)="onClick()">Cancel</goabx-button>
 </goab-button-group>

--- a/docs/src/content/examples/ask-a-user-for-an-address/react.tsx
+++ b/docs/src/content/examples/ask-a-user-for-an-address/react.tsx
@@ -1,14 +1,12 @@
 import { useState } from "react";
 import {
-  GoabBlock,
-  GoabButton,
-  GoabButtonGroup,
-  GoabDropdown,
-  GoabDropdownItem,
-  GoabFormItem,
-  GoabInput,
-  GoabText,
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxFormItem,
+  GoabxInput,
+} from "@abgov/react-components/experimental";
+import { GoabBlock, GoabButtonGroup, GoabText } from "@abgov/react-components";
 
 export function AskAUserForAnAddress() {
   const [address, setAddress] = useState("");
@@ -20,72 +18,72 @@ export function AskAUserForAnAddress() {
   return (
     <>
       <GoabText size="heading-l" mt="none" mb="xl">What is your address?</GoabText>
-      <GoabFormItem label="Street Address">
-        <GoabInput
+      <GoabxFormItem label="Street Address">
+        <GoabxInput
           name="address"
           type="text"
           value={address}
           onChange={(e) => setAddress(e.value)}
           width="100%"
         />
-      </GoabFormItem>
-      <GoabFormItem label="Suite or unit #" mt="l">
-        <GoabInput
+      </GoabxFormItem>
+      <GoabxFormItem label="Suite or unit #" mt="l">
+        <GoabxInput
           name="suite"
           type="text"
           value={suite}
           onChange={(e) => setSuite(e.value)}
           width="100%"
         />
-      </GoabFormItem>
-      <GoabFormItem label="City or town" mt="l">
-        <GoabInput
+      </GoabxFormItem>
+      <GoabxFormItem label="City or town" mt="l">
+        <GoabxInput
           name="city"
           type="text"
           value={city}
           onChange={(e) => setCity(e.value)}
           width="100%"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
       <GoabBlock direction="row" gap="l" mt="l">
-        <GoabFormItem label="Province or territory">
-          <GoabDropdown
+        <GoabxFormItem label="Province or territory">
+          <GoabxDropdown
             onChange={(e) => setProvince(e.value ?? "")}
             name="province"
             value={province}
           >
-            <GoabDropdownItem label="Alberta" value="AB" />
-            <GoabDropdownItem label="British Columbia" value="BC" />
-            <GoabDropdownItem label="Manitoba" value="MB" />
-            <GoabDropdownItem label="New Brunswick" value="NB" />
-            <GoabDropdownItem label="Newfoundland and Labrador" value="NL" />
-            <GoabDropdownItem label="Northwest Territories" value="NT" />
-            <GoabDropdownItem label="Nova Scotia" value="NS" />
-            <GoabDropdownItem label="Nunavut" value="NU" />
-            <GoabDropdownItem label="Ontario" value="ON" />
-            <GoabDropdownItem label="Prince Edward Island" value="PE" />
-            <GoabDropdownItem label="Quebec" value="QC" />
-            <GoabDropdownItem label="Saskatchewan" value="SK" />
-            <GoabDropdownItem label="Yukon" value="YT" />
-          </GoabDropdown>
-        </GoabFormItem>
-        <GoabFormItem label="Postal Code">
-          <GoabInput
+            <GoabxDropdownItem label="Alberta" value="AB" />
+            <GoabxDropdownItem label="British Columbia" value="BC" />
+            <GoabxDropdownItem label="Manitoba" value="MB" />
+            <GoabxDropdownItem label="New Brunswick" value="NB" />
+            <GoabxDropdownItem label="Newfoundland and Labrador" value="NL" />
+            <GoabxDropdownItem label="Northwest Territories" value="NT" />
+            <GoabxDropdownItem label="Nova Scotia" value="NS" />
+            <GoabxDropdownItem label="Nunavut" value="NU" />
+            <GoabxDropdownItem label="Ontario" value="ON" />
+            <GoabxDropdownItem label="Prince Edward Island" value="PE" />
+            <GoabxDropdownItem label="Quebec" value="QC" />
+            <GoabxDropdownItem label="Saskatchewan" value="SK" />
+            <GoabxDropdownItem label="Yukon" value="YT" />
+          </GoabxDropdown>
+        </GoabxFormItem>
+        <GoabxFormItem label="Postal Code">
+          <GoabxInput
             name="postalCode"
             type="text"
             value={postalCode}
             onChange={(e) => setPostalCode(e.value)}
             width="7ch"
           />
-        </GoabFormItem>
+        </GoabxFormItem>
       </GoabBlock>
       <GoabButtonGroup alignment="start" mt="2xl">
-        <GoabButton type="primary" onClick={() => {}}>
+        <GoabxButton type="primary" onClick={() => {}}>
           Save and continue
-        </GoabButton>
-        <GoabButton type="secondary" onClick={() => {}}>
+        </GoabxButton>
+        <GoabxButton type="secondary" onClick={() => {}}>
           Cancel
-        </GoabButton>
+        </GoabxButton>
       </GoabButtonGroup>
     </>
   );

--- a/docs/src/content/examples/ask-a-user-for-an-address/web-components.html
+++ b/docs/src/content/examples/ask-a-user-for-an-address/web-components.html
@@ -1,16 +1,16 @@
 <goa-text size="heading-l" mt="none" mb="xl">What is your address?</goa-text>
-<goa-form-item label="Street Address">
-  <goa-input name="address" type="text" width="100%" id="address-input"></goa-input>
+<goa-form-item version="2" label="Street Address">
+  <goa-input version="2" name="address" type="text" width="100%" id="address-input"></goa-input>
 </goa-form-item>
-<goa-form-item label="Suite or unit #" mt="l">
-  <goa-input name="suite" type="text" width="100%" id="suite-input"></goa-input>
+<goa-form-item version="2" label="Suite or unit #" mt="l">
+  <goa-input version="2" name="suite" type="text" width="100%" id="suite-input"></goa-input>
 </goa-form-item>
-<goa-form-item label="City or town" mt="l">
-  <goa-input name="city" type="text" width="100%" id="city-input"></goa-input>
+<goa-form-item version="2" label="City or town" mt="l">
+  <goa-input version="2" name="city" type="text" width="100%" id="city-input"></goa-input>
 </goa-form-item>
 <goa-block direction="row" gap="l" mt="l">
-  <goa-form-item label="Province or territory">
-    <goa-dropdown name="province" id="province-dropdown">
+  <goa-form-item version="2" label="Province or territory">
+    <goa-dropdown version="2" name="province" id="province-dropdown">
       <goa-dropdown-item label="Alberta" value="AB"></goa-dropdown-item>
       <goa-dropdown-item label="British Columbia" value="BC"></goa-dropdown-item>
       <goa-dropdown-item label="Manitoba" value="MB"></goa-dropdown-item>
@@ -26,13 +26,13 @@
       <goa-dropdown-item label="Yukon" value="YT"></goa-dropdown-item>
     </goa-dropdown>
   </goa-form-item>
-  <goa-form-item label="Postal Code">
-    <goa-input name="postalCode" type="text" width="7ch" id="postal-input"></goa-input>
+  <goa-form-item version="2" label="Postal Code">
+    <goa-input version="2" name="postalCode" type="text" width="7ch" id="postal-input"></goa-input>
   </goa-form-item>
 </goa-block>
 <goa-button-group alignment="start" mt="2xl">
-  <goa-button type="primary" id="save-btn">Save and continue</goa-button>
-  <goa-button type="secondary" id="cancel-btn">Cancel</goa-button>
+  <goa-button version="2" type="primary" id="save-btn">Save and continue</goa-button>
+  <goa-button version="2" type="secondary" id="cancel-btn">Cancel</goa-button>
 </goa-button-group>
 
 <script>

--- a/docs/src/content/examples/ask-a-user-for-an-indian-registration-number/angular.html
+++ b/docs/src/content/examples/ask-a-user-for-an-indian-registration-number/angular.html
@@ -1,28 +1,28 @@
-<goab-form-item label="Indian registration number" labelSize="large">
+<goabx-form-item label="Indian registration number" labelSize="large">
   <goab-block gap="m" direction="row">
-    <goab-form-item label="Band #" helpText="3 digits">
-      <goab-input
+    <goabx-form-item label="Band #" helpText="3 digits">
+      <goabx-input
         [formControl]="form.controls.bandNo"
         name="bandNo"
         width="88px"
         [maxLength]="3">
-      </goab-input>
-    </goab-form-item>
-    <goab-form-item label="Family" helpText="Up to 5 digits">
-      <goab-input
+      </goabx-input>
+    </goabx-form-item>
+    <goabx-form-item label="Family" helpText="Up to 5 digits">
+      <goabx-input
         [formControl]="form.controls.family"
         name="family"
         width="105px"
         [maxLength]="5">
-      </goab-input>
-    </goab-form-item>
-    <goab-form-item label="Position" helpText="2 digits">
-      <goab-input
+      </goabx-input>
+    </goabx-form-item>
+    <goabx-form-item label="Position" helpText="2 digits">
+      <goabx-input
         [formControl]="form.controls.position"
         name="position"
         width="71px"
         [maxLength]="2">
-      </goab-input>
-    </goab-form-item>
+      </goabx-input>
+    </goabx-form-item>
   </goab-block>
-</goab-form-item>
+</goabx-form-item>

--- a/docs/src/content/examples/ask-a-user-for-an-indian-registration-number/react.tsx
+++ b/docs/src/content/examples/ask-a-user-for-an-indian-registration-number/react.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { GoabBlock, GoabFormItem, GoabInput } from "@abgov/react-components";
+import { GoabxFormItem, GoabxInput } from "@abgov/react-components/experimental";
+import { GoabBlock } from "@abgov/react-components";
 
 export function AskAUserForAnIndianRegistrationNumber() {
   const [bandNo, setBandNo] = useState("");
@@ -7,36 +8,36 @@ export function AskAUserForAnIndianRegistrationNumber() {
   const [position, setPosition] = useState("");
 
   return (
-    <GoabFormItem label="Indian registration number" labelSize="large">
+    <GoabxFormItem label="Indian registration number" labelSize="large">
       <GoabBlock gap="m" direction="row">
-        <GoabFormItem label="Band #" helpText="3 digits">
-          <GoabInput
+        <GoabxFormItem label="Band #" helpText="3 digits">
+          <GoabxInput
             onChange={(e) => setBandNo(e.value)}
             value={bandNo}
             name="bandNo"
             width="88px"
             maxLength={3}
           />
-        </GoabFormItem>
-        <GoabFormItem label="Family" helpText="Up to 5 digits">
-          <GoabInput
+        </GoabxFormItem>
+        <GoabxFormItem label="Family" helpText="Up to 5 digits">
+          <GoabxInput
             onChange={(e) => setFamily(e.value)}
             value={family}
             name="family"
             width="105px"
             maxLength={5}
           />
-        </GoabFormItem>
-        <GoabFormItem label="Position" helpText="2 digits">
-          <GoabInput
+        </GoabxFormItem>
+        <GoabxFormItem label="Position" helpText="2 digits">
+          <GoabxInput
             onChange={(e) => setPosition(e.value)}
             value={position}
             name="position"
             width="71px"
             maxLength={2}
           />
-        </GoabFormItem>
+        </GoabxFormItem>
       </GoabBlock>
-    </GoabFormItem>
+    </GoabxFormItem>
   );
 }

--- a/docs/src/content/examples/ask-a-user-for-an-indian-registration-number/web-components.html
+++ b/docs/src/content/examples/ask-a-user-for-an-indian-registration-number/web-components.html
@@ -1,23 +1,23 @@
-<goa-form-item label="Indian registration number" labelsize="large">
+<goa-form-item version="2" label="Indian registration number" labelsize="large">
   <goa-block gap="m" direction="row">
-    <goa-form-item label="Band #" helptext="3 digits">
-      <goa-input
+    <goa-form-item version="2" label="Band #" helptext="3 digits">
+      <goa-input version="2"
         name="bandNo"
         id="band-input"
         width="88px"
         maxlength="3">
       </goa-input>
     </goa-form-item>
-    <goa-form-item label="Family" helptext="Up to 5 digits">
-      <goa-input
+    <goa-form-item version="2" label="Family" helptext="Up to 5 digits">
+      <goa-input version="2"
         name="family"
         id="family-input"
         width="105px"
         maxlength="5">
       </goa-input>
     </goa-form-item>
-    <goa-form-item label="Position" helptext="2 digits">
-      <goa-input
+    <goa-form-item version="2" label="Position" helptext="2 digits">
+      <goa-input version="2"
         name="position"
         id="position-input"
         width="71px"

--- a/docs/src/content/examples/ask-a-user-for-direct-deposit-information/angular.html
+++ b/docs/src/content/examples/ask-a-user-for-direct-deposit-information/angular.html
@@ -4,46 +4,46 @@
   Contact your bank if you can't find this information.
 </goab-text>
 <form [formGroup]="form">
-  <goab-form-item
+  <goabx-form-item
     label="Bank or Institution number"
     helpText="3-4 digits in length">
-    <goab-input
+    <goabx-input
       [maxLength]="4"
       name="bankNumber"
       [formControl]="form.controls.bankNumber"
       ariaLabel="bankNumber"
       width="88px">
-    </goab-input>
-  </goab-form-item>
-  <goab-form-item
+    </goabx-input>
+  </goabx-form-item>
+  <goabx-form-item
     label="Branch or Transit number"
     helpText="5 digits in length"
     mt="l">
-    <goab-input
+    <goabx-input
       [maxLength]="5"
       name="transitNumber"
       [formControl]="form.controls.transitNumber"
       ariaLabel="transitNumber"
       width="143px">
-    </goab-input>
-  </goab-form-item>
-  <goab-form-item
+    </goabx-input>
+  </goabx-form-item>
+  <goabx-form-item
     label="Account number"
     helpText="3-12 digits in length"
     mt="l">
-    <goab-input
+    <goabx-input
       [maxLength]="12"
       name="accountNumber"
       [formControl]="form.controls.accountNumber"
       ariaLabel="accountNumber">
-    </goab-input>
-  </goab-form-item>
+    </goabx-input>
+  </goabx-form-item>
 </form>
 <goab-details heading="Where can I find this information on a personal cheque?" mt="l">
   <goab-text as="p" mb="m">Below is an example of where you can find the required bank information on a personal cheque.</goab-text>
   <img src="https://design.alberta.ca/images/details-demo.jpg" alt="Cheque example" />
 </goab-details>
 
-<goab-button type="submit" mt="2xl" (onClick)="onSubmit()">
+<goabx-button type="submit" mt="2xl" (onClick)="onSubmit()">
   Save and continue
-</goab-button>
+</goabx-button>

--- a/docs/src/content/examples/ask-a-user-for-direct-deposit-information/react.tsx
+++ b/docs/src/content/examples/ask-a-user-for-direct-deposit-information/react.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { GoabButton, GoabDetails, GoabFormItem, GoabInput, GoabText } from "@abgov/react-components";
+import { GoabxButton, GoabxFormItem, GoabxInput } from "@abgov/react-components/experimental";
+import { GoabDetails, GoabText } from "@abgov/react-components";
 
 export function AskAUserForDirectDepositInformation() {
   const [bankNumber, setBankNumber] = useState("");
@@ -14,11 +15,11 @@ export function AskAUserForDirectDepositInformation() {
         Contact your bank if you can't find this information.
       </GoabText>
       <form>
-        <GoabFormItem
+        <GoabxFormItem
           label="Bank or Institution number"
           helpText="3-4 digits in length"
         >
-          <GoabInput
+          <GoabxInput
             maxLength={4}
             name="bankNumber"
             onChange={(e) => setBankNumber(e.value)}
@@ -26,13 +27,13 @@ export function AskAUserForDirectDepositInformation() {
             ariaLabel="bankNumber"
             width="88px"
           />
-        </GoabFormItem>
-        <GoabFormItem
+        </GoabxFormItem>
+        <GoabxFormItem
           label="Branch or Transit number"
           helpText="5 digits in length"
           mt="l"
         >
-          <GoabInput
+          <GoabxInput
             maxLength={5}
             name="transitNumber"
             onChange={(e) => setTransitNumber(e.value)}
@@ -40,20 +41,20 @@ export function AskAUserForDirectDepositInformation() {
             ariaLabel="transitNumber"
             width="143px"
           />
-        </GoabFormItem>
-        <GoabFormItem
+        </GoabxFormItem>
+        <GoabxFormItem
           label="Account number"
           helpText="3-12 digits in length"
           mt="l"
         >
-          <GoabInput
+          <GoabxInput
             maxLength={12}
             name="accountNumber"
             value={accountNumber}
             onChange={(e) => setAccountNumber(e.value)}
             ariaLabel="accountNumber"
           />
-        </GoabFormItem>
+        </GoabxFormItem>
       </form>
       <GoabDetails heading="Where can I find this information on a personal cheque?" mt="l">
         <GoabText as="p" mb="m">
@@ -63,9 +64,9 @@ export function AskAUserForDirectDepositInformation() {
         <img src="https://design.alberta.ca/images/details-demo.jpg" alt="Cheque example showing bank information locations" />
       </GoabDetails>
 
-      <GoabButton type="submit" mt="2xl">
+      <GoabxButton type="submit" mt="2xl">
         Save and continue
-      </GoabButton>
+      </GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/ask-a-user-for-direct-deposit-information/web-components.html
+++ b/docs/src/content/examples/ask-a-user-for-direct-deposit-information/web-components.html
@@ -4,10 +4,10 @@
   Contact your bank if you can't find this information.
 </goa-text>
 <form>
-  <goa-form-item
+  <goa-form-item version="2"
     label="Bank or Institution number"
     helptext="3-4 digits in length">
-    <goa-input
+    <goa-input version="2"
       maxlength="4"
       name="bankNumber"
       id="bank-number-input"
@@ -15,11 +15,11 @@
       width="88px">
     </goa-input>
   </goa-form-item>
-  <goa-form-item
+  <goa-form-item version="2"
     label="Branch or Transit number"
     helptext="5 digits in length"
     mt="l">
-    <goa-input
+    <goa-input version="2"
       maxlength="5"
       name="transitNumber"
       id="transit-number-input"
@@ -27,11 +27,11 @@
       width="143px">
     </goa-input>
   </goa-form-item>
-  <goa-form-item
+  <goa-form-item version="2"
     label="Account number"
     helptext="3-12 digits in length"
     mt="l">
-    <goa-input
+    <goa-input version="2"
       maxlength="12"
       name="accountNumber"
       id="account-number-input"
@@ -44,7 +44,7 @@
   <img src="https://design.alberta.ca/images/details-demo.jpg" alt="Cheque example" />
 </goa-details>
 
-<goa-button id="submit-btn" type="submit" mt="2xl">
+<goa-button version="2" id="submit-btn" type="submit" mt="2xl">
   Save and continue
 </goa-button>
 

--- a/docs/src/content/examples/ask-a-user-for-dollar-amounts/angular.html
+++ b/docs/src/content/examples/ask-a-user-for-dollar-amounts/angular.html
@@ -1,17 +1,17 @@
 <form [formGroup]="costFormGroup">
-  <goab-form-item label="Tuition">
-    <goab-input name="tuition" formControlName="tuitionFeeAmount">
+  <goabx-form-item label="Tuition">
+    <goabx-input name="tuition" formControlName="tuitionFeeAmount">
       <div slot="leadingContent">$</div>
-    </goab-input>
-  </goab-form-item>
-  <goab-form-item label="Books/Supplies/Instruments" mt="l">
-    <goab-input name="book" formControlName="suppliesAmount">
+    </goabx-input>
+  </goabx-form-item>
+  <goabx-form-item label="Books/Supplies/Instruments" mt="l">
+    <goabx-input name="book" formControlName="suppliesAmount">
       <div slot="leadingContent">$</div>
-    </goab-input>
-  </goab-form-item>
-  <goab-form-item label="Other costs" mt="l">
-    <goab-input name="others" formControlName="othersAmount">
+    </goabx-input>
+  </goabx-form-item>
+  <goabx-form-item label="Other costs" mt="l">
+    <goabx-input name="others" formControlName="othersAmount">
       <div slot="leadingContent">$</div>
-    </goab-input>
-  </goab-form-item>
+    </goabx-input>
+  </goabx-form-item>
 </form>

--- a/docs/src/content/examples/ask-a-user-for-dollar-amounts/react.tsx
+++ b/docs/src/content/examples/ask-a-user-for-dollar-amounts/react.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { GoabFormItem, GoabInput } from "@abgov/react-components";
+import { GoabxFormItem, GoabxInput } from "@abgov/react-components/experimental";
 
 export function AskAUserForDollarAmounts() {
   const [tuitionAmount, setTuitionAmount] = useState("");
@@ -8,30 +8,30 @@ export function AskAUserForDollarAmounts() {
 
   return (
     <>
-      <GoabFormItem label="Tuition">
-        <GoabInput
+      <GoabxFormItem label="Tuition">
+        <GoabxInput
           onChange={(e) => setTuitionAmount(e.value)}
           value={tuitionAmount}
           name="tuitionAmount"
           leadingContent="$"
         />
-      </GoabFormItem>
-      <GoabFormItem label="Books/Supplies/Instruments" mt="l">
-        <GoabInput
+      </GoabxFormItem>
+      <GoabxFormItem label="Books/Supplies/Instruments" mt="l">
+        <GoabxInput
           onChange={(e) => setSuppliesAmount(e.value)}
           value={suppliesAmount}
           name="suppliesAmount"
           leadingContent="$"
         />
-      </GoabFormItem>
-      <GoabFormItem label="Other costs" mt="l">
-        <GoabInput
+      </GoabxFormItem>
+      <GoabxFormItem label="Other costs" mt="l">
+        <GoabxInput
           onChange={(e) => setOthersAmount(e.value)}
           value={othersAmount}
           name="othersAmount"
           leadingContent="$"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
     </>
   );
 }

--- a/docs/src/content/examples/ask-a-user-for-dollar-amounts/web-components.html
+++ b/docs/src/content/examples/ask-a-user-for-dollar-amounts/web-components.html
@@ -1,16 +1,16 @@
 <form>
-  <goa-form-item label="Tuition">
-    <goa-input name="tuition" id="tuition-input">
+  <goa-form-item version="2" label="Tuition">
+    <goa-input version="2" name="tuition" id="tuition-input">
       <div slot="leadingContent">$</div>
     </goa-input>
   </goa-form-item>
-  <goa-form-item label="Books/Supplies/Instruments" mt="l">
-    <goa-input name="book" id="supplies-input">
+  <goa-form-item version="2" label="Books/Supplies/Instruments" mt="l">
+    <goa-input version="2" name="book" id="supplies-input">
       <div slot="leadingContent">$</div>
     </goa-input>
   </goa-form-item>
-  <goa-form-item label="Other costs" mt="l">
-    <goa-input name="others" id="others-input">
+  <goa-form-item version="2" label="Other costs" mt="l">
+    <goa-input version="2" name="others" id="others-input">
       <div slot="leadingContent">$</div>
     </goa-input>
   </goa-form-item>

--- a/docs/src/content/examples/ask-a-user-one-question-at-a-time/angular.html
+++ b/docs/src/content/examples/ask-a-user-one-question-at-a-time/angular.html
@@ -1,16 +1,16 @@
-<goab-link leadingIcon="arrow-back" size="small">
+<goabx-link leadingIcon="arrow-back" size="small">
   <a href="#">Back</a>
-</goab-link>
-<goab-form-item
+</goabx-link>
+<goabx-form-item
   mt="xl"
   label="Are you currently in school?"
   labelSize="large"
   helpText="School includes foundational, skills and employment training, micro-credentials, post-secondary and continuing education.">
-  <goab-radio-group name="school" ariaLabel="are you currently in school?" (onChange)="onSchoolChange($event)">
-    <goab-radio-item value="yes" label="Yes"></goab-radio-item>
-    <goab-radio-item value="no" label="No"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>
-<goab-button type="submit" mt="2xl">
+  <goabx-radio-group name="school" ariaLabel="are you currently in school?" (onChange)="onSchoolChange($event)">
+    <goabx-radio-item value="yes" label="Yes"></goabx-radio-item>
+    <goabx-radio-item value="no" label="No"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>
+<goabx-button type="submit" mt="2xl">
   Save and continue
-</goab-button>
+</goabx-button>

--- a/docs/src/content/examples/ask-a-user-one-question-at-a-time/react.tsx
+++ b/docs/src/content/examples/ask-a-user-one-question-at-a-time/react.tsx
@@ -1,30 +1,30 @@
 import {
-  GoabButton,
-  GoabFormItem,
-  GoabLink,
-  GoabRadioGroup,
-  GoabRadioItem
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxFormItem,
+  GoabxLink,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
 
 export function AskAUserOneQuestionAtATime() {
   return (
     <>
-      <GoabLink leadingIcon="arrow-back" size="small">
+      <GoabxLink leadingIcon="arrow-back" size="small">
         <a href="#">Back</a>
-      </GoabLink>
-      <GoabFormItem
+      </GoabxLink>
+      <GoabxFormItem
         mt="xl"
         label="Are you currently in school?"
         labelSize="large"
         helpText="School includes foundational, skills and employment training, micro-credentials, post-secondary and continuing education.">
-        <GoabRadioGroup name="school" ariaLabel="are you currently in school?" onChange={() => {}}>
-          <GoabRadioItem value="yes" label="Yes" />
-          <GoabRadioItem value="no" label="No" />
-        </GoabRadioGroup>
-      </GoabFormItem>
-      <GoabButton type="submit" mt="2xl">
+        <GoabxRadioGroup name="school" ariaLabel="are you currently in school?" onChange={() => {}}>
+          <GoabxRadioItem value="yes" label="Yes" />
+          <GoabxRadioItem value="no" label="No" />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
+      <GoabxButton type="submit" mt="2xl">
         Save and continue
-      </GoabButton>
+      </GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/ask-a-user-one-question-at-a-time/web-components.html
+++ b/docs/src/content/examples/ask-a-user-one-question-at-a-time/web-components.html
@@ -1,17 +1,17 @@
 <goa-link leadingicon="arrow-back" size="small">
   <a href="#">Back</a>
 </goa-link>
-<goa-form-item
+<goa-form-item version="2"
   mt="xl"
   label="Are you currently in school?"
   labelsize="large"
   helptext="School includes foundational, skills and employment training, micro-credentials, post-secondary and continuing education.">
-  <goa-radio-group name="school" aria-label="are you currently in school?">
+  <goa-radio-group version="2" name="school" aria-label="are you currently in school?">
     <goa-radio-item value="yes" label="Yes"></goa-radio-item>
     <goa-radio-item value="no" label="No"></goa-radio-item>
   </goa-radio-group>
 </goa-form-item>
-<goa-button type="submit" mt="2xl">
+<goa-button version="2" type="submit" mt="2xl">
   Save and continue
 </goa-button>
 

--- a/docs/src/content/examples/basic-page-layout/angular.html
+++ b/docs/src/content/examples/basic-page-layout/angular.html
@@ -20,6 +20,6 @@
     </goab-grid>
   </goab-page-block>
   <section slot="footer">
-    <goab-app-footer></goab-app-footer>
+    <goabx-app-footer></goabx-app-footer>
   </section>
 </goab-one-column-layout>

--- a/docs/src/content/examples/basic-page-layout/react.tsx
+++ b/docs/src/content/examples/basic-page-layout/react.tsx
@@ -1,11 +1,11 @@
+import { GoabxAppFooter } from "@abgov/react-components/experimental";
 import {
-  GoabAppFooter,
   GoabAppHeader,
   GoabGrid,
   GoabMicrositeHeader,
   GoabOneColumnLayout,
   GoabPageBlock,
-  GoabSkeleton
+  GoabSkeleton,
 } from "@abgov/react-components";
 
 export function BasicPageLayout() {
@@ -32,7 +32,7 @@ export function BasicPageLayout() {
         </GoabGrid>
       </GoabPageBlock>
       <section slot="footer">
-        <GoabAppFooter />
+        <GoabxAppFooter />
       </section>
     </GoabOneColumnLayout>
   );

--- a/docs/src/content/examples/basic-page-layout/web-components.html
+++ b/docs/src/content/examples/basic-page-layout/web-components.html
@@ -20,6 +20,6 @@
     </goa-grid>
   </goa-page-block>
   <section slot="footer">
-    <goa-app-footer></goa-app-footer>
+    <goa-app-footer version="2"></goa-app-footer>
   </section>
 </goa-one-column-layout>

--- a/docs/src/content/examples/button-with-icon/angular.html
+++ b/docs/src/content/examples/button-with-icon/angular.html
@@ -1,5 +1,5 @@
 <goab-button-group>
-  <goab-button leadingIcon="arrow-back">Go back</goab-button>
-  <goab-button trailingIcon="arrow-forward">Continue</goab-button>
-  <goab-button type="secondary" leadingIcon="add">Add item</goab-button>
+  <goabx-button leadingIcon="arrow-back">Go back</goabx-button>
+  <goabx-button trailingIcon="arrow-forward">Continue</goabx-button>
+  <goabx-button type="secondary" leadingIcon="add">Add item</goabx-button>
 </goab-button-group>

--- a/docs/src/content/examples/button-with-icon/react.tsx
+++ b/docs/src/content/examples/button-with-icon/react.tsx
@@ -1,11 +1,12 @@
-import { GoabButton, GoabButtonGroup } from "@abgov/react-components";
+import { GoabxButton } from "@abgov/react-components/experimental";
+import { GoabButtonGroup } from "@abgov/react-components";
 
 export function ButtonWithIcon() {
   return (
     <GoabButtonGroup>
-      <GoabButton leadingIcon="arrow-back">Go back</GoabButton>
-      <GoabButton trailingIcon="arrow-forward">Continue</GoabButton>
-      <GoabButton type="secondary" leadingIcon="add">Add item</GoabButton>
+      <GoabxButton leadingIcon="arrow-back">Go back</GoabxButton>
+      <GoabxButton trailingIcon="arrow-forward">Continue</GoabxButton>
+      <GoabxButton type="secondary" leadingIcon="add">Add item</GoabxButton>
     </GoabButtonGroup>
   );
 }

--- a/docs/src/content/examples/button-with-icon/web-components.html
+++ b/docs/src/content/examples/button-with-icon/web-components.html
@@ -1,5 +1,5 @@
 <goa-button-group>
-  <goa-button leadingicon="arrow-back">Go back</goa-button>
-  <goa-button trailingicon="arrow-forward">Continue</goa-button>
-  <goa-button type="secondary" leadingicon="add">Add item</goa-button>
+  <goa-button version="2" leadingicon="arrow-back">Go back</goa-button>
+  <goa-button version="2" trailingicon="arrow-forward">Continue</goa-button>
+  <goa-button version="2" type="secondary" leadingicon="add">Add item</goa-button>
 </goa-button-group>

--- a/docs/src/content/examples/card-grid/angular.html
+++ b/docs/src/content/examples/card-grid/angular.html
@@ -1,8 +1,8 @@
 <goab-grid gap="xl" minChildWidth="320px">
   <goab-container accent="thin" mb="none">
-    <goab-link size="large" mb="m">
+    <goabx-link size="large" mb="m">
       <a href="#">Waitlist submission</a>
-    </goab-link>
+    </goabx-link>
     <goab-text mt="none" mb="none">
       Enter and maintain information about the households waiting for affordable housing
       with your organization.
@@ -10,9 +10,9 @@
   </goab-container>
 
   <goab-container accent="thin" mb="none">
-    <goab-link size="large" mb="m">
+    <goabx-link size="large" mb="m">
       <a href="#">Lodge assistance program</a>
-    </goab-link>
+    </goabx-link>
     <goab-text mt="none" mb="none">
       Keep track of the individuals who are placed in lodges and may qualify for the Lodge
       Assistance Program subsidy.
@@ -20,9 +20,9 @@
   </goab-container>
 
   <goab-container accent="thin" mb="none">
-    <goab-link size="large" mb="m">
+    <goabx-link size="large" mb="m">
       <a href="#">Education Support</a>
-    </goab-link>
+    </goabx-link>
     <goab-text mt="none" mb="none">
       Explore educational resources, enroll in courses, and track your academic progress
       effortlessly.
@@ -30,9 +30,9 @@
   </goab-container>
 
   <goab-container accent="thin" mb="none">
-    <goab-link size="large" mb="m">
+    <goabx-link size="large" mb="m">
       <a href="#">Social Assistance</a>
-    </goab-link>
+    </goabx-link>
     <goab-text mt="none" mb="none">
       Learn about available support programs, apply for financial aid, and access community
       resources.
@@ -40,9 +40,9 @@
   </goab-container>
 
   <goab-container accent="thin" mb="none">
-    <goab-link size="large" mb="m">
+    <goabx-link size="large" mb="m">
       <a href="#">Employment Opportunity</a>
-    </goab-link>
+    </goabx-link>
     <goab-text mt="none" mb="none">
       Search for job openings, access career development tools, and receive
       employment-related updates.
@@ -50,9 +50,9 @@
   </goab-container>
 
   <goab-container accent="thin" mb="none">
-    <goab-link size="large" mb="m">
+    <goabx-link size="large" mb="m">
       <a href="#">Housing Assistance</a>
-    </goab-link>
+    </goabx-link>
     <goab-text mt="none" mb="none">
       Find affordable housing options, apply for housing subsidies, and report maintenance
       issues seamlessly.

--- a/docs/src/content/examples/card-grid/react.tsx
+++ b/docs/src/content/examples/card-grid/react.tsx
@@ -1,12 +1,13 @@
-import { GoabContainer, GoabGrid, GoabLink, GoabText } from "@abgov/react-components";
+import { GoabxLink } from "@abgov/react-components/experimental";
+import { GoabContainer, GoabGrid, GoabText } from "@abgov/react-components";
 
 export function CardGrid() {
   return (
     <GoabGrid gap="xl" minChildWidth="320px">
       <GoabContainer accent="thin" mb="none">
-        <GoabLink size="large" mb="m">
+        <GoabxLink size="large" mb="m">
           <a href="#">Waitlist submission</a>
-        </GoabLink>
+        </GoabxLink>
         <GoabText mt="none" mb="none">
           Enter and maintain information about the households waiting for affordable housing
           with your organization.
@@ -14,9 +15,9 @@ export function CardGrid() {
       </GoabContainer>
 
       <GoabContainer accent="thin" mb="none">
-        <GoabLink size="large" mb="m">
+        <GoabxLink size="large" mb="m">
           <a href="#">Lodge assistance program</a>
-        </GoabLink>
+        </GoabxLink>
         <GoabText mt="none" mb="none">
           Keep track of the individuals who are placed in lodges and may qualify for the Lodge
           Assistance Program subsidy.
@@ -24,9 +25,9 @@ export function CardGrid() {
       </GoabContainer>
 
       <GoabContainer accent="thin" mb="none">
-        <GoabLink size="large" mb="m">
+        <GoabxLink size="large" mb="m">
           <a href="#">Education Support</a>
-        </GoabLink>
+        </GoabxLink>
         <GoabText mt="none" mb="none">
           Explore educational resources, enroll in courses, and track your academic progress
           effortlessly.
@@ -34,9 +35,9 @@ export function CardGrid() {
       </GoabContainer>
 
       <GoabContainer accent="thin" mb="none">
-        <GoabLink size="large" mb="m">
+        <GoabxLink size="large" mb="m">
           <a href="#">Social Assistance</a>
-        </GoabLink>
+        </GoabxLink>
         <GoabText mt="none" mb="none">
           Learn about available support programs, apply for financial aid, and access community
           resources.
@@ -44,9 +45,9 @@ export function CardGrid() {
       </GoabContainer>
 
       <GoabContainer accent="thin" mb="none">
-        <GoabLink size="large" mb="m">
+        <GoabxLink size="large" mb="m">
           <a href="#">Employment Opportunity</a>
-        </GoabLink>
+        </GoabxLink>
         <GoabText mt="none" mb="none">
           Search for job openings, access career development tools, and receive
           employment-related updates.
@@ -54,9 +55,9 @@ export function CardGrid() {
       </GoabContainer>
 
       <GoabContainer accent="thin" mb="none">
-        <GoabLink size="large" mb="m">
+        <GoabxLink size="large" mb="m">
           <a href="#">Housing Assistance</a>
-        </GoabLink>
+        </GoabxLink>
         <GoabText mt="none" mb="none">
           Find affordable housing options, apply for housing subsidies, and report maintenance
           issues seamlessly.

--- a/docs/src/content/examples/card-view-of-case-files/angular.html
+++ b/docs/src/content/examples/card-view-of-case-files/angular.html
@@ -5,8 +5,8 @@
       <goab-text size="body-s" mt="none" mb="none">Submitted: April 23, 2023</goab-text>
     </goab-block>
     <goab-block direction="row" gap="l" alignment="center">
-      <goab-badge type="midtone" content="Not started"></goab-badge>
-      <goab-button type="tertiary" size="compact">Start</goab-button>
+      <goabx-badge type="midtone" content="Not started"></goabx-badge>
+      <goabx-button type="tertiary" size="compact">Start</goabx-button>
     </goab-block>
   </div>
 </goab-container>
@@ -18,8 +18,8 @@
       <goab-text size="body-s" mt="none" mb="none">Submitted: April 9, 2022</goab-text>
     </goab-block>
     <goab-block direction="row" gap="l" alignment="center">
-      <goab-badge type="important" content="Information needed"></goab-badge>
-      <goab-button type="tertiary" size="compact">Edit</goab-button>
+      <goabx-badge type="important" content="Information needed"></goabx-badge>
+      <goabx-button type="tertiary" size="compact">Edit</goabx-button>
     </goab-block>
   </div>
 </goab-container>
@@ -31,8 +31,8 @@
       <goab-text size="body-s" mt="none" mb="none">Submitted: April 14, 2021</goab-text>
     </goab-block>
     <goab-block direction="row" gap="l" alignment="center">
-      <goab-badge type="success" content="Approved"></goab-badge>
-      <goab-button type="tertiary" size="compact">View</goab-button>
+      <goabx-badge type="success" content="Approved"></goabx-badge>
+      <goabx-button type="tertiary" size="compact">View</goabx-button>
     </goab-block>
   </div>
 </goab-container>

--- a/docs/src/content/examples/card-view-of-case-files/react.tsx
+++ b/docs/src/content/examples/card-view-of-case-files/react.tsx
@@ -1,4 +1,5 @@
-import { GoabBadge, GoabBlock, GoabButton, GoabContainer, GoabText } from "@abgov/react-components";
+import { GoabxBadge, GoabxButton } from "@abgov/react-components/experimental";
+import { GoabBlock, GoabContainer, GoabText } from "@abgov/react-components";
 
 export function CardViewOfCaseFiles() {
   return (
@@ -20,8 +21,8 @@ export function CardViewOfCaseFiles() {
             <GoabText size="body-s" mt="none" mb="none">Submitted: April 23, 2023</GoabText>
           </GoabBlock>
           <GoabBlock direction="row" gap="l" alignment="center">
-            <GoabBadge type="midtone" content="Not started" />
-            <GoabButton type="tertiary" size="compact">Start</GoabButton>
+            <GoabxBadge type="midtone" content="Not started" />
+            <GoabxButton type="tertiary" size="compact">Start</GoabxButton>
           </GoabBlock>
         </div>
       </GoabContainer>
@@ -33,8 +34,8 @@ export function CardViewOfCaseFiles() {
             <GoabText size="body-s" mt="none" mb="none">Submitted: April 9, 2022</GoabText>
           </GoabBlock>
           <GoabBlock direction="row" gap="l" alignment="center">
-            <GoabBadge type="important" content="Information needed" />
-            <GoabButton type="tertiary" size="compact">Edit</GoabButton>
+            <GoabxBadge type="important" content="Information needed" />
+            <GoabxButton type="tertiary" size="compact">Edit</GoabxButton>
           </GoabBlock>
         </div>
       </GoabContainer>
@@ -46,8 +47,8 @@ export function CardViewOfCaseFiles() {
             <GoabText size="body-s" mt="none" mb="none">Submitted: April 14, 2021</GoabText>
           </GoabBlock>
           <GoabBlock direction="row" gap="l" alignment="center">
-            <GoabBadge type="success" content="Approved" />
-            <GoabButton type="tertiary" size="compact">View</GoabButton>
+            <GoabxBadge type="success" content="Approved" />
+            <GoabxButton type="tertiary" size="compact">View</GoabxButton>
           </GoabBlock>
         </div>
       </GoabContainer>

--- a/docs/src/content/examples/card-view-of-case-files/web-components.html
+++ b/docs/src/content/examples/card-view-of-case-files/web-components.html
@@ -15,8 +15,8 @@
       <goa-text size="body-s" mt="none" mb="none">Submitted: April 23, 2023</goa-text>
     </goa-block>
     <goa-block direction="row" gap="l" alignment="center">
-      <goa-badge type="midtone" content="Not started"></goa-badge>
-      <goa-button type="tertiary" size="compact">Start</goa-button>
+      <goa-badge version="2" type="midtone" content="Not started"></goa-badge>
+      <goa-button version="2" type="tertiary" size="compact">Start</goa-button>
     </goa-block>
   </div>
 </goa-container>
@@ -28,8 +28,8 @@
       <goa-text size="body-s" mt="none" mb="none">Submitted: April 9, 2022</goa-text>
     </goa-block>
     <goa-block direction="row" gap="l" alignment="center">
-      <goa-badge type="important" content="Information needed"></goa-badge>
-      <goa-button type="tertiary" size="compact">Edit</goa-button>
+      <goa-badge version="2" type="important" content="Information needed"></goa-badge>
+      <goa-button version="2" type="tertiary" size="compact">Edit</goa-button>
     </goa-block>
   </div>
 </goa-container>
@@ -41,8 +41,8 @@
       <goa-text size="body-s" mt="none" mb="none">Submitted: April 14, 2021</goa-text>
     </goa-block>
     <goa-block direction="row" gap="l" alignment="center">
-      <goa-badge type="success" content="Approved"></goa-badge>
-      <goa-button type="tertiary" size="compact">View</goa-button>
+      <goa-badge version="2" type="success" content="Approved"></goa-badge>
+      <goa-button version="2" type="tertiary" size="compact">View</goa-button>
     </goa-block>
   </div>
 </goa-container>

--- a/docs/src/content/examples/communicate-a-future-service-outage/angular.html
+++ b/docs/src/content/examples/communicate-a-future-service-outage/angular.html
@@ -1,5 +1,5 @@
-<goab-notification type="important">
+<goabx-notification type="important">
   Our system will be under maintenance from Thursday, September 15, 2025 at 10 pm
   to Friday, September 16, 2025 at 10 am. If you have questions or concerns,
   contact us at <a href="mailto:support@example.com">support&#64;example.com</a>.
-</goab-notification>
+</goabx-notification>

--- a/docs/src/content/examples/communicate-a-future-service-outage/react.tsx
+++ b/docs/src/content/examples/communicate-a-future-service-outage/react.tsx
@@ -1,11 +1,11 @@
-import { GoabNotification } from "@abgov/react-components";
+import { GoabxNotification } from "@abgov/react-components/experimental";
 
 export function CommunicateAFutureServiceOutage() {
   return (
-    <GoabNotification type="important">
+    <GoabxNotification type="important">
       Our system will be under maintenance from Thursday, September 15, 2025 at 10 pm
       to Friday, September 16, 2025 at 10 am. If you have questions or concerns,
       contact us at <a href="mailto:support@example.com">support@example.com</a>.
-    </GoabNotification>
+    </GoabxNotification>
   );
 }

--- a/docs/src/content/examples/communicate-a-future-service-outage/web-components.html
+++ b/docs/src/content/examples/communicate-a-future-service-outage/web-components.html
@@ -1,4 +1,4 @@
-<goa-notification type="important">
+<goa-notification version="2" type="important">
   Our system will be under maintenance from Thursday, September 15, 2025 at 10 pm
   to Friday, September 16, 2025 at 10 am. If you have questions or concerns,
   contact us at <a href="mailto:support@example.com">support@example.com</a>.

--- a/docs/src/content/examples/confirm-a-change/angular.html
+++ b/docs/src/content/examples/confirm-a-change/angular.html
@@ -1,23 +1,23 @@
-<goab-button (onClick)="toggleModal()">Save and continue</goab-button>
+<goabx-button (onClick)="toggleModal()">Save and continue</goabx-button>
 
-<goab-modal [open]="open" (onClose)="toggleModal()" heading="Address has changed" [actions]="actions">
+<goabx-modal [open]="open" (onClose)="toggleModal()" heading="Address has changed" [actions]="actions">
   <goab-container type="non-interactive" accent="filled" padding="compact" width="full">
     <goab-text as="h4" mt="none" mb="s">Before</goab-text>
     <goab-text mt="none">123456 78 Ave NW, Edmonton, Alberta</goab-text>
     <goab-text as="h4" mt="none" mb="s">After</goab-text>
     <goab-text mt="none" mb="none">881 12 Ave NW, Edmonton, Alberta</goab-text>
   </goab-container>
-  <goab-form-item label="Effective date" mt="l">
-    <goab-date-picker (onChange)="onChangeEffectiveDate($event)" name="effectiveDate" [value]="effectiveDate"></goab-date-picker>
-  </goab-form-item>
+  <goabx-form-item label="Effective date" mt="l">
+    <goabx-date-picker (onChange)="onChangeEffectiveDate($event)" name="effectiveDate" [value]="effectiveDate"></goabx-date-picker>
+  </goabx-form-item>
   <ng-template #actions>
     <goab-button-group alignment="end">
-      <goab-button type="secondary" size="compact" (onClick)="toggleModal()">
+      <goabx-button type="secondary" size="compact" (onClick)="toggleModal()">
         Undo address change
-      </goab-button>
-      <goab-button type="primary" size="compact" (onClick)="toggleModal()">
+      </goabx-button>
+      <goabx-button type="primary" size="compact" (onClick)="toggleModal()">
         Confirm
-      </goab-button>
+      </goabx-button>
     </goab-button-group>
   </ng-template>
-</goab-modal>
+</goabx-modal>

--- a/docs/src/content/examples/confirm-a-change/react.tsx
+++ b/docs/src/content/examples/confirm-a-change/react.tsx
@@ -1,13 +1,11 @@
 import { useState } from "react";
 import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabContainer,
-  GoabDatePicker,
-  GoabFormItem,
-  GoabModal,
-  GoabText
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxDatePicker,
+  GoabxFormItem,
+  GoabxModal,
+} from "@abgov/react-components/experimental";
+import { GoabButtonGroup, GoabContainer, GoabText } from "@abgov/react-components";
 import { GoabDatePickerOnChangeDetail } from "@abgov/ui-components-common";
 
 export function ConfirmAChange() {
@@ -20,20 +18,20 @@ export function ConfirmAChange() {
 
   return (
     <>
-      <GoabButton onClick={() => setOpen(true)}>Save and continue</GoabButton>
+      <GoabxButton onClick={() => setOpen(true)}>Save and continue</GoabxButton>
 
-      <GoabModal
+      <GoabxModal
         heading="Address has changed"
         open={open}
         onClose={() => setOpen(false)}
         actions={
           <GoabButtonGroup alignment="end">
-            <GoabButton type="secondary" size="compact" onClick={() => setOpen(false)}>
+            <GoabxButton type="secondary" size="compact" onClick={() => setOpen(false)}>
               Undo address change
-            </GoabButton>
-            <GoabButton type="primary" size="compact" onClick={() => setOpen(false)}>
+            </GoabxButton>
+            <GoabxButton type="primary" size="compact" onClick={() => setOpen(false)}>
               Confirm
-            </GoabButton>
+            </GoabxButton>
           </GoabButtonGroup>
         }>
         <GoabContainer type="non-interactive" accent="filled" padding="compact" width="full">
@@ -42,14 +40,14 @@ export function ConfirmAChange() {
           <GoabText as="h4" mt="none" mb="s">After</GoabText>
           <GoabText mt="none" mb="none">881 12 Ave NW, Edmonton, Alberta</GoabText>
         </GoabContainer>
-        <GoabFormItem label="Effective date" mt="l">
-          <GoabDatePicker
+        <GoabxFormItem label="Effective date" mt="l">
+          <GoabxDatePicker
             onChange={onChangeEffectiveDate}
             name="effectiveDate"
             value={effectiveDate}
           />
-        </GoabFormItem>
-      </GoabModal>
+        </GoabxFormItem>
+      </GoabxModal>
     </>
   );
 }

--- a/docs/src/content/examples/confirm-a-change/web-components.html
+++ b/docs/src/content/examples/confirm-a-change/web-components.html
@@ -1,21 +1,21 @@
-<goa-button id="open-modal-btn">Save and continue</goa-button>
+<goa-button version="2" id="open-modal-btn">Save and continue</goa-button>
 
-<goa-modal id="change-modal" heading="Address has changed">
+<goa-modal version="2" id="change-modal" heading="Address has changed">
   <goa-container type="non-interactive" accent="filled" padding="compact" width="full">
     <goa-text as="h4" mt="none" mb="s">Before</goa-text>
     <goa-text mt="none">123456 78 Ave NW, Edmonton, Alberta</goa-text>
     <goa-text as="h4" mt="none" mb="s">After</goa-text>
     <goa-text mt="none" mb="none">881 12 Ave NW, Edmonton, Alberta</goa-text>
   </goa-container>
-  <goa-form-item label="Effective date" mt="l">
-    <goa-date-picker id="effective-date" name="effectiveDate"></goa-date-picker>
+  <goa-form-item version="2" label="Effective date" mt="l">
+    <goa-date-picker version="2" id="effective-date" name="effectiveDate"></goa-date-picker>
   </goa-form-item>
   <div slot="actions">
     <goa-button-group alignment="end">
-      <goa-button type="secondary" size="compact" id="undo-btn">
+      <goa-button version="2" type="secondary" size="compact" id="undo-btn">
         Undo address change
       </goa-button>
-      <goa-button type="primary" size="compact" id="confirm-btn">
+      <goa-button version="2" type="primary" size="compact" id="confirm-btn">
         Confirm
       </goa-button>
     </goa-button-group>

--- a/docs/src/content/examples/confirm-a-destructive-action/angular.html
+++ b/docs/src/content/examples/confirm-a-destructive-action/angular.html
@@ -1,10 +1,10 @@
-<goab-button type="tertiary" leadingIcon="trash" (onClick)="toggleModal()">Delete record</goab-button>
-<goab-modal [open]="open" (onClose)="toggleModal()" heading="Are you sure you want to delete this record?" [actions]="actions">
+<goabx-button type="tertiary" leadingIcon="trash" (onClick)="toggleModal()">Delete record</goabx-button>
+<goabx-modal [open]="open" (onClose)="toggleModal()" heading="Are you sure you want to delete this record?" [actions]="actions">
   <p>This action cannot be undone.</p>
   <ng-template #actions>
     <goab-button-group alignment="end">
-      <goab-button type="tertiary" size="compact" (onClick)="toggleModal()">Cancel</goab-button>
-      <goab-button type="primary" variant="destructive" size="compact" (onClick)="toggleModal()">Delete record</goab-button>
+      <goabx-button type="tertiary" size="compact" (onClick)="toggleModal()">Cancel</goabx-button>
+      <goabx-button type="primary" variant="destructive" size="compact" (onClick)="toggleModal()">Delete record</goabx-button>
     </goab-button-group>
   </ng-template>
-</goab-modal>
+</goabx-modal>

--- a/docs/src/content/examples/confirm-a-destructive-action/react.tsx
+++ b/docs/src/content/examples/confirm-a-destructive-action/react.tsx
@@ -1,37 +1,38 @@
 import { useState } from "react";
-import { GoabButton, GoabButtonGroup, GoabModal } from "@abgov/react-components";
+import { GoabxButton, GoabxModal } from "@abgov/react-components/experimental";
+import { GoabButtonGroup } from "@abgov/react-components";
 
 export function ConfirmADestructiveAction() {
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      <GoabButton
+      <GoabxButton
         type="tertiary"
         leadingIcon="trash"
         onClick={() => setOpen(true)}>
         Delete record
-      </GoabButton>
-      <GoabModal
+      </GoabxButton>
+      <GoabxModal
         heading="Are you sure you want to delete this record?"
         open={open}
         onClose={() => setOpen(false)}
         actions={
           <GoabButtonGroup alignment="end">
-            <GoabButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
+            <GoabxButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
               Cancel
-            </GoabButton>
-            <GoabButton
+            </GoabxButton>
+            <GoabxButton
               type="primary"
               variant="destructive"
               size="compact"
               onClick={() => setOpen(false)}>
               Delete record
-            </GoabButton>
+            </GoabxButton>
           </GoabButtonGroup>
         }>
         <p>This action cannot be undone.</p>
-      </GoabModal>
+      </GoabxModal>
     </>
   );
 }

--- a/docs/src/content/examples/confirm-a-destructive-action/web-components.html
+++ b/docs/src/content/examples/confirm-a-destructive-action/web-components.html
@@ -1,10 +1,10 @@
-<goa-button type="tertiary" leadingicon="trash" id="delete-btn">Delete record</goa-button>
-<goa-modal id="delete-modal" heading="Are you sure you want to delete this record?">
+<goa-button version="2" type="tertiary" leadingicon="trash" id="delete-btn">Delete record</goa-button>
+<goa-modal version="2" id="delete-modal" heading="Are you sure you want to delete this record?">
   <p>This action cannot be undone.</p>
   <div slot="actions">
     <goa-button-group alignment="end">
-      <goa-button type="tertiary" size="compact" id="cancel-btn">Cancel</goa-button>
-      <goa-button type="primary" variant="destructive" size="compact" id="confirm-delete-btn">Delete record</goa-button>
+      <goa-button version="2" type="tertiary" size="compact" id="cancel-btn">Cancel</goa-button>
+      <goa-button version="2" type="primary" variant="destructive" size="compact" id="confirm-delete-btn">Delete record</goa-button>
     </goa-button-group>
   </div>
 </goa-modal>

--- a/docs/src/content/examples/confirm-before-navigating-away/angular.html
+++ b/docs/src/content/examples/confirm-before-navigating-away/angular.html
@@ -1,9 +1,9 @@
-<goab-button (onClick)="onOpen()">Open</goab-button>
-<goab-modal [open]="open" heading="Are you sure you want to change route?" [actions]="actions">
+<goabx-button (onClick)="onOpen()">Open</goabx-button>
+<goabx-modal [open]="open" heading="Are you sure you want to change route?" [actions]="actions">
   <ng-template #actions>
     <goab-button-group alignment="end">
-      <goab-button type="secondary" size="compact" (onClick)="onClose()">Cancel</goab-button>
-      <goab-button type="primary" size="compact" (onClick)="onChangeRoute()">Change route</goab-button>
+      <goabx-button type="secondary" size="compact" (onClick)="onClose()">Cancel</goabx-button>
+      <goabx-button type="primary" size="compact" (onClick)="onChangeRoute()">Change route</goabx-button>
     </goab-button-group>
   </ng-template>
-</goab-modal>
+</goabx-modal>

--- a/docs/src/content/examples/confirm-before-navigating-away/react.tsx
+++ b/docs/src/content/examples/confirm-before-navigating-away/react.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { GoabButton, GoabButtonGroup, GoabModal } from "@abgov/react-components";
+import { GoabxButton, GoabxModal } from "@abgov/react-components/experimental";
+import { GoabButtonGroup } from "@abgov/react-components";
 
 export function ConfirmBeforeNavigatingAway() {
   const [open, setOpen] = useState(false);
@@ -13,19 +14,19 @@ export function ConfirmBeforeNavigatingAway() {
 
   return (
     <>
-      <GoabButton onClick={() => setOpen(true)}>Open</GoabButton>
-      <GoabModal
+      <GoabxButton onClick={() => setOpen(true)}>Open</GoabxButton>
+      <GoabxModal
         heading="Are you sure you want to change route?"
         open={open}
         onClose={() => setOpen(false)}
         actions={
           <GoabButtonGroup alignment="end">
-            <GoabButton type="secondary" size="compact" onClick={() => setOpen(false)}>
+            <GoabxButton type="secondary" size="compact" onClick={() => setOpen(false)}>
               Cancel
-            </GoabButton>
-            <GoabButton type="primary" size="compact" onClick={handleChangeRoute}>
+            </GoabxButton>
+            <GoabxButton type="primary" size="compact" onClick={handleChangeRoute}>
               Change route
-            </GoabButton>
+            </GoabxButton>
           </GoabButtonGroup>
         }
       />

--- a/docs/src/content/examples/confirm-before-navigating-away/web-components.html
+++ b/docs/src/content/examples/confirm-before-navigating-away/web-components.html
@@ -1,9 +1,9 @@
-<goa-button id="open-btn">Open</goa-button>
-<goa-modal id="route-modal" heading="Are you sure you want to change route?">
+<goa-button version="2" id="open-btn">Open</goa-button>
+<goa-modal version="2" id="route-modal" heading="Are you sure you want to change route?">
   <div slot="actions">
     <goa-button-group alignment="end">
-      <goa-button type="secondary" size="compact" id="cancel-btn">Cancel</goa-button>
-      <goa-button type="primary" size="compact" id="change-route-btn">Change route</goa-button>
+      <goa-button version="2" type="secondary" size="compact" id="cancel-btn">Cancel</goa-button>
+      <goa-button version="2" type="primary" size="compact" id="change-route-btn">Change route</goa-button>
     </goa-button-group>
   </div>
 </goa-modal>

--- a/docs/src/content/examples/confirm-that-an-application-was-submitted/angular.html
+++ b/docs/src/content/examples/confirm-that-an-application-was-submitted/angular.html
@@ -1,9 +1,9 @@
 <goab-text as="h1" mt="none">You have completed the application</goab-text>
 
-<goab-callout type="success" heading="Your application was successful">
+<goabx-callout type="success" heading="Your application was successful">
   <goab-text mt="none" mb="m">You will receive a copy of the confirmation to the email person&#64;email.com</goab-text>
   <goab-text mt="none" mb="none">Confirmation number: <strong>1234ABC</strong></goab-text>
-</goab-callout>
+</goabx-callout>
 
 <goab-text as="h2" mt="xl" mb="m">Go back to the dashboard, or direct your user somewhere else useful.</goab-text>
 <goab-text>Other information about what was just completed, other tertiary information, and/or contact information.
@@ -14,6 +14,6 @@ Email: <a href="mailto:information@gov.ab.ca">information&#64;gov.ab.ca</a>
 </goab-text>
 
 <goab-button-group alignment="start" mt="2xl">
-  <goab-button type="primary">Go to application</goab-button>
-  <goab-button type="secondary">Back to dashboard</goab-button>
+  <goabx-button type="primary">Go to application</goabx-button>
+  <goabx-button type="secondary">Back to dashboard</goabx-button>
 </goab-button-group>

--- a/docs/src/content/examples/confirm-that-an-application-was-submitted/react.tsx
+++ b/docs/src/content/examples/confirm-that-an-application-was-submitted/react.tsx
@@ -1,14 +1,15 @@
-import { GoabButton, GoabButtonGroup, GoabCallout, GoabText } from "@abgov/react-components";
+import { GoabxButton, GoabxCallout } from "@abgov/react-components/experimental";
+import { GoabButtonGroup, GoabText } from "@abgov/react-components";
 
 export function ConfirmThatAnApplicationWasSubmitted() {
   return (
     <>
       <GoabText as="h1" mt="none">You have completed the application</GoabText>
 
-      <GoabCallout type="success" heading="Your application was successful">
+      <GoabxCallout type="success" heading="Your application was successful">
         <GoabText mt="none" mb="m">You will receive a copy of the confirmation to the email person@email.com</GoabText>
         <GoabText mt="none" mb="none">Confirmation number: <strong>1234ABC</strong></GoabText>
-      </GoabCallout>
+      </GoabxCallout>
 
       <GoabText as="h2" mt="xl" mb="m">Go back to the dashboard, or direct your user somewhere else useful.</GoabText>
       <GoabText>
@@ -20,8 +21,8 @@ export function ConfirmThatAnApplicationWasSubmitted() {
       </GoabText>
 
       <GoabButtonGroup alignment="start" mt="2xl">
-        <GoabButton type="primary">Go to application</GoabButton>
-        <GoabButton type="secondary">Back to dashboard</GoabButton>
+        <GoabxButton type="primary">Go to application</GoabxButton>
+        <GoabxButton type="secondary">Back to dashboard</GoabxButton>
       </GoabButtonGroup>
     </>
   );

--- a/docs/src/content/examples/confirm-that-an-application-was-submitted/web-components.html
+++ b/docs/src/content/examples/confirm-that-an-application-was-submitted/web-components.html
@@ -1,6 +1,6 @@
 <goa-text as="h1" mt="none">You have completed the application</goa-text>
 
-<goa-callout type="success" heading="Your application was successful">
+<goa-callout version="2" type="success" heading="Your application was successful">
   <goa-text mt="none" mb="m">You will receive a copy of the confirmation to the email person@email.com</goa-text>
   <goa-text mt="none" mb="none">Confirmation number: <strong>1234ABC</strong></goa-text>
 </goa-callout>
@@ -14,6 +14,6 @@ Email: <a href="mailto:information@gov.ab.ca">information@gov.ab.ca</a>
 </goa-text>
 
 <goa-button-group alignment="start" mt="2xl">
-  <goa-button type="primary">Go to application</goa-button>
-  <goa-button type="secondary">Back to dashboard</goa-button>
+  <goa-button version="2" type="primary">Go to application</goa-button>
+  <goa-button version="2" type="secondary">Back to dashboard</goa-button>
 </goa-button-group>

--- a/docs/src/content/examples/disabled-button-with-a-required-field/angular.html
+++ b/docs/src/content/examples/disabled-button-with-a-required-field/angular.html
@@ -1,20 +1,20 @@
 <form>
-  <goab-form-item label="Name" requirement="required">
-    <goab-input
+  <goabx-form-item label="Name" requirement="required">
+    <goabx-input
       name="input"
       type="text"
       (onChange)="onInputChange($event)"
       [value]="inputValue"
       width="100%">
-    </goab-input>
-  </goab-form-item>
+    </goabx-input>
+  </goabx-form-item>
 
   <goab-button-group alignment="start" mt="xl">
-    <goab-button [disabled]="isDisabled" (onClick)="onConfirm()">
+    <goabx-button [disabled]="isDisabled" (onClick)="onConfirm()">
       Confirm
-    </goab-button>
-    <goab-button type="secondary" (onClick)="onCancel()">
+    </goabx-button>
+    <goabx-button type="secondary" (onClick)="onCancel()">
       Cancel
-    </goab-button>
+    </goabx-button>
   </goab-button-group>
 </form>

--- a/docs/src/content/examples/disabled-button-with-a-required-field/react.tsx
+++ b/docs/src/content/examples/disabled-button-with-a-required-field/react.tsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
-import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabFormItem,
-  GoabInput
-} from "@abgov/react-components";
+import { GoabxButton, GoabxFormItem, GoabxInput } from "@abgov/react-components/experimental";
+import { GoabButtonGroup } from "@abgov/react-components";
 import { GoabInputOnChangeDetail } from "@abgov/ui-components-common";
 
 export function DisabledButtonWithARequiredField() {
@@ -26,23 +22,23 @@ export function DisabledButtonWithARequiredField() {
 
   return (
     <form>
-      <GoabFormItem label="Name" requirement="required">
-        <GoabInput
+      <GoabxFormItem label="Name" requirement="required">
+        <GoabxInput
           name="input"
           type="text"
           onChange={handleInputChange}
           value={inputValue}
           width="100%"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
 
       <GoabButtonGroup alignment="start" mt="xl">
-        <GoabButton disabled={inputValue.trim() === ""} onClick={handleConfirm}>
+        <GoabxButton disabled={inputValue.trim() === ""} onClick={handleConfirm}>
           Confirm
-        </GoabButton>
-        <GoabButton type="secondary" onClick={handleCancel}>
+        </GoabxButton>
+        <GoabxButton type="secondary" onClick={handleCancel}>
           Cancel
-        </GoabButton>
+        </GoabxButton>
       </GoabButtonGroup>
     </form>
   );

--- a/docs/src/content/examples/disabled-button-with-a-required-field/web-components.html
+++ b/docs/src/content/examples/disabled-button-with-a-required-field/web-components.html
@@ -1,11 +1,11 @@
 <form id="required-field-form">
-  <goa-form-item label="Name" requirement="required">
-    <goa-input id="name-input" name="input" type="text" width="100%"></goa-input>
+  <goa-form-item version="2" label="Name" requirement="required">
+    <goa-input version="2" id="name-input" name="input" type="text" width="100%"></goa-input>
   </goa-form-item>
 
   <goa-button-group alignment="start" mt="xl">
-    <goa-button id="confirm-btn" disabled="true">Confirm</goa-button>
-    <goa-button id="cancel-btn" type="secondary">Cancel</goa-button>
+    <goa-button version="2" id="confirm-btn" disabled="true">Confirm</goa-button>
+    <goa-button version="2" id="cancel-btn" type="secondary">Cancel</goa-button>
   </goa-button-group>
 </form>
 

--- a/docs/src/content/examples/display-numbers-in-a-table-so-they-can-be-scanned-easily/angular.html
+++ b/docs/src/content/examples/display-numbers-in-a-table-so-they-can-be-scanned-easily/angular.html
@@ -1,4 +1,4 @@
-<goab-table width="100%">
+<goabx-table width="100%">
   <thead>
     <tr>
       <th>First name</th>
@@ -33,4 +33,4 @@
       <td class="goa-table-number-column">7</td>
     </tr>
   </tbody>
-</goab-table>
+</goabx-table>

--- a/docs/src/content/examples/display-numbers-in-a-table-so-they-can-be-scanned-easily/react.tsx
+++ b/docs/src/content/examples/display-numbers-in-a-table-so-they-can-be-scanned-easily/react.tsx
@@ -1,8 +1,8 @@
-import { GoabTable } from "@abgov/react-components";
+import { GoabxTable } from "@abgov/react-components/experimental";
 
 export function DisplayNumbersInATableSoTheyCanBeScannedEasily() {
   return (
-    <GoabTable width="100%">
+    <GoabxTable width="100%">
       <thead>
         <tr>
           <th>First name</th>
@@ -37,6 +37,6 @@ export function DisplayNumbersInATableSoTheyCanBeScannedEasily() {
           <td className="goa-table-number-column">7</td>
         </tr>
       </tbody>
-    </GoabTable>
+    </GoabxTable>
   );
 }

--- a/docs/src/content/examples/display-numbers-in-a-table-so-they-can-be-scanned-easily/web-components.html
+++ b/docs/src/content/examples/display-numbers-in-a-table-so-they-can-be-scanned-easily/web-components.html
@@ -1,4 +1,4 @@
-<goa-table width="100%">
+<goa-table version="2" width="100%">
   <table style="width: 100%">
     <thead>
       <tr>

--- a/docs/src/content/examples/display-user-information/angular.html
+++ b/docs/src/content/examples/display-user-information/angular.html
@@ -16,11 +16,11 @@
 <goab-container type="non-interactive" accent="thick">
   <div slot="title">Upcoming important due dates</div>
   <div slot="actions">
-    <goab-button type="tertiary" size="compact" leadingIcon="calendar" (onClick)="onAddToCalendar()">
+    <goabx-button type="tertiary" size="compact" leadingIcon="calendar" (onClick)="onAddToCalendar()">
       Add to calendar
-    </goab-button>
+    </goabx-button>
   </div>
-  <goab-table width="100%" [striped]="true">
+  <goabx-table width="100%" [striped]="true">
     <tbody>
       <tr>
         <td>Business plan submission</td>
@@ -39,5 +39,5 @@
         <td style="text-align: right">January 3, 2025</td>
       </tr>
     </tbody>
-  </goab-table>
+  </goabx-table>
 </goab-container>

--- a/docs/src/content/examples/display-user-information/react.tsx
+++ b/docs/src/content/examples/display-user-information/react.tsx
@@ -1,10 +1,5 @@
-import {
-  GoabBlock,
-  GoabButton,
-  GoabContainer,
-  GoabTable,
-  GoabText
-} from "@abgov/react-components";
+import { GoabxButton, GoabxTable } from "@abgov/react-components/experimental";
+import { GoabBlock, GoabContainer, GoabText } from "@abgov/react-components";
 
 export function DisplayUserInformation() {
   const handleAddToCalendar = () => {
@@ -33,15 +28,15 @@ export function DisplayUserInformation() {
         accent="thick"
         heading="Upcoming important due dates"
         actions={
-          <GoabButton
+          <GoabxButton
             type="tertiary"
             size="compact"
             leadingIcon="calendar"
             onClick={handleAddToCalendar}>
             Add to calendar
-          </GoabButton>
+          </GoabxButton>
         }>
-        <GoabTable width="100%" striped>
+        <GoabxTable width="100%" striped>
           <tbody>
             <tr>
               <td>Business plan submission</td>
@@ -60,7 +55,7 @@ export function DisplayUserInformation() {
               <td style={{ textAlign: "right" }}>January 3, 2025</td>
             </tr>
           </tbody>
-        </GoabTable>
+        </GoabxTable>
       </GoabContainer>
     </>
   );

--- a/docs/src/content/examples/display-user-information/web-components.html
+++ b/docs/src/content/examples/display-user-information/web-components.html
@@ -16,11 +16,11 @@
 <goa-container type="non-interactive" accent="thick">
   <div slot="title">Upcoming important due dates</div>
   <div slot="actions">
-    <goa-button id="calendar-btn" type="tertiary" size="compact" leadingicon="calendar">
+    <goa-button version="2" id="calendar-btn" type="tertiary" size="compact" leadingicon="calendar">
       Add to calendar
     </goa-button>
   </div>
-  <goa-table width="100%" striped="true">
+  <goa-table version="2" width="100%" striped="true">
     <table style="width: 100%">
       <tbody>
         <tr>

--- a/docs/src/content/examples/dynamically-add-an-item-to-a-dropdown-list/angular.html
+++ b/docs/src/content/examples/dynamically-add-an-item-to-a-dropdown-list/angular.html
@@ -1,49 +1,49 @@
-<goab-form-item
+<goabx-form-item
   requirement="required"
   label="Name of item"
   [error]="taskError ? 'Please enter item name' : undefined"
   helpText="Add an item to the dropdown list below">
-  <goab-input
+  <goabx-input
     name="item"
     [value]="newTask"
     (onChange)="onNewTaskChange($event)">
-  </goab-input>
-</goab-form-item>
+  </goabx-input>
+</goabx-form-item>
 
-<goab-form-item mt="l" label="Add to">
-  <goab-radio-group
+<goabx-form-item mt="l" label="Add to">
+  <goabx-radio-group
     name="mountType"
     [value]="mountType"
     orientation="horizontal"
     (onChange)="onMountTypeChange($event)">
-    <goab-radio-item value="prepend" label="Start"></goab-radio-item>
-    <goab-radio-item value="append" label="End"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>
+    <goabx-radio-item value="prepend" label="Start"></goabx-radio-item>
+    <goabx-radio-item value="append" label="End"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>
 
 <goab-button-group alignment="start" gap="relaxed" mt="l">
-  <goab-button type="primary" (onClick)="addTask()">
+  <goabx-button type="primary" (onClick)="addTask()">
     Add new item
-  </goab-button>
-  <goab-button type="tertiary" (onClick)="reset()">
+  </goabx-button>
+  <goabx-button type="tertiary" (onClick)="reset()">
     Reset list
-  </goab-button>
+  </goabx-button>
 </goab-button-group>
 
 <goab-divider mt="l"></goab-divider>
 
-<goab-form-item mt="l" label="All items">
+<goabx-form-item mt="l" label="All items">
   <ng-container *ngIf="renderTrigger">
-    <goab-dropdown
+    <goabx-dropdown
       [value]="selectedTask"
       name="selectedTask"
       (onChange)="onSelectedTaskChange($event)">
-      <goab-dropdown-item
+      <goabx-dropdown-item
         *ngFor="let task of tasks; trackBy: trackByFn"
         [value]="task.value"
         [mountType]="task.mount"
         [label]="task.label">
-      </goab-dropdown-item>
-    </goab-dropdown>
+      </goabx-dropdown-item>
+    </goabx-dropdown>
   </ng-container>
-</goab-form-item>
+</goabx-form-item>

--- a/docs/src/content/examples/dynamically-add-an-item-to-a-dropdown-list/react.tsx
+++ b/docs/src/content/examples/dynamically-add-an-item-to-a-dropdown-list/react.tsx
@@ -1,15 +1,14 @@
 import { useState } from "react";
 import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabDivider,
-  GoabDropdown,
-  GoabDropdownItem,
-  GoabFormItem,
-  GoabInput,
-  GoabRadioGroup,
-  GoabRadioItem,
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
+import { GoabButtonGroup, GoabDivider } from "@abgov/react-components";
 import {
   GoabDropdownItemMountType,
   GoabDropdownOnChangeDetail,
@@ -69,43 +68,43 @@ export function DynamicallyAddAnItemToADropdownList() {
 
   return (
     <>
-      <GoabFormItem
+      <GoabxFormItem
           requirement="required"
           label="Name of item"
           error={taskError ? "Please enter item name" : undefined}
           helpText="Add an item to the dropdown list below">
-          <GoabInput
+          <GoabxInput
             onChange={(event: GoabInputOnChangeDetail) => setNewTask(event.value)}
             name="item"
             value={newTask}
           />
-        </GoabFormItem>
+        </GoabxFormItem>
 
-        <GoabFormItem mt="l" label="Add to">
-          <GoabRadioGroup
+        <GoabxFormItem mt="l" label="Add to">
+          <GoabxRadioGroup
             name="mountType"
             onChange={(event: GoabRadioGroupOnChangeDetail) => onMountTypeChange(event.value)}
             value={mountType}
             orientation="horizontal">
-            <GoabRadioItem value="prepend" label="Start" />
-            <GoabRadioItem value="append" label="End" />
-          </GoabRadioGroup>
-        </GoabFormItem>
+            <GoabxRadioItem value="prepend" label="Start" />
+            <GoabxRadioItem value="append" label="End" />
+          </GoabxRadioGroup>
+        </GoabxFormItem>
 
         <GoabButtonGroup alignment="start" gap="relaxed" mt="l">
-          <GoabButton type="primary" onClick={addTask}>
+          <GoabxButton type="primary" onClick={addTask}>
             Add new item
-          </GoabButton>
-          <GoabButton type="tertiary" onClick={reset}>
+          </GoabxButton>
+          <GoabxButton type="tertiary" onClick={reset}>
             Reset list
-          </GoabButton>
+          </GoabxButton>
         </GoabButtonGroup>
 
         <GoabDivider mt="l" />
 
-        <GoabFormItem mt="l" label="All items">
+        <GoabxFormItem mt="l" label="All items">
           <div style={{ width: isReset ? "320px" : "auto" }}>
-            <GoabDropdown
+            <GoabxDropdown
               key={tasks.length}
               onChange={(event: GoabDropdownOnChangeDetail) =>
                 setSelectedTask(event.value as string)
@@ -113,16 +112,16 @@ export function DynamicallyAddAnItemToADropdownList() {
               value={selectedTask}
               name="selectedTask">
               {tasks.map(task => (
-                <GoabDropdownItem
+                <GoabxDropdownItem
                   key={task.value}
                   value={task.value}
                   mountType={task.mount}
                   label={task.label}
                 />
               ))}
-            </GoabDropdown>
+            </GoabxDropdown>
           </div>
-      </GoabFormItem>
+      </GoabxFormItem>
     </>
   );
 }

--- a/docs/src/content/examples/dynamically-add-an-item-to-a-dropdown-list/web-components.html
+++ b/docs/src/content/examples/dynamically-add-an-item-to-a-dropdown-list/web-components.html
@@ -1,27 +1,27 @@
-<goa-form-item
+<goa-form-item version="2"
   id="item-form-item"
   requirement="required"
   label="Name of item"
   helptext="Add an item to the dropdown list below">
-  <goa-input id="item-input" name="item"></goa-input>
+  <goa-input version="2" id="item-input" name="item"></goa-input>
 </goa-form-item>
 
-<goa-form-item mt="l" label="Add to">
-  <goa-radio-group id="mount-type" name="mountType" value="append" orientation="horizontal">
+<goa-form-item version="2" mt="l" label="Add to">
+  <goa-radio-group version="2" id="mount-type" name="mountType" value="append" orientation="horizontal">
     <goa-radio-item value="prepend" label="Start"></goa-radio-item>
     <goa-radio-item value="append" label="End"></goa-radio-item>
   </goa-radio-group>
 </goa-form-item>
 
 <goa-button-group alignment="start" gap="relaxed" mt="l">
-  <goa-button id="add-btn" type="primary">Add new item</goa-button>
-  <goa-button id="reset-btn" type="tertiary">Reset list</goa-button>
+  <goa-button version="2" id="add-btn" type="primary">Add new item</goa-button>
+  <goa-button version="2" id="reset-btn" type="tertiary">Reset list</goa-button>
 </goa-button-group>
 
 <goa-divider mt="l"></goa-divider>
 
-<goa-form-item mt="l" label="All items">
-  <goa-dropdown id="task-dropdown" name="selectedTask">
+<goa-form-item version="2" mt="l" label="All items">
+  <goa-dropdown version="2" id="task-dropdown" name="selectedTask">
     <goa-dropdown-item value="finish-report" label="Finish Report"></goa-dropdown-item>
     <goa-dropdown-item value="attend-meeting" label="Attend Meeting"></goa-dropdown-item>
     <goa-dropdown-item value="reply-emails" label="Reply Emails"></goa-dropdown-item>

--- a/docs/src/content/examples/dynamically-change-items-in-a-dropdown-list/angular.html
+++ b/docs/src/content/examples/dynamically-change-items-in-a-dropdown-list/angular.html
@@ -1,20 +1,20 @@
 <div [formGroup]="changeForm" style="padding: 40px;">
-  <goab-form-item label="Size" requirement="optional" helpText="Choose the size to change the list below">
-    <goab-dropdown formControlName="parentDropdown" placeholder="Select a value" name="parent">
-      <goab-dropdown-item *ngFor="let parent of parents" [value]="parent" [label]="parent" />
-    </goab-dropdown>
-  </goab-form-item>
+  <goabx-form-item label="Size" requirement="optional" helpText="Choose the size to change the list below">
+    <goabx-dropdown formControlName="parentDropdown" placeholder="Select a value" name="parent">
+      <goabx-dropdown-item *ngFor="let parent of parents" [value]="parent" [label]="parent" />
+    </goabx-dropdown>
+  </goabx-form-item>
 
-  <goab-form-item label="Items" requirement="optional" mt="xl">
-    <goab-dropdown formControlName="childDropdown" placeholder="Select a value" name="children">
+  <goabx-form-item label="Items" requirement="optional" mt="xl">
+    <goabx-dropdown formControlName="childDropdown" placeholder="Select a value" name="children">
       <ng-container *ngIf="children.length > 0">
-        <goab-dropdown-item
+        <goabx-dropdown-item
           *ngFor="let child of children; trackBy: generateUniqueKey"
           [value]="child"
           [label]="child"
           [mountType]="'reset'"
         />
       </ng-container>
-    </goab-dropdown>
-  </goab-form-item>
+    </goabx-dropdown>
+  </goabx-form-item>
 </div>

--- a/docs/src/content/examples/dynamically-change-items-in-a-dropdown-list/react.tsx
+++ b/docs/src/content/examples/dynamically-change-items-in-a-dropdown-list/react.tsx
@@ -1,9 +1,5 @@
 import { useState } from "react";
-import {
-  GoabDropdown,
-  GoabDropdownItem,
-  GoabFormItem,
-} from "@abgov/react-components";
+import { GoabxDropdown, GoabxDropdownItem, GoabxFormItem } from "@abgov/react-components/experimental";
 import { GoabDropdownOnChangeDetail } from "@abgov/ui-components-common";
 
 export function DynamicallyChangeItemsInADropdownList() {
@@ -25,34 +21,34 @@ export function DynamicallyChangeItemsInADropdownList() {
 
   return (
     <>
-      <GoabFormItem
+      <GoabxFormItem
           label="Size"
           requirement="optional"
           helpText="Choose the size to change the list below">
-          <GoabDropdown
+          <GoabxDropdown
             name="parent"
             placeholder="Select a value"
             onChange={(event: GoabDropdownOnChangeDetail) =>
               loadItems(event.value as string)
             }>
             {parents.map(parent => (
-              <GoabDropdownItem key={parent} value={parent} label={parent} />
+              <GoabxDropdownItem key={parent} value={parent} label={parent} />
             ))}
-          </GoabDropdown>
-        </GoabFormItem>
+          </GoabxDropdown>
+        </GoabxFormItem>
 
-        <GoabFormItem label="Items" requirement="optional" mt="xl">
-          <GoabDropdown name="children" placeholder="Select a value" onChange={logSelection}>
+        <GoabxFormItem label="Items" requirement="optional" mt="xl">
+          <GoabxDropdown name="children" placeholder="Select a value" onChange={logSelection}>
             {children.map((child) => (
-              <GoabDropdownItem
+              <GoabxDropdownItem
                 key={crypto.randomUUID()}
                 value={child}
                 label={child}
                 mountType="reset"
               />
             ))}
-          </GoabDropdown>
-      </GoabFormItem>
+          </GoabxDropdown>
+      </GoabxFormItem>
     </>
   );
 }

--- a/docs/src/content/examples/dynamically-change-items-in-a-dropdown-list/web-components.html
+++ b/docs/src/content/examples/dynamically-change-items-in-a-dropdown-list/web-components.html
@@ -1,14 +1,14 @@
 <div style="padding: 40px;">
-  <goa-form-item label="Size" requirement="optional" helptext="Choose the size to change the list below">
-    <goa-dropdown id="parent-dropdown" placeholder="Select a value" name="parent">
+  <goa-form-item version="2" label="Size" requirement="optional" helptext="Choose the size to change the list below">
+    <goa-dropdown version="2" id="parent-dropdown" placeholder="Select a value" name="parent">
       <goa-dropdown-item value="All" label="All"></goa-dropdown-item>
       <goa-dropdown-item value="Big" label="Big"></goa-dropdown-item>
       <goa-dropdown-item value="Small" label="Small"></goa-dropdown-item>
     </goa-dropdown>
   </goa-form-item>
 
-  <goa-form-item label="Items" requirement="optional" mt="xl">
-    <goa-dropdown id="child-dropdown" placeholder="Select a value" name="children">
+  <goa-form-item version="2" label="Items" requirement="optional" mt="xl">
+    <goa-dropdown version="2" id="child-dropdown" placeholder="Select a value" name="children">
     </goa-dropdown>
   </goa-form-item>
 </div>

--- a/docs/src/content/examples/expand-or-collapse-part-of-a-form/angular.html
+++ b/docs/src/content/examples/expand-or-collapse-part-of-a-form/angular.html
@@ -2,7 +2,7 @@
 
 <goab-accordion heading="Referral details" [headingContent]="importantBadge">
   <ng-template #importantBadge>
-    <goab-badge type="important" content="Updated"></goab-badge>
+    <goabx-badge type="important" content="Updated"></goabx-badge>
   </ng-template>
   <dl class="accordion-example">
     <dt>Date of referral</dt>

--- a/docs/src/content/examples/expand-or-collapse-part-of-a-form/react.tsx
+++ b/docs/src/content/examples/expand-or-collapse-part-of-a-form/react.tsx
@@ -1,4 +1,5 @@
-import { GoabAccordion, GoabBadge, GoabText } from "@abgov/react-components";
+import { GoabxBadge } from "@abgov/react-components/experimental";
+import { GoabAccordion, GoabText } from "@abgov/react-components";
 
 export function ExpandOrCollapsePartOfAForm() {
   return (
@@ -25,7 +26,7 @@ export function ExpandOrCollapsePartOfAForm() {
 
       <GoabAccordion
         heading="Referral details"
-        headingContent={<GoabBadge type="important" content="Updated" />}>
+        headingContent={<GoabxBadge type="important" content="Updated" />}>
         <dl className="accordion-example">
           <dt>Date of referral</dt>
           <dd>January 27, 2021</dd>

--- a/docs/src/content/examples/expand-or-collapse-part-of-a-form/web-components.html
+++ b/docs/src/content/examples/expand-or-collapse-part-of-a-form/web-components.html
@@ -19,7 +19,7 @@
 <goa-text as="h3" mt="none" mb="m">Review your application</goa-text>
 
 <goa-accordion heading="Referral details">
-  <goa-badge slot="headingcontent" type="important" content="Updated"></goa-badge>
+  <goa-badge version="2" slot="headingcontent" type="important" content="Updated"></goa-badge>
   <dl class="accordion-example">
     <dt>Date of referral</dt>
     <dd>January 27, 2021</dd>

--- a/docs/src/content/examples/filter-data-in-a-table/angular.html
+++ b/docs/src/content/examples/filter-data-in-a-table/angular.html
@@ -1,7 +1,7 @@
-<goab-form-item id="filterChipInput" [error]="inputError" mb="m">
+<goabx-form-item id="filterChipInput" [error]="inputError" mb="m">
     <goab-block gap="xs" direction="row" alignment="start" width="100%">
       <div style="flex: 1;">
-        <goab-input
+        <goabx-input
           name="filterChipInput"
           aria-labelledby="filterChipInput"
           [value]="inputValue"
@@ -9,31 +9,31 @@
           width="100%"
           (onChange)="handleInputChange($event)"
           (onKeyPress)="handleInputKeyPress($event)">
-        </goab-input>
+        </goabx-input>
       </div>
-      <goab-button type="secondary" (onClick)="applyFilter()" leadingIcon="filter">
+      <goabx-button type="secondary" (onClick)="applyFilter()" leadingIcon="filter">
         Filter
-      </goab-button>
+      </goabx-button>
     </goab-block>
-  </goab-form-item>
+  </goabx-form-item>
 
   <ng-container *ngIf="typedChips.length > 0">
     <goab-text tag="span" color="secondary" mb="xs" mr="xs">
       Filter:
     </goab-text>
-    <goab-filter-chip
+    <goabx-filter-chip
       *ngFor="let typedChip of typedChips; let index = index"
       [content]="typedChip"
       mb="xs"
       mr="xs"
       (onClick)="removeTypedChip(typedChip)">
-    </goab-filter-chip>
-    <goab-button type="tertiary" size="compact" mb="xs" (onClick)="removeAllTypedChips()">
+    </goabx-filter-chip>
+    <goabx-button type="tertiary" size="compact" mb="xs" (onClick)="removeAllTypedChips()">
       Clear all
-    </goab-button>
+    </goabx-button>
   </ng-container>
 
-  <goab-table width="full">
+  <goabx-table width="full">
     <thead>
       <tr>
         <th>Status</th>
@@ -44,13 +44,13 @@
     <tbody>
       <tr *ngFor="let item of dataFiltered">
         <td>
-          <goab-badge [type]="item.status.type" [content]="item.status.text" [icon]="false"></goab-badge>
+          <goabx-badge [type]="item.status.type" [content]="item.status.text" [icon]="false"></goabx-badge>
         </td>
         <td>{{ item.name }}</td>
         <td class="goa-table-number-column">{{ item.id }}</td>
       </tr>
     </tbody>
-  </goab-table>
+  </goabx-table>
 
 <goab-block mt="l" mb="l" *ngIf="dataFiltered.length === 0 && data.length > 0">
   No results found

--- a/docs/src/content/examples/filter-data-in-a-table/react.tsx
+++ b/docs/src/content/examples/filter-data-in-a-table/react.tsx
@@ -1,14 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  GoabBadge,
-  GoabBlock,
-  GoabButton,
-  GoabFilterChip,
-  GoabFormItem,
-  GoabInput,
-  GoabTable,
-  GoabText,
-} from "@abgov/react-components";
+  GoabxBadge,
+  GoabxButton,
+  GoabxFilterChip,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxTable,
+} from "@abgov/react-components/experimental";
+import { GoabBlock, GoabText } from "@abgov/react-components";
 import type {
   GoabBadgeType,
   GoabInputOnChangeDetail,
@@ -118,10 +117,10 @@ export function FilterDataInATable() {
 
   return (
     <>
-      <GoabFormItem id="filterChipInput" error={inputError} mb="m">
+      <GoabxFormItem id="filterChipInput" error={inputError} mb="m">
         <GoabBlock gap="xs" direction="row" alignment="start" width="100%">
           <div style={{ flex: 1 }}>
-            <GoabInput
+            <GoabxInput
               name="filterChipInput"
               aria-labelledby="filterChipInput"
               value={inputValue}
@@ -131,11 +130,11 @@ export function FilterDataInATable() {
               onKeyPress={handleInputKeyPress}
             />
           </div>
-          <GoabButton type="secondary" onClick={applyFilter} leadingIcon="filter">
+          <GoabxButton type="secondary" onClick={applyFilter} leadingIcon="filter">
             Filter
-          </GoabButton>
+          </GoabxButton>
         </GoabBlock>
-      </GoabFormItem>
+      </GoabxFormItem>
 
       {typedChips.length > 0 && (
         <div>
@@ -143,7 +142,7 @@ export function FilterDataInATable() {
             Filter:
           </GoabText>
           {typedChips.map((typedChip, index) => (
-            <GoabFilterChip
+            <GoabxFilterChip
               key={index}
               content={typedChip}
               mb="xs"
@@ -151,13 +150,13 @@ export function FilterDataInATable() {
               onClick={() => removeTypedChip(typedChip)}
             />
           ))}
-          <GoabButton type="tertiary" size="compact" mb="xs" onClick={() => setTypedChips([])}>
+          <GoabxButton type="tertiary" size="compact" mb="xs" onClick={() => setTypedChips([])}>
             Clear all
-          </GoabButton>
+          </GoabxButton>
         </div>
       )}
 
-      <GoabTable width="full">
+      <GoabxTable width="full">
         <thead>
           <tr>
             <th>Status</th>
@@ -169,14 +168,14 @@ export function FilterDataInATable() {
           {dataFiltered.map(item => (
             <tr key={item.id}>
               <td>
-                <GoabBadge type={item.status.type} content={item.status.text} icon={false} />
+                <GoabxBadge type={item.status.type} content={item.status.text} icon={false} />
               </td>
               <td>{item.name}</td>
               <td className="goa-table-number-column">{item.id}</td>
             </tr>
           ))}
         </tbody>
-      </GoabTable>
+      </GoabxTable>
 
       {dataFiltered.length === 0 && data.length > 0 && (
         <GoabBlock mt="l" mb="l">

--- a/docs/src/content/examples/filter-data-in-a-table/web-components.html
+++ b/docs/src/content/examples/filter-data-in-a-table/web-components.html
@@ -1,14 +1,14 @@
-<goa-form-item id="filter-form-item" mb="m">
+<goa-form-item version="2" id="filter-form-item" mb="m">
   <goa-block gap="xs" direction="row" alignment="center" width="100%">
     <div style="flex: 1;">
-      <goa-input
+      <goa-input version="2"
         id="filter-input"
         name="filterChipInput"
         leadingicon="search"
         width="100%">
       </goa-input>
     </div>
-    <goa-button id="filter-btn" type="secondary" leadingicon="filter">
+    <goa-button version="2" id="filter-btn" type="secondary" leadingicon="filter">
       Filter
     </goa-button>
   </goa-block>
@@ -17,12 +17,12 @@
 <div id="chips-container" style="display: none;">
   <goa-text tag="span" color="secondary" mb="xs" mr="xs">Filter:</goa-text>
   <span id="chips-list"></span>
-  <goa-button id="clear-all-btn" type="tertiary" size="compact" mb="xs">
+  <goa-button version="2" id="clear-all-btn" type="tertiary" size="compact" mb="xs">
     Clear all
   </goa-button>
 </div>
 
-<goa-table width="100%" mt="s">
+<goa-table version="2" width="100%" mt="s">
   <table style="width: 100%;">
     <thead>
       <tr>
@@ -33,32 +33,32 @@
     </thead>
     <tbody>
       <tr>
-        <td><goa-badge type="information" content="In progress" icon="false"></goa-badge></td>
+        <td><goa-badge version="2" type="information" content="In progress" icon="false"></goa-badge></td>
         <td>Ivan Schmidt</td>
         <td class="goa-table-number-column">7838576954</td>
       </tr>
       <tr>
-        <td><goa-badge type="success" content="Completed" icon="false"></goa-badge></td>
+        <td><goa-badge version="2" type="success" content="Completed" icon="false"></goa-badge></td>
         <td>Luz Lakin</td>
         <td class="goa-table-number-column">8576953364</td>
       </tr>
       <tr>
-        <td><goa-badge type="information" content="In progress" icon="false"></goa-badge></td>
+        <td><goa-badge version="2" type="information" content="In progress" icon="false"></goa-badge></td>
         <td>Keith McGlynn</td>
         <td class="goa-table-number-column">9846041345</td>
       </tr>
       <tr>
-        <td><goa-badge type="success" content="Completed" icon="false"></goa-badge></td>
+        <td><goa-badge version="2" type="success" content="Completed" icon="false"></goa-badge></td>
         <td>Melody Frami</td>
         <td class="goa-table-number-column">7385256175</td>
       </tr>
       <tr>
-        <td><goa-badge type="important" content="Updated" icon="false"></goa-badge></td>
+        <td><goa-badge version="2" type="important" content="Updated" icon="false"></goa-badge></td>
         <td>Frederick Skiles</td>
         <td class="goa-table-number-column">5807570418</td>
       </tr>
       <tr>
-        <td><goa-badge type="success" content="Completed" icon="false"></goa-badge></td>
+        <td><goa-badge version="2" type="success" content="Completed" icon="false"></goa-badge></td>
         <td>Dana Pfannerstill</td>
         <td class="goa-table-number-column">5736306857</td>
       </tr>

--- a/docs/src/content/examples/form-stepper-with-controlled-navigation/angular.html
+++ b/docs/src/content/examples/form-stepper-with-controlled-navigation/angular.html
@@ -29,6 +29,6 @@
 </goab-pages>
 
 <div style="display: flex; justify-content: space-between">
-  <goab-button (onClick)="setPage(step - 1)" type="secondary">Previous</goab-button>
-  <goab-button (onClick)="setPage(step + 1)" type="primary">Next</goab-button>
+  <goabx-button (onClick)="setPage(step - 1)" type="secondary">Previous</goabx-button>
+  <goabx-button (onClick)="setPage(step + 1)" type="primary">Next</goabx-button>
 </div>

--- a/docs/src/content/examples/form-stepper-with-controlled-navigation/react.tsx
+++ b/docs/src/content/examples/form-stepper-with-controlled-navigation/react.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
+import { GoabxButton } from "@abgov/react-components/experimental";
 import {
-  GoabButton,
   GoabFormStep,
   GoabFormStepper,
   GoabPages,
   GoabSkeleton,
-  GoabSpacer
+  GoabSpacer,
 } from "@abgov/react-components";
 import { GoabFormStepperOnChangeDetail } from "@abgov/ui-components-common";
 
@@ -50,12 +50,12 @@ export function FormStepperWithControlledNavigation() {
       </GoabPages>
 
       <div style={{ display: "flex", justifyContent: "space-between" }}>
-        <GoabButton type="secondary" onClick={() => setPage(step - 1)}>
+        <GoabxButton type="secondary" onClick={() => setPage(step - 1)}>
           Previous
-        </GoabButton>
-        <GoabButton type="primary" onClick={() => setPage(step + 1)}>
+        </GoabxButton>
+        <GoabxButton type="primary" onClick={() => setPage(step + 1)}>
           Next
-        </GoabButton>
+        </GoabxButton>
       </div>
     </>
   );

--- a/docs/src/content/examples/form-stepper-with-controlled-navigation/web-components.html
+++ b/docs/src/content/examples/form-stepper-with-controlled-navigation/web-components.html
@@ -29,8 +29,8 @@
 </goa-pages>
 
 <div style="display: flex; justify-content: space-between">
-  <goa-button id="prev-btn" type="secondary">Previous</goa-button>
-  <goa-button id="next-btn" type="primary">Next</goa-button>
+  <goa-button version="2" id="prev-btn" type="secondary">Previous</goa-button>
+  <goa-button version="2" id="next-btn" type="primary">Next</goa-button>
 </div>
 
 <script>

--- a/docs/src/content/examples/give-background-information-before-asking-a-question/angular.html
+++ b/docs/src/content/examples/give-background-information-before-asking-a-question/angular.html
@@ -1,6 +1,6 @@
-<goab-link leadingIcon="arrow-back" size="small" mb="none">
+<goabx-link leadingIcon="arrow-back" size="small" mb="none">
   Back
-</goab-link>
+</goabx-link>
 
 <goab-text as="h2" mt="xl" mb="m">Current school status</goab-text>
 <goab-text mt="none" mb="s">
@@ -18,16 +18,16 @@
   Contact your provider if you're concerned about your school status.
 </goab-text>
 
-<goab-form-item label="Are you currently in school?">
-  <goab-radio-group
+<goabx-form-item label="Are you currently in school?">
+  <goabx-radio-group
     name="school"
     ariaLabel="are you currently in school?"
     (onChange)="onChange($event)">
-    <goab-radio-item value="yes" label="Yes"></goab-radio-item>
-    <goab-radio-item value="no" label="No"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>
+    <goabx-radio-item value="yes" label="Yes"></goabx-radio-item>
+    <goabx-radio-item value="no" label="No"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>
 
-<goab-button type="submit" mt="2xl" (onClick)="onSubmit()">
+<goabx-button type="submit" mt="2xl" (onClick)="onSubmit()">
   Save and continue
-</goab-button>
+</goabx-button>

--- a/docs/src/content/examples/give-background-information-before-asking-a-question/react.tsx
+++ b/docs/src/content/examples/give-background-information-before-asking-a-question/react.tsx
@@ -1,11 +1,11 @@
 import {
-  GoabButton,
-  GoabFormItem,
-  GoabLink,
-  GoabRadioGroup,
-  GoabRadioItem,
-  GoabText
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxFormItem,
+  GoabxLink,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
+import { GoabText } from "@abgov/react-components";
 import { GoabRadioGroupOnChangeDetail } from "@abgov/ui-components-common";
 import { useState } from "react";
 
@@ -22,9 +22,9 @@ export function GiveBackgroundInformationBeforeAskingAQuestion() {
 
   return (
     <>
-      <GoabLink leadingIcon="arrow-back" size="small" mb="none">
+      <GoabxLink leadingIcon="arrow-back" size="small" mb="none">
         Back
-      </GoabLink>
+      </GoabxLink>
 
       <GoabText as="h2" mt="xl" mb="m">Current school status</GoabText>
       <GoabText mt="none" mb="s">
@@ -42,19 +42,19 @@ export function GiveBackgroundInformationBeforeAskingAQuestion() {
         Contact your provider if you're concerned about your school status.
       </GoabText>
 
-      <GoabFormItem label="Are you currently in school?">
-        <GoabRadioGroup
+      <GoabxFormItem label="Are you currently in school?">
+        <GoabxRadioGroup
           name="school"
           ariaLabel="are you currently in school?"
           onChange={handleChange}>
-          <GoabRadioItem value="yes" label="Yes" />
-          <GoabRadioItem value="no" label="No" />
-        </GoabRadioGroup>
-      </GoabFormItem>
+          <GoabxRadioItem value="yes" label="Yes" />
+          <GoabxRadioItem value="no" label="No" />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
 
-      <GoabButton type="submit" mt="2xl" onClick={handleSubmit}>
+      <GoabxButton type="submit" mt="2xl" onClick={handleSubmit}>
         Save and continue
-      </GoabButton>
+      </GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/give-background-information-before-asking-a-question/web-components.html
+++ b/docs/src/content/examples/give-background-information-before-asking-a-question/web-components.html
@@ -18,14 +18,14 @@
   Contact your provider if you're concerned about your school status.
 </goa-text>
 
-<goa-form-item label="Are you currently in school?">
-  <goa-radio-group id="school-radio" name="school" arialabel="are you currently in school?">
+<goa-form-item version="2" label="Are you currently in school?">
+  <goa-radio-group version="2" id="school-radio" name="school" arialabel="are you currently in school?">
     <goa-radio-item value="yes" label="Yes"></goa-radio-item>
     <goa-radio-item value="no" label="No"></goa-radio-item>
   </goa-radio-group>
 </goa-form-item>
 
-<goa-button id="submit-btn" type="submit" mt="2xl">
+<goa-button version="2" id="submit-btn" type="submit" mt="2xl">
   Save and continue
 </goa-button>
 

--- a/docs/src/content/examples/give-context-before-asking-a-long-answer-question/angular.html
+++ b/docs/src/content/examples/give-context-before-asking-a-long-answer-question/angular.html
@@ -1,6 +1,6 @@
-<goab-link leadingIcon="arrow-back" size="small" mb="none">
+<goabx-link leadingIcon="arrow-back" size="small" mb="none">
   Back
-</goab-link>
+</goabx-link>
 
 <goab-text as="h2" mt="xl" mb="m">Submit a question about your benefits</goab-text>
 <goab-text mt="none" mb="xl">
@@ -9,16 +9,16 @@
 </goab-text>
 
 <form [formGroup]="form">
-  <goab-form-item
+  <goabx-form-item
     label="Provide details about your situation"
     helpText="Include specific details to help us answer your question quickly.">
-    <goab-textarea
+    <goabx-textarea
       formControlName="program"
       name="program"
       [maxCount]="400"
       countBy="character">
-    </goab-textarea>
-  </goab-form-item>
+    </goabx-textarea>
+  </goabx-form-item>
 </form>
 
 <goab-details mt="m" heading="What kind of information is useful?">
@@ -29,7 +29,7 @@
 </goab-details>
 
 <goab-button-group alignment="start" mt="2xl">
-  <goab-button type="primary" (onClick)="onContinue()">
+  <goabx-button type="primary" (onClick)="onContinue()">
     Continue
-  </goab-button>
+  </goabx-button>
 </goab-button-group>

--- a/docs/src/content/examples/give-context-before-asking-a-long-answer-question/react.tsx
+++ b/docs/src/content/examples/give-context-before-asking-a-long-answer-question/react.tsx
@@ -1,19 +1,12 @@
 import { useState } from "react";
-import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabDetails,
-  GoabFormItem,
-  GoabLink,
-  GoabText,
-  GoabTextarea
-} from "@abgov/react-components";
-import { GoabTextareaOnChangeDetail } from "@abgov/ui-components-common";
+import { GoabxButton, GoabxFormItem, GoabxLink, GoabxTextArea } from "@abgov/react-components/experimental";
+import { GoabButtonGroup, GoabDetails, GoabText } from "@abgov/react-components";
+import { GoabTextAreaOnChangeDetail } from "@abgov/ui-components-common";
 
 export function GiveContextBeforeAskingALongAnswerQuestion() {
   const [textValue, setTextValue] = useState("");
 
-  const handleChange = (event: GoabTextareaOnChangeDetail) => {
+  const handleChange = (event: GoabTextAreaOnChangeDetail) => {
     setTextValue(event.value);
   };
 
@@ -23,9 +16,9 @@ export function GiveContextBeforeAskingALongAnswerQuestion() {
 
   return (
     <>
-      <GoabLink leadingIcon="arrow-back" size="small" mb="none">
+      <GoabxLink leadingIcon="arrow-back" size="small" mb="none">
         Back
-      </GoabLink>
+      </GoabxLink>
 
       <GoabText as="h2" mt="xl" mb="m">Submit a question about your benefits</GoabText>
       <GoabText mt="none" mb="xl">
@@ -34,17 +27,17 @@ export function GiveContextBeforeAskingALongAnswerQuestion() {
       </GoabText>
 
       <form>
-        <GoabFormItem
+        <GoabxFormItem
           label="Provide details about your situation"
           helpText="Include specific details to help us answer your question quickly.">
-          <GoabTextarea
+          <GoabxTextArea
             name="program"
             onChange={handleChange}
             value={textValue}
             maxCount={400}
             countBy="character"
           />
-        </GoabFormItem>
+        </GoabxFormItem>
       </form>
 
       <GoabDetails mt="m" heading="What kind of information is useful?">
@@ -55,9 +48,9 @@ export function GiveContextBeforeAskingALongAnswerQuestion() {
       </GoabDetails>
 
       <GoabButtonGroup alignment="start" mt="2xl">
-        <GoabButton type="primary" onClick={handleContinue}>
+        <GoabxButton type="primary" onClick={handleContinue}>
           Continue
-        </GoabButton>
+        </GoabxButton>
       </GoabButtonGroup>
     </>
   );

--- a/docs/src/content/examples/give-context-before-asking-a-long-answer-question/web-components.html
+++ b/docs/src/content/examples/give-context-before-asking-a-long-answer-question/web-components.html
@@ -9,10 +9,10 @@
 </goa-text>
 
 <form>
-  <goa-form-item
+  <goa-form-item version="2"
     label="Provide details about your situation"
     helptext="Include specific details to help us answer your question quickly.">
-    <goa-textarea
+    <goa-textarea version="2"
       id="program-textarea"
       name="program"
       maxcount="400"
@@ -29,7 +29,7 @@
 </goa-details>
 
 <goa-button-group alignment="start" mt="2xl">
-  <goa-button id="continue-btn" type="primary">
+  <goa-button version="2" id="continue-btn" type="primary">
     Continue
   </goa-button>
 </goa-button-group>

--- a/docs/src/content/examples/group-related-questions-together-on-a-question-page/angular.html
+++ b/docs/src/content/examples/group-related-questions-together-on-a-question-page/angular.html
@@ -1,71 +1,71 @@
-<goab-link leadingIcon="arrow-back" size="small" mb="none">
+<goabx-link leadingIcon="arrow-back" size="small" mb="none">
   Back
-</goab-link>
+</goabx-link>
 
 <goab-text as="h2" mt="xl" mb="m">Your address</goab-text>
 <goab-text mt="none" mb="xl">This is the home address of the person applying</goab-text>
 
-<goab-form-item label="Address line 1">
-  <goab-input
+<goabx-form-item label="Address line 1">
+  <goabx-input
     (onChange)="onAddressLine1Change($event)"
     [value]="addressLine1"
     name="address-line-1"
     ariaLabel="Address line 1"
     width="100%">
-  </goab-input>
-</goab-form-item>
+  </goabx-input>
+</goabx-form-item>
 
-<goab-form-item label="Address line 2" mt="l">
-  <goab-input
+<goabx-form-item label="Address line 2" mt="l">
+  <goabx-input
     (onChange)="onAddressLine2Change($event)"
     [value]="addressLine2"
     name="address-line-2"
     ariaLabel="Address line 2"
     width="100%">
-  </goab-input>
-</goab-form-item>
+  </goabx-input>
+</goabx-form-item>
 
-<goab-form-item label="Town or city" mt="l">
-  <goab-input
+<goabx-form-item label="Town or city" mt="l">
+  <goabx-input
     (onChange)="onTownCityChange($event)"
     [value]="townCity"
     name="town-city"
     ariaLabel="Town or city name"
     width="460px">
-  </goab-input>
-</goab-form-item>
+  </goabx-input>
+</goabx-form-item>
 
-<goab-form-item label="Province or territory" mt="l" id="provinceLabel">
-  <goab-dropdown
+<goabx-form-item label="Province or territory" mt="l" id="provinceLabel">
+  <goabx-dropdown
     (onChange)="onProvinceChange($event)"
     [value]="province"
     name="province-territory"
     ariaLabelledBy="provinceLabel">
-    <goab-dropdown-item value="AB" label="Alberta"></goab-dropdown-item>
-    <goab-dropdown-item value="BC" label="British Columbia"></goab-dropdown-item>
-    <goab-dropdown-item value="MB" label="Manitoba"></goab-dropdown-item>
-    <goab-dropdown-item value="NB" label="New Brunswick"></goab-dropdown-item>
-    <goab-dropdown-item value="NL" label="Newfoundland and Labrador"></goab-dropdown-item>
-    <goab-dropdown-item value="NS" label="Nova Scotia"></goab-dropdown-item>
-    <goab-dropdown-item value="ON" label="Ontario"></goab-dropdown-item>
-    <goab-dropdown-item value="PE" label="Prince Edward Island"></goab-dropdown-item>
-    <goab-dropdown-item value="QC" label="Quebec"></goab-dropdown-item>
-    <goab-dropdown-item value="SK" label="Saskatchewan"></goab-dropdown-item>
-    <goab-dropdown-item value="NT" label="Northwest Territories"></goab-dropdown-item>
-    <goab-dropdown-item value="NU" label="Nunavut"></goab-dropdown-item>
-    <goab-dropdown-item value="YT" label="Yukon"></goab-dropdown-item>
-  </goab-dropdown>
-</goab-form-item>
+    <goabx-dropdown-item value="AB" label="Alberta"></goabx-dropdown-item>
+    <goabx-dropdown-item value="BC" label="British Columbia"></goabx-dropdown-item>
+    <goabx-dropdown-item value="MB" label="Manitoba"></goabx-dropdown-item>
+    <goabx-dropdown-item value="NB" label="New Brunswick"></goabx-dropdown-item>
+    <goabx-dropdown-item value="NL" label="Newfoundland and Labrador"></goabx-dropdown-item>
+    <goabx-dropdown-item value="NS" label="Nova Scotia"></goabx-dropdown-item>
+    <goabx-dropdown-item value="ON" label="Ontario"></goabx-dropdown-item>
+    <goabx-dropdown-item value="PE" label="Prince Edward Island"></goabx-dropdown-item>
+    <goabx-dropdown-item value="QC" label="Quebec"></goabx-dropdown-item>
+    <goabx-dropdown-item value="SK" label="Saskatchewan"></goabx-dropdown-item>
+    <goabx-dropdown-item value="NT" label="Northwest Territories"></goabx-dropdown-item>
+    <goabx-dropdown-item value="NU" label="Nunavut"></goabx-dropdown-item>
+    <goabx-dropdown-item value="YT" label="Yukon"></goabx-dropdown-item>
+  </goabx-dropdown>
+</goabx-form-item>
 
-<goab-form-item label="Postal code" mt="l">
-  <goab-input
+<goabx-form-item label="Postal code" mt="l">
+  <goabx-input
     (onChange)="onPostalCodeChange($event)"
     [value]="postalCode"
     name="postal-code"
     width="105px">
-  </goab-input>
-</goab-form-item>
+  </goabx-input>
+</goabx-form-item>
 
-<goab-button type="submit" mt="2xl" (onClick)="onSubmit()">
+<goabx-button type="submit" mt="2xl" (onClick)="onSubmit()">
   Save and continue
-</goab-button>
+</goabx-button>

--- a/docs/src/content/examples/group-related-questions-together-on-a-question-page/react.tsx
+++ b/docs/src/content/examples/group-related-questions-together-on-a-question-page/react.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import {
-  GoabButton,
-  GoabDropdown,
-  GoabDropdownItem,
-  GoabFormItem,
-  GoabInput,
-  GoabLink,
-  GoabText,
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxLink,
+} from "@abgov/react-components/experimental";
+import { GoabText } from "@abgov/react-components";
 
 export function GroupRelatedQuestionsTogetherOnAQuestionPage() {
   const [addressLine1, setAddressLine1] = useState("");
@@ -18,78 +18,78 @@ export function GroupRelatedQuestionsTogetherOnAQuestionPage() {
 
   return (
     <>
-      <GoabLink leadingIcon="arrow-back" size="small" mb="none">
+      <GoabxLink leadingIcon="arrow-back" size="small" mb="none">
         Back
-      </GoabLink>
+      </GoabxLink>
 
       <GoabText as="h2" mt="xl" mb="m">Your address</GoabText>
       <GoabText mt="none" mb="xl">This is the home address of the person applying</GoabText>
 
-      <GoabFormItem label="Address line 1">
-        <GoabInput
+      <GoabxFormItem label="Address line 1">
+        <GoabxInput
           onChange={(event) => setAddressLine1(event.value)}
           value={addressLine1}
           name="address-line-1"
           ariaLabel="Address line 1"
           width="100%"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
 
-      <GoabFormItem label="Address line 2" mt="l">
-        <GoabInput
+      <GoabxFormItem label="Address line 2" mt="l">
+        <GoabxInput
           onChange={(event) => setAddressLine2(event.value)}
           value={addressLine2}
           name="address-line-2"
           ariaLabel="Address line 2"
           width="100%"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
 
-      <GoabFormItem label="Town or city" mt="l">
-        <GoabInput
+      <GoabxFormItem label="Town or city" mt="l">
+        <GoabxInput
           onChange={(event) => setTownCity(event.value)}
           value={townCity}
           name="town-city"
           ariaLabel="Town or city name"
           width="460px"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
 
-      <GoabFormItem label="Province or territory" mt="l" id="provinceLabel">
-        <GoabDropdown
+      <GoabxFormItem label="Province or territory" mt="l" id="provinceLabel">
+        <GoabxDropdown
           onChange={(event) => setProvince(event.value ?? "")}
           value={province}
           name="province-territory"
           ariaLabelledBy="provinceLabel"
         >
-          <GoabDropdownItem value="AB" label="Alberta" />
-          <GoabDropdownItem value="BC" label="British Columbia" />
-          <GoabDropdownItem value="MB" label="Manitoba" />
-          <GoabDropdownItem value="NB" label="New Brunswick" />
-          <GoabDropdownItem value="NL" label="Newfoundland and Labrador" />
-          <GoabDropdownItem value="NS" label="Nova Scotia" />
-          <GoabDropdownItem value="ON" label="Ontario" />
-          <GoabDropdownItem value="PE" label="Prince Edward Island" />
-          <GoabDropdownItem value="QC" label="Quebec" />
-          <GoabDropdownItem value="SK" label="Saskatchewan" />
-          <GoabDropdownItem value="NT" label="Northwest Territories" />
-          <GoabDropdownItem value="NU" label="Nunavut" />
-          <GoabDropdownItem value="YT" label="Yukon" />
-        </GoabDropdown>
-      </GoabFormItem>
+          <GoabxDropdownItem value="AB" label="Alberta" />
+          <GoabxDropdownItem value="BC" label="British Columbia" />
+          <GoabxDropdownItem value="MB" label="Manitoba" />
+          <GoabxDropdownItem value="NB" label="New Brunswick" />
+          <GoabxDropdownItem value="NL" label="Newfoundland and Labrador" />
+          <GoabxDropdownItem value="NS" label="Nova Scotia" />
+          <GoabxDropdownItem value="ON" label="Ontario" />
+          <GoabxDropdownItem value="PE" label="Prince Edward Island" />
+          <GoabxDropdownItem value="QC" label="Quebec" />
+          <GoabxDropdownItem value="SK" label="Saskatchewan" />
+          <GoabxDropdownItem value="NT" label="Northwest Territories" />
+          <GoabxDropdownItem value="NU" label="Nunavut" />
+          <GoabxDropdownItem value="YT" label="Yukon" />
+        </GoabxDropdown>
+      </GoabxFormItem>
 
-      <GoabFormItem label="Postal code" mt="l">
-        <GoabInput
+      <GoabxFormItem label="Postal code" mt="l">
+        <GoabxInput
           onChange={(event) => setPostalCode(event.value)}
           value={postalCode}
           name="postal-code"
           width="105px"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
 
-      <GoabButton type="submit" mt="2xl">
+      <GoabxButton type="submit" mt="2xl">
         Save and continue
-      </GoabButton>
+      </GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/group-related-questions-together-on-a-question-page/web-components.html
+++ b/docs/src/content/examples/group-related-questions-together-on-a-question-page/web-components.html
@@ -5,8 +5,8 @@
 <goa-text as="h2" mt="xl" mb="m">Your address</goa-text>
 <goa-text mt="none" mb="xl">This is the home address of the person applying</goa-text>
 
-<goa-form-item label="Address line 1">
-  <goa-input
+<goa-form-item version="2" label="Address line 1">
+  <goa-input version="2"
     id="address-line-1"
     name="address-line-1"
     aria-label="Address line 1"
@@ -14,8 +14,8 @@
   </goa-input>
 </goa-form-item>
 
-<goa-form-item label="Address line 2" mt="l">
-  <goa-input
+<goa-form-item version="2" label="Address line 2" mt="l">
+  <goa-input version="2"
     id="address-line-2"
     name="address-line-2"
     aria-label="Address line 2"
@@ -23,8 +23,8 @@
   </goa-input>
 </goa-form-item>
 
-<goa-form-item label="Town or city" mt="l">
-  <goa-input
+<goa-form-item version="2" label="Town or city" mt="l">
+  <goa-input version="2"
     id="town-city"
     name="town-city"
     aria-label="Town or city name"
@@ -32,8 +32,8 @@
   </goa-input>
 </goa-form-item>
 
-<goa-form-item label="Province or territory" mt="l" id="provinceLabel">
-  <goa-dropdown
+<goa-form-item version="2" label="Province or territory" mt="l" id="provinceLabel">
+  <goa-dropdown version="2"
     id="province-territory"
     name="province-territory"
     aria-labelledby="provinceLabel">
@@ -53,15 +53,15 @@
   </goa-dropdown>
 </goa-form-item>
 
-<goa-form-item label="Postal code" mt="l">
-  <goa-input
+<goa-form-item version="2" label="Postal code" mt="l">
+  <goa-input version="2"
     id="postal-code"
     name="postal-code"
     width="105px">
   </goa-input>
 </goa-form-item>
 
-<goa-button type="submit" mt="2xl" id="submit-btn">
+<goa-button version="2" type="submit" mt="2xl" id="submit-btn">
   Save and continue
 </goa-button>
 

--- a/docs/src/content/examples/header-with-menu-click-event/angular.html
+++ b/docs/src/content/examples/header-with-menu-click-event/angular.html
@@ -1,10 +1,10 @@
-<goab-radio-group
+<goabx-radio-group
   name="device"
   [value]="deviceWidth"
   (onChange)="changeDeviceWidth($event)">
-  <goab-radio-item value="600" label="Desktop"></goab-radio-item>
-  <goab-radio-item value="5000" label="Mobile"></goab-radio-item>
-</goab-radio-group>
+  <goabx-radio-item value="600" label="Desktop"></goabx-radio-item>
+  <goabx-radio-item value="5000" label="Mobile"></goabx-radio-item>
+</goabx-radio-group>
 
 <goab-app-header
   url="https://example.com"

--- a/docs/src/content/examples/header-with-menu-click-event/react.tsx
+++ b/docs/src/content/examples/header-with-menu-click-event/react.tsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
-import {
-  GoabAppHeader,
-  GoabAppHeaderMenu,
-  GoabRadioGroup,
-  GoabRadioItem,
-} from "@abgov/react-components";
+import { GoabxRadioGroup, GoabxRadioItem } from "@abgov/react-components/experimental";
+import { GoabAppHeader, GoabAppHeaderMenu } from "@abgov/react-components";
 import { GoabRadioGroupOnChangeDetail } from "@abgov/ui-components-common";
 
 export function HeaderWithMenuClickEvent() {
@@ -16,16 +12,16 @@ export function HeaderWithMenuClickEvent() {
 
   return (
     <>
-      <GoabRadioGroup
+      <GoabxRadioGroup
         name="device"
         value={deviceWidth}
         onChange={(event: GoabRadioGroupOnChangeDetail) =>
           setDeviceWidth(event.value)
         }
       >
-        <GoabRadioItem value="600" label="Desktop" />
-        <GoabRadioItem value="5000" label="Mobile" />
-      </GoabRadioGroup>
+        <GoabxRadioItem value="600" label="Desktop" />
+        <GoabxRadioItem value="5000" label="Mobile" />
+      </GoabxRadioGroup>
 
       <GoabAppHeader
         url="https://example.com"

--- a/docs/src/content/examples/header-with-menu-click-event/web-components.html
+++ b/docs/src/content/examples/header-with-menu-click-event/web-components.html
@@ -1,4 +1,4 @@
-<goa-radio-group name="device" value="5000" id="device-radio-group">
+<goa-radio-group version="2" name="device" value="5000" id="device-radio-group">
   <goa-radio-item value="600" label="Desktop"></goa-radio-item>
   <goa-radio-item value="5000" label="Mobile"></goa-radio-item>
 </goa-radio-group>

--- a/docs/src/content/examples/hero-banner-with-actions/angular.html
+++ b/docs/src/content/examples/hero-banner-with-actions/angular.html
@@ -1,6 +1,6 @@
 <goab-hero-banner heading="Supporting Businesses" [actions]="heroBannerActionTemplate">
   Resources are available to help Alberta entrepreneurs and small businesses start, grow and succeed.
   <ng-template #heroBannerActionTemplate>
-    <goab-button type="start" (onClick)="onClick()">Call to action</goab-button>
+    <goabx-button type="start" (onClick)="onClick()">Call to action</goabx-button>
   </ng-template>
 </goab-hero-banner>

--- a/docs/src/content/examples/hero-banner-with-actions/react.tsx
+++ b/docs/src/content/examples/hero-banner-with-actions/react.tsx
@@ -1,8 +1,5 @@
-import {
-  GoabButton,
-  GoabHeroBanner,
-  GoabHeroBannerActions,
-} from "@abgov/react-components";
+import { GoabxButton } from "@abgov/react-components/experimental";
+import { GoabHeroBanner, GoabHeroBannerActions } from "@abgov/react-components";
 
 export function HeroBannerWithActions() {
   function handleClick() {
@@ -14,9 +11,9 @@ export function HeroBannerWithActions() {
       Resources are available to help Alberta entrepreneurs and small businesses
       start, grow and succeed.
       <GoabHeroBannerActions>
-        <GoabButton type="start" onClick={handleClick}>
+        <GoabxButton type="start" onClick={handleClick}>
           Call to action
-        </GoabButton>
+        </GoabxButton>
       </GoabHeroBannerActions>
     </GoabHeroBanner>
   );

--- a/docs/src/content/examples/hero-banner-with-actions/web-components.html
+++ b/docs/src/content/examples/hero-banner-with-actions/web-components.html
@@ -1,7 +1,7 @@
 <goa-hero-banner heading="Supporting Businesses">
   Resources are available to help Alberta entrepreneurs and small businesses start, grow and succeed.
   <div slot="actions">
-    <goa-button type="start" id="cta-btn">Call to action</goa-button>
+    <goa-button version="2" type="start" id="cta-btn">Call to action</goa-button>
   </div>
 </goa-hero-banner>
 

--- a/docs/src/content/examples/hide-and-show-many-sections-of-information/angular.html
+++ b/docs/src/content/examples/hide-and-show-many-sections-of-information/angular.html
@@ -1,6 +1,6 @@
-<goab-button type="tertiary" size="compact" mb="m" (onClick)="onClick()">
+<goabx-button type="tertiary" size="compact" mb="m" (onClick)="onClick()">
   {{ accordionStatus }}
-</goab-button>
+</goabx-button>
 
 <goab-accordion
   heading="How do I create an account?"

--- a/docs/src/content/examples/hide-and-show-many-sections-of-information/react.tsx
+++ b/docs/src/content/examples/hide-and-show-many-sections-of-information/react.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
-import { GoabAccordion, GoabButton } from "@abgov/react-components";
+import { GoabxButton } from "@abgov/react-components/experimental";
+import { GoabAccordion } from "@abgov/react-components";
 
 export function HideAndShowManySectionsOfInformation() {
   const [expandedAll, setExpandedAll] = useState<boolean>(false);
@@ -28,9 +29,9 @@ export function HideAndShowManySectionsOfInformation() {
 
   return (
     <>
-      <GoabButton type="tertiary" size="compact" mb="m" onClick={() => expandOrCollapseAll()}>
+      <GoabxButton type="tertiary" size="compact" mb="m" onClick={() => expandOrCollapseAll()}>
         {expandedAll ? "Hide all sections" : "Show all sections"}
-      </GoabButton>
+      </GoabxButton>
 
       <GoabAccordion
         open={expandedList.includes(1)}

--- a/docs/src/content/examples/hide-and-show-many-sections-of-information/web-components.html
+++ b/docs/src/content/examples/hide-and-show-many-sections-of-information/web-components.html
@@ -1,4 +1,4 @@
-<goa-button type="tertiary" size="compact" mb="m" id="toggle-all-btn">
+<goa-button version="2" type="tertiary" size="compact" mb="m" id="toggle-all-btn">
   Show all sections
 </goa-button>
 

--- a/docs/src/content/examples/include-a-link-in-the-helper-text-of-an-option/angular.html
+++ b/docs/src/content/examples/include-a-link-in-the-helper-text-of-an-option/angular.html
@@ -1,6 +1,6 @@
-<goab-form-item label="How would you like to be contacted?">
+<goabx-form-item label="How would you like to be contacted?">
   <goab-checkbox-list name="contact-options">
-    <goab-checkbox
+    <goabx-checkbox
       name="email"
       text="Email"
       value="email"
@@ -8,8 +8,8 @@
       <ng-template #descriptionTemplate>
         <span>Help text with a <a href="#">link</a>.</span>
       </ng-template>
-    </goab-checkbox>
-    <goab-checkbox name="phone" text="Phone" value="phone"></goab-checkbox>
-    <goab-checkbox name="text" text="Text message" value="text"></goab-checkbox>
+    </goabx-checkbox>
+    <goabx-checkbox name="phone" text="Phone" value="phone"></goabx-checkbox>
+    <goabx-checkbox name="text" text="Text message" value="text"></goabx-checkbox>
   </goab-checkbox-list>
-</goab-form-item>
+</goabx-form-item>

--- a/docs/src/content/examples/include-a-link-in-the-helper-text-of-an-option/react.tsx
+++ b/docs/src/content/examples/include-a-link-in-the-helper-text-of-an-option/react.tsx
@@ -1,10 +1,11 @@
-import { GoabCheckbox, GoabCheckboxList, GoabFormItem } from "@abgov/react-components";
+import { GoabxCheckbox, GoabxFormItem } from "@abgov/react-components/experimental";
+import { GoabCheckboxList } from "@abgov/react-components";
 
 export function IncludeALinkInTheHelperTextOfAnOption() {
   return (
-    <GoabFormItem label="How would you like to be contacted?">
+    <GoabxFormItem label="How would you like to be contacted?">
       <GoabCheckboxList name="contact-options">
-        <GoabCheckbox
+        <GoabxCheckbox
           name="email"
           text="Email"
           value="email"
@@ -14,9 +15,9 @@ export function IncludeALinkInTheHelperTextOfAnOption() {
             </span>
           }
         />
-        <GoabCheckbox name="phone" text="Phone" value="phone" />
-        <GoabCheckbox name="text" text="Text message" value="text" />
+        <GoabxCheckbox name="phone" text="Phone" value="phone" />
+        <GoabxCheckbox name="text" text="Text message" value="text" />
       </GoabCheckboxList>
-    </GoabFormItem>
+    </GoabxFormItem>
   );
 }

--- a/docs/src/content/examples/include-a-link-in-the-helper-text-of-an-option/web-components.html
+++ b/docs/src/content/examples/include-a-link-in-the-helper-text-of-an-option/web-components.html
@@ -1,9 +1,9 @@
-<goa-form-item label="How would you like to be contacted?">
+<goa-form-item version="2" label="How would you like to be contacted?">
   <goa-checkbox-list name="contact-options">
-    <goa-checkbox name="email" text="Email" value="email">
+    <goa-checkbox version="2" name="email" text="Email" value="email">
       <span slot="description">Help text with a <a href="#">link</a>.</span>
     </goa-checkbox>
-    <goa-checkbox name="phone" text="Phone" value="phone"></goa-checkbox>
-    <goa-checkbox name="text" text="Text message" value="text"></goa-checkbox>
+    <goa-checkbox version="2" name="phone" text="Phone" value="phone"></goa-checkbox>
+    <goa-checkbox version="2" name="text" text="Text message" value="text"></goa-checkbox>
   </goa-checkbox-list>
 </goa-form-item>

--- a/docs/src/content/examples/include-descriptions-for-items-in-a-checkbox-list/angular.html
+++ b/docs/src/content/examples/include-descriptions-for-items-in-a-checkbox-list/angular.html
@@ -1,20 +1,20 @@
-<goab-form-item label="How do you want to sign in?" [formGroup]="form">
-  <goab-radio-group name="selectOne" formControlName="selectOne">
-    <goab-radio-item
+<goabx-form-item label="How do you want to sign in?" [formGroup]="form">
+  <goabx-radio-group name="selectOne" formControlName="selectOne">
+    <goabx-radio-item
       value="1"
       label="Sign in as a business"
       [description]="optionOneDescription">
       <ng-template #optionOneDescription>
         Use the account associated with the business
       </ng-template>
-    </goab-radio-item>
-    <goab-radio-item
+    </goabx-radio-item>
+    <goabx-radio-item
       value="2"
       label="Sign in as an individual"
       [description]="optionTwoDescription">
       <ng-template #optionTwoDescription>
         If you don't have a Alberta.ca login, you can create one
       </ng-template>
-    </goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>
+    </goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>

--- a/docs/src/content/examples/include-descriptions-for-items-in-a-checkbox-list/react.tsx
+++ b/docs/src/content/examples/include-descriptions-for-items-in-a-checkbox-list/react.tsx
@@ -1,31 +1,27 @@
 import { useState } from "react";
-import {
-  GoabFormItem,
-  GoabRadioGroup,
-  GoabRadioItem,
-} from "@abgov/react-components";
+import { GoabxFormItem, GoabxRadioGroup, GoabxRadioItem } from "@abgov/react-components/experimental";
 
 export function IncludeDescriptionsForItemsInACheckboxList() {
   const [selected, setSelected] = useState("1");
 
   return (
-    <GoabFormItem label="How do you want to sign in?">
-      <GoabRadioGroup
+    <GoabxFormItem label="How do you want to sign in?">
+      <GoabxRadioGroup
         name="selectOne"
         value={selected}
         onChange={(event) => setSelected(event.value)}
       >
-        <GoabRadioItem
+        <GoabxRadioItem
           value="1"
           label="Sign in as a business"
           description="Use the account associated with the business"
         />
-        <GoabRadioItem
+        <GoabxRadioItem
           value="2"
           label="Sign in as an individual"
           description="If you don't have a Alberta.ca login, you can create one"
         />
-      </GoabRadioGroup>
-    </GoabFormItem>
+      </GoabxRadioGroup>
+    </GoabxFormItem>
   );
 }

--- a/docs/src/content/examples/include-descriptions-for-items-in-a-checkbox-list/web-components.html
+++ b/docs/src/content/examples/include-descriptions-for-items-in-a-checkbox-list/web-components.html
@@ -1,5 +1,5 @@
-<goa-form-item label="How do you want to sign in?">
-  <goa-radio-group name="selectOne" value="1">
+<goa-form-item version="2" label="How do you want to sign in?">
+  <goa-radio-group version="2" name="selectOne" value="1">
     <goa-radio-item value="1" label="Sign in as a business">
       <span slot="description">Use the account associated with the business</span>
     </goa-radio-item>

--- a/docs/src/content/examples/link-to-an-external-page/angular.html
+++ b/docs/src/content/examples/link-to-an-external-page/angular.html
@@ -1,3 +1,3 @@
-<goab-link trailingIcon="open">
+<goabx-link trailingIcon="open">
   <a href="#external-url">External link</a>
-</goab-link>
+</goabx-link>

--- a/docs/src/content/examples/link-to-an-external-page/react.tsx
+++ b/docs/src/content/examples/link-to-an-external-page/react.tsx
@@ -1,9 +1,9 @@
-import { GoabLink } from "@abgov/react-components";
+import { GoabxLink } from "@abgov/react-components/experimental";
 
 export function LinkToAnExternalPage() {
   return (
-    <GoabLink trailingIcon="open">
+    <GoabxLink trailingIcon="open">
       <a href="#external-url">External link</a>
-    </GoabLink>
+    </GoabxLink>
   );
 }

--- a/docs/src/content/examples/question-page/angular.html
+++ b/docs/src/content/examples/question-page/angular.html
@@ -1,22 +1,22 @@
-<goab-link leadingIcon="arrow-back" size="small" mb="none">
+<goabx-link leadingIcon="arrow-back" size="small" mb="none">
   Back
-</goab-link>
+</goabx-link>
 
 <goab-text as="h1" mt="xl" mb="m">What is your email address?</goab-text>
 <goab-text mt="none" mb="xl">We'll use this to send you confirmation of your application.</goab-text>
 
-<goab-form-item label="Email address">
-  <goab-input
+<goabx-form-item label="Email address">
+  <goabx-input
     name="email"
     type="email"
     [value]="answer"
     (onChange)="onAnswerChange($event)"
     width="100%">
-  </goab-input>
-</goab-form-item>
+  </goabx-input>
+</goabx-form-item>
 
 <goab-button-group alignment="start" mt="2xl">
-  <goab-button type="primary" (onClick)="handleContinue()">
+  <goabx-button type="primary" (onClick)="handleContinue()">
     Continue
-  </goab-button>
+  </goabx-button>
 </goab-button-group>

--- a/docs/src/content/examples/question-page/react.tsx
+++ b/docs/src/content/examples/question-page/react.tsx
@@ -1,12 +1,11 @@
 import { useState } from "react";
 import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabFormItem,
-  GoabInput,
-  GoabLink,
-  GoabText,
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxLink,
+} from "@abgov/react-components/experimental";
+import { GoabButtonGroup, GoabText } from "@abgov/react-components";
 
 export function QuestionPage() {
   const [answer, setAnswer] = useState("");
@@ -17,27 +16,27 @@ export function QuestionPage() {
 
   return (
     <>
-      <GoabLink leadingIcon="arrow-back" size="small" mb="none">
+      <GoabxLink leadingIcon="arrow-back" size="small" mb="none">
         Back
-      </GoabLink>
+      </GoabxLink>
 
       <GoabText as="h1" mt="xl" mb="m">What is your email address?</GoabText>
       <GoabText mt="none" mb="xl">We'll use this to send you confirmation of your application.</GoabText>
 
-      <GoabFormItem label="Email address">
-        <GoabInput
+      <GoabxFormItem label="Email address">
+        <GoabxInput
           name="email"
           type="email"
           value={answer}
           onChange={(e) => setAnswer(e.value)}
           width="100%"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
 
       <GoabButtonGroup alignment="start" mt="2xl">
-        <GoabButton type="primary" onClick={handleContinue}>
+        <GoabxButton type="primary" onClick={handleContinue}>
           Continue
-        </GoabButton>
+        </GoabxButton>
       </GoabButtonGroup>
     </>
   );

--- a/docs/src/content/examples/question-page/web-components.html
+++ b/docs/src/content/examples/question-page/web-components.html
@@ -5,8 +5,8 @@
 <goa-text as="h1" mt="xl" mb="m">What is your email address?</goa-text>
 <goa-text mt="none" mb="xl">We'll use this to send you confirmation of your application.</goa-text>
 
-<goa-form-item label="Email address">
-  <goa-input
+<goa-form-item version="2" label="Email address">
+  <goa-input version="2"
     id="email-input"
     name="email"
     type="email"
@@ -15,7 +15,7 @@
 </goa-form-item>
 
 <goa-button-group alignment="start" mt="2xl">
-  <goa-button id="continue-btn" type="primary">
+  <goa-button version="2" id="continue-btn" type="primary">
     Continue
   </goa-button>
 </goa-button-group>

--- a/docs/src/content/examples/remove-a-filter/angular.html
+++ b/docs/src/content/examples/remove-a-filter/angular.html
@@ -1,8 +1,8 @@
 <div>
-  <goab-filter-chip
+  <goabx-filter-chip
     *ngFor="let chip of chips"
     [content]="chip"
     (onClick)="deleteChip(chip)"
     mr="s">
-  </goab-filter-chip>
+  </goabx-filter-chip>
 </div>

--- a/docs/src/content/examples/remove-a-filter/react.tsx
+++ b/docs/src/content/examples/remove-a-filter/react.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { GoabFilterChip } from "@abgov/react-components";
+import { GoabxFilterChip } from "@abgov/react-components/experimental";
 
 export function RemoveAFilter() {
   const [chips, setChips] = useState(["Chip 1", "Chip 2", "Chip 3"]);
@@ -11,7 +11,7 @@ export function RemoveAFilter() {
   return (
     <div>
       {chips.map((chip) => (
-        <GoabFilterChip
+        <GoabxFilterChip
           key={chip}
           content={chip}
           onClick={() => deleteChip(chip)}

--- a/docs/src/content/examples/remove-a-filter/web-components.html
+++ b/docs/src/content/examples/remove-a-filter/web-components.html
@@ -8,6 +8,7 @@
     container.innerHTML = "";
     chips.forEach((chip) => {
       const chipEl = document.createElement("goa-filter-chip");
+      chipEl.setAttribute("version", "2");
       chipEl.setAttribute("content", chip);
       chipEl.setAttribute("mr", "s");
       chipEl.addEventListener("_click", () => deleteChip(chip));

--- a/docs/src/content/examples/require-user-action-before-continuing/angular.html
+++ b/docs/src/content/examples/require-user-action-before-continuing/angular.html
@@ -1,5 +1,5 @@
-<goab-button (onClick)="toggleModal()">Open Basic Modal</goab-button>
-<goab-modal
+<goabx-button (onClick)="toggleModal()">Open Basic Modal</goabx-button>
+<goabx-modal
   [open]="open"
   (onClose)="toggleModal()"
   heading="Are you sure you want to continue?"
@@ -7,8 +7,8 @@
   <p>You cannot return to this page.</p>
   <ng-template #actions>
     <goab-button-group alignment="end">
-      <goab-button type="secondary" size="compact" (onClick)="toggleModal()">Back</goab-button>
-      <goab-button type="primary" size="compact" (onClick)="toggleModal()">Continue</goab-button>
+      <goabx-button type="secondary" size="compact" (onClick)="toggleModal()">Back</goabx-button>
+      <goabx-button type="primary" size="compact" (onClick)="toggleModal()">Continue</goabx-button>
     </goab-button-group>
   </ng-template>
-</goab-modal>
+</goabx-modal>

--- a/docs/src/content/examples/require-user-action-before-continuing/react.tsx
+++ b/docs/src/content/examples/require-user-action-before-continuing/react.tsx
@@ -1,33 +1,30 @@
 import { useState } from "react";
-import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabModal,
-} from "@abgov/react-components";
+import { GoabxButton, GoabxModal } from "@abgov/react-components/experimental";
+import { GoabButtonGroup } from "@abgov/react-components";
 
 export function RequireUserActionBeforeContinuing() {
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      <GoabButton onClick={() => setOpen(true)}>Open Basic Modal</GoabButton>
-      <GoabModal
+      <GoabxButton onClick={() => setOpen(true)}>Open Basic Modal</GoabxButton>
+      <GoabxModal
         heading="Are you sure you want to continue?"
         open={open}
         onClose={() => setOpen(false)}
         actions={
           <GoabButtonGroup alignment="end">
-            <GoabButton type="secondary" size="compact" onClick={() => setOpen(false)}>
+            <GoabxButton type="secondary" size="compact" onClick={() => setOpen(false)}>
               Back
-            </GoabButton>
-            <GoabButton type="primary" size="compact" onClick={() => setOpen(false)}>
+            </GoabxButton>
+            <GoabxButton type="primary" size="compact" onClick={() => setOpen(false)}>
               Continue
-            </GoabButton>
+            </GoabxButton>
           </GoabButtonGroup>
         }
       >
         <p>You cannot return to this page.</p>
-      </GoabModal>
+      </GoabxModal>
     </>
   );
 }

--- a/docs/src/content/examples/require-user-action-before-continuing/web-components.html
+++ b/docs/src/content/examples/require-user-action-before-continuing/web-components.html
@@ -1,10 +1,10 @@
-<goa-button id="open-modal-btn">Open Basic Modal</goa-button>
-<goa-modal id="confirmation-modal" heading="Are you sure you want to continue?">
+<goa-button version="2" id="open-modal-btn">Open Basic Modal</goa-button>
+<goa-modal version="2" id="confirmation-modal" heading="Are you sure you want to continue?">
   <p>You cannot return to this page.</p>
   <div slot="actions">
     <goa-button-group alignment="end">
-      <goa-button id="back-btn" type="secondary" size="compact">Back</goa-button>
-      <goa-button id="continue-btn" type="primary" size="compact">Continue</goa-button>
+      <goa-button version="2" id="back-btn" type="secondary" size="compact">Back</goa-button>
+      <goa-button version="2" id="continue-btn" type="primary" size="compact">Continue</goa-button>
     </goa-button-group>
   </div>
 </goa-modal>

--- a/docs/src/content/examples/reset-date-picker-field/angular.html
+++ b/docs/src/content/examples/reset-date-picker-field/angular.html
@@ -1,12 +1,12 @@
-<goab-form-item label="Date Picker">
-  <goab-date-picker
+<goabx-form-item label="Date Picker">
+  <goabx-date-picker
     (onChange)="onChange($event)"
     name="item"
     [value]="item">
-  </goab-date-picker>
-</goab-form-item>
+  </goabx-date-picker>
+</goabx-form-item>
 
 <goab-button-group alignment="start" mt="xs">
-  <goab-button (onClick)="setValue()">Set Value</goab-button>
-  <goab-button (onClick)="clearValue()">Clear Value</goab-button>
+  <goabx-button (onClick)="setValue()">Set Value</goabx-button>
+  <goabx-button (onClick)="clearValue()">Clear Value</goabx-button>
 </goab-button-group>

--- a/docs/src/content/examples/reset-date-picker-field/react.tsx
+++ b/docs/src/content/examples/reset-date-picker-field/react.tsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
-import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabDatePicker,
-  GoabFormItem,
-} from "@abgov/react-components";
+import { GoabxButton, GoabxDatePicker, GoabxFormItem } from "@abgov/react-components/experimental";
+import { GoabButtonGroup } from "@abgov/react-components";
 
 export function ResetDatePickerField() {
   const [date, setDate] = useState<Date | undefined>();
@@ -25,20 +21,20 @@ export function ResetDatePickerField() {
 
   return (
     <>
-      <GoabFormItem label="Date Picker">
-        <GoabDatePicker
+      <GoabxFormItem label="Date Picker">
+        <GoabxDatePicker
           name="item"
           value={date}
           onChange={(e) => setNewDate(e.value as Date)}
           mb="xl"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
 
       <GoabButtonGroup mt="xs" alignment="start">
-        <GoabButton onClick={setValue}>
+        <GoabxButton onClick={setValue}>
           Set Value
-        </GoabButton>
-        <GoabButton onClick={clearValue}>Clear Value</GoabButton>
+        </GoabxButton>
+        <GoabxButton onClick={clearValue}>Clear Value</GoabxButton>
       </GoabButtonGroup>
     </>
   );

--- a/docs/src/content/examples/reset-date-picker-field/web-components.html
+++ b/docs/src/content/examples/reset-date-picker-field/web-components.html
@@ -1,10 +1,10 @@
-<goa-form-item label="Date Picker">
-  <goa-date-picker id="date-picker" name="item"></goa-date-picker>
+<goa-form-item version="2" label="Date Picker">
+  <goa-date-picker version="2" id="date-picker" name="item"></goa-date-picker>
 </goa-form-item>
 
 <goa-button-group alignment="start" mt="xs">
-  <goa-button id="set-value-btn">Set Value</goa-button>
-  <goa-button id="clear-value-btn">Clear Value</goa-button>
+  <goa-button version="2" id="set-value-btn">Set Value</goa-button>
+  <goa-button version="2" id="clear-value-btn">Clear Value</goa-button>
 </goa-button-group>
 
 <script>

--- a/docs/src/content/examples/result-page/angular.html
+++ b/docs/src/content/examples/result-page/angular.html
@@ -1,9 +1,9 @@
 <goab-text as="h1" mt="none">You have completed the application</goab-text>
 
-<goab-callout type="success" heading="Application submitted">
+<goabx-callout type="success" heading="Application submitted">
   <goab-text size="body-m" mt="none" mb="s">You will receive a copy of the confirmation to the email name&#64;email.com</goab-text>
   <goab-text size="body-m" mt="none" mb="none">Your reference number is: <strong>1234ABC</strong></goab-text>
-</goab-callout>
+</goabx-callout>
 
 <goab-text as="h2" mt="xl" mb="m">What happens next</goab-text>
 <goab-text size="body-m" mt="none" mb="s">We've sent your application to service name. They will contact you to confirm your registration.</goab-text>

--- a/docs/src/content/examples/result-page/react.tsx
+++ b/docs/src/content/examples/result-page/react.tsx
@@ -1,14 +1,15 @@
-import { GoabCallout, GoabText } from "@abgov/react-components";
+import { GoabxCallout } from "@abgov/react-components/experimental";
+import { GoabText } from "@abgov/react-components";
 
 export function ResultPage() {
   return (
     <>
       <GoabText as="h1" mt="none">You have completed the application</GoabText>
 
-      <GoabCallout type="success" heading="Application submitted">
+      <GoabxCallout type="success" heading="Application submitted">
         <GoabText size="body-m" mt="none" mb="s">You will receive a copy of the confirmation to the email name@email.com</GoabText>
         <GoabText size="body-m" mt="none" mb="none">Your reference number is: <strong>1234ABC</strong></GoabText>
-      </GoabCallout>
+      </GoabxCallout>
 
       <GoabText as="h2" mt="xl" mb="m">What happens next</GoabText>
       <GoabText size="body-m" mt="none" mb="s">We've sent your application to service name. They will contact you to confirm your registration.</GoabText>

--- a/docs/src/content/examples/result-page/web-components.html
+++ b/docs/src/content/examples/result-page/web-components.html
@@ -1,6 +1,6 @@
 <goa-text as="h1" mt="none">You have completed the application</goa-text>
 
-<goa-callout type="success" heading="Application submitted">
+<goa-callout version="2" type="success" heading="Application submitted">
   <goa-text size="body-m" mt="none" mb="s">You will receive a copy of the confirmation to the email name@email.com</goa-text>
   <goa-text size="body-m" mt="none" mb="none">Your reference number is: <strong>1234ABC</strong></goa-text>
 </goa-callout>

--- a/docs/src/content/examples/reveal-input-based-on-a-selection/angular.html
+++ b/docs/src/content/examples/reveal-input-based-on-a-selection/angular.html
@@ -1,51 +1,51 @@
-<goab-form-item [formGroup]="form" label="How would you like to be contacted?" helpText="Select one option">
-  <goab-radio-group name="contactMethod" formControlName="contactMethod">
-    <goab-radio-item label="Email" value="email" [reveal]="emailReveal">
+<goabx-form-item [formGroup]="form" label="How would you like to be contacted?" helpText="Select one option">
+  <goabx-radio-group name="contactMethod" formControlName="contactMethod">
+    <goabx-radio-item label="Email" value="email" [reveal]="emailReveal">
       <ng-template #emailReveal>
-        <goab-form-item label="Email address">
-          <goab-input name="email" formControlName="emailAddress"></goab-input>
-        </goab-form-item>
+        <goabx-form-item label="Email address">
+          <goabx-input name="email" formControlName="emailAddress"></goabx-input>
+        </goabx-form-item>
       </ng-template>
-    </goab-radio-item>
-    <goab-radio-item value="phone" label="Phone" [reveal]="phoneReveal">
+    </goabx-radio-item>
+    <goabx-radio-item value="phone" label="Phone" [reveal]="phoneReveal">
       <ng-template #phoneReveal>
-        <goab-form-item label="Phone number">
-          <goab-input name="phone" formControlName="phoneNumber"></goab-input>
-        </goab-form-item>
+        <goabx-form-item label="Phone number">
+          <goabx-input name="phone" formControlName="phoneNumber"></goabx-input>
+        </goabx-form-item>
       </ng-template>
-    </goab-radio-item>
-    <goab-radio-item value="text" label="Text message" [reveal]="textReveal">
+    </goabx-radio-item>
+    <goabx-radio-item value="text" label="Text message" [reveal]="textReveal">
       <ng-template #textReveal>
-        <goab-form-item label="Mobile phone number">
-          <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
-        </goab-form-item>
+        <goabx-form-item label="Mobile phone number">
+          <goabx-input name="mobile" formControlName="phoneNumber"></goabx-input>
+        </goabx-form-item>
       </ng-template>
-    </goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>
+    </goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>
 
-<goab-form-item [formGroup]="form" label="How would you like to be contacted?" mt="xl">
+<goabx-form-item [formGroup]="form" label="How would you like to be contacted?" mt="xl">
   <goab-checkbox-list name="contactMethods" formControlName="contactMethods">
-    <goab-checkbox name="email" text="Email" value="email" [reveal]="checkEmailReveal">
+    <goabx-checkbox name="email" text="Email" value="email" [reveal]="checkEmailReveal">
       <ng-template #checkEmailReveal>
-        <goab-form-item label="Email address">
-          <goab-input name="email" formControlName="emailAddress"></goab-input>
-        </goab-form-item>
+        <goabx-form-item label="Email address">
+          <goabx-input name="email" formControlName="emailAddress"></goabx-input>
+        </goabx-form-item>
       </ng-template>
-    </goab-checkbox>
-    <goab-checkbox name="phone" text="Phone" value="phone" [reveal]="checkPhoneReveal">
+    </goabx-checkbox>
+    <goabx-checkbox name="phone" text="Phone" value="phone" [reveal]="checkPhoneReveal">
       <ng-template #checkPhoneReveal>
-        <goab-form-item label="Phone number">
-          <goab-input name="phone" formControlName="phoneNumber"></goab-input>
-        </goab-form-item>
+        <goabx-form-item label="Phone number">
+          <goabx-input name="phone" formControlName="phoneNumber"></goabx-input>
+        </goabx-form-item>
       </ng-template>
-    </goab-checkbox>
-    <goab-checkbox name="text" text="Text message" value="text" [reveal]="checkTextReveal">
+    </goabx-checkbox>
+    <goabx-checkbox name="text" text="Text message" value="text" [reveal]="checkTextReveal">
       <ng-template #checkTextReveal>
-        <goab-form-item label="Mobile phone number">
-          <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
-        </goab-form-item>
+        <goabx-form-item label="Mobile phone number">
+          <goabx-input name="mobile" formControlName="phoneNumber"></goabx-input>
+        </goabx-form-item>
       </ng-template>
-    </goab-checkbox>
+    </goabx-checkbox>
   </goab-checkbox-list>
-</goab-form-item>
+</goabx-form-item>

--- a/docs/src/content/examples/reveal-input-based-on-a-selection/react.tsx
+++ b/docs/src/content/examples/reveal-input-based-on-a-selection/react.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
 import {
-  GoabCheckbox,
-  GoabCheckboxList,
-  GoabFormItem,
-  GoabInput,
-  GoabRadioGroup,
-  GoabRadioItem,
-} from "@abgov/react-components";
+  GoabxCheckbox,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
+import { GoabCheckboxList } from "@abgov/react-components";
 
 export function RevealInputBasedOnASelection() {
   const [contactMethod, setContactMethod] = useState("");
@@ -14,83 +14,83 @@ export function RevealInputBasedOnASelection() {
 
   return (
     <>
-      <GoabFormItem
+      <GoabxFormItem
         label="How would you like to be contacted?"
         helpText="Select one option"
       >
-        <GoabRadioGroup
+        <GoabxRadioGroup
           name="contactMethod"
           value={contactMethod}
           onChange={(e) => setContactMethod(e.value)}
         >
-          <GoabRadioItem
+          <GoabxRadioItem
             value="email"
             label="Email"
             reveal={
-              <GoabFormItem label="Email address">
-                <GoabInput name="email" onChange={() => {}} value="" />
-              </GoabFormItem>
+              <GoabxFormItem label="Email address">
+                <GoabxInput name="email" onChange={() => {}} value="" />
+              </GoabxFormItem>
             }
           />
-          <GoabRadioItem
+          <GoabxRadioItem
             value="phone"
             label="Phone"
             reveal={
-              <GoabFormItem label="Phone number">
-                <GoabInput name="phoneNumber" onChange={() => {}} value="" />
-              </GoabFormItem>
+              <GoabxFormItem label="Phone number">
+                <GoabxInput name="phoneNumber" onChange={() => {}} value="" />
+              </GoabxFormItem>
             }
           />
-          <GoabRadioItem
+          <GoabxRadioItem
             value="text"
             label="Text message"
             reveal={
-              <GoabFormItem label="Mobile phone number">
-                <GoabInput name="mobilePhoneNumber" onChange={() => {}} value="" />
-              </GoabFormItem>
+              <GoabxFormItem label="Mobile phone number">
+                <GoabxInput name="mobilePhoneNumber" onChange={() => {}} value="" />
+              </GoabxFormItem>
             }
           />
-        </GoabRadioGroup>
-      </GoabFormItem>
+        </GoabxRadioGroup>
+      </GoabxFormItem>
 
-      <GoabFormItem label="How would you like to be contacted?" mt="xl">
+      <GoabxFormItem label="How would you like to be contacted?" mt="xl">
         <GoabCheckboxList
           name="contactMethods"
           value={checkboxSelection}
           onChange={(e) => setCheckboxSelection(e.values || [])}
         >
-          <GoabCheckbox
+          <GoabxCheckbox
             name="email"
             text="Email"
             value="email"
             reveal={
-              <GoabFormItem label="Email address">
-                <GoabInput name="email" onChange={() => {}} value="" />
-              </GoabFormItem>
+              <GoabxFormItem label="Email address">
+                <GoabxInput name="email" onChange={() => {}} value="" />
+              </GoabxFormItem>
             }
           />
-          <GoabCheckbox
+          <GoabxCheckbox
             name="phone"
             text="Phone"
             value="phone"
             reveal={
-              <GoabFormItem label="Phone number">
-                <GoabInput name="phoneNumber" onChange={() => {}} value="" />
-              </GoabFormItem>
+              <GoabxFormItem label="Phone number">
+                <GoabxInput name="phoneNumber" onChange={() => {}} value="" />
+              </GoabxFormItem>
             }
           />
-          <GoabCheckbox
+          <GoabxCheckbox
             name="text"
             text="Text message"
             value="text"
             reveal={
-              <GoabFormItem label="Mobile phone number">
-                <GoabInput name="mobilePhoneNumber" onChange={() => {}} value="" />
-              </GoabFormItem>
+              <GoabxFormItem label="Mobile phone number">
+                <GoabxInput name="mobilePhoneNumber" onChange={() => {}} value="" />
+              </GoabxFormItem>
             }
           />
         </GoabCheckboxList>
-      </GoabFormItem>
+      </GoabxFormItem>
     </>
   );
 }

--- a/docs/src/content/examples/reveal-input-based-on-a-selection/web-components.html
+++ b/docs/src/content/examples/reveal-input-based-on-a-selection/web-components.html
@@ -1,49 +1,49 @@
-<goa-form-item label="How would you like to be contacted?" helptext="Select one option">
-  <goa-radio-group name="contactMethod" id="radio-contact">
+<goa-form-item version="2" label="How would you like to be contacted?" helptext="Select one option">
+  <goa-radio-group version="2" name="contactMethod" id="radio-contact">
     <goa-radio-item value="email" label="Email">
       <div slot="reveal">
-        <goa-form-item label="Email address">
-          <goa-input name="email"></goa-input>
+        <goa-form-item version="2" label="Email address">
+          <goa-input version="2" name="email"></goa-input>
         </goa-form-item>
       </div>
     </goa-radio-item>
     <goa-radio-item value="phone" label="Phone">
       <div slot="reveal">
-        <goa-form-item label="Phone number">
-          <goa-input name="phone"></goa-input>
+        <goa-form-item version="2" label="Phone number">
+          <goa-input version="2" name="phone"></goa-input>
         </goa-form-item>
       </div>
     </goa-radio-item>
     <goa-radio-item value="text" label="Text message">
       <div slot="reveal">
-        <goa-form-item label="Mobile phone number">
-          <goa-input name="mobile"></goa-input>
+        <goa-form-item version="2" label="Mobile phone number">
+          <goa-input version="2" name="mobile"></goa-input>
         </goa-form-item>
       </div>
     </goa-radio-item>
   </goa-radio-group>
 </goa-form-item>
 
-<goa-form-item label="How would you like to be contacted?" mt="xl">
+<goa-form-item version="2" label="How would you like to be contacted?" mt="xl">
   <goa-checkbox-list name="contactMethods">
-    <goa-checkbox name="emailContact" text="Email">
+    <goa-checkbox version="2" name="emailContact" text="Email">
       <div slot="reveal">
-        <goa-form-item label="Email address">
-          <goa-input name="emailInput"></goa-input>
+        <goa-form-item version="2" label="Email address">
+          <goa-input version="2" name="emailInput"></goa-input>
         </goa-form-item>
       </div>
     </goa-checkbox>
-    <goa-checkbox name="phoneContact" text="Phone">
+    <goa-checkbox version="2" name="phoneContact" text="Phone">
       <div slot="reveal">
-        <goa-form-item label="Phone number">
-          <goa-input name="phoneInput"></goa-input>
+        <goa-form-item version="2" label="Phone number">
+          <goa-input version="2" name="phoneInput"></goa-input>
         </goa-form-item>
       </div>
     </goa-checkbox>
-    <goa-checkbox name="textContact" text="Text message">
+    <goa-checkbox version="2" name="textContact" text="Text message">
       <div slot="reveal">
-        <goa-form-item label="Mobile phone number">
-          <goa-input name="mobileInput"></goa-input>
+        <goa-form-item version="2" label="Mobile phone number">
+          <goa-input version="2" name="mobileInput"></goa-input>
         </goa-form-item>
       </div>
     </goa-checkbox>

--- a/docs/src/content/examples/review-and-action/angular.html
+++ b/docs/src/content/examples/review-and-action/angular.html
@@ -45,26 +45,26 @@
         Assistance Program subsidy.
       </goab-text>
 
-      <goab-form-item label="Case history and new request" mt="l">
-        <goab-radio-group name="case" orientation="horizontal" formControlName="case">
-          <goab-radio-item value="grant" label="Grant"></goab-radio-item>
-          <goab-radio-item value="deny" label="Deny"></goab-radio-item>
-        </goab-radio-group>
-      </goab-form-item>
+      <goabx-form-item label="Case history and new request" mt="l">
+        <goabx-radio-group name="case" orientation="horizontal" formControlName="case">
+          <goabx-radio-item value="grant" label="Grant"></goabx-radio-item>
+          <goabx-radio-item value="deny" label="Deny"></goabx-radio-item>
+        </goabx-radio-group>
+      </goabx-form-item>
 
-      <goab-form-item label="Reason to deny" mt="l">
-        <goab-dropdown name="reason" width="100%" formControlName="reason">
-          <goab-dropdown-item value="1" label="Incomplete Application"></goab-dropdown-item>
-          <goab-dropdown-item value="2" label="Eligibility Criteria Not Met"></goab-dropdown-item>
-          <goab-dropdown-item value="3" label="Documentation Verification Failure"></goab-dropdown-item>
-        </goab-dropdown>
-      </goab-form-item>
+      <goabx-form-item label="Reason to deny" mt="l">
+        <goabx-dropdown name="reason" width="100%" formControlName="reason">
+          <goabx-dropdown-item value="1" label="Incomplete Application"></goabx-dropdown-item>
+          <goabx-dropdown-item value="2" label="Eligibility Criteria Not Met"></goabx-dropdown-item>
+          <goabx-dropdown-item value="3" label="Documentation Verification Failure"></goabx-dropdown-item>
+        </goabx-dropdown>
+      </goabx-form-item>
 
-      <goab-form-item label="Message" mt="l">
-        <goab-textarea name="message" [rows]="5" width="100%" formControlName="message"></goab-textarea>
-      </goab-form-item>
+      <goabx-form-item label="Message" mt="l">
+        <goabx-textarea name="message" [rows]="5" width="100%" formControlName="message"></goabx-textarea>
+      </goabx-form-item>
 
-      <goab-button mt="xl" (onClick)="onClick()">Confirm adjournment</goab-button>
+      <goabx-button mt="xl" (onClick)="onClick()">Confirm adjournment</goabx-button>
     </form>
   </goab-container>
 </goab-grid>

--- a/docs/src/content/examples/review-and-action/react.tsx
+++ b/docs/src/content/examples/review-and-action/react.tsx
@@ -1,16 +1,13 @@
 import {
-  GoabBlock,
-  GoabButton,
-  GoabContainer,
-  GoabDropdown,
-  GoabDropdownItem,
-  GoabFormItem,
-  GoabGrid,
-  GoabRadioGroup,
-  GoabRadioItem,
-  GoabText,
-  GoabTextarea,
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxFormItem,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+  GoabxTextArea,
+} from "@abgov/react-components/experimental";
+import { GoabBlock, GoabContainer, GoabGrid, GoabText } from "@abgov/react-components";
 
 export function ReviewAndAction() {
   return (
@@ -61,28 +58,28 @@ export function ReviewAndAction() {
             qualify for the Lodge Assistance Program subsidy.
           </GoabText>
 
-          <GoabFormItem label="Case history and new request" mt="l">
-            <GoabRadioGroup name="case" orientation="horizontal" onChange={() => {}}>
-              <GoabRadioItem value="grant" label="Grant" />
-              <GoabRadioItem value="deny" label="Deny" />
-            </GoabRadioGroup>
-          </GoabFormItem>
+          <GoabxFormItem label="Case history and new request" mt="l">
+            <GoabxRadioGroup name="case" orientation="horizontal" onChange={() => {}}>
+              <GoabxRadioItem value="grant" label="Grant" />
+              <GoabxRadioItem value="deny" label="Deny" />
+            </GoabxRadioGroup>
+          </GoabxFormItem>
 
-          <GoabFormItem label="Reason to deny" mt="l">
-            <GoabDropdown name="reason" width="100%" onChange={() => {}}>
-              <GoabDropdownItem value="1" label="Incomplete Application" />
-              <GoabDropdownItem value="2" label="Eligibility Criteria Not Met" />
-              <GoabDropdownItem value="3" label="Documentation Verification Failure" />
-            </GoabDropdown>
-          </GoabFormItem>
+          <GoabxFormItem label="Reason to deny" mt="l">
+            <GoabxDropdown name="reason" width="100%" onChange={() => {}}>
+              <GoabxDropdownItem value="1" label="Incomplete Application" />
+              <GoabxDropdownItem value="2" label="Eligibility Criteria Not Met" />
+              <GoabxDropdownItem value="3" label="Documentation Verification Failure" />
+            </GoabxDropdown>
+          </GoabxFormItem>
 
-          <GoabFormItem label="Message" mt="l">
-            <GoabTextarea name="message" rows={5} width="100%" value="" onChange={() => {}} />
-          </GoabFormItem>
+          <GoabxFormItem label="Message" mt="l">
+            <GoabxTextArea name="message" rows={5} width="100%" value="" onChange={() => {}} />
+          </GoabxFormItem>
 
-          <GoabButton mt="xl" onClick={() => {}}>
+          <GoabxButton mt="xl" onClick={() => {}}>
             Confirm adjournment
-          </GoabButton>
+          </GoabxButton>
         </form>
       </GoabContainer>
     </GoabGrid>

--- a/docs/src/content/examples/review-and-action/web-components.html
+++ b/docs/src/content/examples/review-and-action/web-components.html
@@ -45,26 +45,26 @@
         Assistance Program subsidy.
       </goa-text>
 
-      <goa-form-item label="Case history and new request" mt="l">
-        <goa-radio-group name="case" orientation="horizontal">
+      <goa-form-item version="2" label="Case history and new request" mt="l">
+        <goa-radio-group version="2" name="case" orientation="horizontal">
           <goa-radio-item value="grant" label="Grant"></goa-radio-item>
           <goa-radio-item value="deny" label="Deny"></goa-radio-item>
         </goa-radio-group>
       </goa-form-item>
 
-      <goa-form-item label="Reason to deny" mt="l">
-        <goa-dropdown name="reason" width="100%">
+      <goa-form-item version="2" label="Reason to deny" mt="l">
+        <goa-dropdown version="2" name="reason" width="100%">
           <goa-dropdown-item value="1" label="Incomplete Application"></goa-dropdown-item>
           <goa-dropdown-item value="2" label="Eligibility Criteria Not Met"></goa-dropdown-item>
           <goa-dropdown-item value="3" label="Documentation Verification Failure"></goa-dropdown-item>
         </goa-dropdown>
       </goa-form-item>
 
-      <goa-form-item label="Message" mt="l">
-        <goa-textarea name="message" rows="5" width="100%"></goa-textarea>
+      <goa-form-item version="2" label="Message" mt="l">
+        <goa-textarea version="2" name="message" rows="5" width="100%"></goa-textarea>
       </goa-form-item>
 
-      <goa-button id="confirm-btn" mt="xl">Confirm adjournment</goa-button>
+      <goa-button version="2" id="confirm-btn" mt="xl">Confirm adjournment</goa-button>
     </form>
   </goa-container>
 </goa-grid>

--- a/docs/src/content/examples/review-page/angular.html
+++ b/docs/src/content/examples/review-page/angular.html
@@ -1,45 +1,45 @@
 <goab-text size="heading-l" mt="none" mb="none">Review your answers</goab-text>
 <goab-text size="heading-s" color="secondary" mt="l" mb="none">Your situation</goab-text>
-<goab-table mt="l">
+<goabx-table mt="l">
   <tbody>
     <tr>
       <td><strong>What was your (the applicant's) relationship to the deceased?</strong></td>
       <td>Other</td>
-      <td><goab-link>Change</goab-link></td>
+      <td><goabx-link>Change</goabx-link></td>
     </tr>
     <tr>
       <td><strong>My relationship to the deceased was</strong></td>
       <td>Manager</td>
-      <td><goab-link>Change</goab-link></td>
+      <td><goabx-link>Change</goabx-link></td>
     </tr>
     <tr>
       <td><strong>Was the deceased part of a household that was receiving Assured Income for the Severely Handicapped (AISH) or Income Support?</strong></td>
       <td>No</td>
-      <td><goab-link>Change</goab-link></td>
+      <td><goabx-link>Change</goabx-link></td>
     </tr>
     <tr>
       <td><strong>Was the deceased a minor?</strong></td>
       <td>No</td>
-      <td><goab-link>Change</goab-link></td>
+      <td><goabx-link>Change</goabx-link></td>
     </tr>
     <tr>
       <td><strong>What was the deceased's marital status at time of death?</strong></td>
       <td>Married</td>
-      <td><goab-link>Change</goab-link></td>
+      <td><goabx-link>Change</goabx-link></td>
     </tr>
     <tr>
       <td><strong>Did the deceased have any dependents?</strong></td>
       <td>No</td>
-      <td><goab-link>Change</goab-link></td>
+      <td><goabx-link>Change</goabx-link></td>
     </tr>
     <tr>
       <td><strong>Was the deceased a sponsored immigrant?</strong></td>
       <td>Yes</td>
-      <td><goab-link>Change</goab-link></td>
+      <td><goabx-link>Change</goabx-link></td>
     </tr>
   </tbody>
-</goab-table>
+</goabx-table>
 <goab-button-group alignment="start" mt="2xl">
-  <goab-button type="primary" (onClick)="onConfirmClick()">Confirm and continue</goab-button>
-  <goab-button type="tertiary" (onClick)="onBackClick()">Back to application overview</goab-button>
+  <goabx-button type="primary" (onClick)="onConfirmClick()">Confirm and continue</goabx-button>
+  <goabx-button type="tertiary" (onClick)="onBackClick()">Back to application overview</goabx-button>
 </goab-button-group>

--- a/docs/src/content/examples/review-page/react.tsx
+++ b/docs/src/content/examples/review-page/react.tsx
@@ -1,17 +1,12 @@
-import {
-  GoabButton,
-  GoabButtonGroup,
-  GoabLink,
-  GoabTable,
-  GoabText,
-} from "@abgov/react-components";
+import { GoabxButton, GoabxLink, GoabxTable } from "@abgov/react-components/experimental";
+import { GoabButtonGroup, GoabText } from "@abgov/react-components";
 
 export function ReviewPage() {
   return (
     <>
       <GoabText size="heading-l" mt="none" mb="none">Review your answers</GoabText>
       <GoabText size="heading-s" color="secondary" mt="l" mb="none">Your situation</GoabText>
-      <GoabTable mt="l">
+      <GoabxTable mt="l">
         <tbody>
           <tr>
             <td>
@@ -19,7 +14,7 @@ export function ReviewPage() {
             </td>
             <td>Other</td>
             <td>
-              <GoabLink>Change</GoabLink>
+              <GoabxLink>Change</GoabxLink>
             </td>
           </tr>
           <tr>
@@ -28,7 +23,7 @@ export function ReviewPage() {
             </td>
             <td>Manager</td>
             <td>
-              <GoabLink>Change</GoabLink>
+              <GoabxLink>Change</GoabxLink>
             </td>
           </tr>
           <tr>
@@ -40,7 +35,7 @@ export function ReviewPage() {
             </td>
             <td>No</td>
             <td>
-              <GoabLink>Change</GoabLink>
+              <GoabxLink>Change</GoabxLink>
             </td>
           </tr>
           <tr>
@@ -49,7 +44,7 @@ export function ReviewPage() {
             </td>
             <td>No</td>
             <td>
-              <GoabLink>Change</GoabLink>
+              <GoabxLink>Change</GoabxLink>
             </td>
           </tr>
           <tr>
@@ -58,7 +53,7 @@ export function ReviewPage() {
             </td>
             <td>Married</td>
             <td>
-              <GoabLink>Change</GoabLink>
+              <GoabxLink>Change</GoabxLink>
             </td>
           </tr>
           <tr>
@@ -67,7 +62,7 @@ export function ReviewPage() {
             </td>
             <td>No</td>
             <td>
-              <GoabLink>Change</GoabLink>
+              <GoabxLink>Change</GoabxLink>
             </td>
           </tr>
           <tr>
@@ -76,14 +71,14 @@ export function ReviewPage() {
             </td>
             <td>Yes</td>
             <td>
-              <GoabLink>Change</GoabLink>
+              <GoabxLink>Change</GoabxLink>
             </td>
           </tr>
         </tbody>
-      </GoabTable>
+      </GoabxTable>
       <GoabButtonGroup alignment="start" mt="2xl">
-        <GoabButton type="primary">Confirm and continue</GoabButton>
-        <GoabButton type="tertiary">Back to application overview</GoabButton>
+        <GoabxButton type="primary">Confirm and continue</GoabxButton>
+        <GoabxButton type="tertiary">Back to application overview</GoabxButton>
       </GoabButtonGroup>
     </>
   );

--- a/docs/src/content/examples/review-page/web-components.html
+++ b/docs/src/content/examples/review-page/web-components.html
@@ -1,6 +1,6 @@
 <goa-text size="heading-l" mt="none" mb="none">Review your answers</goa-text>
 <goa-text size="heading-s" color="secondary" mt="l" mb="none">Your situation</goa-text>
-<goa-table mt="l">
+<goa-table version="2" mt="l">
   <table>
     <tbody>
     <tr>
@@ -42,8 +42,8 @@
   </table>
 </goa-table>
 <goa-button-group alignment="start" mt="2xl">
-  <goa-button type="primary" id="confirm-btn">Confirm and continue</goa-button>
-  <goa-button type="tertiary" id="back-btn">Back to application overview</goa-button>
+  <goa-button version="2" type="primary" id="confirm-btn">Confirm and continue</goa-button>
+  <goa-button version="2" type="tertiary" id="back-btn">Back to application overview</goa-button>
 </goa-button-group>
 
 <script>

--- a/docs/src/content/examples/search/angular.html
+++ b/docs/src/content/examples/search/angular.html
@@ -1,13 +1,13 @@
 <form [formGroup]="form">
-  <goab-form-item>
+  <goabx-form-item>
     <goab-block gap="xs" direction="row">
-      <goab-input
+      <goabx-input
         type="search"
         name="search"
         formControlName="search"
         leadingIcon="search">
-      </goab-input>
-      <goab-button type="primary" (onClick)="onClick()">Search</goab-button>
+      </goabx-input>
+      <goabx-button type="primary" (onClick)="onClick()">Search</goabx-button>
     </goab-block>
-  </goab-form-item>
+  </goabx-form-item>
 </form>

--- a/docs/src/content/examples/search/react.tsx
+++ b/docs/src/content/examples/search/react.tsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
-import {
-  GoabBlock,
-  GoabButton,
-  GoabFormItem,
-  GoabInput,
-} from "@abgov/react-components";
+import { GoabxButton, GoabxFormItem, GoabxInput } from "@abgov/react-components/experimental";
+import { GoabBlock } from "@abgov/react-components";
 
 export function Search() {
   const [search, setSearch] = useState("");
@@ -15,20 +11,20 @@ export function Search() {
 
   return (
     <form>
-      <GoabFormItem>
+      <GoabxFormItem>
         <GoabBlock gap="xs" direction="row">
-          <GoabInput
+          <GoabxInput
             type="search"
             name="search"
             value={search}
             onChange={(e) => setSearch(e.value)}
             leadingIcon="search"
           />
-          <GoabButton type="primary" onClick={onClick}>
+          <GoabxButton type="primary" onClick={onClick}>
             Search
-          </GoabButton>
+          </GoabxButton>
         </GoabBlock>
-      </GoabFormItem>
+      </GoabxFormItem>
     </form>
   );
 }

--- a/docs/src/content/examples/search/web-components.html
+++ b/docs/src/content/examples/search/web-components.html
@@ -1,13 +1,13 @@
 <form>
-  <goa-form-item>
+  <goa-form-item version="2">
     <goa-block gap="xs" direction="row">
-      <goa-input
+      <goa-input version="2"
         id="search-input"
         type="search"
         name="search"
         leadingicon="search">
       </goa-input>
-      <goa-button id="search-btn" type="primary">Search</goa-button>
+      <goa-button version="2" id="search-btn" type="primary">Search</goa-button>
     </goa-block>
   </goa-form-item>
 </form>

--- a/docs/src/content/examples/select-one-or-more-from-a-list-of-options/angular.html
+++ b/docs/src/content/examples/select-one-or-more-from-a-list-of-options/angular.html
@@ -1,12 +1,12 @@
-<goab-form-item
+<goabx-form-item
   label="How would you like to be contacted?"
   helpText="Choose all that apply">
   <goab-checkbox-list
     name="contactPreferences"
     [value]="selectedOptions"
     (onChange)="onSelectionChange($event)">
-    <goab-checkbox name="email" text="Email" value="email"></goab-checkbox>
-    <goab-checkbox name="phone" text="Phone" value="phone"></goab-checkbox>
-    <goab-checkbox name="text" text="Text message" value="text"></goab-checkbox>
+    <goabx-checkbox name="email" text="Email" value="email"></goabx-checkbox>
+    <goabx-checkbox name="phone" text="Phone" value="phone"></goabx-checkbox>
+    <goabx-checkbox name="text" text="Text message" value="text"></goabx-checkbox>
   </goab-checkbox-list>
-</goab-form-item>
+</goabx-form-item>

--- a/docs/src/content/examples/select-one-or-more-from-a-list-of-options/react.tsx
+++ b/docs/src/content/examples/select-one-or-more-from-a-list-of-options/react.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { GoabCheckbox, GoabCheckboxList, GoabFormItem } from "@abgov/react-components";
+import { GoabxCheckbox, GoabxFormItem } from "@abgov/react-components/experimental";
+import { GoabCheckboxList } from "@abgov/react-components";
 
 export function SelectOneOrMoreFromAListOfOptions() {
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
 
   return (
-    <GoabFormItem
+    <GoabxFormItem
       label="How would you like to be contacted?"
       helpText="Choose all that apply"
     >
@@ -14,10 +15,10 @@ export function SelectOneOrMoreFromAListOfOptions() {
         value={selectedOptions}
         onChange={(e) => setSelectedOptions(e.detail.value)}
       >
-        <GoabCheckbox name="email" text="Email" value="email" />
-        <GoabCheckbox name="phone" text="Phone" value="phone" />
-        <GoabCheckbox name="text" text="Text message" value="text" />
+        <GoabxCheckbox name="email" text="Email" value="email" />
+        <GoabxCheckbox name="phone" text="Phone" value="phone" />
+        <GoabxCheckbox name="text" text="Text message" value="text" />
       </GoabCheckboxList>
-    </GoabFormItem>
+    </GoabxFormItem>
   );
 }

--- a/docs/src/content/examples/select-one-or-more-from-a-list-of-options/web-components.html
+++ b/docs/src/content/examples/select-one-or-more-from-a-list-of-options/web-components.html
@@ -1,10 +1,10 @@
-<goa-form-item
+<goa-form-item version="2"
   label="How would you like to be contacted?"
   helptext="Choose all that apply">
   <goa-checkbox-list name="contactPreferences">
-    <goa-checkbox name="email" text="Email" value="email"></goa-checkbox>
-    <goa-checkbox name="phone" text="Phone" value="phone"></goa-checkbox>
-    <goa-checkbox name="text" text="Text message" value="text"></goa-checkbox>
+    <goa-checkbox version="2" name="email" text="Email" value="email"></goa-checkbox>
+    <goa-checkbox version="2" name="phone" text="Phone" value="phone"></goa-checkbox>
+    <goa-checkbox version="2" name="text" text="Text message" value="text"></goa-checkbox>
   </goa-checkbox-list>
 </goa-form-item>
 

--- a/docs/src/content/examples/set-a-max-width-on-a-long-radio-item/angular.html
+++ b/docs/src/content/examples/set-a-max-width-on-a-long-radio-item/angular.html
@@ -1,16 +1,16 @@
 <form>
-  <goab-form-item label="Select one option">
-    <goab-radio-group
+  <goabx-form-item label="Select one option">
+    <goabx-radio-group
       name="selectOne"
       [value]="selectOne"
       (onChange)="onRadioChange($event)">
-      <goab-radio-item
+      <goabx-radio-item
         value="1"
         label="Option one which has a very long label with lots of text"
         maxWidth="300px">
-      </goab-radio-item>
-      <goab-radio-item value="2" label="Option two"></goab-radio-item>
-      <goab-radio-item value="3" label="Option three"></goab-radio-item>
-    </goab-radio-group>
-  </goab-form-item>
+      </goabx-radio-item>
+      <goabx-radio-item value="2" label="Option two"></goabx-radio-item>
+      <goabx-radio-item value="3" label="Option three"></goabx-radio-item>
+    </goabx-radio-group>
+  </goabx-form-item>
 </form>

--- a/docs/src/content/examples/set-a-max-width-on-a-long-radio-item/react.tsx
+++ b/docs/src/content/examples/set-a-max-width-on-a-long-radio-item/react.tsx
@@ -1,9 +1,5 @@
 import { useState } from "react";
-import {
-  GoabFormItem,
-  GoabRadioGroup,
-  GoabRadioItem
-} from "@abgov/react-components";
+import { GoabxFormItem, GoabxRadioGroup, GoabxRadioItem } from "@abgov/react-components/experimental";
 import { GoabRadioGroupOnChangeDetail } from "@abgov/ui-components-common";
 
 export function SetAMaxWidthOnALongRadioItem() {
@@ -11,20 +7,20 @@ export function SetAMaxWidthOnALongRadioItem() {
 
   return (
     <form>
-      <GoabFormItem label="Select one option">
-        <GoabRadioGroup
+      <GoabxFormItem label="Select one option">
+        <GoabxRadioGroup
           name="selectOne"
           value={selectOne}
           onChange={(e: GoabRadioGroupOnChangeDetail) => setSelectOne(e.value)}>
-          <GoabRadioItem
+          <GoabxRadioItem
             value="1"
             label="Option one which has a very long label with lots of text"
             maxWidth="300px"
           />
-          <GoabRadioItem value="2" label="Option two" />
-          <GoabRadioItem value="3" label="Option three" />
-        </GoabRadioGroup>
-      </GoabFormItem>
+          <GoabxRadioItem value="2" label="Option two" />
+          <GoabxRadioItem value="3" label="Option three" />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
     </form>
   );
 }

--- a/docs/src/content/examples/set-a-max-width-on-a-long-radio-item/web-components.html
+++ b/docs/src/content/examples/set-a-max-width-on-a-long-radio-item/web-components.html
@@ -1,6 +1,6 @@
 <form>
-  <goa-form-item label="Select one option">
-    <goa-radio-group name="selectOne" value="1">
+  <goa-form-item version="2" label="Select one option">
+    <goa-radio-group version="2" name="selectOne" value="1">
       <goa-radio-item
         value="1"
         label="Option one which has a very long label with lots of text"

--- a/docs/src/content/examples/set-a-specific-tab-to-be-active/angular.html
+++ b/docs/src/content/examples/set-a-specific-tab-to-be-active/angular.html
@@ -1,6 +1,6 @@
-<goab-tabs [initialTab]="2">
+<goabx-tabs [initialTab]="2">
   <goab-tab heading="All">
-    <goab-table width="100%">
+    <goabx-table width="100%">
       <thead>
         <tr>
           <th>Status</th>
@@ -12,30 +12,30 @@
       <tbody>
         <tr *ngFor="let i of review">
           <td>
-            <goab-badge type="important" content="Review pending"></goab-badge>
+            <goabx-badge type="important" content="Review pending"></goabx-badge>
           </td>
           <td>Lorem Ipsum</td>
           <td class="goa-table-number-column">1234567890</td>
           <td>
-            <goab-button type="tertiary" size="compact">Action</goab-button>
+            <goabx-button type="tertiary" size="compact">Action</goabx-button>
           </td>
         </tr>
         <tr *ngFor="let i of complete">
           <td>
-            <goab-badge type="information" content="Complete"></goab-badge>
+            <goabx-badge type="information" content="Complete"></goabx-badge>
           </td>
           <td>Lorem Ipsum</td>
           <td class="goa-table-number-column">1234567890</td>
           <td>
-            <goab-button type="tertiary" size="compact">Action</goab-button>
+            <goabx-button type="tertiary" size="compact">Action</goabx-button>
           </td>
         </tr>
       </tbody>
-    </goab-table>
+    </goabx-table>
   </goab-tab>
   <goab-tab [heading]="reviewPending">
-    <ng-template #reviewPending>Review pending<goab-badge type="important" content="4" [icon]="false"></goab-badge></ng-template>
-    <goab-table width="100%">
+    <ng-template #reviewPending>Review pending<goabx-badge type="important" content="4" [icon]="false"></goabx-badge></ng-template>
+    <goabx-table width="100%">
       <thead>
         <tr>
           <th>Status</th>
@@ -47,20 +47,20 @@
       <tbody>
         <tr *ngFor="let i of review">
           <td>
-            <goab-badge type="important" content="Review pending"></goab-badge>
+            <goabx-badge type="important" content="Review pending"></goabx-badge>
           </td>
           <td>Lorem Ipsum</td>
           <td class="goa-table-number-column">1234567890</td>
           <td>
-            <goab-button type="tertiary" size="compact">Action</goab-button>
+            <goabx-button type="tertiary" size="compact">Action</goabx-button>
           </td>
         </tr>
       </tbody>
-    </goab-table>
+    </goabx-table>
   </goab-tab>
   <goab-tab [heading]="completeTemplate">
-    <ng-template #completeTemplate>Complete<goab-badge type="information" content="338" [icon]="false"></goab-badge></ng-template>
-    <goab-table width="100%">
+    <ng-template #completeTemplate>Complete<goabx-badge type="information" content="338" [icon]="false"></goabx-badge></ng-template>
+    <goabx-table width="100%">
       <thead>
         <tr>
           <th>Status</th>
@@ -72,15 +72,15 @@
       <tbody>
         <tr *ngFor="let i of complete">
           <td>
-            <goab-badge type="information" content="Complete"></goab-badge>
+            <goabx-badge type="information" content="Complete"></goabx-badge>
           </td>
           <td>Lorem Ipsum</td>
           <td class="goa-table-number-column">1234567890</td>
           <td>
-            <goab-button type="tertiary" size="compact">Action</goab-button>
+            <goabx-button type="tertiary" size="compact">Action</goabx-button>
           </td>
         </tr>
       </tbody>
-    </goab-table>
+    </goabx-table>
   </goab-tab>
-</goab-tabs>
+</goabx-tabs>

--- a/docs/src/content/examples/set-a-specific-tab-to-be-active/react.tsx
+++ b/docs/src/content/examples/set-a-specific-tab-to-be-active/react.tsx
@@ -1,19 +1,19 @@
 import {
-  GoabBadge,
-  GoabButton,
-  GoabTab,
-  GoabTable,
-  GoabTabs,
-} from "@abgov/react-components";
+  GoabxBadge,
+  GoabxButton,
+  GoabxTable,
+  GoabxTabs,
+} from "@abgov/react-components/experimental";
+import { GoabTab } from "@abgov/react-components";
 
 export function SetASpecificTabToBeActive() {
   const review = [0, 1, 2, 3];
   const complete = [0, 1];
 
   return (
-    <GoabTabs initialTab={2}>
+    <GoabxTabs initialTab={2}>
       <GoabTab heading="All">
-        <GoabTable width="100%">
+        <GoabxTable width="100%">
           <thead>
             <tr>
               <th>Status</th>
@@ -26,32 +26,32 @@ export function SetASpecificTabToBeActive() {
             {review.map((i) => (
               <tr key={`review-${i}`}>
                 <td>
-                  <GoabBadge type="important" content="Review pending" />
+                  <GoabxBadge type="important" content="Review pending" />
                 </td>
                 <td>Lorem Ipsum</td>
                 <td className="goa-table-number-column">1234567890</td>
                 <td>
-                  <GoabButton type="tertiary" size="compact">Action</GoabButton>
+                  <GoabxButton type="tertiary" size="compact">Action</GoabxButton>
                 </td>
               </tr>
             ))}
             {complete.map((i) => (
               <tr key={`complete-${i}`}>
                 <td>
-                  <GoabBadge type="information" content="Complete" />
+                  <GoabxBadge type="information" content="Complete" />
                 </td>
                 <td>Lorem Ipsum</td>
                 <td className="goa-table-number-column">1234567890</td>
                 <td>
-                  <GoabButton type="tertiary" size="compact">Action</GoabButton>
+                  <GoabxButton type="tertiary" size="compact">Action</GoabxButton>
                 </td>
               </tr>
             ))}
           </tbody>
-        </GoabTable>
+        </GoabxTable>
       </GoabTab>
-      <GoabTab heading={<>Review pending<GoabBadge type="important" content="4" icon={false} /></>}>
-        <GoabTable width="100%">
+      <GoabTab heading={<>Review pending<GoabxBadge type="important" content="4" icon={false} /></>}>
+        <GoabxTable width="100%">
           <thead>
             <tr>
               <th>Status</th>
@@ -64,20 +64,20 @@ export function SetASpecificTabToBeActive() {
             {review.map((i) => (
               <tr key={i}>
                 <td>
-                  <GoabBadge type="important" content="Review pending" />
+                  <GoabxBadge type="important" content="Review pending" />
                 </td>
                 <td>Lorem Ipsum</td>
                 <td className="goa-table-number-column">1234567890</td>
                 <td>
-                  <GoabButton type="tertiary" size="compact">Action</GoabButton>
+                  <GoabxButton type="tertiary" size="compact">Action</GoabxButton>
                 </td>
               </tr>
             ))}
           </tbody>
-        </GoabTable>
+        </GoabxTable>
       </GoabTab>
-      <GoabTab heading={<>Complete<GoabBadge type="information" content="338" icon={false} /></>}>
-        <GoabTable width="100%">
+      <GoabTab heading={<>Complete<GoabxBadge type="information" content="338" icon={false} /></>}>
+        <GoabxTable width="100%">
           <thead>
             <tr>
               <th>Status</th>
@@ -90,18 +90,18 @@ export function SetASpecificTabToBeActive() {
             {complete.map((i) => (
               <tr key={i}>
                 <td>
-                  <GoabBadge type="information" content="Complete" />
+                  <GoabxBadge type="information" content="Complete" />
                 </td>
                 <td>Lorem Ipsum</td>
                 <td className="goa-table-number-column">1234567890</td>
                 <td>
-                  <GoabButton type="tertiary" size="compact">Action</GoabButton>
+                  <GoabxButton type="tertiary" size="compact">Action</GoabxButton>
                 </td>
               </tr>
             ))}
           </tbody>
-        </GoabTable>
+        </GoabxTable>
       </GoabTab>
-    </GoabTabs>
+    </GoabxTabs>
   );
 }

--- a/docs/src/content/examples/set-a-specific-tab-to-be-active/web-components.html
+++ b/docs/src/content/examples/set-a-specific-tab-to-be-active/web-components.html
@@ -1,7 +1,7 @@
-<goa-tabs initialtab="2">
+<goa-tabs version="2" initialtab="2">
   <goa-tab>
     <div slot="heading">All</div>
-    <goa-table width="100%">
+    <goa-table version="2" width="100%">
       <table width="100%">
         <thead>
           <tr>
@@ -13,30 +13,30 @@
         </thead>
         <tbody>
           <tr>
-            <td><goa-badge type="important" content="Review pending"></goa-badge></td>
+            <td><goa-badge version="2" type="important" content="Review pending"></goa-badge></td>
             <td>Lorem Ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
           <tr>
-            <td><goa-badge type="important" content="Review pending"></goa-badge></td>
+            <td><goa-badge version="2" type="important" content="Review pending"></goa-badge></td>
             <td>Lorem Ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
           <tr>
-            <td><goa-badge type="information" content="Complete"></goa-badge></td>
+            <td><goa-badge version="2" type="information" content="Complete"></goa-badge></td>
             <td>Lorem Ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
         </tbody>
       </table>
     </goa-table>
   </goa-tab>
   <goa-tab>
-    <div slot="heading">Review pending<goa-badge type="important" content="4" icon="false"></goa-badge></div>
-    <goa-table width="100%">
+    <div slot="heading">Review pending<goa-badge version="2" type="important" content="4" icon="false"></goa-badge></div>
+    <goa-table version="2" width="100%">
       <table width="100%">
         <thead>
           <tr>
@@ -48,24 +48,24 @@
         </thead>
         <tbody>
           <tr>
-            <td><goa-badge type="important" content="Review pending"></goa-badge></td>
+            <td><goa-badge version="2" type="important" content="Review pending"></goa-badge></td>
             <td>Lorem Ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
           <tr>
-            <td><goa-badge type="important" content="Review pending"></goa-badge></td>
+            <td><goa-badge version="2" type="important" content="Review pending"></goa-badge></td>
             <td>Lorem Ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
         </tbody>
       </table>
     </goa-table>
   </goa-tab>
   <goa-tab>
-    <div slot="heading">Complete<goa-badge type="information" content="338" icon="false"></goa-badge></div>
-    <goa-table width="100%">
+    <div slot="heading">Complete<goa-badge version="2" type="information" content="338" icon="false"></goa-badge></div>
+    <goa-table version="2" width="100%">
       <table width="100%">
         <thead>
           <tr>
@@ -77,16 +77,16 @@
         </thead>
         <tbody>
           <tr>
-            <td><goa-badge type="information" content="Complete"></goa-badge></td>
+            <td><goa-badge version="2" type="information" content="Complete"></goa-badge></td>
             <td>Lorem Ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
           <tr>
-            <td><goa-badge type="information" content="Complete"></goa-badge></td>
+            <td><goa-badge version="2" type="information" content="Complete"></goa-badge></td>
             <td>Lorem Ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
         </tbody>
       </table>

--- a/docs/src/content/examples/set-the-status-of-step-on-a-form-stepper/angular.html
+++ b/docs/src/content/examples/set-the-status-of-step-on-a-form-stepper/angular.html
@@ -11,6 +11,6 @@
   <div><!-- Page 4 content --></div>
 </goab-pages>
 <div style="display: flex; justify-content: space-between">
-  <goab-button (onClick)="setPage(step-1)" type="secondary">Previous</goab-button>
-  <goab-button (onClick)="setPage(step+1)" type="primary">Next</goab-button>
+  <goabx-button (onClick)="setPage(step-1)" type="secondary">Previous</goabx-button>
+  <goabx-button (onClick)="setPage(step+1)" type="primary">Next</goabx-button>
 </div>

--- a/docs/src/content/examples/set-the-status-of-step-on-a-form-stepper/react.tsx
+++ b/docs/src/content/examples/set-the-status-of-step-on-a-form-stepper/react.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
+import { GoabxButton } from "@abgov/react-components/experimental";
 import {
-  GoabButton,
   GoabFormStep,
   GoabFormStepper,
   GoabPages,
   GoabSkeleton,
-  GoabSpacer
+  GoabSpacer,
 } from "@abgov/react-components";
 import { GoabFormStepStatus } from "@abgov/ui-components-common";
 
@@ -54,12 +54,12 @@ export function SetTheStatusOfStepOnAFormStepper() {
         </div>
       </GoabPages>
       <div style={{ display: "flex", justifyContent: "space-between" }}>
-        <GoabButton type="secondary" onClick={() => setPage(step - 1)}>
+        <GoabxButton type="secondary" onClick={() => setPage(step - 1)}>
           Previous
-        </GoabButton>
-        <GoabButton type="primary" onClick={() => setPage(step + 1)}>
+        </GoabxButton>
+        <GoabxButton type="primary" onClick={() => setPage(step + 1)}>
           Next
-        </GoabButton>
+        </GoabxButton>
       </div>
     </>
   );

--- a/docs/src/content/examples/set-the-status-of-step-on-a-form-stepper/web-components.html
+++ b/docs/src/content/examples/set-the-status-of-step-on-a-form-stepper/web-components.html
@@ -11,8 +11,8 @@
   <div><!-- Page 4 content --></div>
 </goa-pages>
 <div style="display: flex; justify-content: space-between">
-  <goa-button type="secondary">Previous</goa-button>
-  <goa-button type="primary">Next</goa-button>
+  <goa-button version="2" type="secondary">Previous</goa-button>
+  <goa-button version="2" type="primary">Next</goa-button>
 </div>
 
 <script>

--- a/docs/src/content/examples/show-a-label-on-an-icon-only-button/react.tsx
+++ b/docs/src/content/examples/show-a-label-on-an-icon-only-button/react.tsx
@@ -1,8 +1,4 @@
-import {
-  GoabButtonGroup,
-  GoabIconButton,
-  GoabTooltip
-} from "@abgov/react-components";
+import { GoabButtonGroup, GoabIconButton, GoabTooltip } from "@abgov/react-components";
 
 export function ShowALabelOnAnIconOnlyButton() {
   return (

--- a/docs/src/content/examples/show-a-list-to-help-answer-a-question/angular.html
+++ b/docs/src/content/examples/show-a-list-to-help-answer-a-question/angular.html
@@ -1,13 +1,13 @@
 <form [formGroup]="form">
-  <goab-form-item
+  <goabx-form-item
     label="Do you have additional education expenses?"
     helpText="You can request funding for these now or at any time during your program."
     mb="m">
-    <goab-radio-group name="additional" (onChange)="onRadioChange($event)">
-      <goab-radio-item label="Yes" value="yes" name="additional"></goab-radio-item>
-      <goab-radio-item label="No" value="no" name="additional"></goab-radio-item>
-    </goab-radio-group>
-  </goab-form-item>
+    <goabx-radio-group name="additional" (onChange)="onRadioChange($event)">
+      <goabx-radio-item label="Yes" value="yes" name="additional"></goabx-radio-item>
+      <goabx-radio-item label="No" value="no" name="additional"></goabx-radio-item>
+    </goabx-radio-group>
+  </goabx-form-item>
 
   <goab-details heading="What are additional education expenses?">
     <goab-block gap="m" mt="m">

--- a/docs/src/content/examples/show-a-list-to-help-answer-a-question/react.tsx
+++ b/docs/src/content/examples/show-a-list-to-help-answer-a-question/react.tsx
@@ -1,10 +1,5 @@
-import {
-  GoabBlock,
-  GoabDetails,
-  GoabFormItem,
-  GoabRadioGroup,
-  GoabRadioItem
-} from "@abgov/react-components";
+import { GoabxFormItem, GoabxRadioGroup, GoabxRadioItem } from "@abgov/react-components/experimental";
+import { GoabBlock, GoabDetails } from "@abgov/react-components";
 import { GoabRadioGroupOnChangeDetail } from "@abgov/ui-components-common";
 
 export function ShowAListToHelpAnswerAQuestion() {
@@ -14,15 +9,15 @@ export function ShowAListToHelpAnswerAQuestion() {
 
   return (
     <form>
-      <GoabFormItem
+      <GoabxFormItem
         label="Do you have additional education expenses?"
         helpText="You can request funding for these now or at any time during your program."
         mb="m">
-        <GoabRadioGroup name="additional" onChange={handleChange}>
-          <GoabRadioItem label="Yes" value="yes" name="additional" />
-          <GoabRadioItem label="No" value="no" name="additional" />
-        </GoabRadioGroup>
-      </GoabFormItem>
+        <GoabxRadioGroup name="additional" onChange={handleChange}>
+          <GoabxRadioItem label="Yes" value="yes" name="additional" />
+          <GoabxRadioItem label="No" value="no" name="additional" />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
 
       <GoabDetails heading="What are additional education expenses?">
         <GoabBlock gap="m" mt="m">

--- a/docs/src/content/examples/show-a-list-to-help-answer-a-question/web-components.html
+++ b/docs/src/content/examples/show-a-list-to-help-answer-a-question/web-components.html
@@ -1,9 +1,9 @@
 <form>
-  <goa-form-item
+  <goa-form-item version="2"
     label="Do you have additional education expenses?"
     helptext="You can request funding for these now or at any time during your program."
     mb="m">
-    <goa-radio-group name="additional">
+    <goa-radio-group version="2" name="additional">
       <goa-radio-item label="Yes" value="yes" name="additional"></goa-radio-item>
       <goa-radio-item label="No" value="no" name="additional"></goa-radio-item>
     </goa-radio-group>

--- a/docs/src/content/examples/show-a-notification-with-an-action/angular.html
+++ b/docs/src/content/examples/show-a-notification-with-an-action/angular.html
@@ -1,3 +1,3 @@
 <goab-temporary-notification-ctrl></goab-temporary-notification-ctrl>
 
-<goab-button (onClick)="comment()">Comment</goab-button>
+<goabx-button (onClick)="comment()">Comment</goabx-button>

--- a/docs/src/content/examples/show-a-notification-with-an-action/react.tsx
+++ b/docs/src/content/examples/show-a-notification-with-an-action/react.tsx
@@ -1,4 +1,5 @@
-import { GoabButton, GoabTemporaryNotificationCtrl } from "@abgov/react-components";
+import { GoabxButton } from "@abgov/react-components/experimental";
+import { GoabTemporaryNotificationCtrl } from "@abgov/react-components";
 import { TemporaryNotification } from "@abgov/ui-components-common";
 
 export function ShowANotificationWithAnAction() {
@@ -17,7 +18,7 @@ export function ShowANotificationWithAnAction() {
   return (
     <>
       <GoabTemporaryNotificationCtrl />
-      <GoabButton onClick={comment}>Comment</GoabButton>
+      <GoabxButton onClick={comment}>Comment</GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/show-a-notification-with-an-action/web-components.html
+++ b/docs/src/content/examples/show-a-notification-with-an-action/web-components.html
@@ -1,6 +1,6 @@
 <goa-temp-notification-ctrl></goa-temp-notification-ctrl>
 
-<goa-button id="comment-btn">Comment</goa-button>
+<goa-button version="2" id="comment-btn">Comment</goa-button>
 
 <script>
   const commentBtn = document.getElementById('comment-btn');

--- a/docs/src/content/examples/show-a-notification/angular.html
+++ b/docs/src/content/examples/show-a-notification/angular.html
@@ -1,3 +1,3 @@
 <goab-temporary-notification-ctrl></goab-temporary-notification-ctrl>
 
-<goab-button type="secondary" (onClick)="save()">Save</goab-button>
+<goabx-button type="secondary" (onClick)="save()">Save</goabx-button>

--- a/docs/src/content/examples/show-a-notification/react.tsx
+++ b/docs/src/content/examples/show-a-notification/react.tsx
@@ -1,4 +1,5 @@
-import { GoabButton, GoabTemporaryNotificationCtrl } from "@abgov/react-components";
+import { GoabxButton } from "@abgov/react-components/experimental";
+import { GoabTemporaryNotificationCtrl } from "@abgov/react-components";
 import { TemporaryNotification } from "@abgov/ui-components-common";
 
 export function ShowANotification() {
@@ -13,7 +14,7 @@ export function ShowANotification() {
   return (
     <>
       <GoabTemporaryNotificationCtrl />
-      <GoabButton type="secondary" onClick={save}>Save</GoabButton>
+      <GoabxButton type="secondary" onClick={save}>Save</GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/show-a-notification/web-components.html
+++ b/docs/src/content/examples/show-a-notification/web-components.html
@@ -1,6 +1,6 @@
 <goa-temp-notification-ctrl></goa-temp-notification-ctrl>
 
-<goa-button id="save-btn" type="secondary">Save</goa-button>
+<goa-button version="2" id="save-btn" type="secondary">Save</goa-button>
 
 <script>
   document.getElementById('save-btn').addEventListener('_click', () => {

--- a/docs/src/content/examples/show-a-section-title-on-a-question-page/angular.html
+++ b/docs/src/content/examples/show-a-section-title-on-a-question-page/angular.html
@@ -1,19 +1,19 @@
-<goab-link leadingIcon="arrow-back" size="small" mb="none">
+<goabx-link leadingIcon="arrow-back" size="small" mb="none">
   Back
-</goab-link>
+</goabx-link>
 
 <goab-text as="h3" size="body-m" mt="xl" mb="m" color="secondary">Personal information</goab-text>
 
-<goab-form-item label="Do you currently live in Canada?" labelSize="large">
-  <goab-radio-group
+<goabx-form-item label="Do you currently live in Canada?" labelSize="large">
+  <goabx-radio-group
     name="canada"
     ariaLabel="Do you currently live in Canada?"
     (onChange)="onRadioChange($event)">
-    <goab-radio-item value="yes" label="Yes"></goab-radio-item>
-    <goab-radio-item value="no" label="No"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>
+    <goabx-radio-item value="yes" label="Yes"></goabx-radio-item>
+    <goabx-radio-item value="no" label="No"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>
 
-<goab-button type="submit" mt="2xl">
+<goabx-button type="submit" mt="2xl">
   Save and continue
-</goab-button>
+</goabx-button>

--- a/docs/src/content/examples/show-a-section-title-on-a-question-page/react.tsx
+++ b/docs/src/content/examples/show-a-section-title-on-a-question-page/react.tsx
@@ -1,34 +1,34 @@
 import {
-  GoabButton,
-  GoabFormItem,
-  GoabLink,
-  GoabRadioGroup,
-  GoabRadioItem,
-  GoabText
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxFormItem,
+  GoabxLink,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
+import { GoabText } from "@abgov/react-components";
 
 export function ShowASectionTitleOnAQuestionPage() {
   return (
     <>
-      <GoabLink leadingIcon="arrow-back" size="small" mb="none">
+      <GoabxLink leadingIcon="arrow-back" size="small" mb="none">
         Back
-      </GoabLink>
+      </GoabxLink>
 
       <GoabText as="h3" size="body-m" mt="xl" mb="m" color="secondary">Personal information</GoabText>
 
-      <GoabFormItem label="Do you currently live in Canada?" labelSize="large">
-        <GoabRadioGroup
+      <GoabxFormItem label="Do you currently live in Canada?" labelSize="large">
+        <GoabxRadioGroup
           name="canada"
           ariaLabel="Do you currently live in Canada?"
           onChange={() => {}}>
-          <GoabRadioItem value="yes" label="Yes" />
-          <GoabRadioItem value="no" label="No" />
-        </GoabRadioGroup>
-      </GoabFormItem>
+          <GoabxRadioItem value="yes" label="Yes" />
+          <GoabxRadioItem value="no" label="No" />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
 
-      <GoabButton type="submit" mt="2xl">
+      <GoabxButton type="submit" mt="2xl">
         Save and continue
-      </GoabButton>
+      </GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/show-a-section-title-on-a-question-page/web-components.html
+++ b/docs/src/content/examples/show-a-section-title-on-a-question-page/web-components.html
@@ -4,14 +4,14 @@
 
 <goa-text as="h3" size="body-m" mt="xl" mb="m" color="secondary">Personal information</goa-text>
 
-<goa-form-item label="Do you currently live in Canada?" labelsize="large">
-  <goa-radio-group name="canada" aria-label="Do you currently live in Canada?">
+<goa-form-item version="2" label="Do you currently live in Canada?" labelsize="large">
+  <goa-radio-group version="2" name="canada" aria-label="Do you currently live in Canada?">
     <goa-radio-item value="yes" label="Yes"></goa-radio-item>
     <goa-radio-item value="no" label="No"></goa-radio-item>
   </goa-radio-group>
 </goa-form-item>
 
-<goa-button type="submit" mt="2xl">
+<goa-button version="2" type="submit" mt="2xl">
   Save and continue
 </goa-button>
 

--- a/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions/angular.html
+++ b/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions/angular.html
@@ -1,24 +1,24 @@
-<goab-link leadingIcon="arrow-back" size="small" mb="none">
+<goabx-link leadingIcon="arrow-back" size="small" mb="none">
   Back
-</goab-link>
+</goabx-link>
 
 <goab-text as="h3" size="body-m" mt="xl" mb="none" color="secondary">Step 1 of 5</goab-text>
 <goab-text as="h2" mt="xs" mb="xl">Personal information</goab-text>
 
-<goab-form-item label="What is your name?">
-  <goab-input (onChange)="onChange($event)" name="name" ariaLabel="what is your name?" width="50ch"></goab-input>
-</goab-form-item>
+<goabx-form-item label="What is your name?">
+  <goabx-input (onChange)="onChange($event)" name="name" ariaLabel="what is your name?" width="50ch"></goabx-input>
+</goabx-form-item>
 
-<goab-form-item label="What is your phone number?" mt="l">
-  <goab-input (onChange)="onChange($event)" name="phone-number" ariaLabel="what is your phone number?">
+<goabx-form-item label="What is your phone number?" mt="l">
+  <goabx-input (onChange)="onChange($event)" name="phone-number" ariaLabel="what is your phone number?">
     <div slot="leadingContent">+1</div>
-  </goab-input>
-</goab-form-item>
+  </goabx-input>
+</goabx-form-item>
 
-<goab-form-item label="What is your home postal code?" mt="l">
-  <goab-input (onChange)="onChange($event)" name="postal-code" width="14ch" ariaLabel="what is your home postal code"></goab-input>
-</goab-form-item>
+<goabx-form-item label="What is your home postal code?" mt="l">
+  <goabx-input (onChange)="onChange($event)" name="postal-code" width="14ch" ariaLabel="what is your home postal code"></goabx-input>
+</goabx-form-item>
 
-<goab-button type="submit" mt="2xl">
+<goabx-button type="submit" mt="2xl">
   Save and continue
-</goab-button>
+</goabx-button>

--- a/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions/react.tsx
+++ b/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions/react.tsx
@@ -1,46 +1,46 @@
 import {
-  GoabButton,
-  GoabFormItem,
-  GoabInput,
-  GoabLink,
-  GoabText
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxLink,
+} from "@abgov/react-components/experimental";
+import { GoabText } from "@abgov/react-components";
 
 export function ShowASimpleProgressIndicatorOnAQuestionPageWithMultipleQuestions() {
   return (
     <>
-      <GoabLink leadingIcon="arrow-back" size="small" mb="none">
+      <GoabxLink leadingIcon="arrow-back" size="small" mb="none">
         Back
-      </GoabLink>
+      </GoabxLink>
 
       <GoabText as="h3" size="body-m" mt="xl" mb="none" color="secondary">Step 1 of 5</GoabText>
       <GoabText as="h2" mt="xs" mb="xl">Personal information</GoabText>
 
-      <GoabFormItem label="What is your name?">
-        <GoabInput onChange={() => {}} name="name" ariaLabel="what is your name?" width="50ch" />
-      </GoabFormItem>
+      <GoabxFormItem label="What is your name?">
+        <GoabxInput onChange={() => {}} name="name" ariaLabel="what is your name?" width="50ch" />
+      </GoabxFormItem>
 
-      <GoabFormItem label="What is your phone number?" mt="l">
-        <GoabInput
+      <GoabxFormItem label="What is your phone number?" mt="l">
+        <GoabxInput
           onChange={() => {}}
           name="phone-number"
           ariaLabel="what is your phone number?"
           leadingContent="+1"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
 
-      <GoabFormItem label="What is your home postal code?" mt="l">
-        <GoabInput
+      <GoabxFormItem label="What is your home postal code?" mt="l">
+        <GoabxInput
           onChange={() => {}}
           name="postal-code"
           width="14ch"
           ariaLabel="what is your home postal code"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
 
-      <GoabButton type="submit" mt="2xl">
+      <GoabxButton type="submit" mt="2xl">
         Save and continue
-      </GoabButton>
+      </GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions/web-components.html
+++ b/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions/web-components.html
@@ -5,21 +5,21 @@
 <goa-text as="h3" size="body-m" mt="xl" mb="none" color="secondary">Step 1 of 5</goa-text>
 <goa-text as="h2" mt="xs" mb="xl">Personal information</goa-text>
 
-<goa-form-item label="What is your name?">
-  <goa-input name="name" aria-label="what is your name?" width="50ch"></goa-input>
+<goa-form-item version="2" label="What is your name?">
+  <goa-input version="2" name="name" aria-label="what is your name?" width="50ch"></goa-input>
 </goa-form-item>
 
-<goa-form-item label="What is your phone number?" mt="l">
-  <goa-input name="phone-number" aria-label="what is your phone number?">
+<goa-form-item version="2" label="What is your phone number?" mt="l">
+  <goa-input version="2" name="phone-number" aria-label="what is your phone number?">
     <div slot="leadingContent">+1</div>
   </goa-input>
 </goa-form-item>
 
-<goa-form-item label="What is your home postal code?" mt="l">
-  <goa-input name="postal-code" width="14ch" aria-label="what is your home postal code"></goa-input>
+<goa-form-item version="2" label="What is your home postal code?" mt="l">
+  <goa-input version="2" name="postal-code" width="14ch" aria-label="what is your home postal code"></goa-input>
 </goa-form-item>
 
-<goa-button type="submit" mt="2xl">
+<goa-button version="2" type="submit" mt="2xl">
   Save and continue
 </goa-button>
 

--- a/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page/angular.html
+++ b/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page/angular.html
@@ -1,19 +1,19 @@
-<goab-link leadingIcon="arrow-back" size="small" mb="none">
+<goabx-link leadingIcon="arrow-back" size="small" mb="none">
   Back
-</goab-link>
+</goabx-link>
 
 <goab-text as="h3" size="body-m" mt="xl" mb="m" color="secondary">Question 3 of 9</goab-text>
 
-<goab-form-item label="Do you currently live in Canada?" labelSize="large">
-  <goab-radio-group
+<goabx-form-item label="Do you currently live in Canada?" labelSize="large">
+  <goabx-radio-group
     name="canada"
     ariaLabel="Do you currently live in Canada?"
     (onChange)="onRadioChange($event)">
-    <goab-radio-item value="yes" label="Yes"></goab-radio-item>
-    <goab-radio-item value="no" label="No"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>
+    <goabx-radio-item value="yes" label="Yes"></goabx-radio-item>
+    <goabx-radio-item value="no" label="No"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>
 
-<goab-button type="submit" mt="2xl">
+<goabx-button type="submit" mt="2xl">
   Save and continue
-</goab-button>
+</goabx-button>

--- a/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page/react.tsx
+++ b/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page/react.tsx
@@ -1,34 +1,34 @@
 import {
-  GoabButton,
-  GoabFormItem,
-  GoabLink,
-  GoabRadioGroup,
-  GoabRadioItem,
-  GoabText
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxFormItem,
+  GoabxLink,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
+import { GoabText } from "@abgov/react-components";
 
 export function ShowASimpleProgressIndicatorOnAQuestionPage() {
   return (
     <>
-      <GoabLink leadingIcon="arrow-back" size="small" mb="none">
+      <GoabxLink leadingIcon="arrow-back" size="small" mb="none">
         Back
-      </GoabLink>
+      </GoabxLink>
 
       <GoabText as="h3" size="body-m" mt="xl" mb="m" color="secondary">Question 3 of 9</GoabText>
 
-      <GoabFormItem label="Do you currently live in Canada?" labelSize="large">
-        <GoabRadioGroup
+      <GoabxFormItem label="Do you currently live in Canada?" labelSize="large">
+        <GoabxRadioGroup
           name="canada"
           ariaLabel="Do you currently live in Canada?"
           onChange={() => {}}>
-          <GoabRadioItem value="yes" label="Yes" />
-          <GoabRadioItem value="no" label="No" />
-        </GoabRadioGroup>
-      </GoabFormItem>
+          <GoabxRadioItem value="yes" label="Yes" />
+          <GoabxRadioItem value="no" label="No" />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
 
-      <GoabButton type="submit" mt="2xl">
+      <GoabxButton type="submit" mt="2xl">
         Save and continue
-      </GoabButton>
+      </GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page/web-components.html
+++ b/docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page/web-components.html
@@ -4,14 +4,14 @@
 
 <goa-text as="h3" size="body-m" mt="xl" mb="m" color="secondary">Question 3 of 9</goa-text>
 
-<goa-form-item label="Do you currently live in Canada?" labelsize="large">
-  <goa-radio-group name="canada" aria-label="Do you currently live in Canada?">
+<goa-form-item version="2" label="Do you currently live in Canada?" labelsize="large">
+  <goa-radio-group version="2" name="canada" aria-label="Do you currently live in Canada?">
     <goa-radio-item value="yes" label="Yes"></goa-radio-item>
     <goa-radio-item value="no" label="No"></goa-radio-item>
   </goa-radio-group>
 </goa-form-item>
 
-<goa-button type="submit" mt="2xl">
+<goa-button version="2" type="submit" mt="2xl">
   Save and continue
 </goa-button>
 

--- a/docs/src/content/examples/show-a-user-progress-when-the-time-is-unknown/angular.html
+++ b/docs/src/content/examples/show-a-user-progress-when-the-time-is-unknown/angular.html
@@ -1,5 +1,5 @@
 <goab-temporary-notification-ctrl></goab-temporary-notification-ctrl>
 
-<goab-button type="secondary" leadingIcon="search" (onClick)="search()">
+<goabx-button type="secondary" leadingIcon="search" (onClick)="search()">
   Search case history
-</goab-button>
+</goabx-button>

--- a/docs/src/content/examples/show-a-user-progress-when-the-time-is-unknown/react.tsx
+++ b/docs/src/content/examples/show-a-user-progress-when-the-time-is-unknown/react.tsx
@@ -1,4 +1,5 @@
-import { GoabButton, GoabTemporaryNotificationCtrl } from "@abgov/react-components";
+import { GoabxButton } from "@abgov/react-components/experimental";
+import { GoabTemporaryNotificationCtrl } from "@abgov/react-components";
 import { TemporaryNotification } from "@abgov/ui-components-common";
 
 export function ShowAUserProgressWhenTheTimeIsUnknown() {
@@ -40,9 +41,9 @@ export function ShowAUserProgressWhenTheTimeIsUnknown() {
   return (
     <>
       <GoabTemporaryNotificationCtrl />
-      <GoabButton type="secondary" leadingIcon="search" onClick={search}>
+      <GoabxButton type="secondary" leadingIcon="search" onClick={search}>
         Search case history
-      </GoabButton>
+      </GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/show-a-user-progress-when-the-time-is-unknown/web-components.html
+++ b/docs/src/content/examples/show-a-user-progress-when-the-time-is-unknown/web-components.html
@@ -1,6 +1,6 @@
 <goa-temp-notification-ctrl></goa-temp-notification-ctrl>
 
-<goa-button id="search-btn" type="secondary" leadingicon="search">
+<goa-button version="2" id="search-btn" type="secondary" leadingicon="search">
   Search case history
 </goa-button>
 

--- a/docs/src/content/examples/show-a-user-progress/angular.html
+++ b/docs/src/content/examples/show-a-user-progress/angular.html
@@ -1,5 +1,5 @@
 <goab-temporary-notification-ctrl></goab-temporary-notification-ctrl>
 
-<goab-button type="tertiary" leadingIcon="download" (onClick)="downloadReport()">
+<goabx-button type="tertiary" leadingIcon="download" (onClick)="downloadReport()">
   Download report
-</goab-button>
+</goabx-button>

--- a/docs/src/content/examples/show-a-user-progress/react.tsx
+++ b/docs/src/content/examples/show-a-user-progress/react.tsx
@@ -1,4 +1,5 @@
-import { GoabButton, GoabTemporaryNotificationCtrl } from "@abgov/react-components";
+import { GoabxButton } from "@abgov/react-components/experimental";
+import { GoabTemporaryNotificationCtrl } from "@abgov/react-components";
 import { TemporaryNotification } from "@abgov/ui-components-common";
 
 export function ShowAUserProgress() {
@@ -69,9 +70,9 @@ export function ShowAUserProgress() {
   return (
     <>
       <GoabTemporaryNotificationCtrl />
-      <GoabButton type="tertiary" leadingIcon="download" onClick={downloadReport}>
+      <GoabxButton type="tertiary" leadingIcon="download" onClick={downloadReport}>
         Download report
-      </GoabButton>
+      </GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/show-a-user-progress/web-components.html
+++ b/docs/src/content/examples/show-a-user-progress/web-components.html
@@ -1,6 +1,6 @@
 <goa-temp-notification-ctrl></goa-temp-notification-ctrl>
 
-<goa-button id="download-btn" type="tertiary" leadingicon="download">
+<goa-button version="2" id="download-btn" type="tertiary" leadingicon="download">
   Download report
 </goa-button>
 

--- a/docs/src/content/examples/show-different-views-of-data-in-a-table/angular.html
+++ b/docs/src/content/examples/show-different-views-of-data-in-a-table/angular.html
@@ -1,6 +1,6 @@
-<goab-tabs>
+<goabx-tabs>
   <goab-tab heading="All">
-    <goab-table width="100%">
+    <goabx-table width="100%">
       <thead>
         <tr>
           <th>Status</th>
@@ -11,23 +11,23 @@
       </thead>
       <tbody>
         <tr *ngFor="let i of reviewItems">
-          <td><goab-badge type="important" content="Review pending"></goab-badge></td>
+          <td><goabx-badge type="important" content="Review pending"></goabx-badge></td>
           <td>Lorem ipsum</td>
           <td class="goa-table-number-column">1234567890</td>
-          <td><goab-button type="tertiary" size="compact">Action</goab-button></td>
+          <td><goabx-button type="tertiary" size="compact">Action</goabx-button></td>
         </tr>
         <tr *ngFor="let i of completeItems">
-          <td><goab-badge type="information" content="Complete"></goab-badge></td>
+          <td><goabx-badge type="information" content="Complete"></goabx-badge></td>
           <td>Lorem Ipsum</td>
           <td class="goa-table-number-column">1234567890</td>
-          <td><goab-button type="tertiary" size="compact">Action</goab-button></td>
+          <td><goabx-button type="tertiary" size="compact">Action</goabx-button></td>
         </tr>
       </tbody>
-    </goab-table>
+    </goabx-table>
   </goab-tab>
   <goab-tab [heading]="reviewPending">
-    <ng-template #reviewPending>Review pending<goab-badge type="important" content="4" [icon]="false"></goab-badge></ng-template>
-    <goab-table width="100%">
+    <ng-template #reviewPending>Review pending<goabx-badge type="important" content="4" [icon]="false"></goabx-badge></ng-template>
+    <goabx-table width="100%">
       <thead>
         <tr>
           <th>Status</th>
@@ -38,17 +38,17 @@
       </thead>
       <tbody>
         <tr *ngFor="let i of reviewItems">
-          <td><goab-badge type="important" content="Review pending"></goab-badge></td>
+          <td><goabx-badge type="important" content="Review pending"></goabx-badge></td>
           <td>Lorem ipsum</td>
           <td class="goa-table-number-column">1234567890</td>
-          <td><goab-button type="tertiary" size="compact">Action</goab-button></td>
+          <td><goabx-button type="tertiary" size="compact">Action</goabx-button></td>
         </tr>
       </tbody>
-    </goab-table>
+    </goabx-table>
   </goab-tab>
   <goab-tab [heading]="completeTab">
-    <ng-template #completeTab>Complete<goab-badge type="information" content="338" [icon]="false"></goab-badge></ng-template>
-    <goab-table width="100%">
+    <ng-template #completeTab>Complete<goabx-badge type="information" content="338" [icon]="false"></goabx-badge></ng-template>
+    <goabx-table width="100%">
       <thead>
         <tr>
           <th>Status</th>
@@ -59,12 +59,12 @@
       </thead>
       <tbody>
         <tr *ngFor="let i of completeItems">
-          <td><goab-badge type="information" content="Complete"></goab-badge></td>
+          <td><goabx-badge type="information" content="Complete"></goabx-badge></td>
           <td>Lorem Ipsum</td>
           <td class="goa-table-number-column">1234567890</td>
-          <td><goab-button type="tertiary" size="compact">Action</goab-button></td>
+          <td><goabx-button type="tertiary" size="compact">Action</goabx-button></td>
         </tr>
       </tbody>
-    </goab-table>
+    </goabx-table>
   </goab-tab>
-</goab-tabs>
+</goabx-tabs>

--- a/docs/src/content/examples/show-different-views-of-data-in-a-table/react.tsx
+++ b/docs/src/content/examples/show-different-views-of-data-in-a-table/react.tsx
@@ -1,19 +1,19 @@
 import {
-  GoabBadge,
-  GoabButton,
-  GoabTab,
-  GoabTable,
-  GoabTabs,
-} from "@abgov/react-components";
+  GoabxBadge,
+  GoabxButton,
+  GoabxTable,
+  GoabxTabs,
+} from "@abgov/react-components/experimental";
+import { GoabTab } from "@abgov/react-components";
 
 export function ShowDifferentViewsOfDataInATable() {
   const review = [0, 1, 2, 3];
   const complete = [0, 1];
 
   return (
-    <GoabTabs initialTab={1}>
+    <GoabxTabs initialTab={1}>
           <GoabTab heading="All">
-            <GoabTable width="100%">
+            <GoabxTable width="100%">
               <thead>
                 <tr>
                   <th>Status</th>
@@ -26,39 +26,39 @@ export function ShowDifferentViewsOfDataInATable() {
                 {review.map((i) => (
                   <tr key={`review-${i}`}>
                     <td>
-                      <GoabBadge type="important" content="Review pending" />
+                      <GoabxBadge type="important" content="Review pending" />
                     </td>
                     <td>Lorem Ipsum</td>
                     <td className="goa-table-number-column">1234567890</td>
                     <td>
-                      <GoabButton type="tertiary" size="compact">Action</GoabButton>
+                      <GoabxButton type="tertiary" size="compact">Action</GoabxButton>
                     </td>
                   </tr>
                 ))}
                 {complete.map((i) => (
                   <tr key={`complete-${i}`}>
                     <td>
-                      <GoabBadge type="information" content="Complete" />
+                      <GoabxBadge type="information" content="Complete" />
                     </td>
                     <td>Lorem Ipsum</td>
                     <td className="goa-table-number-column">1234567890</td>
                     <td>
-                      <GoabButton type="tertiary" size="compact">Action</GoabButton>
+                      <GoabxButton type="tertiary" size="compact">Action</GoabxButton>
                     </td>
                   </tr>
                 ))}
               </tbody>
-            </GoabTable>
+            </GoabxTable>
           </GoabTab>
           <GoabTab
             heading={
               <>
                 Review pending
-                <GoabBadge type="important" content="4" icon={false} />
+                <GoabxBadge type="important" content="4" icon={false} />
               </>
             }
           >
-            <GoabTable width="100%">
+            <GoabxTable width="100%">
               <thead>
                 <tr>
                   <th>Status</th>
@@ -71,27 +71,27 @@ export function ShowDifferentViewsOfDataInATable() {
                 {review.map((i) => (
                   <tr key={i}>
                     <td>
-                      <GoabBadge type="important" content="Review pending" />
+                      <GoabxBadge type="important" content="Review pending" />
                     </td>
                     <td>Lorem Ipsum</td>
                     <td className="goa-table-number-column">1234567890</td>
                     <td>
-                      <GoabButton type="tertiary" size="compact">Action</GoabButton>
+                      <GoabxButton type="tertiary" size="compact">Action</GoabxButton>
                     </td>
                   </tr>
                 ))}
               </tbody>
-            </GoabTable>
+            </GoabxTable>
           </GoabTab>
           <GoabTab
             heading={
               <>
                 Complete
-                <GoabBadge type="information" content="338" icon={false} />
+                <GoabxBadge type="information" content="338" icon={false} />
               </>
             }
           >
-            <GoabTable width="100%">
+            <GoabxTable width="100%">
               <thead>
                 <tr>
                   <th>Status</th>
@@ -104,18 +104,18 @@ export function ShowDifferentViewsOfDataInATable() {
                 {complete.map((i) => (
                   <tr key={i}>
                     <td>
-                      <GoabBadge type="information" content="Complete" />
+                      <GoabxBadge type="information" content="Complete" />
                     </td>
                     <td>Lorem Ipsum</td>
                     <td className="goa-table-number-column">1234567890</td>
                     <td>
-                      <GoabButton type="tertiary" size="compact">Action</GoabButton>
+                      <GoabxButton type="tertiary" size="compact">Action</GoabxButton>
                     </td>
                   </tr>
                 ))}
               </tbody>
-            </GoabTable>
+            </GoabxTable>
           </GoabTab>
-    </GoabTabs>
+    </GoabxTabs>
   );
 }

--- a/docs/src/content/examples/show-different-views-of-data-in-a-table/web-components.html
+++ b/docs/src/content/examples/show-different-views-of-data-in-a-table/web-components.html
@@ -1,7 +1,7 @@
-<goa-tabs>
+<goa-tabs version="2">
   <goa-tab>
     <div slot="heading">All</div>
-    <goa-table width="100%">
+    <goa-table version="2" width="100%">
       <table width="100%">
         <thead>
           <tr>
@@ -13,30 +13,30 @@
         </thead>
         <tbody>
           <tr>
-            <td><goa-badge type="important" content="Review pending"></goa-badge></td>
+            <td><goa-badge version="2" type="important" content="Review pending"></goa-badge></td>
             <td>Lorem ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
           <tr>
-            <td><goa-badge type="important" content="Review pending"></goa-badge></td>
+            <td><goa-badge version="2" type="important" content="Review pending"></goa-badge></td>
             <td>Lorem ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
           <tr>
-            <td><goa-badge type="information" content="Complete"></goa-badge></td>
+            <td><goa-badge version="2" type="information" content="Complete"></goa-badge></td>
             <td>Lorem Ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
         </tbody>
       </table>
     </goa-table>
   </goa-tab>
   <goa-tab>
-    <div slot="heading">Review pending<goa-badge type="important" content="4" icon="false"></goa-badge></div>
-    <goa-table width="100%">
+    <div slot="heading">Review pending<goa-badge version="2" type="important" content="4" icon="false"></goa-badge></div>
+    <goa-table version="2" width="100%">
       <table width="100%">
         <thead>
           <tr>
@@ -48,24 +48,24 @@
         </thead>
         <tbody>
           <tr>
-            <td><goa-badge type="important" content="Review pending"></goa-badge></td>
+            <td><goa-badge version="2" type="important" content="Review pending"></goa-badge></td>
             <td>Lorem ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
           <tr>
-            <td><goa-badge type="important" content="Review pending"></goa-badge></td>
+            <td><goa-badge version="2" type="important" content="Review pending"></goa-badge></td>
             <td>Lorem ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
         </tbody>
       </table>
     </goa-table>
   </goa-tab>
   <goa-tab>
-    <div slot="heading">Complete<goa-badge type="information" content="338" icon="false"></goa-badge></div>
-    <goa-table width="100%">
+    <div slot="heading">Complete<goa-badge version="2" type="information" content="338" icon="false"></goa-badge></div>
+    <goa-table version="2" width="100%">
       <table width="100%">
         <thead>
           <tr>
@@ -77,10 +77,10 @@
         </thead>
         <tbody>
           <tr>
-            <td><goa-badge type="information" content="Complete"></goa-badge></td>
+            <td><goa-badge version="2" type="information" content="Complete"></goa-badge></td>
             <td>Lorem Ipsum</td>
             <td class="goa-table-number-column">1234567890</td>
-            <td><goa-button type="tertiary" size="compact">Action</goa-button></td>
+            <td><goa-button version="2" type="tertiary" size="compact">Action</goa-button></td>
           </tr>
         </tbody>
       </table>

--- a/docs/src/content/examples/show-links-to-navigation-items/angular.html
+++ b/docs/src/content/examples/show-links-to-navigation-items/angular.html
@@ -1,5 +1,5 @@
-<goab-app-footer maxContentWidth="100%">
-  <goab-app-footer-nav-section slot="nav" [maxColumnCount]="1">
+<goabx-app-footer maxContentWidth="100%">
+  <goabx-app-footer-nav-section slot="nav" [maxColumnCount]="1">
     <a href="a.html">Arts and culture</a>
     <a href="b.html">Education and training</a>
     <a href="c.html">Family and social supports</a>
@@ -10,11 +10,11 @@
     <a href="h.html">Government</a>
     <a href="i.html">Jobs and employment</a>
     <a href="j.html">Moving to Alberta</a>
-  </goab-app-footer-nav-section>
-  <goab-app-footer-meta-section slot="meta">
+  </goabx-app-footer-nav-section>
+  <goabx-app-footer-meta-section slot="meta">
     <a href="privacy.html">Privacy</a>
     <a href="disclaimer.html">Disclaimer</a>
     <a href="accessibility.html">Accessibility</a>
     <a href="using-alberta.html">Using Alberta.ca</a>
-  </goab-app-footer-meta-section>
-</goab-app-footer>
+  </goabx-app-footer-meta-section>
+</goabx-app-footer>

--- a/docs/src/content/examples/show-links-to-navigation-items/react.tsx
+++ b/docs/src/content/examples/show-links-to-navigation-items/react.tsx
@@ -1,13 +1,9 @@
-import {
-  GoabAppFooter,
-  GoabAppFooterMetaSection,
-  GoabAppFooterNavSection,
-} from "@abgov/react-components";
+import { GoabxAppFooter, GoabxAppFooterMetaSection, GoabxAppFooterNavSection } from "@abgov/react-components/experimental";
 
 export function ShowLinksToNavigationItems() {
   return (
-    <GoabAppFooter maxContentWidth="100%">
-      <GoabAppFooterNavSection maxColumnCount={1}>
+    <GoabxAppFooter maxContentWidth="100%">
+      <GoabxAppFooterNavSection maxColumnCount={1}>
         <a href="a.html">Arts and culture</a>
         <a href="b.html">Education and training</a>
         <a href="c.html">Family and social supports</a>
@@ -18,13 +14,13 @@ export function ShowLinksToNavigationItems() {
         <a href="h.html">Government</a>
         <a href="i.html">Jobs and employment</a>
         <a href="j.html">Moving to Alberta</a>
-      </GoabAppFooterNavSection>
-      <GoabAppFooterMetaSection>
+      </GoabxAppFooterNavSection>
+      <GoabxAppFooterMetaSection>
         <a href="privacy.html">Privacy</a>
         <a href="disclaimer.html">Disclaimer</a>
         <a href="accessibility.html">Accessibility</a>
         <a href="using-alberta.html">Using Alberta.ca</a>
-      </GoabAppFooterMetaSection>
-    </GoabAppFooter>
+      </GoabxAppFooterMetaSection>
+    </GoabxAppFooter>
   );
 }

--- a/docs/src/content/examples/show-links-to-navigation-items/web-components.html
+++ b/docs/src/content/examples/show-links-to-navigation-items/web-components.html
@@ -1,4 +1,4 @@
-<goa-app-footer maxcontentwidth="100%">
+<goa-app-footer version="2" maxcontentwidth="100%">
   <goa-app-footer-nav-section slot="nav" maxcolumncount="1">
     <a href="a.html">Arts and culture</a>
     <a href="b.html">Education and training</a>

--- a/docs/src/content/examples/show-more-information-to-help-answer-a-question/angular.html
+++ b/docs/src/content/examples/show-more-information-to-help-answer-a-question/angular.html
@@ -1,23 +1,23 @@
-<goab-link leadingIcon="arrow-back" size="small" mb="none">
+<goabx-link leadingIcon="arrow-back" size="small" mb="none">
   Back
-</goab-link>
+</goabx-link>
 
-<goab-form-item
+<goabx-form-item
   mt="xl"
   label="Do you pay for child care?"
   labelSize="large"
   helpText="Examples of child care are daycares, day homes and baby-sisters.">
-  <goab-radio-group
+  <goabx-radio-group
     name="child-care"
     ariaLabel="Do you pay for child care?"
     (onChange)="onRadioChange($event)">
-    <goab-radio-item value="yes" label="Yes"></goab-radio-item>
-    <goab-radio-item value="no" label="No"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>
+    <goabx-radio-item value="yes" label="Yes"></goabx-radio-item>
+    <goabx-radio-item value="no" label="No"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>
 
 <goab-details heading="Why are we asking this question?" mt="l">
   <p>We ask this question to determine if you are eligible for child care benefits.</p>
 </goab-details>
 
-<goab-button type="submit" mt="2xl">Save and continue</goab-button>
+<goabx-button type="submit" mt="2xl">Save and continue</goabx-button>

--- a/docs/src/content/examples/show-more-information-to-help-answer-a-question/react.tsx
+++ b/docs/src/content/examples/show-more-information-to-help-answer-a-question/react.tsx
@@ -1,42 +1,42 @@
 import {
-  GoabButton,
-  GoabDetails,
-  GoabFormItem,
-  GoabLink,
-  GoabRadioGroup,
-  GoabRadioItem,
-} from "@abgov/react-components";
+  GoabxButton,
+  GoabxFormItem,
+  GoabxLink,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
+import { GoabDetails } from "@abgov/react-components";
 
 export function ShowMoreInformationToHelpAnswerAQuestion() {
   return (
     <>
-      <GoabLink leadingIcon="arrow-back" size="small" mb="none">
+      <GoabxLink leadingIcon="arrow-back" size="small" mb="none">
         Back
-      </GoabLink>
+      </GoabxLink>
 
-      <GoabFormItem
+      <GoabxFormItem
         mt="xl"
         label="Do you pay for child care?"
         labelSize="large"
         helpText="Examples of child care are daycares, day homes and baby-sisters."
       >
-        <GoabRadioGroup
+        <GoabxRadioGroup
           name="child-care"
           ariaLabel="Do you pay for child care?"
           onChange={() => {}}
         >
-          <GoabRadioItem value="yes" label="Yes" />
-          <GoabRadioItem value="no" label="No" />
-        </GoabRadioGroup>
-      </GoabFormItem>
+          <GoabxRadioItem value="yes" label="Yes" />
+          <GoabxRadioItem value="no" label="No" />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
 
       <GoabDetails heading="Why are we asking this question?" mt="l">
         <p>We ask this question to determine if you are eligible for child care benefits.</p>
       </GoabDetails>
 
-      <GoabButton type="submit" mt="2xl">
+      <GoabxButton type="submit" mt="2xl">
         Save and continue
-      </GoabButton>
+      </GoabxButton>
     </>
   );
 }

--- a/docs/src/content/examples/show-more-information-to-help-answer-a-question/web-components.html
+++ b/docs/src/content/examples/show-more-information-to-help-answer-a-question/web-components.html
@@ -2,12 +2,12 @@
   Back
 </goa-link>
 
-<goa-form-item
+<goa-form-item version="2"
   mt="xl"
   label="Do you pay for child care?"
   labelsize="large"
   helptext="Examples of child care are daycares, day homes and baby-sisters.">
-  <goa-radio-group
+  <goa-radio-group version="2"
     name="child-care"
     arialabel="Do you pay for child care?">
     <goa-radio-item value="yes" label="Yes"></goa-radio-item>
@@ -19,4 +19,4 @@
   <p>We ask this question to determine if you are eligible for child care benefits.</p>
 </goa-details>
 
-<goa-button type="submit" mt="2xl">Save and continue</goa-button>
+<goa-button version="2" type="submit" mt="2xl">Save and continue</goa-button>

--- a/docs/src/content/examples/show-multiple-actions-in-a-compact-table/angular.html
+++ b/docs/src/content/examples/show-multiple-actions-in-a-compact-table/angular.html
@@ -1,4 +1,4 @@
-<goab-table width="100%">
+<goabx-table width="100%">
   <thead>
     <tr>
       <th>Status</th>
@@ -10,7 +10,7 @@
   <tbody>
     <tr *ngFor="let row of rows">
       <td>
-        <goab-badge [type]="row.status" [content]="row.statusText" [icon]="false"></goab-badge>
+        <goabx-badge [type]="row.status" [content]="row.statusText" [icon]="false"></goabx-badge>
       </td>
       <td>{{ row.name }}</td>
       <td class="goa-table-number-column">{{ row.id }}</td>
@@ -23,4 +23,4 @@
       </td>
     </tr>
   </tbody>
-</goab-table>
+</goabx-table>

--- a/docs/src/content/examples/show-multiple-actions-in-a-compact-table/react.tsx
+++ b/docs/src/content/examples/show-multiple-actions-in-a-compact-table/react.tsx
@@ -1,9 +1,5 @@
-import {
-  GoabBadge,
-  GoabBlock,
-  GoabIconButton,
-  GoabTable,
-} from "@abgov/react-components";
+import { GoabxBadge, GoabxTable } from "@abgov/react-components/experimental";
+import { GoabBlock, GoabIconButton } from "@abgov/react-components";
 
 export function ShowMultipleActionsInACompactTable() {
   const rows = [
@@ -16,7 +12,7 @@ export function ShowMultipleActionsInACompactTable() {
   ];
 
   return (
-    <GoabTable width="100%">
+    <GoabxTable width="100%">
       <thead>
         <tr>
           <th>Status</th>
@@ -29,7 +25,7 @@ export function ShowMultipleActionsInACompactTable() {
         {rows.map((row) => (
           <tr key={row.id}>
             <td>
-              <GoabBadge
+              <GoabxBadge
                 type={row.status as "information" | "dark" | "success" | "important"}
                 content={row.statusText}
                 icon={false}
@@ -47,6 +43,6 @@ export function ShowMultipleActionsInACompactTable() {
           </tr>
         ))}
       </tbody>
-    </GoabTable>
+    </GoabxTable>
   );
 }

--- a/docs/src/content/examples/show-multiple-actions-in-a-compact-table/web-components.html
+++ b/docs/src/content/examples/show-multiple-actions-in-a-compact-table/web-components.html
@@ -1,4 +1,4 @@
-<goa-table width="100%">
+<goa-table version="2" width="100%">
   <table width="100%">
     <thead>
     <tr>
@@ -10,7 +10,7 @@
   </thead>
   <tbody>
     <tr>
-      <td><goa-badge type="information" content="In progress" icon="false"></goa-badge></td>
+      <td><goa-badge version="2" type="information" content="In progress" icon="false"></goa-badge></td>
       <td>Darlene Robertson</td>
       <td class="goa-table-number-column">45904</td>
       <td>
@@ -22,7 +22,7 @@
       </td>
     </tr>
     <tr>
-      <td><goa-badge type="dark" content="Inactive" icon="false"></goa-badge></td>
+      <td><goa-badge version="2" type="dark" content="Inactive" icon="false"></goa-badge></td>
       <td>Floyd Miles</td>
       <td class="goa-table-number-column">47838</td>
       <td>
@@ -34,7 +34,7 @@
       </td>
     </tr>
     <tr>
-      <td><goa-badge type="success" content="Active" icon="false"></goa-badge></td>
+      <td><goa-badge version="2" type="success" content="Active" icon="false"></goa-badge></td>
       <td>Kathryn Murphy</td>
       <td class="goa-table-number-column">34343</td>
       <td>
@@ -46,7 +46,7 @@
       </td>
     </tr>
     <tr>
-      <td><goa-badge type="important" content="Recent" icon="false"></goa-badge></td>
+      <td><goa-badge version="2" type="important" content="Recent" icon="false"></goa-badge></td>
       <td>Annette Black</td>
       <td class="goa-table-number-column">89897</td>
       <td>
@@ -58,7 +58,7 @@
       </td>
     </tr>
     <tr>
-      <td><goa-badge type="success" content="Active" icon="false"></goa-badge></td>
+      <td><goa-badge version="2" type="success" content="Active" icon="false"></goa-badge></td>
       <td>Esther Howard</td>
       <td class="goa-table-number-column">12323</td>
       <td>
@@ -70,7 +70,7 @@
       </td>
     </tr>
     <tr>
-      <td><goa-badge type="success" content="Active" icon="false"></goa-badge></td>
+      <td><goa-badge version="2" type="success" content="Active" icon="false"></goa-badge></td>
       <td>Jane Cooper</td>
       <td class="goa-table-number-column">56565</td>
       <td>

--- a/docs/src/content/examples/show-multiple-tags-together/angular.html
+++ b/docs/src/content/examples/show-multiple-tags-together/angular.html
@@ -1,5 +1,5 @@
 <goab-block gap="xs">
-  <goab-badge type="information" content="In progress"></goab-badge>
-  <goab-badge type="important" content="Priority"></goab-badge>
-  <goab-badge type="emergency" content="Past deadline"></goab-badge>
+  <goabx-badge type="information" content="In progress"></goabx-badge>
+  <goabx-badge type="important" content="Priority"></goabx-badge>
+  <goabx-badge type="emergency" content="Past deadline"></goabx-badge>
 </goab-block>

--- a/docs/src/content/examples/show-multiple-tags-together/react.tsx
+++ b/docs/src/content/examples/show-multiple-tags-together/react.tsx
@@ -1,11 +1,12 @@
-import { GoabBadge, GoabBlock } from "@abgov/react-components";
+import { GoabxBadge } from "@abgov/react-components/experimental";
+import { GoabBlock } from "@abgov/react-components";
 
 export function ShowMultipleTagsTogether() {
   return (
     <GoabBlock gap="xs">
-      <GoabBadge type="information" content="In progress" />
-      <GoabBadge type="important" content="Priority" />
-      <GoabBadge type="emergency" content="Past deadline" />
+      <GoabxBadge type="information" content="In progress" />
+      <GoabxBadge type="important" content="Priority" />
+      <GoabxBadge type="emergency" content="Past deadline" />
     </GoabBlock>
   );
 }

--- a/docs/src/content/examples/show-multiple-tags-together/web-components.html
+++ b/docs/src/content/examples/show-multiple-tags-together/web-components.html
@@ -1,5 +1,5 @@
 <goa-block gap="xs">
-  <goa-badge type="information" content="In progress"></goa-badge>
-  <goa-badge type="important" content="Priority"></goa-badge>
-  <goa-badge type="emergency" content="Past deadline"></goa-badge>
+  <goa-badge version="2" type="information" content="In progress"></goa-badge>
+  <goa-badge version="2" type="important" content="Priority"></goa-badge>
+  <goa-badge version="2" type="emergency" content="Past deadline"></goa-badge>
 </goa-block>

--- a/docs/src/content/examples/show-number-of-results-per-page/angular.html
+++ b/docs/src/content/examples/show-number-of-results-per-page/angular.html
@@ -1,4 +1,4 @@
-<goab-table width="100%" mb="xl">
+<goabx-table width="100%" mb="xl">
   <thead>
     <tr>
       <th>First name</th>
@@ -13,28 +13,28 @@
       <td>{{ user.age }}</td>
     </tr>
   </tbody>
-</goab-table>
+</goabx-table>
 
 <goab-block alignment="center" width="100%">
   <goab-block mb="m" alignment="center">
     Show
-    <goab-dropdown
+    <goabx-dropdown
       (onChange)="handlePerPageCountChangeEvent($event)"
       value="10"
       width="9ch">
-      <goab-dropdown-item value="10" label="10"></goab-dropdown-item>
-      <goab-dropdown-item value="20" label="20"></goab-dropdown-item>
-      <goab-dropdown-item value="30" label="30"></goab-dropdown-item>
-    </goab-dropdown>
+      <goabx-dropdown-item value="10" label="10"></goabx-dropdown-item>
+      <goabx-dropdown-item value="20" label="20"></goabx-dropdown-item>
+      <goabx-dropdown-item value="30" label="30"></goabx-dropdown-item>
+    </goabx-dropdown>
     <span style="width: 75px">per page</span>
   </goab-block>
 
   <goab-spacer hSpacing="fill"></goab-spacer>
 
-  <goab-pagination
+  <goabx-pagination
     [itemCount]="users.length"
     [perPageCount]="perPage"
     [pageNumber]="page"
     (onChange)="handlePageChange($event)">
-  </goab-pagination>
+  </goabx-pagination>
 </goab-block>

--- a/docs/src/content/examples/show-number-of-results-per-page/react.tsx
+++ b/docs/src/content/examples/show-number-of-results-per-page/react.tsx
@@ -1,12 +1,11 @@
 import { useState, useEffect } from "react";
 import {
-  GoabBlock,
-  GoabDropdown,
-  GoabDropdownItem,
-  GoabPagination,
-  GoabSpacer,
-  GoabTable,
-} from "@abgov/react-components";
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxPagination,
+  GoabxTable,
+} from "@abgov/react-components/experimental";
+import { GoabBlock, GoabSpacer } from "@abgov/react-components";
 import { GoabDropdownOnChangeDetail } from "@abgov/ui-components-common";
 
 interface User {
@@ -56,7 +55,7 @@ export function ShowNumberOfResultsPerPage() {
 
   return (
     <>
-      <GoabTable width="100%" mb="xl">
+      <GoabxTable width="100%" mb="xl">
         <thead>
           <tr>
             <th>First name</th>
@@ -73,24 +72,24 @@ export function ShowNumberOfResultsPerPage() {
             </tr>
           ))}
         </tbody>
-      </GoabTable>
+      </GoabxTable>
 
       <GoabBlock alignment="center" width="100%">
         <GoabBlock mb="m" alignment="center">
           Show
-          <GoabDropdown
+          <GoabxDropdown
             onChange={handlePerPageCountChangeEvent}
             value={perPage.toString()}
             width="9ch"
           >
-            <GoabDropdownItem value="10" label="10" />
-            <GoabDropdownItem value="20" label="20" />
-            <GoabDropdownItem value="30" label="30" />
-          </GoabDropdown>
+            <GoabxDropdownItem value="10" label="10" />
+            <GoabxDropdownItem value="20" label="20" />
+            <GoabxDropdownItem value="30" label="30" />
+          </GoabxDropdown>
           <span style={{ width: "75px" }}>per page</span>
         </GoabBlock>
         <GoabSpacer hSpacing="fill" />
-        <GoabPagination
+        <GoabxPagination
           itemCount={users.length}
           perPageCount={perPage}
           pageNumber={page}

--- a/docs/src/content/examples/show-number-of-results-per-page/web-components.html
+++ b/docs/src/content/examples/show-number-of-results-per-page/web-components.html
@@ -1,4 +1,4 @@
-<goa-table width="100%" mb="xl">
+<goa-table version="2" width="100%" mb="xl">
   <table width="100%">
     <thead>
       <tr>
@@ -16,7 +16,7 @@
 <goa-block alignment="center" width="100%">
   <goa-block mb="m" alignment="center">
     Show
-    <goa-dropdown id="per-page-dropdown" value="10" width="9ch">
+    <goa-dropdown version="2" id="per-page-dropdown" value="10" width="9ch">
       <goa-dropdown-item value="10" label="10"></goa-dropdown-item>
       <goa-dropdown-item value="20" label="20"></goa-dropdown-item>
       <goa-dropdown-item value="30" label="30"></goa-dropdown-item>
@@ -26,7 +26,7 @@
 
   <goa-spacer hspacing="fill"></goa-spacer>
 
-  <goa-pagination
+  <goa-pagination version="2"
     id="pagination"
     itemcount="100"
     perpagecount="10"

--- a/docs/src/content/examples/show-quick-links/angular.html
+++ b/docs/src/content/examples/show-quick-links/angular.html
@@ -1,8 +1,8 @@
-<goab-app-footer maxContentWidth="100%">
-  <goab-app-footer-meta-section slot="meta">
+<goabx-app-footer maxContentWidth="100%">
+  <goabx-app-footer-meta-section slot="meta">
     <a href="#">Give feedback</a>
     <a href="#">Accessibility</a>
     <a href="#">Privacy</a>
     <a href="#">Contact us</a>
-  </goab-app-footer-meta-section>
-</goab-app-footer>
+  </goabx-app-footer-meta-section>
+</goabx-app-footer>

--- a/docs/src/content/examples/show-quick-links/react.tsx
+++ b/docs/src/content/examples/show-quick-links/react.tsx
@@ -1,14 +1,14 @@
-import { GoabAppFooter, GoabAppFooterMetaSection } from "@abgov/react-components";
+import { GoabxAppFooter, GoabxAppFooterMetaSection } from "@abgov/react-components/experimental";
 
 export function ShowQuickLinks() {
   return (
-    <GoabAppFooter maxContentWidth="100%">
-      <GoabAppFooterMetaSection>
+    <GoabxAppFooter maxContentWidth="100%">
+      <GoabxAppFooterMetaSection>
         <a href="#">Give feedback</a>
         <a href="#">Accessibility</a>
         <a href="#">Privacy</a>
         <a href="#">Contact us</a>
-      </GoabAppFooterMetaSection>
-    </GoabAppFooter>
+      </GoabxAppFooterMetaSection>
+    </GoabxAppFooter>
   );
 }

--- a/docs/src/content/examples/show-quick-links/web-components.html
+++ b/docs/src/content/examples/show-quick-links/web-components.html
@@ -1,4 +1,4 @@
-<goa-app-footer maxcontentwidth="100%">
+<goa-app-footer version="2" maxcontentwidth="100%">
   <goa-app-footer-meta-section slot="meta">
     <a href="#">Give feedback</a>
     <a href="#">Accessibility</a>

--- a/docs/src/content/examples/show-status-in-a-table/angular.html
+++ b/docs/src/content/examples/show-status-in-a-table/angular.html
@@ -1,4 +1,4 @@
-<goab-table width="100%">
+<goabx-table width="100%">
   <thead>
     <tr>
       <th>Status</th>
@@ -10,13 +10,13 @@
   <tbody>
     <tr *ngFor="let badge of badgeValues">
       <td>
-        <goab-badge [type]="badge.type" [content]="badge.content" [icon]="false"></goab-badge>
+        <goabx-badge [type]="badge.type" [content]="badge.content" [icon]="false"></goabx-badge>
       </td>
       <td>Lorem ipsum dolor sit amet consectetur.</td>
       <td class="goa-table-number-column">1234567890</td>
       <td>
-        <goab-button size="compact" type="tertiary" (onClick)="onClick()">Assign</goab-button>
+        <goabx-button size="compact" type="tertiary" (onClick)="onClick()">Assign</goabx-button>
       </td>
     </tr>
   </tbody>
-</goab-table>
+</goabx-table>

--- a/docs/src/content/examples/show-status-in-a-table/react.tsx
+++ b/docs/src/content/examples/show-status-in-a-table/react.tsx
@@ -1,8 +1,4 @@
-import {
-  GoabBadge,
-  GoabButton,
-  GoabTable,
-} from "@abgov/react-components";
+import { GoabxBadge, GoabxButton, GoabxTable } from "@abgov/react-components/experimental";
 import type { GoabBadgeType } from "@abgov/ui-components-common";
 
 interface BadgeValue {
@@ -26,7 +22,7 @@ export function ShowStatusInATable() {
   };
 
   return (
-    <GoabTable width="100%">
+    <GoabxTable width="100%">
       <thead>
         <tr>
           <th>Status</th>
@@ -39,18 +35,18 @@ export function ShowStatusInATable() {
         {badgeValues.map((badge) => (
           <tr key={badge.key}>
             <td>
-              <GoabBadge type={badge.type} content={badge.content} icon={false} />
+              <GoabxBadge type={badge.type} content={badge.content} icon={false} />
             </td>
             <td>Lorem ipsum dolor sit amet consectetur</td>
             <td className="goa-table-number-column">1234567890</td>
             <td>
-              <GoabButton size="compact" type="tertiary" onClick={handleClick}>
+              <GoabxButton size="compact" type="tertiary" onClick={handleClick}>
                 Assign
-              </GoabButton>
+              </GoabxButton>
             </td>
           </tr>
         ))}
       </tbody>
-    </GoabTable>
+    </GoabxTable>
   );
 }

--- a/docs/src/content/examples/show-status-in-a-table/web-components.html
+++ b/docs/src/content/examples/show-status-in-a-table/web-components.html
@@ -1,4 +1,4 @@
-<goa-table width="100%" id="status-table">
+<goa-table version="2" width="100%" id="status-table">
   <table width="100%">
     <thead>
       <tr>
@@ -27,10 +27,10 @@
   badgeValues.forEach((badge) => {
     const row = document.createElement("tr");
     row.innerHTML = `
-      <td><goa-badge type="${badge.type}" content="${badge.content}" icon="false"></goa-badge></td>
+      <td><goa-badge version="2" type="${badge.type}" content="${badge.content}" icon="false"></goa-badge></td>
       <td>Lorem ipsum dolor sit amet consectetur</td>
       <td class="goa-table-number-column">1234567890</td>
-      <td><goa-button size="compact" type="tertiary">Assign</goa-button></td>
+      <td><goa-button version="2" size="compact" type="tertiary">Assign</goa-button></td>
     `;
     const button = row.querySelector("goa-button");
     button.addEventListener("_click", () => console.log("clicked"));

--- a/docs/src/content/examples/show-status-on-a-card/angular.html
+++ b/docs/src/content/examples/show-status-on-a-card/angular.html
@@ -1,7 +1,7 @@
 <goab-container type="non-interactive" accent="thick" [title]="title" [actions]="actions">
   <ng-template #title>Heading</ng-template>
   <ng-template #actions>
-    <goab-badge type="important" content="Priority"></goab-badge>
+    <goabx-badge type="important" content="Priority"></goabx-badge>
   </ng-template>
   Content
 </goab-container>

--- a/docs/src/content/examples/show-status-on-a-card/react.tsx
+++ b/docs/src/content/examples/show-status-on-a-card/react.tsx
@@ -1,4 +1,5 @@
-import { GoabBadge, GoabContainer } from "@abgov/react-components";
+import { GoabxBadge } from "@abgov/react-components/experimental";
+import { GoabContainer } from "@abgov/react-components";
 
 export function ShowStatusOnACard() {
   return (
@@ -6,7 +7,7 @@ export function ShowStatusOnACard() {
       type="non-interactive"
       accent="thick"
       heading="Heading"
-      actions={<GoabBadge type="important" content="Priority" />}
+      actions={<GoabxBadge type="important" content="Priority" />}
     >
       Content
     </GoabContainer>

--- a/docs/src/content/examples/show-status-on-a-card/web-components.html
+++ b/docs/src/content/examples/show-status-on-a-card/web-components.html
@@ -1,7 +1,7 @@
 <goa-container type="non-interactive" accent="thick">
   <div slot="title">Heading</div>
   <div slot="actions">
-    <goa-badge type="important" content="Priority"></goa-badge>
+    <goa-badge version="2" type="important" content="Priority"></goa-badge>
   </div>
   Content
 </goa-container>

--- a/docs/src/content/examples/slotted-error-text-in-a-form-item/angular.html
+++ b/docs/src/content/examples/slotted-error-text-in-a-form-item/angular.html
@@ -1,8 +1,8 @@
-<goab-form-item label="First name" [formGroup]="form">
-  <goab-input name="item" formControlName="item" [error]="true"></goab-input>
-  <goab-form-item-slot slot="error">
+<goabx-form-item label="First name" [formGroup]="form">
+  <goabx-input name="item" formControlName="item" [error]="true"></goabx-input>
+  <goabx-form-item-slot slot="error">
     <span>This is </span>
     <i>slotted </i>
     <b>error text.</b>
-  </goab-form-item-slot>
-</goab-form-item>
+  </goabx-form-item-slot>
+</goabx-form-item>

--- a/docs/src/content/examples/slotted-error-text-in-a-form-item/react.tsx
+++ b/docs/src/content/examples/slotted-error-text-in-a-form-item/react.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { GoabFormItem, GoabInput } from "@abgov/react-components";
+import { GoabxFormItem, GoabxInput } from "@abgov/react-components/experimental";
 import type { GoabInputOnChangeDetail } from "@abgov/ui-components-common";
 
 export function SlottedErrorTextInAFormItem() {
@@ -16,8 +16,8 @@ export function SlottedErrorTextInAFormItem() {
   );
 
   return (
-    <GoabFormItem label="First name" error={errorMessage}>
-      <GoabInput onChange={onChange} value={value} name="item" error={true} />
-    </GoabFormItem>
+    <GoabxFormItem label="First name" error={errorMessage}>
+      <GoabxInput onChange={onChange} value={value} name="item" error={true} />
+    </GoabxFormItem>
   );
 }

--- a/docs/src/content/examples/slotted-error-text-in-a-form-item/web-components.html
+++ b/docs/src/content/examples/slotted-error-text-in-a-form-item/web-components.html
@@ -1,5 +1,5 @@
-<goa-form-item label="First name">
-  <goa-input name="item" error="true"></goa-input>
+<goa-form-item version="2" label="First name">
+  <goa-input version="2" name="item" error="true"></goa-input>
   <div slot="error">
     <span>This is </span>
     <i>slotted </i>

--- a/docs/src/content/examples/slotted-helper-text-in-a-form-item/angular.html
+++ b/docs/src/content/examples/slotted-helper-text-in-a-form-item/angular.html
@@ -1,8 +1,8 @@
-<goab-form-item label="First name" [formGroup]="form">
-  <goab-input name="item" formControlName="item"></goab-input>
-  <goab-form-item-slot slot="helptext">
+<goabx-form-item label="First name" [formGroup]="form">
+  <goabx-input name="item" formControlName="item"></goabx-input>
+  <goabx-form-item-slot slot="helptext">
     <span>This is </span>
     <i>slotted </i>
     <b>help text</b>.
-  </goab-form-item-slot>
-</goab-form-item>
+  </goabx-form-item-slot>
+</goabx-form-item>

--- a/docs/src/content/examples/slotted-helper-text-in-a-form-item/react.tsx
+++ b/docs/src/content/examples/slotted-helper-text-in-a-form-item/react.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { GoabFormItem, GoabInput } from "@abgov/react-components";
+import { GoabxFormItem, GoabxInput } from "@abgov/react-components/experimental";
 import type { GoabInputOnChangeDetail } from "@abgov/ui-components-common";
 
 export function SlottedHelperTextInAFormItem() {
@@ -16,8 +16,8 @@ export function SlottedHelperTextInAFormItem() {
   );
 
   return (
-    <GoabFormItem label="First name" helpText={helpText}>
-      <GoabInput onChange={onChange} value={value} name="item" />
-    </GoabFormItem>
+    <GoabxFormItem label="First name" helpText={helpText}>
+      <GoabxInput onChange={onChange} value={value} name="item" />
+    </GoabxFormItem>
   );
 }

--- a/docs/src/content/examples/slotted-helper-text-in-a-form-item/web-components.html
+++ b/docs/src/content/examples/slotted-helper-text-in-a-form-item/web-components.html
@@ -1,5 +1,5 @@
-<goa-form-item label="First name">
-  <goa-input name="item"></goa-input>
+<goa-form-item version="2" label="First name">
+  <goa-input version="2" name="item"></goa-input>
   <div slot="helptext">
     <span>This is </span>
     <i>slotted </i>

--- a/docs/src/content/examples/sort-data-in-a-table/angular.html
+++ b/docs/src/content/examples/sort-data-in-a-table/angular.html
@@ -1,4 +1,4 @@
-<goab-table width="100%" mb="xl" (onSort)="handleSort($event)">
+<goabx-table width="100%" mb="xl" (onSort)="handleSort($event)">
   <thead>
     <tr>
       <th>
@@ -19,4 +19,4 @@
       <td>{{ user.age }}</td>
     </tr>
   </tbody>
-</goab-table>
+</goabx-table>

--- a/docs/src/content/examples/sort-data-in-a-table/react.tsx
+++ b/docs/src/content/examples/sort-data-in-a-table/react.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { GoabTable, GoabTableSortHeader } from "@abgov/react-components";
+import { GoabxTable, GoabxTableSortHeader } from "@abgov/react-components/experimental";
 import type { GoabTableOnSortDetail } from "@abgov/ui-components-common";
 
 interface User {
@@ -30,19 +30,19 @@ export function SortDataInATable() {
   }
 
   return (
-    <GoabTable onSort={sortData} width="100%">
+    <GoabxTable onSort={sortData} width="100%">
       <thead>
         <tr>
           <th>
-            <GoabTableSortHeader name="firstName">First name</GoabTableSortHeader>
+            <GoabxTableSortHeader name="firstName">First name</GoabxTableSortHeader>
           </th>
           <th>
-            <GoabTableSortHeader name="lastName">Last name</GoabTableSortHeader>
+            <GoabxTableSortHeader name="lastName">Last name</GoabxTableSortHeader>
           </th>
           <th>
-            <GoabTableSortHeader name="age" direction="asc">
+            <GoabxTableSortHeader name="age" direction="asc">
               Age
-            </GoabTableSortHeader>
+            </GoabxTableSortHeader>
           </th>
         </tr>
       </thead>
@@ -55,6 +55,6 @@ export function SortDataInATable() {
           </tr>
         ))}
       </tbody>
-    </GoabTable>
+    </GoabxTable>
   );
 }

--- a/docs/src/content/examples/sort-data-in-a-table/web-components.html
+++ b/docs/src/content/examples/sort-data-in-a-table/web-components.html
@@ -1,4 +1,4 @@
-<goa-table width="100%" mb="xl">
+<goa-table version="2" width="100%" mb="xl">
   <table width="100%">
     <thead>
       <tr>

--- a/docs/src/content/examples/start-page/angular.html
+++ b/docs/src/content/examples/start-page/angular.html
@@ -17,9 +17,9 @@
 <ul>
   <li>government issued ID for the person applying</li>
 </ul>
-<goab-button mt="2xl" mb="xl" type="start" (onClick)="onClick()">
+<goabx-button mt="2xl" mb="xl" type="start" (onClick)="onClick()">
   Get started
-</goab-button>
+</goabx-button>
 
 <goab-text size="heading-l" mt="xl" mb="none">Other information about the service</goab-text>
 <goab-text size="body-m" mt="l" mb="none">

--- a/docs/src/content/examples/start-page/react.tsx
+++ b/docs/src/content/examples/start-page/react.tsx
@@ -1,4 +1,5 @@
-import { GoabButton, GoabText } from "@abgov/react-components";
+import { GoabxButton } from "@abgov/react-components/experimental";
+import { GoabText } from "@abgov/react-components";
 
 export function StartPage() {
   const handleClick = () => {
@@ -27,9 +28,9 @@ export function StartPage() {
       <ul>
         <li>government issued ID for the person applying</li>
       </ul>
-      <GoabButton mt="2xl" mb="xl" type="start" onClick={handleClick}>
+      <GoabxButton mt="2xl" mb="xl" type="start" onClick={handleClick}>
         Get started
-      </GoabButton>
+      </GoabxButton>
 
       <GoabText size="heading-l" mt="xl" mb="none">Other information about the service</GoabText>
       <GoabText size="body-m" mt="l" mb="none">

--- a/docs/src/content/examples/start-page/web-components.html
+++ b/docs/src/content/examples/start-page/web-components.html
@@ -17,7 +17,7 @@
 <ul>
   <li>government issued ID for the person applying</li>
 </ul>
-<goa-button mt="2xl" mb="xl" type="start" id="start-btn">Get started</goa-button>
+<goa-button version="2" mt="2xl" mb="xl" type="start" id="start-btn">Get started</goa-button>
 
 <goa-text size="heading-l" mt="xl" mb="none">Other information about the service</goa-text>
 <goa-text size="body-m" mt="l" mb="none">

--- a/docs/src/content/examples/task-list-page/angular.html
+++ b/docs/src/content/examples/task-list-page/angular.html
@@ -1,59 +1,59 @@
 <goab-text as="h1" mt="none">Apply for a service</goab-text>
-<goab-callout type="important" emphasis="low" size="medium" heading="Application incomplete" mb="2xl" mt="xl" maxWidth="360px">
+<goabx-callout type="important" emphasis="low" size="medium" heading="Application incomplete" mb="2xl" mt="xl" maxWidth="360px">
   You have completed 1 of 3 sections.
-</goab-callout>
+</goabx-callout>
 
 <goab-text as="h2">1. Before you start</goab-text>
-<goab-table width="100%" mb="2xl" mt="l">
+<goabx-table width="100%" mb="2xl" mt="l">
   <tbody>
     <tr>
       <td><a href="#">Read terms of use</a></td>
       <td class="goa-table-number-column">
-        <goab-badge type="success" content="Completed" ariaLabel="completed" [icon]="false"></goab-badge>
+        <goabx-badge type="success" content="Completed" ariaLabel="completed" [icon]="false"></goabx-badge>
       </td>
     </tr>
   </tbody>
-</goab-table>
+</goabx-table>
 
 <goab-text as="h2">2. Prepare application</goab-text>
-<goab-table width="100%" mb="2xl" mt="l">
+<goabx-table width="100%" mb="2xl" mt="l">
   <tbody>
     <tr>
       <td><a href="#">Your contact details</a></td>
       <td class="goa-table-number-column">
-        <goab-badge type="information" content="Not started" ariaLabel="not started" [icon]="false"></goab-badge>
+        <goabx-badge type="information" content="Not started" ariaLabel="not started" [icon]="false"></goabx-badge>
       </td>
     </tr>
     <tr>
       <td><a href="#">Your family</a></td>
       <td class="goa-table-number-column">
-        <goab-badge type="information" content="Not started" ariaLabel="not started" [icon]="false"></goab-badge>
+        <goabx-badge type="information" content="Not started" ariaLabel="not started" [icon]="false"></goabx-badge>
       </td>
     </tr>
     <tr>
       <td><a href="#">Verify your identity</a></td>
       <td class="goa-table-number-column">
-        <goab-badge type="information" content="Not started" ariaLabel="not started" [icon]="false"></goab-badge>
+        <goabx-badge type="information" content="Not started" ariaLabel="not started" [icon]="false"></goabx-badge>
       </td>
     </tr>
   </tbody>
-</goab-table>
+</goabx-table>
 
 <goab-text as="h2" mb="s">3. Schedule service</goab-text>
 <goab-text size="body-s" color="secondary" mt="2xs">You need to complete the previous section before you can start this task.</goab-text>
-<goab-table width="100%" mt="l" mb="3xl">
+<goabx-table width="100%" mt="l" mb="3xl">
   <tbody>
     <tr>
       <td>Receive email confirmation</td>
       <td class="goa-table-number-column">
-        <goab-badge type="light" content="Cannot start yet" ariaLabel="cannot start yet" [icon]="false"></goab-badge>
+        <goabx-badge type="light" content="Cannot start yet" ariaLabel="cannot start yet" [icon]="false"></goabx-badge>
       </td>
     </tr>
     <tr>
       <td>Pay service fee</td>
       <td class="goa-table-number-column">
-        <goab-badge type="light" content="Cannot start yet" ariaLabel="cannot start yet" [icon]="false"></goab-badge>
+        <goabx-badge type="light" content="Cannot start yet" ariaLabel="cannot start yet" [icon]="false"></goabx-badge>
       </td>
     </tr>
   </tbody>
-</goab-table>
+</goabx-table>

--- a/docs/src/content/examples/task-list-page/react.tsx
+++ b/docs/src/content/examples/task-list-page/react.tsx
@@ -1,10 +1,11 @@
-import { GoabBadge, GoabCallout, GoabTable, GoabText } from "@abgov/react-components";
+import { GoabxBadge, GoabxCallout, GoabxTable } from "@abgov/react-components/experimental";
+import { GoabText } from "@abgov/react-components";
 
 export function TaskListPage() {
   return (
     <>
       <GoabText as="h1" mt="none">Apply for a service</GoabText>
-      <GoabCallout
+      <GoabxCallout
         type="important"
         emphasis="low"
         size="medium"
@@ -14,31 +15,31 @@ export function TaskListPage() {
         maxWidth="360px"
       >
         You have completed 1 of 3 sections.
-      </GoabCallout>
+      </GoabxCallout>
 
       <GoabText as="h2">1. Before you start</GoabText>
-      <GoabTable width="100%" mb="2xl" mt="l">
+      <GoabxTable width="100%" mb="2xl" mt="l">
         <tbody>
           <tr>
             <td>
               <a href="#">Read terms of use</a>
             </td>
             <td className="goa-table-number-column">
-              <GoabBadge type="success" content="Completed" ariaLabel="completed" icon={false} />
+              <GoabxBadge type="success" content="Completed" ariaLabel="completed" icon={false} />
             </td>
           </tr>
         </tbody>
-      </GoabTable>
+      </GoabxTable>
 
       <GoabText as="h2">2. Prepare application</GoabText>
-      <GoabTable width="100%" mb="2xl" mt="l">
+      <GoabxTable width="100%" mb="2xl" mt="l">
         <tbody>
           <tr>
             <td>
               <a href="#">Your contact details</a>
             </td>
             <td className="goa-table-number-column">
-              <GoabBadge type="information" content="Not started" ariaLabel="not started" icon={false} />
+              <GoabxBadge type="information" content="Not started" ariaLabel="not started" icon={false} />
             </td>
           </tr>
           <tr>
@@ -46,7 +47,7 @@ export function TaskListPage() {
               <a href="#">Your family</a>
             </td>
             <td className="goa-table-number-column">
-              <GoabBadge type="information" content="Not started" ariaLabel="not started" icon={false} />
+              <GoabxBadge type="information" content="Not started" ariaLabel="not started" icon={false} />
             </td>
           </tr>
           <tr>
@@ -54,32 +55,32 @@ export function TaskListPage() {
               <a href="#">Verify your identity</a>
             </td>
             <td className="goa-table-number-column">
-              <GoabBadge type="information" content="Not started" ariaLabel="not started" icon={false} />
+              <GoabxBadge type="information" content="Not started" ariaLabel="not started" icon={false} />
             </td>
           </tr>
         </tbody>
-      </GoabTable>
+      </GoabxTable>
 
       <GoabText as="h2" mb="s">3. Schedule service</GoabText>
       <GoabText size="body-s" color="secondary" mt="2xs">
         You need to complete the previous section before you can start this task.
       </GoabText>
-      <GoabTable width="100%" mt="l" mb="3xl">
+      <GoabxTable width="100%" mt="l" mb="3xl">
         <tbody>
           <tr>
             <td>Receive email confirmation</td>
             <td className="goa-table-number-column">
-              <GoabBadge type="light" content="Cannot start yet" ariaLabel="cannot start yet" icon={false} />
+              <GoabxBadge type="light" content="Cannot start yet" ariaLabel="cannot start yet" icon={false} />
             </td>
           </tr>
           <tr>
             <td>Pay service fee</td>
             <td className="goa-table-number-column">
-              <GoabBadge type="light" content="Cannot start yet" ariaLabel="cannot start yet" icon={false} />
+              <GoabxBadge type="light" content="Cannot start yet" ariaLabel="cannot start yet" icon={false} />
             </td>
           </tr>
         </tbody>
-      </GoabTable>
+      </GoabxTable>
     </>
   );
 }

--- a/docs/src/content/examples/task-list-page/web-components.html
+++ b/docs/src/content/examples/task-list-page/web-components.html
@@ -1,16 +1,16 @@
 <goa-text as="h1" mt="none">Apply for a service</goa-text>
-<goa-callout type="important" emphasis="low" size="medium" heading="Application incomplete" mb="2xl" mt="xl" maxwidth="360px">
+<goa-callout version="2" type="important" emphasis="low" size="medium" heading="Application incomplete" mb="2xl" mt="xl" maxwidth="360px">
   You have completed 1 of 3 sections.
 </goa-callout>
 
 <goa-text as="h2">1. Before you start</goa-text>
-<goa-table width="100%" mb="2xl" mt="l">
+<goa-table version="2" width="100%" mb="2xl" mt="l">
   <table style="width: 100%;">
     <tbody>
     <tr>
       <td><a href="#">Read terms of use</a></td>
       <td class="goa-table-number-column">
-        <goa-badge type="success" content="Completed" aria-label="completed" icon="false"></goa-badge>
+        <goa-badge version="2" type="success" content="Completed" aria-label="completed" icon="false"></goa-badge>
       </td>
     </tr>
     </tbody>
@@ -18,25 +18,25 @@
 </goa-table>
 
 <goa-text as="h2">2. Prepare application</goa-text>
-<goa-table width="100%" mb="2xl" mt="l">
+<goa-table version="2" width="100%" mb="2xl" mt="l">
   <table style="width: 100%;">
     <tbody>
     <tr>
       <td><a href="#">Your contact details</a></td>
       <td class="goa-table-number-column">
-        <goa-badge type="information" content="Not started" aria-label="not started" icon="false"></goa-badge>
+        <goa-badge version="2" type="information" content="Not started" aria-label="not started" icon="false"></goa-badge>
       </td>
     </tr>
     <tr>
       <td><a href="#">Your family</a></td>
       <td class="goa-table-number-column">
-        <goa-badge type="information" content="Not started" aria-label="not started" icon="false"></goa-badge>
+        <goa-badge version="2" type="information" content="Not started" aria-label="not started" icon="false"></goa-badge>
       </td>
     </tr>
     <tr>
       <td><a href="#">Verify your identity</a></td>
       <td class="goa-table-number-column">
-        <goa-badge type="information" content="Not started" aria-label="not started" icon="false"></goa-badge>
+        <goa-badge version="2" type="information" content="Not started" aria-label="not started" icon="false"></goa-badge>
       </td>
     </tr>
     </tbody>
@@ -45,19 +45,19 @@
 
 <goa-text as="h2" mb="s">3. Schedule service</goa-text>
 <goa-text size="body-s" color="secondary" mt="2xs">You need to complete the previous section before you can start this task.</goa-text>
-<goa-table width="100%" mt="l" mb="3xl">
+<goa-table version="2" width="100%" mt="l" mb="3xl">
   <table style="width: 100%;">
     <tbody>
     <tr>
       <td>Receive email confirmation</td>
       <td class="goa-table-number-column">
-        <goa-badge type="light" content="Cannot start yet" aria-label="cannot start yet" icon="false"></goa-badge>
+        <goa-badge version="2" type="light" content="Cannot start yet" aria-label="cannot start yet" icon="false"></goa-badge>
       </td>
     </tr>
     <tr>
       <td>Pay service fee</td>
       <td class="goa-table-number-column">
-        <goa-badge type="light" content="Cannot start yet" aria-label="cannot start yet" icon="false"></goa-badge>
+        <goa-badge version="2" type="light" content="Cannot start yet" aria-label="cannot start yet" icon="false"></goa-badge>
       </td>
     </tr>
     </tbody>

--- a/docs/src/content/examples/type-to-create-a-new-filter/angular.html
+++ b/docs/src/content/examples/type-to-create-a-new-filter/angular.html
@@ -1,17 +1,17 @@
-<goab-form-item label="Type to create a chip" mb="m">
-  <goab-input
+<goabx-form-item label="Type to create a chip" mb="m">
+  <goabx-input
     [value]="inputValue"
     (onChange)="handleInputChange($event)"
     (onKeyPress)="handleInputKeyPress($event)"
     width="100%">
-  </goab-input>
-</goab-form-item>
+  </goabx-input>
+</goabx-form-item>
 <div *ngIf="typedChips.length > 0">
-  <goab-filter-chip
+  <goabx-filter-chip
     *ngFor="let typedChip of typedChips"
     [content]="typedChip"
     mb="xs"
     mr="xs"
     (onClick)="removeTypedChip(typedChip)">
-  </goab-filter-chip>
+  </goabx-filter-chip>
 </div>

--- a/docs/src/content/examples/type-to-create-a-new-filter/react.tsx
+++ b/docs/src/content/examples/type-to-create-a-new-filter/react.tsx
@@ -1,9 +1,5 @@
 import { useState } from "react";
-import {
-  GoabFilterChip,
-  GoabFormItem,
-  GoabInput,
-} from "@abgov/react-components";
+import { GoabxFilterChip, GoabxFormItem, GoabxInput } from "@abgov/react-components/experimental";
 
 export function TypeToCreateANewFilter() {
   const [typedChips, setTypedChips] = useState<string[]>([]);
@@ -11,8 +7,8 @@ export function TypeToCreateANewFilter() {
 
   return (
     <>
-      <GoabFormItem label="Type to create a chip" mb="m">
-        <GoabInput
+      <GoabxFormItem label="Type to create a chip" mb="m">
+        <GoabxInput
           name="chipInput"
           value={inputValue}
           onChange={(e) => setInputValue(e.value.trim())}
@@ -26,10 +22,10 @@ export function TypeToCreateANewFilter() {
           }}
           width="100%"
         />
-      </GoabFormItem>
+      </GoabxFormItem>
       <div>
         {typedChips.map((chip, index) => (
-          <GoabFilterChip
+          <GoabxFilterChip
             key={index}
             content={chip}
             mb="xs"

--- a/docs/src/content/examples/type-to-create-a-new-filter/web-components.html
+++ b/docs/src/content/examples/type-to-create-a-new-filter/web-components.html
@@ -1,9 +1,9 @@
-<goa-form-item label="Type to create a chip" mb="m">
+<goa-form-item version="2" label="Type to create a chip" mb="m">
   <goa-block gap="xs" direction="row">
     <div style="flex: 1">
-      <goa-input id="chip-input" width="100%"></goa-input>
+      <goa-input version="2" id="chip-input" width="100%"></goa-input>
     </div>
-    <goa-button id="add-btn" type="secondary">Add</goa-button>
+    <goa-button version="2" id="add-btn" type="secondary">Add</goa-button>
   </goa-block>
 </goa-form-item>
 <div id="chips-container"></div>

--- a/docs/src/content/examples/warn-a-user-of-a-deadline/angular.html
+++ b/docs/src/content/examples/warn-a-user-of-a-deadline/angular.html
@@ -1,5 +1,5 @@
-<goab-button type="secondary" (onClick)="toggleModal()">Save for later</goab-button>
-<goab-modal
+<goabx-button type="secondary" (onClick)="toggleModal()">Save for later</goabx-button>
+<goabx-modal
   [open]="open"
   calloutVariant="important"
   (onClose)="toggleModal()"
@@ -12,7 +12,7 @@
   </p>
   <ng-template #actions>
     <goab-button-group alignment="end">
-      <goab-button type="primary" (onClick)="toggleModal()">I understand</goab-button>
+      <goabx-button type="primary" (onClick)="toggleModal()">I understand</goabx-button>
     </goab-button-group>
   </ng-template>
-</goab-modal>
+</goabx-modal>

--- a/docs/src/content/examples/warn-a-user-of-a-deadline/react.tsx
+++ b/docs/src/content/examples/warn-a-user-of-a-deadline/react.tsx
@@ -1,24 +1,25 @@
 import { useState } from "react";
-import { GoabButton, GoabButtonGroup, GoabModal } from "@abgov/react-components";
+import { GoabxButton, GoabxModal } from "@abgov/react-components/experimental";
+import { GoabButtonGroup } from "@abgov/react-components";
 
 export function WarnAUserOfADeadline() {
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      <GoabButton type="secondary" onClick={() => setOpen(true)}>
+      <GoabxButton type="secondary" onClick={() => setOpen(true)}>
         Save for later
-      </GoabButton>
-      <GoabModal
+      </GoabxButton>
+      <GoabxModal
         heading="Complete submission prior to 1PM"
         calloutVariant="important"
         open={open}
         onClose={() => setOpen(false)}
         actions={
           <GoabButtonGroup alignment="end">
-            <GoabButton type="primary" onClick={() => setOpen(false)}>
+            <GoabxButton type="primary" onClick={() => setOpen(false)}>
               I understand
-            </GoabButton>
+            </GoabxButton>
           </GoabButtonGroup>
         }
       >
@@ -27,7 +28,7 @@ export function WarnAUserOfADeadline() {
           location does not accept adjournment requests past 1PM MST. Please submit your
           adjournment request as soon as possible.
         </p>
-      </GoabModal>
+      </GoabxModal>
     </>
   );
 }

--- a/docs/src/content/examples/warn-a-user-of-a-deadline/web-components.html
+++ b/docs/src/content/examples/warn-a-user-of-a-deadline/web-components.html
@@ -1,5 +1,5 @@
-<goa-button type="secondary" id="open-modal-btn">Save for later</goa-button>
-<goa-modal
+<goa-button version="2" type="secondary" id="open-modal-btn">Save for later</goa-button>
+<goa-modal version="2"
   id="deadline-modal"
   calloutvariant="important"
   heading="Complete submission prior to 1PM">
@@ -8,7 +8,7 @@
   request as soon as possible.
   <div slot="actions">
     <goa-button-group alignment="end">
-      <goa-button type="primary" size="compact" id="understand-btn">I understand</goa-button>
+      <goa-button version="2" type="primary" size="compact" id="understand-btn">I understand</goa-button>
     </goa-button-group>
   </div>
 </goa-modal>

--- a/docs/src/data/configurations/app-header.ts
+++ b/docs/src/data/configurations/app-header.ts
@@ -45,14 +45,14 @@ export const appHeaderConfigurations: ComponentConfigurations = {
 </GoabAppHeader>`,
         angular: `<goab-app-header heading="My Application" url="/">
   <div slot="actions">
-    <goab-button type="tertiary">Help</goab-button>
-    <goab-button type="tertiary">Sign out</goab-button>
+    <goabx-button type="tertiary">Help</goabx-button>
+    <goabx-button type="tertiary">Sign out</goabx-button>
   </div>
 </goab-app-header>`,
         webComponents: `<goa-app-header heading="My Application" url="/">
   <div slot="actions">
-    <goa-button type="tertiary">Help</goa-button>
-    <goa-button type="tertiary">Sign out</goa-button>
+    <goa-button version="2" type="tertiary">Help</goa-button>
+    <goa-button version="2" type="tertiary">Sign out</goa-button>
   </div>
 </goa-app-header>`,
       },
@@ -79,7 +79,7 @@ export const appHeaderConfigurations: ComponentConfigurations = {
     <a href="/settings">Settings</a>
   </goab-app-header-menu>
   <div slot="actions">
-    <goab-button type="tertiary" leadingIcon="person">John Smith</goab-button>
+    <goabx-button type="tertiary" leadingIcon="person">John Smith</goabx-button>
   </div>
 </goab-app-header>`,
         webComponents: `<goa-app-header heading="Service Portal" url="/">
@@ -89,7 +89,7 @@ export const appHeaderConfigurations: ComponentConfigurations = {
     <a href="/settings">Settings</a>
   </goa-app-header-menu>
   <div slot="actions">
-    <goa-button type="tertiary" leadingicon="person">John Smith</goa-button>
+    <goa-button version="2" type="tertiary" leadingicon="person">John Smith</goa-button>
   </div>
 </goa-app-header>`,
       },

--- a/docs/src/data/configurations/app-header.ts
+++ b/docs/src/data/configurations/app-header.ts
@@ -39,8 +39,8 @@ export const appHeaderConfigurations: ComponentConfigurations = {
       code: {
         react: `<GoabAppHeader heading="My Application" url="/">
   <div slot="actions">
-    <GoabButton type="tertiary">Help</GoabButton>
-    <GoabButton type="tertiary">Sign out</GoabButton>
+    <GoabxButton type="tertiary">Help</GoabxButton>
+    <GoabxButton type="tertiary">Sign out</GoabxButton>
   </div>
 </GoabAppHeader>`,
         angular: `<goab-app-header heading="My Application" url="/">
@@ -69,7 +69,7 @@ export const appHeaderConfigurations: ComponentConfigurations = {
     <a href="/settings">Settings</a>
   </GoabAppHeaderMenu>
   <div slot="actions">
-    <GoabButton type="tertiary" leadingIcon="person">John Smith</GoabButton>
+    <GoabxButton type="tertiary" leadingIcon="person">John Smith</GoabxButton>
   </div>
 </GoabAppHeader>`,
         angular: `<goab-app-header heading="Service Portal" url="/">

--- a/docs/src/data/configurations/badge.ts
+++ b/docs/src/data/configurations/badge.ts
@@ -18,8 +18,8 @@ export const badgeConfigurations: ComponentConfigurations = {
       description: 'Simple badge with text',
       code: {
         react: `<GoabxBadge type="default" content="New" emphasis="subtle" icon={false} />`,
-        angular: `<goab-badge type="default" content="New" emphasis="subtle" [icon]="false"></goab-badge>`,
-        webComponents: `<goa-badge type="default" content="New" emphasis="subtle" icon="false"></goa-badge>`,
+        angular: `<goabx-badge type="default" content="New" emphasis="subtle" [icon]="false"></goabx-badge>`,
+        webComponents: `<goa-badge version="2" type="default" content="New" emphasis="subtle" icon="false"></goa-badge>`,
       },
     },
     {
@@ -32,16 +32,16 @@ export const badgeConfigurations: ComponentConfigurations = {
 <GoabxBadge type="emergency" content="Emergency" />
 <GoabxBadge type="success" content="Success" />
 <GoabxBadge type="archived" content="Archived" />`,
-        angular: `<goab-badge type="information" content="Information"></goab-badge>
-<goab-badge type="important" content="Important"></goab-badge>
-<goab-badge type="emergency" content="Emergency"></goab-badge>
-<goab-badge type="success" content="Success"></goab-badge>
-<goab-badge type="archived" content="Archived"></goab-badge>`,
-        webComponents: `<goa-badge type="information" content="Information"></goa-badge>
-<goa-badge type="important" content="Important"></goa-badge>
-<goa-badge type="emergency" content="Emergency"></goa-badge>
-<goa-badge type="success" content="Success"></goa-badge>
-<goa-badge type="archived" content="Archived"></goa-badge>`,
+        angular: `<goabx-badge type="information" content="Information"></goabx-badge>
+<goabx-badge type="important" content="Important"></goabx-badge>
+<goabx-badge type="emergency" content="Emergency"></goabx-badge>
+<goabx-badge type="success" content="Success"></goabx-badge>
+<goabx-badge type="archived" content="Archived"></goabx-badge>`,
+        webComponents: `<goa-badge version="2" type="information" content="Information"></goa-badge>
+<goa-badge version="2" type="important" content="Important"></goa-badge>
+<goa-badge version="2" type="emergency" content="Emergency"></goa-badge>
+<goa-badge version="2" type="success" content="Success"></goa-badge>
+<goa-badge version="2" type="archived" content="Archived"></goa-badge>`,
       },
     },
     {
@@ -61,30 +61,30 @@ export const badgeConfigurations: ComponentConfigurations = {
 <GoabxBadge type="sunset" content="Sunset" icon={false} emphasis="subtle" />
 <GoabxBadge type="dawn" content="Dawn" icon={false} />
 <GoabxBadge type="dawn" content="Dawn" icon={false} emphasis="subtle" />`,
-        angular: `<goab-badge type="sky" content="Sky" [icon]="false"></goab-badge>
-<goab-badge type="sky" content="Sky" [icon]="false" emphasis="subtle"></goab-badge>
-<goab-badge type="prairie" content="Prairie" [icon]="false"></goab-badge>
-<goab-badge type="prairie" content="Prairie" [icon]="false" emphasis="subtle"></goab-badge>
-<goab-badge type="lilac" content="Lilac" [icon]="false"></goab-badge>
-<goab-badge type="lilac" content="Lilac" [icon]="false" emphasis="subtle"></goab-badge>
-<goab-badge type="pasture" content="Pasture" [icon]="false"></goab-badge>
-<goab-badge type="pasture" content="Pasture" [icon]="false" emphasis="subtle"></goab-badge>
-<goab-badge type="sunset" content="Sunset" [icon]="false"></goab-badge>
-<goab-badge type="sunset" content="Sunset" [icon]="false" emphasis="subtle"></goab-badge>
-<goab-badge type="dawn" content="Dawn" [icon]="false"></goab-badge>
-<goab-badge type="dawn" content="Dawn" [icon]="false" emphasis="subtle"></goab-badge>`,
-        webComponents: `<goa-badge type="sky" content="Sky" icon="false"></goa-badge>
-<goa-badge type="sky" content="Sky" icon="false" emphasis="subtle"></goa-badge>
-<goa-badge type="prairie" content="Prairie" icon="false"></goa-badge>
-<goa-badge type="prairie" content="Prairie" icon="false" emphasis="subtle"></goa-badge>
-<goa-badge type="lilac" content="Lilac" icon="false"></goa-badge>
-<goa-badge type="lilac" content="Lilac" icon="false" emphasis="subtle"></goa-badge>
-<goa-badge type="pasture" content="Pasture" icon="false"></goa-badge>
-<goa-badge type="pasture" content="Pasture" icon="false" emphasis="subtle"></goa-badge>
-<goa-badge type="sunset" content="Sunset" icon="false"></goa-badge>
-<goa-badge type="sunset" content="Sunset" icon="false" emphasis="subtle"></goa-badge>
-<goa-badge type="dawn" content="Dawn" icon="false"></goa-badge>
-<goa-badge type="dawn" content="Dawn" icon="false" emphasis="subtle"></goa-badge>`,
+        angular: `<goabx-badge type="sky" content="Sky" [icon]="false"></goabx-badge>
+<goabx-badge type="sky" content="Sky" [icon]="false" emphasis="subtle"></goabx-badge>
+<goabx-badge type="prairie" content="Prairie" [icon]="false"></goabx-badge>
+<goabx-badge type="prairie" content="Prairie" [icon]="false" emphasis="subtle"></goabx-badge>
+<goabx-badge type="lilac" content="Lilac" [icon]="false"></goabx-badge>
+<goabx-badge type="lilac" content="Lilac" [icon]="false" emphasis="subtle"></goabx-badge>
+<goabx-badge type="pasture" content="Pasture" [icon]="false"></goabx-badge>
+<goabx-badge type="pasture" content="Pasture" [icon]="false" emphasis="subtle"></goabx-badge>
+<goabx-badge type="sunset" content="Sunset" [icon]="false"></goabx-badge>
+<goabx-badge type="sunset" content="Sunset" [icon]="false" emphasis="subtle"></goabx-badge>
+<goabx-badge type="dawn" content="Dawn" [icon]="false"></goabx-badge>
+<goabx-badge type="dawn" content="Dawn" [icon]="false" emphasis="subtle"></goabx-badge>`,
+        webComponents: `<goa-badge version="2" type="sky" content="Sky" icon="false"></goa-badge>
+<goa-badge version="2" type="sky" content="Sky" icon="false" emphasis="subtle"></goa-badge>
+<goa-badge version="2" type="prairie" content="Prairie" icon="false"></goa-badge>
+<goa-badge version="2" type="prairie" content="Prairie" icon="false" emphasis="subtle"></goa-badge>
+<goa-badge version="2" type="lilac" content="Lilac" icon="false"></goa-badge>
+<goa-badge version="2" type="lilac" content="Lilac" icon="false" emphasis="subtle"></goa-badge>
+<goa-badge version="2" type="pasture" content="Pasture" icon="false"></goa-badge>
+<goa-badge version="2" type="pasture" content="Pasture" icon="false" emphasis="subtle"></goa-badge>
+<goa-badge version="2" type="sunset" content="Sunset" icon="false"></goa-badge>
+<goa-badge version="2" type="sunset" content="Sunset" icon="false" emphasis="subtle"></goa-badge>
+<goa-badge version="2" type="dawn" content="Dawn" icon="false"></goa-badge>
+<goa-badge version="2" type="dawn" content="Dawn" icon="false" emphasis="subtle"></goa-badge>`,
       },
     },
     {
@@ -104,30 +104,30 @@ export const badgeConfigurations: ComponentConfigurations = {
 <GoabxBadge type="pasture" content="Pasture" icon={false} />
 <GoabxBadge type="sunset" content="Sunset" icon={false} />
 <GoabxBadge type="dawn" content="Dawn" icon={false} />`,
-        angular: `<goab-badge type="default" content="Default" [icon]="false"></goab-badge>
-<goab-badge type="information" content="Information" [icon]="false"></goab-badge>
-<goab-badge type="important" content="Important" [icon]="false"></goab-badge>
-<goab-badge type="emergency" content="Emergency" [icon]="false"></goab-badge>
-<goab-badge type="success" content="Success" [icon]="false"></goab-badge>
-<goab-badge type="archived" content="Archived" [icon]="false"></goab-badge>
-<goab-badge type="sky" content="Sky" [icon]="false"></goab-badge>
-<goab-badge type="prairie" content="Prairie" [icon]="false"></goab-badge>
-<goab-badge type="lilac" content="Lilac" [icon]="false"></goab-badge>
-<goab-badge type="pasture" content="Pasture" [icon]="false"></goab-badge>
-<goab-badge type="sunset" content="Sunset" [icon]="false"></goab-badge>
-<goab-badge type="dawn" content="Dawn" [icon]="false"></goab-badge>`,
-        webComponents: `<goa-badge type="default" content="Default" icon="false"></goa-badge>
-<goa-badge type="information" content="Information" icon="false"></goa-badge>
-<goa-badge type="important" content="Important" icon="false"></goa-badge>
-<goa-badge type="emergency" content="Emergency" icon="false"></goa-badge>
-<goa-badge type="success" content="Success" icon="false"></goa-badge>
-<goa-badge type="archived" content="Archived" icon="false"></goa-badge>
-<goa-badge type="sky" content="Sky" icon="false"></goa-badge>
-<goa-badge type="prairie" content="Prairie" icon="false"></goa-badge>
-<goa-badge type="lilac" content="Lilac" icon="false"></goa-badge>
-<goa-badge type="pasture" content="Pasture" icon="false"></goa-badge>
-<goa-badge type="sunset" content="Sunset" icon="false"></goa-badge>
-<goa-badge type="dawn" content="Dawn" icon="false"></goa-badge>`,
+        angular: `<goabx-badge type="default" content="Default" [icon]="false"></goabx-badge>
+<goabx-badge type="information" content="Information" [icon]="false"></goabx-badge>
+<goabx-badge type="important" content="Important" [icon]="false"></goabx-badge>
+<goabx-badge type="emergency" content="Emergency" [icon]="false"></goabx-badge>
+<goabx-badge type="success" content="Success" [icon]="false"></goabx-badge>
+<goabx-badge type="archived" content="Archived" [icon]="false"></goabx-badge>
+<goabx-badge type="sky" content="Sky" [icon]="false"></goabx-badge>
+<goabx-badge type="prairie" content="Prairie" [icon]="false"></goabx-badge>
+<goabx-badge type="lilac" content="Lilac" [icon]="false"></goabx-badge>
+<goabx-badge type="pasture" content="Pasture" [icon]="false"></goabx-badge>
+<goabx-badge type="sunset" content="Sunset" [icon]="false"></goabx-badge>
+<goabx-badge type="dawn" content="Dawn" [icon]="false"></goabx-badge>`,
+        webComponents: `<goa-badge version="2" type="default" content="Default" icon="false"></goa-badge>
+<goa-badge version="2" type="information" content="Information" icon="false"></goa-badge>
+<goa-badge version="2" type="important" content="Important" icon="false"></goa-badge>
+<goa-badge version="2" type="emergency" content="Emergency" icon="false"></goa-badge>
+<goa-badge version="2" type="success" content="Success" icon="false"></goa-badge>
+<goa-badge version="2" type="archived" content="Archived" icon="false"></goa-badge>
+<goa-badge version="2" type="sky" content="Sky" icon="false"></goa-badge>
+<goa-badge version="2" type="prairie" content="Prairie" icon="false"></goa-badge>
+<goa-badge version="2" type="lilac" content="Lilac" icon="false"></goa-badge>
+<goa-badge version="2" type="pasture" content="Pasture" icon="false"></goa-badge>
+<goa-badge version="2" type="sunset" content="Sunset" icon="false"></goa-badge>
+<goa-badge version="2" type="dawn" content="Dawn" icon="false"></goa-badge>`,
       },
     },
     {
@@ -147,30 +147,30 @@ export const badgeConfigurations: ComponentConfigurations = {
 <GoabxBadge type="pasture" content="Pasture" emphasis="subtle" icon={false} />
 <GoabxBadge type="sunset" content="Sunset" emphasis="subtle" icon={false} />
 <GoabxBadge type="dawn" content="Dawn" emphasis="subtle" icon={false} />`,
-        angular: `<goab-badge type="default" content="Default" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="information" content="Information" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="important" content="Important" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="emergency" content="Emergency" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="success" content="Success" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="archived" content="Archived" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="sky" content="Sky" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="prairie" content="Prairie" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="lilac" content="Lilac" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="pasture" content="Pasture" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="sunset" content="Sunset" emphasis="subtle" [icon]="false"></goab-badge>
-<goab-badge type="dawn" content="Dawn" emphasis="subtle" [icon]="false"></goab-badge>`,
-        webComponents: `<goa-badge type="default" content="Default" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="information" content="Information" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="important" content="Important" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="emergency" content="Emergency" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="success" content="Success" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="archived" content="Archived" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="sky" content="Sky" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="prairie" content="Prairie" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="lilac" content="Lilac" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="pasture" content="Pasture" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="sunset" content="Sunset" emphasis="subtle" icon="false"></goa-badge>
-<goa-badge type="dawn" content="Dawn" emphasis="subtle" icon="false"></goa-badge>`,
+        angular: `<goabx-badge type="default" content="Default" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="information" content="Information" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="important" content="Important" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="emergency" content="Emergency" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="success" content="Success" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="archived" content="Archived" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="sky" content="Sky" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="prairie" content="Prairie" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="lilac" content="Lilac" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="pasture" content="Pasture" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="sunset" content="Sunset" emphasis="subtle" [icon]="false"></goabx-badge>
+<goabx-badge type="dawn" content="Dawn" emphasis="subtle" [icon]="false"></goabx-badge>`,
+        webComponents: `<goa-badge version="2" type="default" content="Default" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="information" content="Information" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="important" content="Important" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="emergency" content="Emergency" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="success" content="Success" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="archived" content="Archived" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="sky" content="Sky" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="prairie" content="Prairie" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="lilac" content="Lilac" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="pasture" content="Pasture" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="sunset" content="Sunset" emphasis="subtle" icon="false"></goa-badge>
+<goa-badge version="2" type="dawn" content="Dawn" emphasis="subtle" icon="false"></goa-badge>`,
       },
     },
     {
@@ -181,12 +181,12 @@ export const badgeConfigurations: ComponentConfigurations = {
         react: `<GoabxBadge type="success" content="Approved" iconType="checkmark" />
 <GoabxBadge type="emergency" content="Rejected" iconType="close" />
 <GoabxBadge type="information" content="Pending" iconType="time" />`,
-        angular: `<goab-badge type="success" content="Approved" iconType="checkmark"></goab-badge>
-<goab-badge type="emergency" content="Rejected" iconType="close"></goab-badge>
-<goab-badge type="information" content="Pending" iconType="time"></goab-badge>`,
-        webComponents: `<goa-badge type="success" content="Approved" icontype="checkmark"></goa-badge>
-<goa-badge type="emergency" content="Rejected" icontype="close"></goa-badge>
-<goa-badge type="information" content="Pending" icontype="time"></goa-badge>`,
+        angular: `<goabx-badge type="success" content="Approved" iconType="checkmark"></goabx-badge>
+<goabx-badge type="emergency" content="Rejected" iconType="close"></goabx-badge>
+<goabx-badge type="information" content="Pending" iconType="time"></goabx-badge>`,
+        webComponents: `<goa-badge version="2" type="success" content="Approved" icontype="checkmark"></goa-badge>
+<goa-badge version="2" type="emergency" content="Rejected" icontype="close"></goa-badge>
+<goa-badge version="2" type="information" content="Pending" icontype="time"></goa-badge>`,
       },
     },
     {
@@ -196,10 +196,10 @@ export const badgeConfigurations: ComponentConfigurations = {
       code: {
         react: `<GoabxBadge type="default" content="Medium" size="medium" emphasis="subtle" />
 <GoabxBadge type="default" content="Large" size="large" emphasis="subtle" />`,
-        angular: `<goab-badge type="default" content="Medium" size="medium" emphasis="subtle"></goab-badge>
-<goab-badge type="default" content="Large" size="large" emphasis="subtle"></goab-badge>`,
-        webComponents: `<goa-badge type="default" content="Medium" size="medium" emphasis="subtle"></goa-badge>
-<goa-badge type="default" content="Large" size="large" emphasis="subtle"></goa-badge>`,
+        angular: `<goabx-badge type="default" content="Medium" size="medium" emphasis="subtle"></goabx-badge>
+<goabx-badge type="default" content="Large" size="large" emphasis="subtle"></goabx-badge>`,
+        webComponents: `<goa-badge version="2" type="default" content="Medium" size="medium" emphasis="subtle"></goa-badge>
+<goa-badge version="2" type="default" content="Large" size="large" emphasis="subtle"></goa-badge>`,
       },
     },
   ],

--- a/docs/src/data/configurations/badge.ts
+++ b/docs/src/data/configurations/badge.ts
@@ -17,7 +17,7 @@ export const badgeConfigurations: ComponentConfigurations = {
       name: 'Basic badge',
       description: 'Simple badge with text',
       code: {
-        react: `<GoabBadge type="default" content="New" emphasis="subtle" icon={false} />`,
+        react: `<GoabxBadge type="default" content="New" emphasis="subtle" icon={false} />`,
         angular: `<goab-badge type="default" content="New" emphasis="subtle" [icon]="false"></goab-badge>`,
         webComponents: `<goa-badge type="default" content="New" emphasis="subtle" icon="false"></goa-badge>`,
       },
@@ -27,11 +27,11 @@ export const badgeConfigurations: ComponentConfigurations = {
       name: 'Semantic types',
       description: 'Badges for different statuses',
       code: {
-        react: `<GoabBadge type="information" content="Information" />
-<GoabBadge type="important" content="Important" />
-<GoabBadge type="emergency" content="Emergency" />
-<GoabBadge type="success" content="Success" />
-<GoabBadge type="archived" content="Archived" />`,
+        react: `<GoabxBadge type="information" content="Information" />
+<GoabxBadge type="important" content="Important" />
+<GoabxBadge type="emergency" content="Emergency" />
+<GoabxBadge type="success" content="Success" />
+<GoabxBadge type="archived" content="Archived" />`,
         angular: `<goab-badge type="information" content="Information"></goab-badge>
 <goab-badge type="important" content="Important"></goab-badge>
 <goab-badge type="emergency" content="Emergency"></goab-badge>
@@ -49,18 +49,18 @@ export const badgeConfigurations: ComponentConfigurations = {
       name: 'Extended colours',
       description: 'Additional colour options for categorization',
       code: {
-        react: `<GoabBadge type="sky" content="Sky" icon={false} />
-<GoabBadge type="sky" content="Sky" icon={false} emphasis="subtle" />
-<GoabBadge type="prairie" content="Prairie" icon={false} />
-<GoabBadge type="prairie" content="Prairie" icon={false} emphasis="subtle" />
-<GoabBadge type="lilac" content="Lilac" icon={false} />
-<GoabBadge type="lilac" content="Lilac" icon={false} emphasis="subtle" />
-<GoabBadge type="pasture" content="Pasture" icon={false} />
-<GoabBadge type="pasture" content="Pasture" icon={false} emphasis="subtle" />
-<GoabBadge type="sunset" content="Sunset" icon={false} />
-<GoabBadge type="sunset" content="Sunset" icon={false} emphasis="subtle" />
-<GoabBadge type="dawn" content="Dawn" icon={false} />
-<GoabBadge type="dawn" content="Dawn" icon={false} emphasis="subtle" />`,
+        react: `<GoabxBadge type="sky" content="Sky" icon={false} />
+<GoabxBadge type="sky" content="Sky" icon={false} emphasis="subtle" />
+<GoabxBadge type="prairie" content="Prairie" icon={false} />
+<GoabxBadge type="prairie" content="Prairie" icon={false} emphasis="subtle" />
+<GoabxBadge type="lilac" content="Lilac" icon={false} />
+<GoabxBadge type="lilac" content="Lilac" icon={false} emphasis="subtle" />
+<GoabxBadge type="pasture" content="Pasture" icon={false} />
+<GoabxBadge type="pasture" content="Pasture" icon={false} emphasis="subtle" />
+<GoabxBadge type="sunset" content="Sunset" icon={false} />
+<GoabxBadge type="sunset" content="Sunset" icon={false} emphasis="subtle" />
+<GoabxBadge type="dawn" content="Dawn" icon={false} />
+<GoabxBadge type="dawn" content="Dawn" icon={false} emphasis="subtle" />`,
         angular: `<goab-badge type="sky" content="Sky" [icon]="false"></goab-badge>
 <goab-badge type="sky" content="Sky" [icon]="false" emphasis="subtle"></goab-badge>
 <goab-badge type="prairie" content="Prairie" [icon]="false"></goab-badge>
@@ -92,18 +92,18 @@ export const badgeConfigurations: ComponentConfigurations = {
       name: 'High emphasis',
       description: 'Strong versions of all badge types',
       code: {
-        react: `<GoabBadge type="default" content="Default" icon={false} />
-<GoabBadge type="information" content="Information" icon={false} />
-<GoabBadge type="important" content="Important" icon={false} />
-<GoabBadge type="emergency" content="Emergency" icon={false} />
-<GoabBadge type="success" content="Success" icon={false} />
-<GoabBadge type="archived" content="Archived" icon={false} />
-<GoabBadge type="sky" content="Sky" icon={false} />
-<GoabBadge type="prairie" content="Prairie" icon={false} />
-<GoabBadge type="lilac" content="Lilac" icon={false} />
-<GoabBadge type="pasture" content="Pasture" icon={false} />
-<GoabBadge type="sunset" content="Sunset" icon={false} />
-<GoabBadge type="dawn" content="Dawn" icon={false} />`,
+        react: `<GoabxBadge type="default" content="Default" icon={false} />
+<GoabxBadge type="information" content="Information" icon={false} />
+<GoabxBadge type="important" content="Important" icon={false} />
+<GoabxBadge type="emergency" content="Emergency" icon={false} />
+<GoabxBadge type="success" content="Success" icon={false} />
+<GoabxBadge type="archived" content="Archived" icon={false} />
+<GoabxBadge type="sky" content="Sky" icon={false} />
+<GoabxBadge type="prairie" content="Prairie" icon={false} />
+<GoabxBadge type="lilac" content="Lilac" icon={false} />
+<GoabxBadge type="pasture" content="Pasture" icon={false} />
+<GoabxBadge type="sunset" content="Sunset" icon={false} />
+<GoabxBadge type="dawn" content="Dawn" icon={false} />`,
         angular: `<goab-badge type="default" content="Default" [icon]="false"></goab-badge>
 <goab-badge type="information" content="Information" [icon]="false"></goab-badge>
 <goab-badge type="important" content="Important" [icon]="false"></goab-badge>
@@ -135,18 +135,18 @@ export const badgeConfigurations: ComponentConfigurations = {
       name: 'Low emphasis',
       description: 'Subtle versions of all badge types',
       code: {
-        react: `<GoabBadge type="default" content="Default" emphasis="subtle" icon={false} />
-<GoabBadge type="information" content="Information" emphasis="subtle" icon={false} />
-<GoabBadge type="important" content="Important" emphasis="subtle" icon={false} />
-<GoabBadge type="emergency" content="Emergency" emphasis="subtle" icon={false} />
-<GoabBadge type="success" content="Success" emphasis="subtle" icon={false} />
-<GoabBadge type="archived" content="Archived" emphasis="subtle" icon={false} />
-<GoabBadge type="sky" content="Sky" emphasis="subtle" icon={false} />
-<GoabBadge type="prairie" content="Prairie" emphasis="subtle" icon={false} />
-<GoabBadge type="lilac" content="Lilac" emphasis="subtle" icon={false} />
-<GoabBadge type="pasture" content="Pasture" emphasis="subtle" icon={false} />
-<GoabBadge type="sunset" content="Sunset" emphasis="subtle" icon={false} />
-<GoabBadge type="dawn" content="Dawn" emphasis="subtle" icon={false} />`,
+        react: `<GoabxBadge type="default" content="Default" emphasis="subtle" icon={false} />
+<GoabxBadge type="information" content="Information" emphasis="subtle" icon={false} />
+<GoabxBadge type="important" content="Important" emphasis="subtle" icon={false} />
+<GoabxBadge type="emergency" content="Emergency" emphasis="subtle" icon={false} />
+<GoabxBadge type="success" content="Success" emphasis="subtle" icon={false} />
+<GoabxBadge type="archived" content="Archived" emphasis="subtle" icon={false} />
+<GoabxBadge type="sky" content="Sky" emphasis="subtle" icon={false} />
+<GoabxBadge type="prairie" content="Prairie" emphasis="subtle" icon={false} />
+<GoabxBadge type="lilac" content="Lilac" emphasis="subtle" icon={false} />
+<GoabxBadge type="pasture" content="Pasture" emphasis="subtle" icon={false} />
+<GoabxBadge type="sunset" content="Sunset" emphasis="subtle" icon={false} />
+<GoabxBadge type="dawn" content="Dawn" emphasis="subtle" icon={false} />`,
         angular: `<goab-badge type="default" content="Default" emphasis="subtle" [icon]="false"></goab-badge>
 <goab-badge type="information" content="Information" emphasis="subtle" [icon]="false"></goab-badge>
 <goab-badge type="important" content="Important" emphasis="subtle" [icon]="false"></goab-badge>
@@ -178,9 +178,9 @@ export const badgeConfigurations: ComponentConfigurations = {
       name: 'With custom icon',
       description: 'Badge with an icon',
       code: {
-        react: `<GoabBadge type="success" content="Approved" iconType="checkmark" />
-<GoabBadge type="emergency" content="Rejected" iconType="close" />
-<GoabBadge type="information" content="Pending" iconType="time" />`,
+        react: `<GoabxBadge type="success" content="Approved" iconType="checkmark" />
+<GoabxBadge type="emergency" content="Rejected" iconType="close" />
+<GoabxBadge type="information" content="Pending" iconType="time" />`,
         angular: `<goab-badge type="success" content="Approved" iconType="checkmark"></goab-badge>
 <goab-badge type="emergency" content="Rejected" iconType="close"></goab-badge>
 <goab-badge type="information" content="Pending" iconType="time"></goab-badge>`,
@@ -194,8 +194,8 @@ export const badgeConfigurations: ComponentConfigurations = {
       name: 'Sizes',
       description: 'Medium and large badge sizes',
       code: {
-        react: `<GoabBadge type="default" content="Medium" size="medium" emphasis="subtle" />
-<GoabBadge type="default" content="Large" size="large" emphasis="subtle" />`,
+        react: `<GoabxBadge type="default" content="Medium" size="medium" emphasis="subtle" />
+<GoabxBadge type="default" content="Large" size="large" emphasis="subtle" />`,
         angular: `<goab-badge type="default" content="Medium" size="medium" emphasis="subtle"></goab-badge>
 <goab-badge type="default" content="Large" size="large" emphasis="subtle"></goab-badge>`,
         webComponents: `<goa-badge type="default" content="Medium" size="medium" emphasis="subtle"></goa-badge>

--- a/docs/src/data/configurations/block.ts
+++ b/docs/src/data/configurations/block.ts
@@ -83,19 +83,19 @@ export const blockConfigurations: ComponentConfigurations = {
       description: 'Horizontal alignment options',
       code: {
         react: `<GoabBlock alignment="start">
-  <GoabFormItem label="Start aligned">
-    <GoabInput name="start" width="20ch" />
-  </GoabFormItem>
+  <GoabxFormItem label="Start aligned">
+    <GoabxInput name="start" width="20ch" />
+  </GoabxFormItem>
 </GoabBlock>
 <GoabBlock alignment="center">
-  <GoabFormItem label="Center aligned">
-    <GoabInput name="center" width="20ch" />
-  </GoabFormItem>
+  <GoabxFormItem label="Center aligned">
+    <GoabxInput name="center" width="20ch" />
+  </GoabxFormItem>
 </GoabBlock>
 <GoabBlock alignment="end">
-  <GoabFormItem label="End aligned">
-    <GoabInput name="end" width="20ch" />
-  </GoabFormItem>
+  <GoabxFormItem label="End aligned">
+    <GoabxInput name="end" width="20ch" />
+  </GoabxFormItem>
 </GoabBlock>`,
         angular: `<goab-block alignment="start">
   <goab-form-item label="Start aligned">
@@ -135,12 +135,12 @@ export const blockConfigurations: ComponentConfigurations = {
       description: 'Items arranged horizontally',
       code: {
         react: `<GoabBlock direction="row" gap="l">
-  <GoabFormItem label="First name">
-    <GoabInput name="firstName" />
-  </GoabFormItem>
-  <GoabFormItem label="Last name">
-    <GoabInput name="lastName" />
-  </GoabFormItem>
+  <GoabxFormItem label="First name">
+    <GoabxInput name="firstName" />
+  </GoabxFormItem>
+  <GoabxFormItem label="Last name">
+    <GoabxInput name="lastName" />
+  </GoabxFormItem>
 </GoabBlock>`,
         angular: `<goab-block direction="row" gap="l">
   <goab-form-item label="First name">

--- a/docs/src/data/configurations/block.ts
+++ b/docs/src/data/configurations/block.ts
@@ -98,33 +98,33 @@ export const blockConfigurations: ComponentConfigurations = {
   </GoabxFormItem>
 </GoabBlock>`,
         angular: `<goab-block alignment="start">
-  <goab-form-item label="Start aligned">
-    <goab-input name="start" width="20ch"></goab-input>
-  </goab-form-item>
+  <goabx-form-item label="Start aligned">
+    <goabx-input name="start" width="20ch"></goabx-input>
+  </goabx-form-item>
 </goab-block>
 <goab-block alignment="center">
-  <goab-form-item label="Center aligned">
-    <goab-input name="center" width="20ch"></goab-input>
-  </goab-form-item>
+  <goabx-form-item label="Center aligned">
+    <goabx-input name="center" width="20ch"></goabx-input>
+  </goabx-form-item>
 </goab-block>
 <goab-block alignment="end">
-  <goab-form-item label="End aligned">
-    <goab-input name="end" width="20ch"></goab-input>
-  </goab-form-item>
+  <goabx-form-item label="End aligned">
+    <goabx-input name="end" width="20ch"></goabx-input>
+  </goabx-form-item>
 </goab-block>`,
         webComponents: `<goa-block alignment="start">
-  <goa-form-item label="Start aligned">
-    <goa-input name="start" width="20ch"></goa-input>
+  <goa-form-item version="2" label="Start aligned">
+    <goa-input version="2" name="start" width="20ch"></goa-input>
   </goa-form-item>
 </goa-block>
 <goa-block alignment="center">
-  <goa-form-item label="Center aligned">
-    <goa-input name="center" width="20ch"></goa-input>
+  <goa-form-item version="2" label="Center aligned">
+    <goa-input version="2" name="center" width="20ch"></goa-input>
   </goa-form-item>
 </goa-block>
 <goa-block alignment="end">
-  <goa-form-item label="End aligned">
-    <goa-input name="end" width="20ch"></goa-input>
+  <goa-form-item version="2" label="End aligned">
+    <goa-input version="2" name="end" width="20ch"></goa-input>
   </goa-form-item>
 </goa-block>`,
       },
@@ -143,19 +143,19 @@ export const blockConfigurations: ComponentConfigurations = {
   </GoabxFormItem>
 </GoabBlock>`,
         angular: `<goab-block direction="row" gap="l">
-  <goab-form-item label="First name">
-    <goab-input name="firstName"></goab-input>
-  </goab-form-item>
-  <goab-form-item label="Last name">
-    <goab-input name="lastName"></goab-input>
-  </goab-form-item>
+  <goabx-form-item label="First name">
+    <goabx-input name="firstName"></goabx-input>
+  </goabx-form-item>
+  <goabx-form-item label="Last name">
+    <goabx-input name="lastName"></goabx-input>
+  </goabx-form-item>
 </goab-block>`,
         webComponents: `<goa-block direction="row" gap="l">
-  <goa-form-item label="First name">
-    <goa-input name="firstName"></goa-input>
+  <goa-form-item version="2" label="First name">
+    <goa-input version="2" name="firstName"></goa-input>
   </goa-form-item>
-  <goa-form-item label="Last name">
-    <goa-input name="lastName"></goa-input>
+  <goa-form-item version="2" label="Last name">
+    <goa-input version="2" name="lastName"></goa-input>
   </goa-form-item>
 </goa-block>`,
       },

--- a/docs/src/data/configurations/button-group.ts
+++ b/docs/src/data/configurations/button-group.ts
@@ -22,12 +22,12 @@ export const buttonGroupConfigurations: ComponentConfigurations = {
   <GoabxButton>Submit</GoabxButton>
 </GoabButtonGroup>`,
         angular: `<goab-button-group>
-  <goab-button type="secondary">Cancel</goab-button>
-  <goab-button>Submit</goab-button>
+  <goabx-button type="secondary">Cancel</goabx-button>
+  <goabx-button>Submit</goabx-button>
 </goab-button-group>`,
         webComponents: `<goa-button-group>
-  <goa-button type="secondary">Cancel</goa-button>
-  <goa-button>Submit</goa-button>
+  <goa-button version="2" type="secondary">Cancel</goa-button>
+  <goa-button version="2">Submit</goa-button>
 </goa-button-group>`,
       },
     },
@@ -46,22 +46,22 @@ export const buttonGroupConfigurations: ComponentConfigurations = {
   <GoabxButton>End aligned</GoabxButton>
 </GoabButtonGroup>`,
         angular: `<goab-button-group alignment="start">
-  <goab-button>Start aligned</goab-button>
+  <goabx-button>Start aligned</goabx-button>
 </goab-button-group>
 <goab-button-group alignment="center">
-  <goab-button>Center aligned</goab-button>
+  <goabx-button>Center aligned</goabx-button>
 </goab-button-group>
 <goab-button-group alignment="end">
-  <goab-button>End aligned</goab-button>
+  <goabx-button>End aligned</goabx-button>
 </goab-button-group>`,
         webComponents: `<goa-button-group alignment="start">
-  <goa-button>Start aligned</goa-button>
+  <goa-button version="2">Start aligned</goa-button>
 </goa-button-group>
 <goa-button-group alignment="center">
-  <goa-button>Center aligned</goa-button>
+  <goa-button version="2">Center aligned</goa-button>
 </goa-button-group>
 <goa-button-group alignment="end">
-  <goa-button>End aligned</goa-button>
+  <goa-button version="2">End aligned</goa-button>
 </goa-button-group>`,
       },
     },
@@ -79,20 +79,20 @@ export const buttonGroupConfigurations: ComponentConfigurations = {
   <GoabxButton size="compact">Continue</GoabxButton>
 </GoabButtonGroup>`,
         angular: `<goab-button-group gap="relaxed">
-  <goab-button type="secondary">Back</goab-button>
-  <goab-button>Continue</goab-button>
+  <goabx-button type="secondary">Back</goabx-button>
+  <goabx-button>Continue</goabx-button>
 </goab-button-group>
 <goab-button-group gap="compact">
-  <goab-button type="secondary" size="compact">Back</goab-button>
-  <goab-button size="compact">Continue</goab-button>
+  <goabx-button type="secondary" size="compact">Back</goabx-button>
+  <goabx-button size="compact">Continue</goabx-button>
 </goab-button-group>`,
         webComponents: `<goa-button-group gap="relaxed">
-  <goa-button type="secondary">Back</goa-button>
-  <goa-button>Continue</goa-button>
+  <goa-button version="2" type="secondary">Back</goa-button>
+  <goa-button version="2">Continue</goa-button>
 </goa-button-group>
 <goa-button-group gap="compact">
-  <goa-button type="secondary" size="compact">Back</goa-button>
-  <goa-button size="compact">Continue</goa-button>
+  <goa-button version="2" type="secondary" size="compact">Back</goa-button>
+  <goa-button version="2" size="compact">Continue</goa-button>
 </goa-button-group>`,
       },
     },
@@ -107,14 +107,14 @@ export const buttonGroupConfigurations: ComponentConfigurations = {
   <GoabxButton type="tertiary">Cancel</GoabxButton>
 </GoabButtonGroup>`,
         angular: `<goab-button-group alignment="start">
-  <goab-button type="primary">Save and continue</goab-button>
-  <goab-button type="secondary">Save as draft</goab-button>
-  <goab-button type="tertiary">Cancel</goab-button>
+  <goabx-button type="primary">Save and continue</goabx-button>
+  <goabx-button type="secondary">Save as draft</goabx-button>
+  <goabx-button type="tertiary">Cancel</goabx-button>
 </goab-button-group>`,
         webComponents: `<goa-button-group alignment="start">
-  <goa-button type="primary">Save and continue</goa-button>
-  <goa-button type="secondary">Save as draft</goa-button>
-  <goa-button type="tertiary">Cancel</goa-button>
+  <goa-button version="2" type="primary">Save and continue</goa-button>
+  <goa-button version="2" type="secondary">Save as draft</goa-button>
+  <goa-button version="2" type="tertiary">Cancel</goa-button>
 </goa-button-group>`,
       },
     },
@@ -143,8 +143,8 @@ handleAction(event: GoabMenuButtonOnActionDetail) {
 }
 
 <goab-button-group>
-  <goab-button>Submit</goab-button>
-  <goab-button type="secondary">Save draft</goab-button>
+  <goabx-button>Submit</goabx-button>
+  <goabx-button type="secondary">Save draft</goabx-button>
   <goab-menu-button text="More" type="tertiary" (_action)="handleAction($event)">
     <goab-menu-action text="Preview" action="preview"></goab-menu-action>
     <goab-menu-action text="Duplicate" action="duplicate"></goab-menu-action>
@@ -153,8 +153,8 @@ handleAction(event: GoabMenuButtonOnActionDetail) {
   </goab-menu-button>
 </goab-button-group>`,
         webComponents: `<goa-button-group>
-  <goa-button>Submit</goa-button>
-  <goa-button type="secondary">Save draft</goa-button>
+  <goa-button version="2">Submit</goa-button>
+  <goa-button version="2" type="secondary">Save draft</goa-button>
   <goa-menu-button text="More" type="tertiary">
     <goa-menu-action text="Preview" action="preview"></goa-menu-action>
     <goa-menu-action text="Duplicate" action="duplicate"></goa-menu-action>

--- a/docs/src/data/configurations/button-group.ts
+++ b/docs/src/data/configurations/button-group.ts
@@ -18,8 +18,8 @@ export const buttonGroupConfigurations: ComponentConfigurations = {
       description: 'Group of buttons with default spacing',
       code: {
         react: `<GoabButtonGroup>
-  <GoabButton type="secondary">Cancel</GoabButton>
-  <GoabButton>Submit</GoabButton>
+  <GoabxButton type="secondary">Cancel</GoabxButton>
+  <GoabxButton>Submit</GoabxButton>
 </GoabButtonGroup>`,
         angular: `<goab-button-group>
   <goab-button type="secondary">Cancel</goab-button>
@@ -37,13 +37,13 @@ export const buttonGroupConfigurations: ComponentConfigurations = {
       description: 'Different alignment options',
       code: {
         react: `<GoabButtonGroup alignment="start">
-  <GoabButton>Start aligned</GoabButton>
+  <GoabxButton>Start aligned</GoabxButton>
 </GoabButtonGroup>
 <GoabButtonGroup alignment="center">
-  <GoabButton>Center aligned</GoabButton>
+  <GoabxButton>Center aligned</GoabxButton>
 </GoabButtonGroup>
 <GoabButtonGroup alignment="end">
-  <GoabButton>End aligned</GoabButton>
+  <GoabxButton>End aligned</GoabxButton>
 </GoabButtonGroup>`,
         angular: `<goab-button-group alignment="start">
   <goab-button>Start aligned</goab-button>
@@ -71,12 +71,12 @@ export const buttonGroupConfigurations: ComponentConfigurations = {
       description: 'Button group with specific spacing',
       code: {
         react: `<GoabButtonGroup gap="relaxed">
-  <GoabButton type="secondary">Back</GoabButton>
-  <GoabButton>Continue</GoabButton>
+  <GoabxButton type="secondary">Back</GoabxButton>
+  <GoabxButton>Continue</GoabxButton>
 </GoabButtonGroup>
 <GoabButtonGroup gap="compact">
-  <GoabButton type="secondary" size="compact">Back</GoabButton>
-  <GoabButton size="compact">Continue</GoabButton>
+  <GoabxButton type="secondary" size="compact">Back</GoabxButton>
+  <GoabxButton size="compact">Continue</GoabxButton>
 </GoabButtonGroup>`,
         angular: `<goab-button-group gap="relaxed">
   <goab-button type="secondary">Back</goab-button>
@@ -102,9 +102,9 @@ export const buttonGroupConfigurations: ComponentConfigurations = {
       description: 'Common pattern for form button placement',
       code: {
         react: `<GoabButtonGroup alignment="start">
-  <GoabButton type="primary">Save and continue</GoabButton>
-  <GoabButton type="secondary">Save as draft</GoabButton>
-  <GoabButton type="tertiary">Cancel</GoabButton>
+  <GoabxButton type="primary">Save and continue</GoabxButton>
+  <GoabxButton type="secondary">Save as draft</GoabxButton>
+  <GoabxButton type="tertiary">Cancel</GoabxButton>
 </GoabButtonGroup>`,
         angular: `<goab-button-group alignment="start">
   <goab-button type="primary">Save and continue</goab-button>
@@ -128,8 +128,8 @@ export const buttonGroupConfigurations: ComponentConfigurations = {
 };
 
 <GoabButtonGroup>
-  <GoabButton>Submit</GoabButton>
-  <GoabButton type="secondary">Save draft</GoabButton>
+  <GoabxButton>Submit</GoabxButton>
+  <GoabxButton type="secondary">Save draft</GoabxButton>
   <GoabMenuButton text="More" type="tertiary" onAction={handleAction}>
     <GoabMenuAction text="Preview" action="preview" />
     <GoabMenuAction text="Duplicate" action="duplicate" />

--- a/docs/src/data/configurations/button.ts
+++ b/docs/src/data/configurations/button.ts
@@ -19,7 +19,7 @@ export const buttonConfigurations: ComponentConfigurations = {
       name: 'Primary button',
       description: 'Simple button with default styling',
       code: {
-        react: `<GoabButton>Submit</GoabButton>`,
+        react: `<GoabxButton>Submit</GoabxButton>`,
         angular: `<goab-button>Submit</goab-button>`,
         webComponents: `<goa-button>Submit</goa-button>`,
       },
@@ -29,9 +29,9 @@ export const buttonConfigurations: ComponentConfigurations = {
       name: 'Variants',
       description: 'Primary, secondary, and tertiary button types',
       code: {
-        react: `<GoabButton type="primary">Primary</GoabButton>
-<GoabButton type="secondary">Secondary</GoabButton>
-<GoabButton type="tertiary">Tertiary</GoabButton>`,
+        react: `<GoabxButton type="primary">Primary</GoabxButton>
+<GoabxButton type="secondary">Secondary</GoabxButton>
+<GoabxButton type="tertiary">Tertiary</GoabxButton>`,
         angular: `<goab-button type="primary">Primary</goab-button>
 <goab-button type="secondary">Secondary</goab-button>
 <goab-button type="tertiary">Tertiary</goab-button>`,
@@ -45,8 +45,8 @@ export const buttonConfigurations: ComponentConfigurations = {
       name: 'Sizes',
       description: 'Normal and compact button sizes',
       code: {
-        react: `<GoabButton size="normal">Normal</GoabButton>
-<GoabButton size="compact">Compact</GoabButton>`,
+        react: `<GoabxButton size="normal">Normal</GoabxButton>
+<GoabxButton size="compact">Compact</GoabxButton>`,
         angular: `<goab-button size="normal">Normal</goab-button>
 <goab-button size="compact">Compact</goab-button>`,
         webComponents: `<goa-button size="normal">Normal</goa-button>
@@ -58,8 +58,8 @@ export const buttonConfigurations: ComponentConfigurations = {
       name: 'With icons',
       description: 'Buttons with leading or trailing icons',
       code: {
-        react: `<GoabButton leadingIcon="add">Add item</GoabButton>
-<GoabButton trailingIcon="arrow-forward">Next</GoabButton>`,
+        react: `<GoabxButton leadingIcon="add">Add item</GoabxButton>
+<GoabxButton trailingIcon="arrow-forward">Next</GoabxButton>`,
         angular: `<goab-button leadingIcon="add">Add item</goab-button>
 <goab-button trailingIcon="arrow-forward">Next</goab-button>`,
         webComponents: `<goa-button leadingicon="add">Add item</goa-button>
@@ -71,8 +71,8 @@ export const buttonConfigurations: ComponentConfigurations = {
       name: 'Disabled',
       description: 'Buttons in disabled state',
       code: {
-        react: `<GoabButton disabled>Disabled primary</GoabButton>
-<GoabButton type="secondary" disabled>Disabled secondary</GoabButton>`,
+        react: `<GoabxButton disabled>Disabled primary</GoabxButton>
+<GoabxButton type="secondary" disabled>Disabled secondary</GoabxButton>`,
         angular: `<goab-button disabled="true">Disabled primary</goab-button>
 <goab-button type="secondary" disabled="true">Disabled secondary</goab-button>`,
         webComponents: `<goa-button disabled>Disabled primary</goa-button>
@@ -84,8 +84,8 @@ export const buttonConfigurations: ComponentConfigurations = {
       name: 'Destructive',
       description: 'Buttons for destructive actions like delete',
       code: {
-        react: `<GoabButton variant="destructive">Delete</GoabButton>
-<GoabButton variant="destructive" type="secondary">Cancel subscription</GoabButton>`,
+        react: `<GoabxButton variant="destructive">Delete</GoabxButton>
+<GoabxButton variant="destructive" type="secondary">Cancel subscription</GoabxButton>`,
         angular: `<goab-button variant="destructive">Delete</goab-button>
 <goab-button variant="destructive" type="secondary">Cancel subscription</goab-button>`,
         webComponents: `<goa-button variant="destructive">Delete</goa-button>
@@ -97,8 +97,8 @@ export const buttonConfigurations: ComponentConfigurations = {
       name: 'Inverse',
       description: 'Buttons for use on dark backgrounds',
       code: {
-        react: `<GoabButton variant="inverse">Learn more</GoabButton>
-<GoabButton variant="inverse" type="secondary">Contact us</GoabButton>`,
+        react: `<GoabxButton variant="inverse">Learn more</GoabxButton>
+<GoabxButton variant="inverse" type="secondary">Contact us</GoabxButton>`,
         angular: `<goab-button variant="inverse">Learn more</goab-button>
 <goab-button variant="inverse" type="secondary">Contact us</goab-button>`,
         webComponents: `<goa-button variant="inverse">Learn more</goa-button>

--- a/docs/src/data/configurations/button.ts
+++ b/docs/src/data/configurations/button.ts
@@ -20,8 +20,8 @@ export const buttonConfigurations: ComponentConfigurations = {
       description: 'Simple button with default styling',
       code: {
         react: `<GoabxButton>Submit</GoabxButton>`,
-        angular: `<goab-button>Submit</goab-button>`,
-        webComponents: `<goa-button>Submit</goa-button>`,
+        angular: `<goabx-button>Submit</goabx-button>`,
+        webComponents: `<goa-button version="2">Submit</goa-button>`,
       },
     },
     {
@@ -32,12 +32,12 @@ export const buttonConfigurations: ComponentConfigurations = {
         react: `<GoabxButton type="primary">Primary</GoabxButton>
 <GoabxButton type="secondary">Secondary</GoabxButton>
 <GoabxButton type="tertiary">Tertiary</GoabxButton>`,
-        angular: `<goab-button type="primary">Primary</goab-button>
-<goab-button type="secondary">Secondary</goab-button>
-<goab-button type="tertiary">Tertiary</goab-button>`,
-        webComponents: `<goa-button type="primary">Primary</goa-button>
-<goa-button type="secondary">Secondary</goa-button>
-<goa-button type="tertiary">Tertiary</goa-button>`,
+        angular: `<goabx-button type="primary">Primary</goabx-button>
+<goabx-button type="secondary">Secondary</goabx-button>
+<goabx-button type="tertiary">Tertiary</goabx-button>`,
+        webComponents: `<goa-button version="2" type="primary">Primary</goa-button>
+<goa-button version="2" type="secondary">Secondary</goa-button>
+<goa-button version="2" type="tertiary">Tertiary</goa-button>`,
       },
     },
     {
@@ -47,10 +47,10 @@ export const buttonConfigurations: ComponentConfigurations = {
       code: {
         react: `<GoabxButton size="normal">Normal</GoabxButton>
 <GoabxButton size="compact">Compact</GoabxButton>`,
-        angular: `<goab-button size="normal">Normal</goab-button>
-<goab-button size="compact">Compact</goab-button>`,
-        webComponents: `<goa-button size="normal">Normal</goa-button>
-<goa-button size="compact">Compact</goa-button>`,
+        angular: `<goabx-button size="normal">Normal</goabx-button>
+<goabx-button size="compact">Compact</goabx-button>`,
+        webComponents: `<goa-button version="2" size="normal">Normal</goa-button>
+<goa-button version="2" size="compact">Compact</goa-button>`,
       },
     },
     {
@@ -60,10 +60,10 @@ export const buttonConfigurations: ComponentConfigurations = {
       code: {
         react: `<GoabxButton leadingIcon="add">Add item</GoabxButton>
 <GoabxButton trailingIcon="arrow-forward">Next</GoabxButton>`,
-        angular: `<goab-button leadingIcon="add">Add item</goab-button>
-<goab-button trailingIcon="arrow-forward">Next</goab-button>`,
-        webComponents: `<goa-button leadingicon="add">Add item</goa-button>
-<goa-button trailingicon="arrow-forward">Next</goa-button>`,
+        angular: `<goabx-button leadingIcon="add">Add item</goabx-button>
+<goabx-button trailingIcon="arrow-forward">Next</goabx-button>`,
+        webComponents: `<goa-button version="2" leadingicon="add">Add item</goa-button>
+<goa-button version="2" trailingicon="arrow-forward">Next</goa-button>`,
       },
     },
     {
@@ -73,10 +73,10 @@ export const buttonConfigurations: ComponentConfigurations = {
       code: {
         react: `<GoabxButton disabled>Disabled primary</GoabxButton>
 <GoabxButton type="secondary" disabled>Disabled secondary</GoabxButton>`,
-        angular: `<goab-button disabled="true">Disabled primary</goab-button>
-<goab-button type="secondary" disabled="true">Disabled secondary</goab-button>`,
-        webComponents: `<goa-button disabled>Disabled primary</goa-button>
-<goa-button type="secondary" disabled>Disabled secondary</goa-button>`,
+        angular: `<goabx-button disabled="true">Disabled primary</goabx-button>
+<goabx-button type="secondary" disabled="true">Disabled secondary</goabx-button>`,
+        webComponents: `<goa-button version="2" disabled>Disabled primary</goa-button>
+<goa-button version="2" type="secondary" disabled>Disabled secondary</goa-button>`,
       },
     },
     {
@@ -86,10 +86,10 @@ export const buttonConfigurations: ComponentConfigurations = {
       code: {
         react: `<GoabxButton variant="destructive">Delete</GoabxButton>
 <GoabxButton variant="destructive" type="secondary">Cancel subscription</GoabxButton>`,
-        angular: `<goab-button variant="destructive">Delete</goab-button>
-<goab-button variant="destructive" type="secondary">Cancel subscription</goab-button>`,
-        webComponents: `<goa-button variant="destructive">Delete</goa-button>
-<goa-button variant="destructive" type="secondary">Cancel subscription</goa-button>`,
+        angular: `<goabx-button variant="destructive">Delete</goabx-button>
+<goabx-button variant="destructive" type="secondary">Cancel subscription</goabx-button>`,
+        webComponents: `<goa-button version="2" variant="destructive">Delete</goa-button>
+<goa-button version="2" variant="destructive" type="secondary">Cancel subscription</goa-button>`,
       },
     },
     {
@@ -99,10 +99,10 @@ export const buttonConfigurations: ComponentConfigurations = {
       code: {
         react: `<GoabxButton variant="inverse">Learn more</GoabxButton>
 <GoabxButton variant="inverse" type="secondary">Contact us</GoabxButton>`,
-        angular: `<goab-button variant="inverse">Learn more</goab-button>
-<goab-button variant="inverse" type="secondary">Contact us</goab-button>`,
-        webComponents: `<goa-button variant="inverse">Learn more</goa-button>
-<goa-button variant="inverse" type="secondary">Contact us</goa-button>`,
+        angular: `<goabx-button variant="inverse">Learn more</goabx-button>
+<goabx-button variant="inverse" type="secondary">Contact us</goabx-button>`,
+        webComponents: `<goa-button version="2" variant="inverse">Learn more</goa-button>
+<goa-button version="2" variant="inverse" type="secondary">Contact us</goa-button>`,
       },
     },
   ],

--- a/docs/src/data/configurations/calendar.ts
+++ b/docs/src/data/configurations/calendar.ts
@@ -18,8 +18,8 @@ export const calendarConfigurations: ComponentConfigurations = {
       description: 'Simple date calendar',
       code: {
         react: `<GoabxCalendar name="calendar" onChange={handleDateChange} />`,
-        angular: `<goab-calendar name="calendar" (_change)="handleDateChange($event)"></goab-calendar>`,
-        webComponents: `<goa-calendar name="calendar"></goa-calendar>`,
+        angular: `<goabx-calendar name="calendar" (_change)="handleDateChange($event)"></goabx-calendar>`,
+        webComponents: `<goa-calendar version="2" name="calendar"></goa-calendar>`,
       },
     },
     {
@@ -28,8 +28,8 @@ export const calendarConfigurations: ComponentConfigurations = {
       description: 'Calendar with preset selection',
       code: {
         react: `<GoabxCalendar name="calendar" value="2024-06-15" onChange={handleDateChange} />`,
-        angular: `<goab-calendar name="calendar" value="2024-06-15" (_change)="handleDateChange($event)"></goab-calendar>`,
-        webComponents: `<goa-calendar name="calendar" value="2024-06-15"></goa-calendar>`,
+        angular: `<goabx-calendar name="calendar" value="2024-06-15" (_change)="handleDateChange($event)"></goabx-calendar>`,
+        webComponents: `<goa-calendar version="2" name="calendar" value="2024-06-15"></goa-calendar>`,
       },
     },
     {
@@ -43,13 +43,13 @@ export const calendarConfigurations: ComponentConfigurations = {
   max="2024-12-31"
   onChange={handleDateChange}
 />`,
-        angular: `<goab-calendar
+        angular: `<goabx-calendar
   name="booking"
   min="2024-01-01"
   max="2024-12-31"
   (_change)="handleDateChange($event)">
-</goab-calendar>`,
-        webComponents: `<goa-calendar
+</goabx-calendar>`,
+        webComponents: `<goa-calendar version="2"
   name="booking"
   min="2024-01-01"
   max="2024-12-31">

--- a/docs/src/data/configurations/calendar.ts
+++ b/docs/src/data/configurations/calendar.ts
@@ -17,7 +17,7 @@ export const calendarConfigurations: ComponentConfigurations = {
       name: 'Basic calendar',
       description: 'Simple date calendar',
       code: {
-        react: `<GoabCalendar name="calendar" onChange={handleDateChange} />`,
+        react: `<GoabxCalendar name="calendar" onChange={handleDateChange} />`,
         angular: `<goab-calendar name="calendar" (_change)="handleDateChange($event)"></goab-calendar>`,
         webComponents: `<goa-calendar name="calendar"></goa-calendar>`,
       },
@@ -27,7 +27,7 @@ export const calendarConfigurations: ComponentConfigurations = {
       name: 'With selected date',
       description: 'Calendar with preset selection',
       code: {
-        react: `<GoabCalendar name="calendar" value="2024-06-15" onChange={handleDateChange} />`,
+        react: `<GoabxCalendar name="calendar" value="2024-06-15" onChange={handleDateChange} />`,
         angular: `<goab-calendar name="calendar" value="2024-06-15" (_change)="handleDateChange($event)"></goab-calendar>`,
         webComponents: `<goa-calendar name="calendar" value="2024-06-15"></goa-calendar>`,
       },
@@ -37,7 +37,7 @@ export const calendarConfigurations: ComponentConfigurations = {
       name: 'Date range',
       description: 'Calendar with min/max dates',
       code: {
-        react: `<GoabCalendar
+        react: `<GoabxCalendar
   name="booking"
   min="2024-01-01"
   max="2024-12-31"

--- a/docs/src/data/configurations/callout.ts
+++ b/docs/src/data/configurations/callout.ts
@@ -17,9 +17,9 @@ export const calloutConfigurations: ComponentConfigurations = {
       name: 'Information callout',
       description: 'Default informational callout',
       code: {
-        react: `<GoabCallout type="information" emphasis="low" maxWidth="480px">
+        react: `<GoabxCallout type="information" emphasis="low" maxWidth="480px">
   This is important information for the user.
-</GoabCallout>`,
+</GoabxCallout>`,
         angular: `<goab-callout type="information" emphasis="low" maxWidth="480px">
   This is important information for the user.
 </goab-callout>`,
@@ -33,18 +33,18 @@ export const calloutConfigurations: ComponentConfigurations = {
       name: 'Callout types',
       description: 'Different semantic types for various contexts',
       code: {
-        react: `<GoabCallout type="information" heading="Information">
+        react: `<GoabxCallout type="information" heading="Information">
   General information for the user.
-</GoabCallout>
-<GoabCallout type="important" heading="Important">
+</GoabxCallout>
+<GoabxCallout type="important" heading="Important">
   Something the user should pay attention to.
-</GoabCallout>
-<GoabCallout type="emergency" heading="Emergency">
+</GoabxCallout>
+<GoabxCallout type="emergency" heading="Emergency">
   Critical information requiring immediate attention.
-</GoabCallout>
-<GoabCallout type="success" heading="Success">
+</GoabxCallout>
+<GoabxCallout type="success" heading="Success">
   Confirmation that an action was successful.
-</GoabCallout>`,
+</GoabxCallout>`,
         angular: `<goab-callout type="information" heading="Information">
   General information for the user.
 </goab-callout>
@@ -76,9 +76,9 @@ export const calloutConfigurations: ComponentConfigurations = {
       name: 'With heading',
       description: 'Callout with a heading',
       code: {
-        react: `<GoabCallout type="important" heading="Application deadline">
+        react: `<GoabxCallout type="important" heading="Application deadline">
   Your application must be submitted by December 31, 2024.
-</GoabCallout>`,
+</GoabxCallout>`,
         angular: `<goab-callout type="important" heading="Application deadline">
   Your application must be submitted by December 31, 2024.
 </goab-callout>`,
@@ -92,18 +92,18 @@ export const calloutConfigurations: ComponentConfigurations = {
       name: 'Emphasis levels',
       description: 'Different visual prominence levels',
       code: {
-        react: `<GoabCallout type="important" emphasis="high" heading="High emphasis">
+        react: `<GoabxCallout type="important" emphasis="high" heading="High emphasis">
   Full background color for maximum visibility.
-</GoabCallout>
-<GoabCallout type="important" emphasis="medium" heading="Medium emphasis">
+</GoabxCallout>
+<GoabxCallout type="important" emphasis="medium" heading="Medium emphasis">
   Subtle background for balanced visibility.
-</GoabCallout>
-<GoabCallout type="important" emphasis="low" heading="Low emphasis">
+</GoabxCallout>
+<GoabxCallout type="important" emphasis="low" heading="Low emphasis">
   Minimal styling for less prominent messaging.
-</GoabCallout>
-<GoabCallout type="important" emphasis="low">
+</GoabxCallout>
+<GoabxCallout type="important" emphasis="low">
   A callout without a heading for simple inline messages.
-</GoabCallout>`,
+</GoabxCallout>`,
         angular: `<goab-callout type="important" emphasis="high" heading="High emphasis">
   Full background color for maximum visibility.
 </goab-callout>

--- a/docs/src/data/configurations/callout.ts
+++ b/docs/src/data/configurations/callout.ts
@@ -20,10 +20,10 @@ export const calloutConfigurations: ComponentConfigurations = {
         react: `<GoabxCallout type="information" emphasis="low" maxWidth="480px">
   This is important information for the user.
 </GoabxCallout>`,
-        angular: `<goab-callout type="information" emphasis="low" maxWidth="480px">
+        angular: `<goabx-callout type="information" emphasis="low" maxWidth="480px">
   This is important information for the user.
-</goab-callout>`,
-        webComponents: `<goa-callout type="information" emphasis="low" maxwidth="480px">
+</goabx-callout>`,
+        webComponents: `<goa-callout version="2" type="information" emphasis="low" maxwidth="480px">
   This is important information for the user.
 </goa-callout>`,
       },
@@ -45,28 +45,28 @@ export const calloutConfigurations: ComponentConfigurations = {
 <GoabxCallout type="success" heading="Success">
   Confirmation that an action was successful.
 </GoabxCallout>`,
-        angular: `<goab-callout type="information" heading="Information">
+        angular: `<goabx-callout type="information" heading="Information">
   General information for the user.
-</goab-callout>
-<goab-callout type="important" heading="Important">
+</goabx-callout>
+<goabx-callout type="important" heading="Important">
   Something the user should pay attention to.
-</goab-callout>
-<goab-callout type="emergency" heading="Emergency">
+</goabx-callout>
+<goabx-callout type="emergency" heading="Emergency">
   Critical information requiring immediate attention.
-</goab-callout>
-<goab-callout type="success" heading="Success">
+</goabx-callout>
+<goabx-callout type="success" heading="Success">
   Confirmation that an action was successful.
-</goab-callout>`,
-        webComponents: `<goa-callout type="information" heading="Information">
+</goabx-callout>`,
+        webComponents: `<goa-callout version="2" type="information" heading="Information">
   General information for the user.
 </goa-callout>
-<goa-callout type="important" heading="Important">
+<goa-callout version="2" type="important" heading="Important">
   Something the user should pay attention to.
 </goa-callout>
-<goa-callout type="emergency" heading="Emergency">
+<goa-callout version="2" type="emergency" heading="Emergency">
   Critical information requiring immediate attention.
 </goa-callout>
-<goa-callout type="success" heading="Success">
+<goa-callout version="2" type="success" heading="Success">
   Confirmation that an action was successful.
 </goa-callout>`,
       },
@@ -79,10 +79,10 @@ export const calloutConfigurations: ComponentConfigurations = {
         react: `<GoabxCallout type="important" heading="Application deadline">
   Your application must be submitted by December 31, 2024.
 </GoabxCallout>`,
-        angular: `<goab-callout type="important" heading="Application deadline">
+        angular: `<goabx-callout type="important" heading="Application deadline">
   Your application must be submitted by December 31, 2024.
-</goab-callout>`,
-        webComponents: `<goa-callout type="important" heading="Application deadline">
+</goabx-callout>`,
+        webComponents: `<goa-callout version="2" type="important" heading="Application deadline">
   Your application must be submitted by December 31, 2024.
 </goa-callout>`,
       },
@@ -104,28 +104,28 @@ export const calloutConfigurations: ComponentConfigurations = {
 <GoabxCallout type="important" emphasis="low">
   A callout without a heading for simple inline messages.
 </GoabxCallout>`,
-        angular: `<goab-callout type="important" emphasis="high" heading="High emphasis">
+        angular: `<goabx-callout type="important" emphasis="high" heading="High emphasis">
   Full background color for maximum visibility.
-</goab-callout>
-<goab-callout type="important" emphasis="medium" heading="Medium emphasis">
+</goabx-callout>
+<goabx-callout type="important" emphasis="medium" heading="Medium emphasis">
   Subtle background for balanced visibility.
-</goab-callout>
-<goab-callout type="important" emphasis="low" heading="Low emphasis">
+</goabx-callout>
+<goabx-callout type="important" emphasis="low" heading="Low emphasis">
   Minimal styling for less prominent messaging.
-</goab-callout>
-<goab-callout type="important" emphasis="low">
+</goabx-callout>
+<goabx-callout type="important" emphasis="low">
   A callout without a heading for simple inline messages.
-</goab-callout>`,
-        webComponents: `<goa-callout type="important" emphasis="high" heading="High emphasis">
+</goabx-callout>`,
+        webComponents: `<goa-callout version="2" type="important" emphasis="high" heading="High emphasis">
   Full background color for maximum visibility.
 </goa-callout>
-<goa-callout type="important" emphasis="medium" heading="Medium emphasis">
+<goa-callout version="2" type="important" emphasis="medium" heading="Medium emphasis">
   Subtle background for balanced visibility.
 </goa-callout>
-<goa-callout type="important" emphasis="low" heading="Low emphasis">
+<goa-callout version="2" type="important" emphasis="low" heading="Low emphasis">
   Minimal styling for less prominent messaging.
 </goa-callout>
-<goa-callout type="important" emphasis="low">
+<goa-callout version="2" type="important" emphasis="low">
   A callout without a heading for simple inline messages.
 </goa-callout>`,
       },

--- a/docs/src/data/configurations/card-actions.ts
+++ b/docs/src/data/configurations/card-actions.ts
@@ -33,8 +33,8 @@ export const cardActionsConfigurations: ComponentConfigurations = {
     <p>Review and submit your application.</p>
   </goab-card-content>
   <goab-card-actions>
-    <goab-button type="tertiary">Cancel</goab-button>
-    <goab-button>Submit</goab-button>
+    <goabx-button type="tertiary">Cancel</goabx-button>
+    <goabx-button>Submit</goabx-button>
   </goab-card-actions>
 </goab-card>`,
         webComponents: `<goa-card>
@@ -43,8 +43,8 @@ export const cardActionsConfigurations: ComponentConfigurations = {
     <p>Review and submit your application.</p>
   </goa-card-content>
   <goa-card-actions>
-    <goa-button type="tertiary">Cancel</goa-button>
-    <goa-button>Submit</goa-button>
+    <goa-button version="2" type="tertiary">Cancel</goa-button>
+    <goa-button version="2">Submit</goa-button>
   </goa-card-actions>
 </goa-card>`,
       },

--- a/docs/src/data/configurations/card-actions.ts
+++ b/docs/src/data/configurations/card-actions.ts
@@ -23,8 +23,8 @@ export const cardActionsConfigurations: ComponentConfigurations = {
     <p>Review and submit your application.</p>
   </GoabCardContent>
   <GoabCardActions>
-    <GoabButton type="tertiary">Cancel</GoabButton>
-    <GoabButton>Submit</GoabButton>
+    <GoabxButton type="tertiary">Cancel</GoabxButton>
+    <GoabxButton>Submit</GoabxButton>
   </GoabCardActions>
 </GoabCard>`,
         angular: `<goab-card>

--- a/docs/src/data/configurations/card.ts
+++ b/docs/src/data/configurations/card.ts
@@ -95,8 +95,8 @@ export const cardConfigurations: ComponentConfigurations = {
     <p>Review your application status and next steps.</p>
   </GoabCardContent>
   <GoabCardActions>
-    <GoabButton type="tertiary">View details</GoabButton>
-    <GoabButton>Continue</GoabButton>
+    <GoabxButton type="tertiary">View details</GoabxButton>
+    <GoabxButton>Continue</GoabxButton>
   </GoabCardActions>
 </GoabCard>`,
         angular: `<goab-card>

--- a/docs/src/data/configurations/card.ts
+++ b/docs/src/data/configurations/card.ts
@@ -105,8 +105,8 @@ export const cardConfigurations: ComponentConfigurations = {
     <p>Review your application status and next steps.</p>
   </goab-card-content>
   <goab-card-actions>
-    <goab-button type="tertiary">View details</goab-button>
-    <goab-button>Continue</goab-button>
+    <goabx-button type="tertiary">View details</goabx-button>
+    <goabx-button>Continue</goabx-button>
   </goab-card-actions>
 </goab-card>`,
         webComponents: `<goa-card>
@@ -115,8 +115,8 @@ export const cardConfigurations: ComponentConfigurations = {
     <p>Review your application status and next steps.</p>
   </goa-card-content>
   <goa-card-actions>
-    <goa-button type="tertiary">View details</goa-button>
-    <goa-button>Continue</goa-button>
+    <goa-button version="2" type="tertiary">View details</goa-button>
+    <goa-button version="2">Continue</goa-button>
   </goa-card-actions>
 </goa-card>`,
       },

--- a/docs/src/data/configurations/checkbox-list.ts
+++ b/docs/src/data/configurations/checkbox-list.ts
@@ -17,12 +17,12 @@ export const checkboxListConfigurations: ComponentConfigurations = {
       name: 'Basic checkbox list',
       description: 'Group of related checkboxes',
       code: {
-        react: `<GoabFormItem label="Select interests" mb="l">
-  <GoabCheckbox name="sports" text="Sports" />
-  <GoabCheckbox name="music" text="Music" />
-  <GoabCheckbox name="travel" text="Travel" />
-  <GoabCheckbox name="reading" text="Reading" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Select interests" mb="l">
+  <GoabxCheckbox name="sports" text="Sports" />
+  <GoabxCheckbox name="music" text="Music" />
+  <GoabxCheckbox name="travel" text="Travel" />
+  <GoabxCheckbox name="reading" text="Reading" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Select interests" mb="l">
   <goab-checkbox name="sports" text="Sports"></goab-checkbox>
   <goab-checkbox name="music" text="Music"></goab-checkbox>
@@ -42,10 +42,10 @@ export const checkboxListConfigurations: ComponentConfigurations = {
       name: 'With select all',
       description: 'Checkbox list with select all option',
       code: {
-        react: `<GoabCheckbox name="selectAll" text="Select all" indeterminate={someSelected} checked={allSelected} />
-<GoabCheckbox name="option1" text="Option 1" checked={selected.includes('option1')} />
-<GoabCheckbox name="option2" text="Option 2" checked={selected.includes('option2')} />
-<GoabCheckbox name="option3" text="Option 3" checked={selected.includes('option3')} />`,
+        react: `<GoabxCheckbox name="selectAll" text="Select all" indeterminate={someSelected} checked={allSelected} />
+<GoabxCheckbox name="option1" text="Option 1" checked={selected.includes('option1')} />
+<GoabxCheckbox name="option2" text="Option 2" checked={selected.includes('option2')} />
+<GoabxCheckbox name="option3" text="Option 3" checked={selected.includes('option3')} />`,
         angular: `<goab-checkbox name="selectAll" text="Select all" [indeterminate]="someSelected" [checked]="allSelected"></goab-checkbox>
 <goab-checkbox name="option1" text="Option 1" [checked]="isSelected('option1')"></goab-checkbox>
 <goab-checkbox name="option2" text="Option 2" [checked]="isSelected('option2')"></goab-checkbox>
@@ -61,11 +61,11 @@ export const checkboxListConfigurations: ComponentConfigurations = {
       name: 'With error',
       description: 'Checkbox list showing validation error',
       code: {
-        react: `<GoabFormItem label="Select at least one" error="Please select at least one option" mb="l">
-  <GoabCheckbox name="opt1" text="Option 1" error />
-  <GoabCheckbox name="opt2" text="Option 2" error />
-  <GoabCheckbox name="opt3" text="Option 3" error />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Select at least one" error="Please select at least one option" mb="l">
+  <GoabxCheckbox name="opt1" text="Option 1" error />
+  <GoabxCheckbox name="opt2" text="Option 2" error />
+  <GoabxCheckbox name="opt3" text="Option 3" error />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Select at least one" error="Please select at least one option" mb="l">
   <goab-checkbox name="opt1" text="Option 1" [error]="true"></goab-checkbox>
   <goab-checkbox name="opt2" text="Option 2" [error]="true"></goab-checkbox>

--- a/docs/src/data/configurations/checkbox-list.ts
+++ b/docs/src/data/configurations/checkbox-list.ts
@@ -23,17 +23,17 @@ export const checkboxListConfigurations: ComponentConfigurations = {
   <GoabxCheckbox name="travel" text="Travel" />
   <GoabxCheckbox name="reading" text="Reading" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Select interests" mb="l">
-  <goab-checkbox name="sports" text="Sports"></goab-checkbox>
-  <goab-checkbox name="music" text="Music"></goab-checkbox>
-  <goab-checkbox name="travel" text="Travel"></goab-checkbox>
-  <goab-checkbox name="reading" text="Reading"></goab-checkbox>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Select interests" mb="l">
-  <goa-checkbox name="sports" text="Sports"></goa-checkbox>
-  <goa-checkbox name="music" text="Music"></goa-checkbox>
-  <goa-checkbox name="travel" text="Travel"></goa-checkbox>
-  <goa-checkbox name="reading" text="Reading"></goa-checkbox>
+        angular: `<goabx-form-item label="Select interests" mb="l">
+  <goabx-checkbox name="sports" text="Sports"></goabx-checkbox>
+  <goabx-checkbox name="music" text="Music"></goabx-checkbox>
+  <goabx-checkbox name="travel" text="Travel"></goabx-checkbox>
+  <goabx-checkbox name="reading" text="Reading"></goabx-checkbox>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Select interests" mb="l">
+  <goa-checkbox version="2" name="sports" text="Sports"></goa-checkbox>
+  <goa-checkbox version="2" name="music" text="Music"></goa-checkbox>
+  <goa-checkbox version="2" name="travel" text="Travel"></goa-checkbox>
+  <goa-checkbox version="2" name="reading" text="Reading"></goa-checkbox>
 </goa-form-item>`,
       },
     },
@@ -46,14 +46,14 @@ export const checkboxListConfigurations: ComponentConfigurations = {
 <GoabxCheckbox name="option1" text="Option 1" checked={selected.includes('option1')} />
 <GoabxCheckbox name="option2" text="Option 2" checked={selected.includes('option2')} />
 <GoabxCheckbox name="option3" text="Option 3" checked={selected.includes('option3')} />`,
-        angular: `<goab-checkbox name="selectAll" text="Select all" [indeterminate]="someSelected" [checked]="allSelected"></goab-checkbox>
-<goab-checkbox name="option1" text="Option 1" [checked]="isSelected('option1')"></goab-checkbox>
-<goab-checkbox name="option2" text="Option 2" [checked]="isSelected('option2')"></goab-checkbox>
-<goab-checkbox name="option3" text="Option 3" [checked]="isSelected('option3')"></goab-checkbox>`,
-        webComponents: `<goa-checkbox name="selectAll" text="Select all" indeterminate></goa-checkbox>
-<goa-checkbox name="option1" text="Option 1"></goa-checkbox>
-<goa-checkbox name="option2" text="Option 2"></goa-checkbox>
-<goa-checkbox name="option3" text="Option 3"></goa-checkbox>`,
+        angular: `<goabx-checkbox name="selectAll" text="Select all" [indeterminate]="someSelected" [checked]="allSelected"></goabx-checkbox>
+<goabx-checkbox name="option1" text="Option 1" [checked]="isSelected('option1')"></goabx-checkbox>
+<goabx-checkbox name="option2" text="Option 2" [checked]="isSelected('option2')"></goabx-checkbox>
+<goabx-checkbox name="option3" text="Option 3" [checked]="isSelected('option3')"></goabx-checkbox>`,
+        webComponents: `<goa-checkbox version="2" name="selectAll" text="Select all" indeterminate></goa-checkbox>
+<goa-checkbox version="2" name="option1" text="Option 1"></goa-checkbox>
+<goa-checkbox version="2" name="option2" text="Option 2"></goa-checkbox>
+<goa-checkbox version="2" name="option3" text="Option 3"></goa-checkbox>`,
       },
     },
     {
@@ -66,15 +66,15 @@ export const checkboxListConfigurations: ComponentConfigurations = {
   <GoabxCheckbox name="opt2" text="Option 2" error />
   <GoabxCheckbox name="opt3" text="Option 3" error />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Select at least one" error="Please select at least one option" mb="l">
-  <goab-checkbox name="opt1" text="Option 1" [error]="true"></goab-checkbox>
-  <goab-checkbox name="opt2" text="Option 2" [error]="true"></goab-checkbox>
-  <goab-checkbox name="opt3" text="Option 3" [error]="true"></goab-checkbox>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Select at least one" error="Please select at least one option" mb="l">
-  <goa-checkbox name="opt1" text="Option 1" error></goa-checkbox>
-  <goa-checkbox name="opt2" text="Option 2" error></goa-checkbox>
-  <goa-checkbox name="opt3" text="Option 3" error></goa-checkbox>
+        angular: `<goabx-form-item label="Select at least one" error="Please select at least one option" mb="l">
+  <goabx-checkbox name="opt1" text="Option 1" [error]="true"></goabx-checkbox>
+  <goabx-checkbox name="opt2" text="Option 2" [error]="true"></goabx-checkbox>
+  <goabx-checkbox name="opt3" text="Option 3" [error]="true"></goabx-checkbox>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Select at least one" error="Please select at least one option" mb="l">
+  <goa-checkbox version="2" name="opt1" text="Option 1" error></goa-checkbox>
+  <goa-checkbox version="2" name="opt2" text="Option 2" error></goa-checkbox>
+  <goa-checkbox version="2" name="opt3" text="Option 3" error></goa-checkbox>
 </goa-form-item>`,
       },
     },

--- a/docs/src/data/configurations/checkbox.ts
+++ b/docs/src/data/configurations/checkbox.ts
@@ -15,7 +15,7 @@ export const checkboxConfigurations: ComponentConfigurations = {
       name: 'Basic checkbox',
       description: 'Single checkbox with label',
       code: {
-        react: `<GoabCheckbox name="agree" text="I agree to the terms" />`,
+        react: `<GoabxCheckbox name="agree" text="I agree to the terms" />`,
         angular: `<goab-checkbox name="agree" text="I agree to the terms"></goab-checkbox>`,
         webComponents: `<goa-checkbox name="agree" text="I agree to the terms"></goa-checkbox>`,
       },
@@ -25,7 +25,7 @@ export const checkboxConfigurations: ComponentConfigurations = {
       name: 'With description',
       description: 'Checkbox with additional description text',
       code: {
-        react: `<GoabCheckbox
+        react: `<GoabxCheckbox
   name="newsletter"
   text="Subscribe to newsletter"
   description="Receive weekly updates about new features"
@@ -47,7 +47,7 @@ export const checkboxConfigurations: ComponentConfigurations = {
       name: 'Checked state',
       description: 'Checkbox in checked state',
       code: {
-        react: `<GoabCheckbox name="remember" text="Remember me" checked />`,
+        react: `<GoabxCheckbox name="remember" text="Remember me" checked />`,
         angular: `<goab-checkbox name="remember" text="Remember me" [checked]="true"></goab-checkbox>`,
         webComponents: `<goa-checkbox name="remember" text="Remember me" checked></goa-checkbox>`,
       },
@@ -57,7 +57,7 @@ export const checkboxConfigurations: ComponentConfigurations = {
       name: 'Indeterminate',
       description: 'Mixed state for "select all" scenarios',
       code: {
-        react: `<GoabCheckbox name="selectAll" text="Select all items" indeterminate />`,
+        react: `<GoabxCheckbox name="selectAll" text="Select all items" indeterminate />`,
         angular: `<goab-checkbox name="selectAll" text="Select all items" [indeterminate]="true"></goab-checkbox>`,
         webComponents: `<goa-checkbox name="selectAll" text="Select all items" indeterminate></goa-checkbox>`,
       },
@@ -67,8 +67,8 @@ export const checkboxConfigurations: ComponentConfigurations = {
       name: 'Disabled',
       description: 'Checkbox in disabled state',
       code: {
-        react: `<GoabCheckbox name="disabled" text="Cannot be changed" disabled />
-<GoabCheckbox name="disabledChecked" text="Checked and disabled" checked disabled />`,
+        react: `<GoabxCheckbox name="disabled" text="Cannot be changed" disabled />
+<GoabxCheckbox name="disabledChecked" text="Checked and disabled" checked disabled />`,
         angular: `<goab-checkbox name="disabled" text="Cannot be changed" [disabled]="true"></goab-checkbox>
 <goab-checkbox name="disabledChecked" text="Checked and disabled" [checked]="true" [disabled]="true"></goab-checkbox>`,
         webComponents: `<goa-checkbox name="disabled" text="Cannot be changed" disabled></goa-checkbox>
@@ -80,7 +80,7 @@ export const checkboxConfigurations: ComponentConfigurations = {
       name: 'Error state',
       description: 'Checkbox showing validation error',
       code: {
-        react: `<GoabCheckbox name="terms" text="Accept terms and conditions" error />`,
+        react: `<GoabxCheckbox name="terms" text="Accept terms and conditions" error />`,
         angular: `<goab-checkbox name="terms" text="Accept terms and conditions" [error]="true"></goab-checkbox>`,
         webComponents: `<goa-checkbox name="terms" text="Accept terms and conditions" error></goa-checkbox>`,
       },

--- a/docs/src/data/configurations/checkbox.ts
+++ b/docs/src/data/configurations/checkbox.ts
@@ -16,8 +16,8 @@ export const checkboxConfigurations: ComponentConfigurations = {
       description: 'Single checkbox with label',
       code: {
         react: `<GoabxCheckbox name="agree" text="I agree to the terms" />`,
-        angular: `<goab-checkbox name="agree" text="I agree to the terms"></goab-checkbox>`,
-        webComponents: `<goa-checkbox name="agree" text="I agree to the terms"></goa-checkbox>`,
+        angular: `<goabx-checkbox name="agree" text="I agree to the terms"></goabx-checkbox>`,
+        webComponents: `<goa-checkbox version="2" name="agree" text="I agree to the terms"></goa-checkbox>`,
       },
     },
     {
@@ -30,12 +30,12 @@ export const checkboxConfigurations: ComponentConfigurations = {
   text="Subscribe to newsletter"
   description="Receive weekly updates about new features"
 />`,
-        angular: `<goab-checkbox
+        angular: `<goabx-checkbox
   name="newsletter"
   text="Subscribe to newsletter"
   description="Receive weekly updates about new features">
-</goab-checkbox>`,
-        webComponents: `<goa-checkbox
+</goabx-checkbox>`,
+        webComponents: `<goa-checkbox version="2"
   name="newsletter"
   text="Subscribe to newsletter"
   description="Receive weekly updates about new features">
@@ -48,8 +48,8 @@ export const checkboxConfigurations: ComponentConfigurations = {
       description: 'Checkbox in checked state',
       code: {
         react: `<GoabxCheckbox name="remember" text="Remember me" checked />`,
-        angular: `<goab-checkbox name="remember" text="Remember me" [checked]="true"></goab-checkbox>`,
-        webComponents: `<goa-checkbox name="remember" text="Remember me" checked></goa-checkbox>`,
+        angular: `<goabx-checkbox name="remember" text="Remember me" [checked]="true"></goabx-checkbox>`,
+        webComponents: `<goa-checkbox version="2" name="remember" text="Remember me" checked></goa-checkbox>`,
       },
     },
     {
@@ -58,8 +58,8 @@ export const checkboxConfigurations: ComponentConfigurations = {
       description: 'Mixed state for "select all" scenarios',
       code: {
         react: `<GoabxCheckbox name="selectAll" text="Select all items" indeterminate />`,
-        angular: `<goab-checkbox name="selectAll" text="Select all items" [indeterminate]="true"></goab-checkbox>`,
-        webComponents: `<goa-checkbox name="selectAll" text="Select all items" indeterminate></goa-checkbox>`,
+        angular: `<goabx-checkbox name="selectAll" text="Select all items" [indeterminate]="true"></goabx-checkbox>`,
+        webComponents: `<goa-checkbox version="2" name="selectAll" text="Select all items" indeterminate></goa-checkbox>`,
       },
     },
     {
@@ -69,10 +69,10 @@ export const checkboxConfigurations: ComponentConfigurations = {
       code: {
         react: `<GoabxCheckbox name="disabled" text="Cannot be changed" disabled />
 <GoabxCheckbox name="disabledChecked" text="Checked and disabled" checked disabled />`,
-        angular: `<goab-checkbox name="disabled" text="Cannot be changed" [disabled]="true"></goab-checkbox>
-<goab-checkbox name="disabledChecked" text="Checked and disabled" [checked]="true" [disabled]="true"></goab-checkbox>`,
-        webComponents: `<goa-checkbox name="disabled" text="Cannot be changed" disabled></goa-checkbox>
-<goa-checkbox name="disabledChecked" text="Checked and disabled" checked disabled></goa-checkbox>`,
+        angular: `<goabx-checkbox name="disabled" text="Cannot be changed" [disabled]="true"></goabx-checkbox>
+<goabx-checkbox name="disabledChecked" text="Checked and disabled" [checked]="true" [disabled]="true"></goabx-checkbox>`,
+        webComponents: `<goa-checkbox version="2" name="disabled" text="Cannot be changed" disabled></goa-checkbox>
+<goa-checkbox version="2" name="disabledChecked" text="Checked and disabled" checked disabled></goa-checkbox>`,
       },
     },
     {
@@ -81,8 +81,8 @@ export const checkboxConfigurations: ComponentConfigurations = {
       description: 'Checkbox showing validation error',
       code: {
         react: `<GoabxCheckbox name="terms" text="Accept terms and conditions" error />`,
-        angular: `<goab-checkbox name="terms" text="Accept terms and conditions" [error]="true"></goab-checkbox>`,
-        webComponents: `<goa-checkbox name="terms" text="Accept terms and conditions" error></goa-checkbox>`,
+        angular: `<goabx-checkbox name="terms" text="Accept terms and conditions" [error]="true"></goabx-checkbox>`,
+        webComponents: `<goa-checkbox version="2" name="terms" text="Accept terms and conditions" error></goa-checkbox>`,
       },
     },
   ],

--- a/docs/src/data/configurations/date-picker.ts
+++ b/docs/src/data/configurations/date-picker.ts
@@ -20,11 +20,11 @@ export const datePickerConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Date" mb="l">
   <GoabxDatePicker name="date" onChange={handleDateChange} />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Date" mb="l">
-  <goab-date-picker name="date" (_change)="handleDateChange($event)"></goab-date-picker>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Date" mb="l">
-  <goa-date-picker name="date"></goa-date-picker>
+        angular: `<goabx-form-item label="Date" mb="l">
+  <goabx-date-picker name="date" (_change)="handleDateChange($event)"></goabx-date-picker>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Date" mb="l">
+  <goa-date-picker version="2" name="date"></goa-date-picker>
 </goa-form-item>`,
       },
     },
@@ -36,11 +36,11 @@ export const datePickerConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Start date" mb="l">
   <GoabxDatePicker name="startDate" value="2024-01-15" onChange={handleDateChange} />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Start date" mb="l">
-  <goab-date-picker name="startDate" value="2024-01-15" (_change)="handleDateChange($event)"></goab-date-picker>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Start date" mb="l">
-  <goa-date-picker name="startDate" value="2024-01-15"></goa-date-picker>
+        angular: `<goabx-form-item label="Start date" mb="l">
+  <goabx-date-picker name="startDate" value="2024-01-15" (_change)="handleDateChange($event)"></goabx-date-picker>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Start date" mb="l">
+  <goa-date-picker version="2" name="startDate" value="2024-01-15"></goa-date-picker>
 </goa-form-item>`,
       },
     },
@@ -57,16 +57,16 @@ export const datePickerConfigurations: ComponentConfigurations = {
     onChange={handleDateChange}
   />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Appointment date" helpText="Select a date within the next 30 days" mb="l">
-  <goab-date-picker
+        angular: `<goabx-form-item label="Appointment date" helpText="Select a date within the next 30 days" mb="l">
+  <goabx-date-picker
     name="appointment"
     min="2024-01-01"
     max="2024-01-31"
     (_change)="handleDateChange($event)">
-  </goab-date-picker>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Appointment date" helpText="Select a date within the next 30 days" mb="l">
-  <goa-date-picker
+  </goabx-date-picker>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Appointment date" helpText="Select a date within the next 30 days" mb="l">
+  <goa-date-picker version="2"
     name="appointment"
     min="2024-01-01"
     max="2024-01-31">
@@ -82,11 +82,11 @@ export const datePickerConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Locked date" mb="l">
   <GoabxDatePicker name="locked" value="2024-01-01" disabled />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Locked date" mb="l">
-  <goab-date-picker name="locked" value="2024-01-01" [disabled]="true"></goab-date-picker>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Locked date" mb="l">
-  <goa-date-picker name="locked" value="2024-01-01" disabled></goa-date-picker>
+        angular: `<goabx-form-item label="Locked date" mb="l">
+  <goabx-date-picker name="locked" value="2024-01-01" [disabled]="true"></goabx-date-picker>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Locked date" mb="l">
+  <goa-date-picker version="2" name="locked" value="2024-01-01" disabled></goa-date-picker>
 </goa-form-item>`,
       },
     },

--- a/docs/src/data/configurations/date-picker.ts
+++ b/docs/src/data/configurations/date-picker.ts
@@ -17,9 +17,9 @@ export const datePickerConfigurations: ComponentConfigurations = {
       name: 'Basic date picker',
       description: 'Simple date selection',
       code: {
-        react: `<GoabFormItem label="Date" mb="l">
-  <GoabDatePicker name="date" onChange={handleDateChange} />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Date" mb="l">
+  <GoabxDatePicker name="date" onChange={handleDateChange} />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Date" mb="l">
   <goab-date-picker name="date" (_change)="handleDateChange($event)"></goab-date-picker>
 </goab-form-item>`,
@@ -33,9 +33,9 @@ export const datePickerConfigurations: ComponentConfigurations = {
       name: 'With initial value',
       description: 'Date picker with preset date',
       code: {
-        react: `<GoabFormItem label="Start date" mb="l">
-  <GoabDatePicker name="startDate" value="2024-01-15" onChange={handleDateChange} />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Start date" mb="l">
+  <GoabxDatePicker name="startDate" value="2024-01-15" onChange={handleDateChange} />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Start date" mb="l">
   <goab-date-picker name="startDate" value="2024-01-15" (_change)="handleDateChange($event)"></goab-date-picker>
 </goab-form-item>`,
@@ -49,14 +49,14 @@ export const datePickerConfigurations: ComponentConfigurations = {
       name: 'With date range',
       description: 'Restrict selectable dates',
       code: {
-        react: `<GoabFormItem label="Appointment date" helpText="Select a date within the next 30 days" mb="l">
-  <GoabDatePicker
+        react: `<GoabxFormItem label="Appointment date" helpText="Select a date within the next 30 days" mb="l">
+  <GoabxDatePicker
     name="appointment"
     min="2024-01-01"
     max="2024-01-31"
     onChange={handleDateChange}
   />
-</GoabFormItem>`,
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Appointment date" helpText="Select a date within the next 30 days" mb="l">
   <goab-date-picker
     name="appointment"
@@ -79,9 +79,9 @@ export const datePickerConfigurations: ComponentConfigurations = {
       name: 'Disabled',
       description: 'Date picker in disabled state',
       code: {
-        react: `<GoabFormItem label="Locked date" mb="l">
-  <GoabDatePicker name="locked" value="2024-01-01" disabled />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Locked date" mb="l">
+  <GoabxDatePicker name="locked" value="2024-01-01" disabled />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Locked date" mb="l">
   <goab-date-picker name="locked" value="2024-01-01" [disabled]="true"></goab-date-picker>
 </goab-form-item>`,

--- a/docs/src/data/configurations/drawer.ts
+++ b/docs/src/data/configurations/drawer.ts
@@ -26,7 +26,7 @@ export const drawerConfigurations: ComponentConfigurations = {
       name: 'Basic drawer',
       description: 'Simple drawer from right side',
       code: {
-        react: `<GoabDrawer heading="Application details" position="right" open={isOpen} onClose={handleClose}>
+        react: `<GoabxDrawer heading="Application details" position="right" open={isOpen} onClose={handleClose}>
   <p>Use a drawer to display supplementary content or actions without navigating away from the current page.</p>
   <p>Drawers are useful for:</p>
   <ul>
@@ -34,7 +34,7 @@ export const drawerConfigurations: ComponentConfigurations = {
     <li>Editing settings or preferences</li>
     <li>Completing a quick task related to the main content</li>
   </ul>
-</GoabDrawer>`,
+</GoabxDrawer>`,
         angular: `<goab-drawer heading="Application details" position="right" [open]="isOpen" (_close)="handleClose()">
   <p>Use a drawer to display supplementary content or actions without navigating away from the current page.</p>
   <p>Drawers are useful for:</p>
@@ -62,9 +62,9 @@ export const drawerConfigurations: ComponentConfigurations = {
       name: 'Bottom position',
       description: 'Drawer opening from the bottom of the screen',
       code: {
-        react: `<GoabDrawer heading="Bottom drawer" position="bottom" open={isOpen} onClose={handleClose}>
+        react: `<GoabxDrawer heading="Bottom drawer" position="bottom" open={isOpen} onClose={handleClose}>
   <p>Opens from the bottom of the screen.</p>
-</GoabDrawer>`,
+</GoabxDrawer>`,
         angular: `<goab-drawer heading="Bottom drawer" position="bottom" [open]="isOpen" (_close)="handleClose()">
   <p>Opens from the bottom of the screen.</p>
 </goab-drawer>`,
@@ -80,13 +80,13 @@ export const drawerConfigurations: ComponentConfigurations = {
       name: 'With actions',
       description: 'Drawer with footer actions',
       code: {
-        react: `<GoabDrawer heading="Edit settings" position="right" open={isOpen} onClose={handleClose}>
+        react: `<GoabxDrawer heading="Edit settings" position="right" open={isOpen} onClose={handleClose}>
   <p>Make changes to your settings here.</p>
   <GoabButtonGroup slot="actions" alignment="end">
-    <GoabButton type="secondary" onClick={handleClose}>Cancel</GoabButton>
-    <GoabButton onClick={handleSave}>Save</GoabButton>
+    <GoabxButton type="secondary" onClick={handleClose}>Cancel</GoabxButton>
+    <GoabxButton onClick={handleSave}>Save</GoabxButton>
   </GoabButtonGroup>
-</GoabDrawer>`,
+</GoabxDrawer>`,
         angular: `<goab-drawer heading="Edit settings" position="right" [open]="isOpen" (_close)="handleClose()">
   <p>Make changes to your settings here.</p>
   <goab-button-group slot="actions" alignment="end">
@@ -110,9 +110,9 @@ export const drawerConfigurations: ComponentConfigurations = {
       name: 'Narrow size',
       description: 'Narrow drawer for simple content',
       code: {
-        react: `<GoabDrawer heading="Narrow drawer" position="right" size="narrow" open={isOpen} onClose={handleClose}>
+        react: `<GoabxDrawer heading="Narrow drawer" position="right" size="narrow" open={isOpen} onClose={handleClose}>
   <p>Narrow width for simple content.</p>
-</GoabDrawer>`,
+</GoabxDrawer>`,
         angular: `<goab-drawer heading="Narrow drawer" position="right" size="narrow" [open]="isOpen" (_close)="handleClose()">
   <p>Narrow width for simple content.</p>
 </goab-drawer>`,
@@ -128,9 +128,9 @@ export const drawerConfigurations: ComponentConfigurations = {
       name: 'Wide size',
       description: 'Wide drawer for complex content',
       code: {
-        react: `<GoabDrawer heading="Wide drawer" position="right" size="wide" open={isOpen} onClose={handleClose}>
+        react: `<GoabxDrawer heading="Wide drawer" position="right" size="wide" open={isOpen} onClose={handleClose}>
   <p>Wide width for more complex content.</p>
-</GoabDrawer>`,
+</GoabxDrawer>`,
         angular: `<goab-drawer heading="Wide drawer" position="right" size="wide" [open]="isOpen" (_close)="handleClose()">
   <p>Wide width for more complex content.</p>
 </goab-drawer>`,

--- a/docs/src/data/configurations/drawer.ts
+++ b/docs/src/data/configurations/drawer.ts
@@ -35,7 +35,7 @@ export const drawerConfigurations: ComponentConfigurations = {
     <li>Completing a quick task related to the main content</li>
   </ul>
 </GoabxDrawer>`,
-        angular: `<goab-drawer heading="Application details" position="right" [open]="isOpen" (_close)="handleClose()">
+        angular: `<goabx-drawer heading="Application details" position="right" [open]="isOpen" (_close)="handleClose()">
   <p>Use a drawer to display supplementary content or actions without navigating away from the current page.</p>
   <p>Drawers are useful for:</p>
   <ul>
@@ -43,9 +43,9 @@ export const drawerConfigurations: ComponentConfigurations = {
     <li>Editing settings or preferences</li>
     <li>Completing a quick task related to the main content</li>
   </ul>
-</goab-drawer>`,
-        webComponents: `<goa-button id="open-drawer">Open drawer</goa-button>
-<goa-drawer id="demo-drawer" heading="Application details" position="right">
+</goabx-drawer>`,
+        webComponents: `<goa-button version="2" id="open-drawer">Open drawer</goa-button>
+<goa-drawer version="2" id="demo-drawer" heading="Application details" position="right">
   <p>Use a drawer to display supplementary content or actions without navigating away from the current page.</p>
   <p>Drawers are useful for:</p>
   <ul>
@@ -65,11 +65,11 @@ export const drawerConfigurations: ComponentConfigurations = {
         react: `<GoabxDrawer heading="Bottom drawer" position="bottom" open={isOpen} onClose={handleClose}>
   <p>Opens from the bottom of the screen.</p>
 </GoabxDrawer>`,
-        angular: `<goab-drawer heading="Bottom drawer" position="bottom" [open]="isOpen" (_close)="handleClose()">
+        angular: `<goabx-drawer heading="Bottom drawer" position="bottom" [open]="isOpen" (_close)="handleClose()">
   <p>Opens from the bottom of the screen.</p>
-</goab-drawer>`,
-        webComponents: `<goa-button id="open-drawer">Open drawer</goa-button>
-<goa-drawer id="demo-drawer" heading="Bottom drawer" position="bottom">
+</goabx-drawer>`,
+        webComponents: `<goa-button version="2" id="open-drawer">Open drawer</goa-button>
+<goa-drawer version="2" id="demo-drawer" heading="Bottom drawer" position="bottom">
   <p>Opens from the bottom of the screen.</p>
 </goa-drawer>
 <script>${drawerScript}</script>`,
@@ -87,19 +87,19 @@ export const drawerConfigurations: ComponentConfigurations = {
     <GoabxButton onClick={handleSave}>Save</GoabxButton>
   </GoabButtonGroup>
 </GoabxDrawer>`,
-        angular: `<goab-drawer heading="Edit settings" position="right" [open]="isOpen" (_close)="handleClose()">
+        angular: `<goabx-drawer heading="Edit settings" position="right" [open]="isOpen" (_close)="handleClose()">
   <p>Make changes to your settings here.</p>
   <goab-button-group slot="actions" alignment="end">
-    <goab-button type="secondary" (_click)="handleClose()">Cancel</goab-button>
-    <goab-button (_click)="handleSave()">Save</goab-button>
+    <goabx-button type="secondary" (_click)="handleClose()">Cancel</goabx-button>
+    <goabx-button (_click)="handleSave()">Save</goabx-button>
   </goab-button-group>
-</goab-drawer>`,
-        webComponents: `<goa-button id="open-drawer">Open drawer</goa-button>
-<goa-drawer id="demo-drawer" heading="Edit settings" position="right">
+</goabx-drawer>`,
+        webComponents: `<goa-button version="2" id="open-drawer">Open drawer</goa-button>
+<goa-drawer version="2" id="demo-drawer" heading="Edit settings" position="right">
   <p>Make changes to your settings here.</p>
   <goa-button-group slot="actions" alignment="end">
-    <goa-button type="secondary">Cancel</goa-button>
-    <goa-button>Save</goa-button>
+    <goa-button version="2" type="secondary">Cancel</goa-button>
+    <goa-button version="2">Save</goa-button>
   </goa-button-group>
 </goa-drawer>
 <script>${drawerScript}</script>`,
@@ -113,11 +113,11 @@ export const drawerConfigurations: ComponentConfigurations = {
         react: `<GoabxDrawer heading="Narrow drawer" position="right" size="narrow" open={isOpen} onClose={handleClose}>
   <p>Narrow width for simple content.</p>
 </GoabxDrawer>`,
-        angular: `<goab-drawer heading="Narrow drawer" position="right" size="narrow" [open]="isOpen" (_close)="handleClose()">
+        angular: `<goabx-drawer heading="Narrow drawer" position="right" size="narrow" [open]="isOpen" (_close)="handleClose()">
   <p>Narrow width for simple content.</p>
-</goab-drawer>`,
-        webComponents: `<goa-button id="open-drawer">Open drawer</goa-button>
-<goa-drawer id="demo-drawer" heading="Narrow drawer" position="right" size="narrow">
+</goabx-drawer>`,
+        webComponents: `<goa-button version="2" id="open-drawer">Open drawer</goa-button>
+<goa-drawer version="2" id="demo-drawer" heading="Narrow drawer" position="right" size="narrow">
   <p>Narrow width for simple content.</p>
 </goa-drawer>
 <script>${drawerScript}</script>`,
@@ -131,11 +131,11 @@ export const drawerConfigurations: ComponentConfigurations = {
         react: `<GoabxDrawer heading="Wide drawer" position="right" size="wide" open={isOpen} onClose={handleClose}>
   <p>Wide width for more complex content.</p>
 </GoabxDrawer>`,
-        angular: `<goab-drawer heading="Wide drawer" position="right" size="wide" [open]="isOpen" (_close)="handleClose()">
+        angular: `<goabx-drawer heading="Wide drawer" position="right" size="wide" [open]="isOpen" (_close)="handleClose()">
   <p>Wide width for more complex content.</p>
-</goab-drawer>`,
-        webComponents: `<goa-button id="open-drawer">Open drawer</goa-button>
-<goa-drawer id="demo-drawer" heading="Wide drawer" position="right" size="wide">
+</goabx-drawer>`,
+        webComponents: `<goa-button version="2" id="open-drawer">Open drawer</goa-button>
+<goa-drawer version="2" id="demo-drawer" heading="Wide drawer" position="right" size="wide">
   <p>Wide width for more complex content.</p>
 </goa-drawer>
 <script>${drawerScript}</script>`,

--- a/docs/src/data/configurations/dropdown.ts
+++ b/docs/src/data/configurations/dropdown.ts
@@ -18,23 +18,23 @@ export const dropdownConfigurations: ComponentConfigurations = {
       name: 'Basic example',
       description: 'Simple dropdown with options',
       code: {
-        react: `<GoabFormItem label="Province or territory" mb="l">
-  <GoabDropdown name="province">
-    <GoabDropdownItem value="Alberta" />
-    <GoabDropdownItem value="British Columbia" />
-    <GoabDropdownItem value="Manitoba" />
-    <GoabDropdownItem value="New Brunswick" />
-    <GoabDropdownItem value="Newfoundland and Labrador" />
-    <GoabDropdownItem value="Nova Scotia" />
-    <GoabDropdownItem value="Northwest Territories" />
-    <GoabDropdownItem value="Nunavut" />
-    <GoabDropdownItem value="Ontario" />
-    <GoabDropdownItem value="Prince Edward Island" />
-    <GoabDropdownItem value="Quebec" />
-    <GoabDropdownItem value="Saskatchewan" />
-    <GoabDropdownItem value="Yukon" />
-  </GoabDropdown>
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Province or territory" mb="l">
+  <GoabxDropdown name="province">
+    <GoabxDropdownItem value="Alberta" />
+    <GoabxDropdownItem value="British Columbia" />
+    <GoabxDropdownItem value="Manitoba" />
+    <GoabxDropdownItem value="New Brunswick" />
+    <GoabxDropdownItem value="Newfoundland and Labrador" />
+    <GoabxDropdownItem value="Nova Scotia" />
+    <GoabxDropdownItem value="Northwest Territories" />
+    <GoabxDropdownItem value="Nunavut" />
+    <GoabxDropdownItem value="Ontario" />
+    <GoabxDropdownItem value="Prince Edward Island" />
+    <GoabxDropdownItem value="Quebec" />
+    <GoabxDropdownItem value="Saskatchewan" />
+    <GoabxDropdownItem value="Yukon" />
+  </GoabxDropdown>
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Province or territory" mb="l">
   <goab-dropdown name="province">
     <goab-dropdown-item value="Alberta"></goab-dropdown-item>
@@ -76,13 +76,13 @@ export const dropdownConfigurations: ComponentConfigurations = {
       name: 'With custom placeholder',
       description: 'Dropdown with placeholder text when no selection',
       code: {
-        react: `<GoabFormItem label="How would you like to be contacted?" mb="l">
-  <GoabDropdown name="contactMethod" placeholder="—Select contact method—">
-    <GoabDropdownItem value="Email" />
-    <GoabDropdownItem value="Phone" />
-    <GoabDropdownItem value="Mail" />
-  </GoabDropdown>
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="How would you like to be contacted?" mb="l">
+  <GoabxDropdown name="contactMethod" placeholder="—Select contact method—">
+    <GoabxDropdownItem value="Email" />
+    <GoabxDropdownItem value="Phone" />
+    <GoabxDropdownItem value="Mail" />
+  </GoabxDropdown>
+</GoabxFormItem>`,
         angular: `<goab-form-item label="How would you like to be contacted?" mb="l">
   <goab-dropdown name="contactMethod" placeholder="—Select contact method—">
     <goab-dropdown-item value="Email"></goab-dropdown-item>
@@ -104,30 +104,30 @@ export const dropdownConfigurations: ComponentConfigurations = {
       name: 'Filterable',
       description: 'Dropdown with search/filter capability for long lists',
       code: {
-        react: `<GoabFormItem label="City" mb="l">
-  <GoabDropdown name="city" filterable>
-    <GoabDropdownItem value="Airdrie" />
-    <GoabDropdownItem value="Beaumont" />
-    <GoabDropdownItem value="Brooks" />
-    <GoabDropdownItem value="Calgary" />
-    <GoabDropdownItem value="Camrose" />
-    <GoabDropdownItem value="Chestermere" />
-    <GoabDropdownItem value="Cold Lake" />
-    <GoabDropdownItem value="Edmonton" />
-    <GoabDropdownItem value="Fort Saskatchewan" />
-    <GoabDropdownItem value="Grande Prairie" />
-    <GoabDropdownItem value="Lacombe" />
-    <GoabDropdownItem value="Leduc" />
-    <GoabDropdownItem value="Lethbridge" />
-    <GoabDropdownItem value="Lloydminster" />
-    <GoabDropdownItem value="Medicine Hat" />
-    <GoabDropdownItem value="Okotoks" />
-    <GoabDropdownItem value="Red Deer" />
-    <GoabDropdownItem value="Spruce Grove" />
-    <GoabDropdownItem value="St. Albert" />
-    <GoabDropdownItem value="Wetaskiwin" />
-  </GoabDropdown>
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="City" mb="l">
+  <GoabxDropdown name="city" filterable>
+    <GoabxDropdownItem value="Airdrie" />
+    <GoabxDropdownItem value="Beaumont" />
+    <GoabxDropdownItem value="Brooks" />
+    <GoabxDropdownItem value="Calgary" />
+    <GoabxDropdownItem value="Camrose" />
+    <GoabxDropdownItem value="Chestermere" />
+    <GoabxDropdownItem value="Cold Lake" />
+    <GoabxDropdownItem value="Edmonton" />
+    <GoabxDropdownItem value="Fort Saskatchewan" />
+    <GoabxDropdownItem value="Grande Prairie" />
+    <GoabxDropdownItem value="Lacombe" />
+    <GoabxDropdownItem value="Leduc" />
+    <GoabxDropdownItem value="Lethbridge" />
+    <GoabxDropdownItem value="Lloydminster" />
+    <GoabxDropdownItem value="Medicine Hat" />
+    <GoabxDropdownItem value="Okotoks" />
+    <GoabxDropdownItem value="Red Deer" />
+    <GoabxDropdownItem value="Spruce Grove" />
+    <GoabxDropdownItem value="St. Albert" />
+    <GoabxDropdownItem value="Wetaskiwin" />
+  </GoabxDropdown>
+</GoabxFormItem>`,
         angular: `<goab-form-item label="City" mb="l">
   <goab-dropdown name="city" [filterable]="true">
     <goab-dropdown-item value="Airdrie"></goab-dropdown-item>
@@ -183,18 +183,18 @@ export const dropdownConfigurations: ComponentConfigurations = {
       name: 'States',
       description: 'Disabled and error states',
       code: {
-        react: `<GoabFormItem label="Disabled dropdown" mb="l">
-  <GoabDropdown name="disabled" disabled value="AB">
-    <GoabDropdownItem value="AB">Alberta</GoabDropdownItem>
-    <GoabDropdownItem value="BC">British Columbia</GoabDropdownItem>
-  </GoabDropdown>
-</GoabFormItem>
-<GoabFormItem label="Dropdown with error" error="Please select an option" mb="l">
-  <GoabDropdown name="error" error placeholder="Select an option">
-    <GoabDropdownItem value="opt1">Option 1</GoabDropdownItem>
-    <GoabDropdownItem value="opt2">Option 2</GoabDropdownItem>
-  </GoabDropdown>
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Disabled dropdown" mb="l">
+  <GoabxDropdown name="disabled" disabled value="AB">
+    <GoabxDropdownItem value="AB">Alberta</GoabxDropdownItem>
+    <GoabxDropdownItem value="BC">British Columbia</GoabxDropdownItem>
+  </GoabxDropdown>
+</GoabxFormItem>
+<GoabxFormItem label="Dropdown with error" error="Please select an option" mb="l">
+  <GoabxDropdown name="error" error placeholder="Select an option">
+    <GoabxDropdownItem value="opt1">Option 1</GoabxDropdownItem>
+    <GoabxDropdownItem value="opt2">Option 2</GoabxDropdownItem>
+  </GoabxDropdown>
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Disabled dropdown" mb="l">
   <goab-dropdown name="disabled" [disabled]="true" value="AB">
     <goab-dropdown-item value="AB">Alberta</goab-dropdown-item>

--- a/docs/src/data/configurations/dropdown.ts
+++ b/docs/src/data/configurations/dropdown.ts
@@ -35,25 +35,25 @@ export const dropdownConfigurations: ComponentConfigurations = {
     <GoabxDropdownItem value="Yukon" />
   </GoabxDropdown>
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Province or territory" mb="l">
-  <goab-dropdown name="province">
-    <goab-dropdown-item value="Alberta"></goab-dropdown-item>
-    <goab-dropdown-item value="British Columbia"></goab-dropdown-item>
-    <goab-dropdown-item value="Manitoba"></goab-dropdown-item>
-    <goab-dropdown-item value="New Brunswick"></goab-dropdown-item>
-    <goab-dropdown-item value="Newfoundland and Labrador"></goab-dropdown-item>
-    <goab-dropdown-item value="Nova Scotia"></goab-dropdown-item>
-    <goab-dropdown-item value="Northwest Territories"></goab-dropdown-item>
-    <goab-dropdown-item value="Nunavut"></goab-dropdown-item>
-    <goab-dropdown-item value="Ontario"></goab-dropdown-item>
-    <goab-dropdown-item value="Prince Edward Island"></goab-dropdown-item>
-    <goab-dropdown-item value="Quebec"></goab-dropdown-item>
-    <goab-dropdown-item value="Saskatchewan"></goab-dropdown-item>
-    <goab-dropdown-item value="Yukon"></goab-dropdown-item>
-  </goab-dropdown>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Province or territory" mb="l">
-  <goa-dropdown name="province">
+        angular: `<goabx-form-item label="Province or territory" mb="l">
+  <goabx-dropdown name="province">
+    <goabx-dropdown-item value="Alberta"></goabx-dropdown-item>
+    <goabx-dropdown-item value="British Columbia"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Manitoba"></goabx-dropdown-item>
+    <goabx-dropdown-item value="New Brunswick"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Newfoundland and Labrador"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Nova Scotia"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Northwest Territories"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Nunavut"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Ontario"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Prince Edward Island"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Quebec"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Saskatchewan"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Yukon"></goabx-dropdown-item>
+  </goabx-dropdown>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Province or territory" mb="l">
+  <goa-dropdown version="2" name="province">
     <goa-dropdown-item value="Alberta"></goa-dropdown-item>
     <goa-dropdown-item value="British Columbia"></goa-dropdown-item>
     <goa-dropdown-item value="Manitoba"></goa-dropdown-item>
@@ -83,15 +83,15 @@ export const dropdownConfigurations: ComponentConfigurations = {
     <GoabxDropdownItem value="Mail" />
   </GoabxDropdown>
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="How would you like to be contacted?" mb="l">
-  <goab-dropdown name="contactMethod" placeholder="—Select contact method—">
-    <goab-dropdown-item value="Email"></goab-dropdown-item>
-    <goab-dropdown-item value="Phone"></goab-dropdown-item>
-    <goab-dropdown-item value="Mail"></goab-dropdown-item>
-  </goab-dropdown>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="How would you like to be contacted?" mb="l">
-  <goa-dropdown name="contactMethod" placeholder="—Select contact method—">
+        angular: `<goabx-form-item label="How would you like to be contacted?" mb="l">
+  <goabx-dropdown name="contactMethod" placeholder="—Select contact method—">
+    <goabx-dropdown-item value="Email"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Phone"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Mail"></goabx-dropdown-item>
+  </goabx-dropdown>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="How would you like to be contacted?" mb="l">
+  <goa-dropdown version="2" name="contactMethod" placeholder="—Select contact method—">
     <goa-dropdown-item value="Email"></goa-dropdown-item>
     <goa-dropdown-item value="Phone"></goa-dropdown-item>
     <goa-dropdown-item value="Mail"></goa-dropdown-item>
@@ -128,32 +128,32 @@ export const dropdownConfigurations: ComponentConfigurations = {
     <GoabxDropdownItem value="Wetaskiwin" />
   </GoabxDropdown>
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="City" mb="l">
-  <goab-dropdown name="city" [filterable]="true">
-    <goab-dropdown-item value="Airdrie"></goab-dropdown-item>
-    <goab-dropdown-item value="Beaumont"></goab-dropdown-item>
-    <goab-dropdown-item value="Brooks"></goab-dropdown-item>
-    <goab-dropdown-item value="Calgary"></goab-dropdown-item>
-    <goab-dropdown-item value="Camrose"></goab-dropdown-item>
-    <goab-dropdown-item value="Chestermere"></goab-dropdown-item>
-    <goab-dropdown-item value="Cold Lake"></goab-dropdown-item>
-    <goab-dropdown-item value="Edmonton"></goab-dropdown-item>
-    <goab-dropdown-item value="Fort Saskatchewan"></goab-dropdown-item>
-    <goab-dropdown-item value="Grande Prairie"></goab-dropdown-item>
-    <goab-dropdown-item value="Lacombe"></goab-dropdown-item>
-    <goab-dropdown-item value="Leduc"></goab-dropdown-item>
-    <goab-dropdown-item value="Lethbridge"></goab-dropdown-item>
-    <goab-dropdown-item value="Lloydminster"></goab-dropdown-item>
-    <goab-dropdown-item value="Medicine Hat"></goab-dropdown-item>
-    <goab-dropdown-item value="Okotoks"></goab-dropdown-item>
-    <goab-dropdown-item value="Red Deer"></goab-dropdown-item>
-    <goab-dropdown-item value="Spruce Grove"></goab-dropdown-item>
-    <goab-dropdown-item value="St. Albert"></goab-dropdown-item>
-    <goab-dropdown-item value="Wetaskiwin"></goab-dropdown-item>
-  </goab-dropdown>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="City" mb="l">
-  <goa-dropdown name="city" filterable>
+        angular: `<goabx-form-item label="City" mb="l">
+  <goabx-dropdown name="city" [filterable]="true">
+    <goabx-dropdown-item value="Airdrie"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Beaumont"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Brooks"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Calgary"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Camrose"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Chestermere"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Cold Lake"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Edmonton"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Fort Saskatchewan"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Grande Prairie"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Lacombe"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Leduc"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Lethbridge"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Lloydminster"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Medicine Hat"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Okotoks"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Red Deer"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Spruce Grove"></goabx-dropdown-item>
+    <goabx-dropdown-item value="St. Albert"></goabx-dropdown-item>
+    <goabx-dropdown-item value="Wetaskiwin"></goabx-dropdown-item>
+  </goabx-dropdown>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="City" mb="l">
+  <goa-dropdown version="2" name="city" filterable>
     <goa-dropdown-item value="Airdrie"></goa-dropdown-item>
     <goa-dropdown-item value="Beaumont"></goa-dropdown-item>
     <goa-dropdown-item value="Brooks"></goa-dropdown-item>
@@ -195,26 +195,26 @@ export const dropdownConfigurations: ComponentConfigurations = {
     <GoabxDropdownItem value="opt2">Option 2</GoabxDropdownItem>
   </GoabxDropdown>
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Disabled dropdown" mb="l">
-  <goab-dropdown name="disabled" [disabled]="true" value="AB">
-    <goab-dropdown-item value="AB">Alberta</goab-dropdown-item>
-    <goab-dropdown-item value="BC">British Columbia</goab-dropdown-item>
-  </goab-dropdown>
-</goab-form-item>
-<goab-form-item label="Dropdown with error" error="Please select an option" mb="l">
-  <goab-dropdown name="error" [error]="true" placeholder="Select an option">
-    <goab-dropdown-item value="opt1">Option 1</goab-dropdown-item>
-    <goab-dropdown-item value="opt2">Option 2</goab-dropdown-item>
-  </goab-dropdown>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Disabled dropdown" mb="l">
-  <goa-dropdown name="disabled" disabled value="AB">
+        angular: `<goabx-form-item label="Disabled dropdown" mb="l">
+  <goabx-dropdown name="disabled" [disabled]="true" value="AB">
+    <goabx-dropdown-item value="AB">Alberta</goabx-dropdown-item>
+    <goabx-dropdown-item value="BC">British Columbia</goabx-dropdown-item>
+  </goabx-dropdown>
+</goabx-form-item>
+<goabx-form-item label="Dropdown with error" error="Please select an option" mb="l">
+  <goabx-dropdown name="error" [error]="true" placeholder="Select an option">
+    <goabx-dropdown-item value="opt1">Option 1</goabx-dropdown-item>
+    <goabx-dropdown-item value="opt2">Option 2</goabx-dropdown-item>
+  </goabx-dropdown>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Disabled dropdown" mb="l">
+  <goa-dropdown version="2" name="disabled" disabled value="AB">
     <goa-dropdown-item value="AB">Alberta</goa-dropdown-item>
     <goa-dropdown-item value="BC">British Columbia</goa-dropdown-item>
   </goa-dropdown>
 </goa-form-item>
-<goa-form-item label="Dropdown with error" error="Please select an option" mb="l">
-  <goa-dropdown name="error" error placeholder="Select an option">
+<goa-form-item version="2" label="Dropdown with error" error="Please select an option" mb="l">
+  <goa-dropdown version="2" name="error" error placeholder="Select an option">
     <goa-dropdown-item value="opt1">Option 1</goa-dropdown-item>
     <goa-dropdown-item value="opt2">Option 2</goa-dropdown-item>
   </goa-dropdown>

--- a/docs/src/data/configurations/file-upload-card.ts
+++ b/docs/src/data/configurations/file-upload-card.ts
@@ -17,7 +17,7 @@ export const fileUploadCardConfigurations: ComponentConfigurations = {
       name: 'Basic file upload card',
       description: 'Card showing uploaded file',
       code: {
-        react: `<GoabFileUploadCard
+        react: `<GoabxFileUploadCard
   filename="document.pdf"
   size={1024000}
   onDelete={handleDelete}
@@ -38,7 +38,7 @@ export const fileUploadCardConfigurations: ComponentConfigurations = {
       name: 'With upload progress',
       description: 'Card showing upload in progress',
       code: {
-        react: `<GoabFileUploadCard
+        react: `<GoabxFileUploadCard
   filename="image.png"
   size={2048000}
   progress={65}
@@ -60,7 +60,7 @@ export const fileUploadCardConfigurations: ComponentConfigurations = {
       name: 'Error state',
       description: 'Card showing upload error',
       code: {
-        react: `<GoabFileUploadCard
+        react: `<GoabxFileUploadCard
   filename="large-file.zip"
   size={104857600}
   error="File exceeds maximum size limit"

--- a/docs/src/data/configurations/file-upload-card.ts
+++ b/docs/src/data/configurations/file-upload-card.ts
@@ -22,12 +22,12 @@ export const fileUploadCardConfigurations: ComponentConfigurations = {
   size={1024000}
   onDelete={handleDelete}
 />`,
-        angular: `<goab-file-upload-card
+        angular: `<goabx-file-upload-card
   filename="document.pdf"
   [size]="1024000"
   (_delete)="handleDelete()">
-</goab-file-upload-card>`,
-        webComponents: `<goa-file-upload-card
+</goabx-file-upload-card>`,
+        webComponents: `<goa-file-upload-card version="2"
   filename="document.pdf"
   size="1024000">
 </goa-file-upload-card>`,
@@ -43,12 +43,12 @@ export const fileUploadCardConfigurations: ComponentConfigurations = {
   size={2048000}
   progress={65}
 />`,
-        angular: `<goab-file-upload-card
+        angular: `<goabx-file-upload-card
   filename="image.png"
   [size]="2048000"
   [progress]="65">
-</goab-file-upload-card>`,
-        webComponents: `<goa-file-upload-card
+</goabx-file-upload-card>`,
+        webComponents: `<goa-file-upload-card version="2"
   filename="image.png"
   size="2048000"
   progress="65">
@@ -66,13 +66,13 @@ export const fileUploadCardConfigurations: ComponentConfigurations = {
   error="File exceeds maximum size limit"
   onDelete={handleDelete}
 />`,
-        angular: `<goab-file-upload-card
+        angular: `<goabx-file-upload-card
   filename="large-file.zip"
   [size]="104857600"
   error="File exceeds maximum size limit"
   (_delete)="handleDelete()">
-</goab-file-upload-card>`,
-        webComponents: `<goa-file-upload-card
+</goabx-file-upload-card>`,
+        webComponents: `<goa-file-upload-card version="2"
   filename="large-file.zip"
   size="104857600"
   error="File exceeds maximum size limit">

--- a/docs/src/data/configurations/file-upload-input.ts
+++ b/docs/src/data/configurations/file-upload-input.ts
@@ -17,9 +17,9 @@ export const fileUploadInputConfigurations: ComponentConfigurations = {
       name: 'Basic file upload',
       description: 'Simple file selection input',
       code: {
-        react: `<GoabFormItem label="Upload document" mb="l">
-  <GoabFileUploadInput onChange={handleFileChange} />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Upload document" mb="l">
+  <GoabxFileUploadInput onChange={handleFileChange} />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Upload document" mb="l">
   <goab-file-upload-input (_change)="handleFileChange($event)"></goab-file-upload-input>
 </goab-form-item>`,
@@ -33,12 +33,12 @@ export const fileUploadInputConfigurations: ComponentConfigurations = {
       name: 'Accepted file types',
       description: 'Restrict to specific file types',
       code: {
-        react: `<GoabFormItem label="Upload image" mb="l">
-  <GoabFileUploadInput accept="image/*" onChange={handleFileChange} />
-</GoabFormItem>
-<GoabFormItem label="Upload PDF" mb="l">
-  <GoabFileUploadInput accept=".pdf" onChange={handleFileChange} />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Upload image" mb="l">
+  <GoabxFileUploadInput accept="image/*" onChange={handleFileChange} />
+</GoabxFormItem>
+<GoabxFormItem label="Upload PDF" mb="l">
+  <GoabxFileUploadInput accept=".pdf" onChange={handleFileChange} />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Upload image" mb="l">
   <goab-file-upload-input accept="image/*" (_change)="handleFileChange($event)"></goab-file-upload-input>
 </goab-form-item>
@@ -58,9 +58,9 @@ export const fileUploadInputConfigurations: ComponentConfigurations = {
       name: 'Multiple files',
       description: 'Allow selecting multiple files',
       code: {
-        react: `<GoabFormItem label="Upload files" mb="l">
-  <GoabFileUploadInput multiple onChange={handleFilesChange} />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Upload files" mb="l">
+  <GoabxFileUploadInput multiple onChange={handleFilesChange} />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Upload files" mb="l">
   <goab-file-upload-input [multiple]="true" (_change)="handleFilesChange($event)"></goab-file-upload-input>
 </goab-form-item>`,
@@ -74,12 +74,12 @@ export const fileUploadInputConfigurations: ComponentConfigurations = {
       name: 'Variants',
       description: 'Different visual styles',
       code: {
-        react: `<GoabFormItem label="Button variant" mb="l">
-  <GoabFileUploadInput variant="button" onChange={handleFileChange} />
-</GoabFormItem>
-<GoabFormItem label="Dragdrop variant" mb="l">
-  <GoabFileUploadInput variant="dragdrop" onChange={handleFileChange} />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Button variant" mb="l">
+  <GoabxFileUploadInput variant="button" onChange={handleFileChange} />
+</GoabxFormItem>
+<GoabxFormItem label="Dragdrop variant" mb="l">
+  <GoabxFileUploadInput variant="dragdrop" onChange={handleFileChange} />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Button variant" mb="l">
   <goab-file-upload-input variant="button" (_change)="handleFileChange($event)"></goab-file-upload-input>
 </goab-form-item>

--- a/docs/src/data/configurations/file-upload-input.ts
+++ b/docs/src/data/configurations/file-upload-input.ts
@@ -20,11 +20,11 @@ export const fileUploadInputConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Upload document" mb="l">
   <GoabxFileUploadInput onChange={handleFileChange} />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Upload document" mb="l">
-  <goab-file-upload-input (_change)="handleFileChange($event)"></goab-file-upload-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Upload document" mb="l">
-  <goa-file-upload-input></goa-file-upload-input>
+        angular: `<goabx-form-item label="Upload document" mb="l">
+  <goabx-file-upload-input (_change)="handleFileChange($event)"></goabx-file-upload-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Upload document" mb="l">
+  <goa-file-upload-input version="2"></goa-file-upload-input>
 </goa-form-item>`,
       },
     },
@@ -39,17 +39,17 @@ export const fileUploadInputConfigurations: ComponentConfigurations = {
 <GoabxFormItem label="Upload PDF" mb="l">
   <GoabxFileUploadInput accept=".pdf" onChange={handleFileChange} />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Upload image" mb="l">
-  <goab-file-upload-input accept="image/*" (_change)="handleFileChange($event)"></goab-file-upload-input>
-</goab-form-item>
-<goab-form-item label="Upload PDF" mb="l">
-  <goab-file-upload-input accept=".pdf" (_change)="handleFileChange($event)"></goab-file-upload-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Upload image" mb="l">
-  <goa-file-upload-input accept="image/*"></goa-file-upload-input>
+        angular: `<goabx-form-item label="Upload image" mb="l">
+  <goabx-file-upload-input accept="image/*" (_change)="handleFileChange($event)"></goabx-file-upload-input>
+</goabx-form-item>
+<goabx-form-item label="Upload PDF" mb="l">
+  <goabx-file-upload-input accept=".pdf" (_change)="handleFileChange($event)"></goabx-file-upload-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Upload image" mb="l">
+  <goa-file-upload-input version="2" accept="image/*"></goa-file-upload-input>
 </goa-form-item>
-<goa-form-item label="Upload PDF" mb="l">
-  <goa-file-upload-input accept=".pdf"></goa-file-upload-input>
+<goa-form-item version="2" label="Upload PDF" mb="l">
+  <goa-file-upload-input version="2" accept=".pdf"></goa-file-upload-input>
 </goa-form-item>`,
       },
     },
@@ -61,11 +61,11 @@ export const fileUploadInputConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Upload files" mb="l">
   <GoabxFileUploadInput multiple onChange={handleFilesChange} />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Upload files" mb="l">
-  <goab-file-upload-input [multiple]="true" (_change)="handleFilesChange($event)"></goab-file-upload-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Upload files" mb="l">
-  <goa-file-upload-input multiple></goa-file-upload-input>
+        angular: `<goabx-form-item label="Upload files" mb="l">
+  <goabx-file-upload-input [multiple]="true" (_change)="handleFilesChange($event)"></goabx-file-upload-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Upload files" mb="l">
+  <goa-file-upload-input version="2" multiple></goa-file-upload-input>
 </goa-form-item>`,
       },
     },
@@ -80,17 +80,17 @@ export const fileUploadInputConfigurations: ComponentConfigurations = {
 <GoabxFormItem label="Dragdrop variant" mb="l">
   <GoabxFileUploadInput variant="dragdrop" onChange={handleFileChange} />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Button variant" mb="l">
-  <goab-file-upload-input variant="button" (_change)="handleFileChange($event)"></goab-file-upload-input>
-</goab-form-item>
-<goab-form-item label="Dragdrop variant" mb="l">
-  <goab-file-upload-input variant="dragdrop" (_change)="handleFileChange($event)"></goab-file-upload-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Button variant" mb="l">
-  <goa-file-upload-input variant="button"></goa-file-upload-input>
+        angular: `<goabx-form-item label="Button variant" mb="l">
+  <goabx-file-upload-input variant="button" (_change)="handleFileChange($event)"></goabx-file-upload-input>
+</goabx-form-item>
+<goabx-form-item label="Dragdrop variant" mb="l">
+  <goabx-file-upload-input variant="dragdrop" (_change)="handleFileChange($event)"></goabx-file-upload-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Button variant" mb="l">
+  <goa-file-upload-input version="2" variant="button"></goa-file-upload-input>
 </goa-form-item>
-<goa-form-item label="Dragdrop variant" mb="l">
-  <goa-file-upload-input variant="dragdrop"></goa-file-upload-input>
+<goa-form-item version="2" label="Dragdrop variant" mb="l">
+  <goa-file-upload-input version="2" variant="dragdrop"></goa-file-upload-input>
 </goa-form-item>`,
       },
     },

--- a/docs/src/data/configurations/filter-chip.ts
+++ b/docs/src/data/configurations/filter-chip.ts
@@ -17,7 +17,7 @@ export const filterChipConfigurations: ComponentConfigurations = {
       name: 'Basic filter chip',
       description: 'Simple filter toggle',
       code: {
-        react: `<GoabFilterChip content="Active" onClick={handleToggle} />`,
+        react: `<GoabxFilterChip content="Active" onClick={handleToggle} />`,
         angular: `<goab-filter-chip content="Active" (_click)="handleToggle()"></goab-filter-chip>`,
         webComponents: `<goa-filter-chip content="Active"></goa-filter-chip>`,
       },
@@ -27,7 +27,7 @@ export const filterChipConfigurations: ComponentConfigurations = {
       name: 'Selected state',
       description: 'Filter chip in selected state',
       code: {
-        react: `<GoabFilterChip content="In Progress" selected onClick={handleToggle} />`,
+        react: `<GoabxFilterChip content="In Progress" selected onClick={handleToggle} />`,
         angular: `<goab-filter-chip content="In Progress" [selected]="true" (_click)="handleToggle()"></goab-filter-chip>`,
         webComponents: `<goa-filter-chip content="In Progress" selected></goa-filter-chip>`,
       },
@@ -37,10 +37,10 @@ export const filterChipConfigurations: ComponentConfigurations = {
       name: 'Filter group',
       description: 'Multiple filter options',
       code: {
-        react: `<GoabFilterChip content="All" selected onClick={() => setFilter('all')} />
-<GoabFilterChip content="Active" onClick={() => setFilter('active')} />
-<GoabFilterChip content="Pending" onClick={() => setFilter('pending')} />
-<GoabFilterChip content="Completed" onClick={() => setFilter('completed')} />`,
+        react: `<GoabxFilterChip content="All" selected onClick={() => setFilter('all')} />
+<GoabxFilterChip content="Active" onClick={() => setFilter('active')} />
+<GoabxFilterChip content="Pending" onClick={() => setFilter('pending')} />
+<GoabxFilterChip content="Completed" onClick={() => setFilter('completed')} />`,
         angular: `<goab-filter-chip content="All" [selected]="filter === 'all'" (_click)="setFilter('all')"></goab-filter-chip>
 <goab-filter-chip content="Active" [selected]="filter === 'active'" (_click)="setFilter('active')"></goab-filter-chip>
 <goab-filter-chip content="Pending" [selected]="filter === 'pending'" (_click)="setFilter('pending')"></goab-filter-chip>
@@ -56,7 +56,7 @@ export const filterChipConfigurations: ComponentConfigurations = {
       name: 'Error state',
       description: 'Filter chip showing error',
       code: {
-        react: `<GoabFilterChip content="Invalid filter" error />`,
+        react: `<GoabxFilterChip content="Invalid filter" error />`,
         angular: `<goab-filter-chip content="Invalid filter" [error]="true"></goab-filter-chip>`,
         webComponents: `<goa-filter-chip content="Invalid filter" error></goa-filter-chip>`,
       },

--- a/docs/src/data/configurations/filter-chip.ts
+++ b/docs/src/data/configurations/filter-chip.ts
@@ -18,8 +18,8 @@ export const filterChipConfigurations: ComponentConfigurations = {
       description: 'Simple filter toggle',
       code: {
         react: `<GoabxFilterChip content="Active" onClick={handleToggle} />`,
-        angular: `<goab-filter-chip content="Active" (_click)="handleToggle()"></goab-filter-chip>`,
-        webComponents: `<goa-filter-chip content="Active"></goa-filter-chip>`,
+        angular: `<goabx-filter-chip content="Active" (_click)="handleToggle()"></goabx-filter-chip>`,
+        webComponents: `<goa-filter-chip version="2" content="Active"></goa-filter-chip>`,
       },
     },
     {
@@ -28,8 +28,8 @@ export const filterChipConfigurations: ComponentConfigurations = {
       description: 'Filter chip in selected state',
       code: {
         react: `<GoabxFilterChip content="In Progress" selected onClick={handleToggle} />`,
-        angular: `<goab-filter-chip content="In Progress" [selected]="true" (_click)="handleToggle()"></goab-filter-chip>`,
-        webComponents: `<goa-filter-chip content="In Progress" selected></goa-filter-chip>`,
+        angular: `<goabx-filter-chip content="In Progress" [selected]="true" (_click)="handleToggle()"></goabx-filter-chip>`,
+        webComponents: `<goa-filter-chip version="2" content="In Progress" selected></goa-filter-chip>`,
       },
     },
     {
@@ -41,14 +41,14 @@ export const filterChipConfigurations: ComponentConfigurations = {
 <GoabxFilterChip content="Active" onClick={() => setFilter('active')} />
 <GoabxFilterChip content="Pending" onClick={() => setFilter('pending')} />
 <GoabxFilterChip content="Completed" onClick={() => setFilter('completed')} />`,
-        angular: `<goab-filter-chip content="All" [selected]="filter === 'all'" (_click)="setFilter('all')"></goab-filter-chip>
-<goab-filter-chip content="Active" [selected]="filter === 'active'" (_click)="setFilter('active')"></goab-filter-chip>
-<goab-filter-chip content="Pending" [selected]="filter === 'pending'" (_click)="setFilter('pending')"></goab-filter-chip>
-<goab-filter-chip content="Completed" [selected]="filter === 'completed'" (_click)="setFilter('completed')"></goab-filter-chip>`,
-        webComponents: `<goa-filter-chip content="All" selected></goa-filter-chip>
-<goa-filter-chip content="Active"></goa-filter-chip>
-<goa-filter-chip content="Pending"></goa-filter-chip>
-<goa-filter-chip content="Completed"></goa-filter-chip>`,
+        angular: `<goabx-filter-chip content="All" [selected]="filter === 'all'" (_click)="setFilter('all')"></goabx-filter-chip>
+<goabx-filter-chip content="Active" [selected]="filter === 'active'" (_click)="setFilter('active')"></goabx-filter-chip>
+<goabx-filter-chip content="Pending" [selected]="filter === 'pending'" (_click)="setFilter('pending')"></goabx-filter-chip>
+<goabx-filter-chip content="Completed" [selected]="filter === 'completed'" (_click)="setFilter('completed')"></goabx-filter-chip>`,
+        webComponents: `<goa-filter-chip version="2" content="All" selected></goa-filter-chip>
+<goa-filter-chip version="2" content="Active"></goa-filter-chip>
+<goa-filter-chip version="2" content="Pending"></goa-filter-chip>
+<goa-filter-chip version="2" content="Completed"></goa-filter-chip>`,
       },
     },
     {
@@ -57,8 +57,8 @@ export const filterChipConfigurations: ComponentConfigurations = {
       description: 'Filter chip showing error',
       code: {
         react: `<GoabxFilterChip content="Invalid filter" error />`,
-        angular: `<goab-filter-chip content="Invalid filter" [error]="true"></goab-filter-chip>`,
-        webComponents: `<goa-filter-chip content="Invalid filter" error></goa-filter-chip>`,
+        angular: `<goabx-filter-chip content="Invalid filter" [error]="true"></goabx-filter-chip>`,
+        webComponents: `<goa-filter-chip version="2" content="Invalid filter" error></goa-filter-chip>`,
       },
     },
   ],

--- a/docs/src/data/configurations/focus-trap.ts
+++ b/docs/src/data/configurations/focus-trap.ts
@@ -18,13 +18,13 @@ export const focusTrapConfigurations: ComponentConfigurations = {
       description: 'Container that traps keyboard focus',
       code: {
         react: `<GoabFocusTrap active={isActive}>
-  <GoabFormItem label="Username" mb="l">
-    <GoabInput name="username" width="100%" />
-  </GoabFormItem>
-  <GoabFormItem label="Password" mb="l">
-    <GoabInput name="password" type="password" width="100%" />
-  </GoabFormItem>
-  <GoabButton>Submit</GoabButton>
+  <GoabxFormItem label="Username" mb="l">
+    <GoabxInput name="username" width="100%" />
+  </GoabxFormItem>
+  <GoabxFormItem label="Password" mb="l">
+    <GoabxInput name="password" type="password" width="100%" />
+  </GoabxFormItem>
+  <GoabxButton>Submit</GoabxButton>
 </GoabFocusTrap>`,
         angular: `<goab-focus-trap [active]="isActive">
   <goab-form-item label="Username" mb="l">

--- a/docs/src/data/configurations/focus-trap.ts
+++ b/docs/src/data/configurations/focus-trap.ts
@@ -27,22 +27,22 @@ export const focusTrapConfigurations: ComponentConfigurations = {
   <GoabxButton>Submit</GoabxButton>
 </GoabFocusTrap>`,
         angular: `<goab-focus-trap [active]="isActive">
-  <goab-form-item label="Username" mb="l">
-    <goab-input name="username" width="100%"></goab-input>
-  </goab-form-item>
-  <goab-form-item label="Password" mb="l">
-    <goab-input name="password" type="password" width="100%"></goab-input>
-  </goab-form-item>
-  <goab-button>Submit</goab-button>
+  <goabx-form-item label="Username" mb="l">
+    <goabx-input name="username" width="100%"></goabx-input>
+  </goabx-form-item>
+  <goabx-form-item label="Password" mb="l">
+    <goabx-input name="password" type="password" width="100%"></goabx-input>
+  </goabx-form-item>
+  <goabx-button>Submit</goabx-button>
 </goab-focus-trap>`,
         webComponents: `<goa-focus-trap active>
-  <goa-form-item label="Username" mb="l">
-    <goa-input name="username" width="100%"></goa-input>
+  <goa-form-item version="2" label="Username" mb="l">
+    <goa-input version="2" name="username" width="100%"></goa-input>
   </goa-form-item>
-  <goa-form-item label="Password" mb="l">
-    <goa-input name="password" type="password" width="100%"></goa-input>
+  <goa-form-item version="2" label="Password" mb="l">
+    <goa-input version="2" name="password" type="password" width="100%"></goa-input>
   </goa-form-item>
-  <goa-button>Submit</goa-button>
+  <goa-button version="2">Submit</goa-button>
 </goa-focus-trap>`,
       },
     },

--- a/docs/src/data/configurations/footer-meta-section.ts
+++ b/docs/src/data/configurations/footer-meta-section.ts
@@ -17,13 +17,13 @@ export const footerMetaSectionConfigurations: ComponentConfigurations = {
       name: 'Basic footer meta section',
       description: 'Meta links section within Footer',
       code: {
-        react: `<GoabFooter>
-  <GoabFooterMetaSection>
+        react: `<GoabxAppFooter>
+  <GoabxAppFooterMetaSection>
     <a href="/privacy">Privacy</a>
     <a href="/terms">Terms of use</a>
     <a href="/accessibility">Accessibility</a>
-  </GoabFooterMetaSection>
-</GoabFooter>`,
+  </GoabxAppFooterMetaSection>
+</GoabxAppFooter>`,
         angular: `<goab-footer>
   <goab-footer-meta-section>
     <a href="/privacy">Privacy</a>

--- a/docs/src/data/configurations/footer-nav-section.ts
+++ b/docs/src/data/configurations/footer-nav-section.ts
@@ -17,13 +17,13 @@ export const footerNavSectionConfigurations: ComponentConfigurations = {
       name: 'Basic footer nav section',
       description: 'Navigation section within Footer',
       code: {
-        react: `<GoabFooter>
-  <GoabFooterNavSection heading="Services">
+        react: `<GoabxAppFooter>
+  <GoabxAppFooterNavSection heading="Services">
     <a href="/apply">Apply online</a>
     <a href="/renew">Renew</a>
     <a href="/check-status">Check status</a>
-  </GoabFooterNavSection>
-</GoabFooter>`,
+  </GoabxAppFooterNavSection>
+</GoabxAppFooter>`,
         angular: `<goab-footer>
   <goab-footer-nav-section heading="Services">
     <a href="/apply">Apply online</a>

--- a/docs/src/data/configurations/footer.ts
+++ b/docs/src/data/configurations/footer.ts
@@ -17,7 +17,7 @@ export const footerConfigurations: ComponentConfigurations = {
       name: 'Basic footer',
       description: 'Simple page footer',
       code: {
-        react: `<GoabFooter />`,
+        react: `<GoabxAppFooter />`,
         angular: `<goab-footer></goab-footer>`,
         webComponents: `<goa-footer></goa-footer>`,
       },
@@ -27,17 +27,17 @@ export const footerConfigurations: ComponentConfigurations = {
       name: 'With navigation',
       description: 'Footer with navigation sections',
       code: {
-        react: `<GoabFooter>
-  <GoabFooterNavSection heading="Services">
+        react: `<GoabxAppFooter>
+  <GoabxAppFooterNavSection heading="Services">
     <a href="/apply">Apply online</a>
     <a href="/renew">Renew</a>
     <a href="/status">Check status</a>
-  </GoabFooterNavSection>
-  <GoabFooterNavSection heading="Contact">
+  </GoabxAppFooterNavSection>
+  <GoabxAppFooterNavSection heading="Contact">
     <a href="/help">Help center</a>
     <a href="/feedback">Feedback</a>
-  </GoabFooterNavSection>
-</GoabFooter>`,
+  </GoabxAppFooterNavSection>
+</GoabxAppFooter>`,
         angular: `<goab-footer>
   <goab-footer-nav-section heading="Services">
     <a href="/apply">Apply online</a>
@@ -67,13 +67,13 @@ export const footerConfigurations: ComponentConfigurations = {
       name: 'With meta section',
       description: 'Footer with copyright and links',
       code: {
-        react: `<GoabFooter>
-  <GoabFooterMetaSection>
+        react: `<GoabxAppFooter>
+  <GoabxAppFooterMetaSection>
     <a href="/privacy">Privacy</a>
     <a href="/terms">Terms of use</a>
     <a href="/accessibility">Accessibility</a>
-  </GoabFooterMetaSection>
-</GoabFooter>`,
+  </GoabxAppFooterMetaSection>
+</GoabxAppFooter>`,
         angular: `<goab-footer>
   <goab-footer-meta-section>
     <a href="/privacy">Privacy</a>

--- a/docs/src/data/configurations/form-item.ts
+++ b/docs/src/data/configurations/form-item.ts
@@ -21,11 +21,11 @@ export const formItemConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Email address" mb="l">
   <GoabxInput name="email" type="email" width="100%" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Email address" mb="l">
-  <goab-input name="email" type="email" width="100%"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Email address" mb="l">
-  <goa-input name="email" type="email" width="100%"></goa-input>
+        angular: `<goabx-form-item label="Email address" mb="l">
+  <goabx-input name="email" type="email" width="100%"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Email address" mb="l">
+  <goa-input version="2" name="email" type="email" width="100%"></goa-input>
 </goa-form-item>`,
       },
     },
@@ -37,11 +37,11 @@ export const formItemConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Password" helpText="Must be at least 8 characters" mb="l">
   <GoabxInput name="password" type="password" width="100%" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Password" helpText="Must be at least 8 characters" mb="l">
-  <goab-input name="password" type="password" width="100%"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Password" helpText="Must be at least 8 characters" mb="l">
-  <goa-input name="password" type="password" width="100%"></goa-input>
+        angular: `<goabx-form-item label="Password" helpText="Must be at least 8 characters" mb="l">
+  <goabx-input name="password" type="password" width="100%"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Password" helpText="Must be at least 8 characters" mb="l">
+  <goa-input version="2" name="password" type="password" width="100%"></goa-input>
 </goa-form-item>`,
       },
     },
@@ -53,11 +53,11 @@ export const formItemConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Full name" requirement="required" mb="l">
   <GoabxInput name="fullName" width="100%" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Full name" requirement="required" mb="l">
-  <goab-input name="fullName" width="100%"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Full name" requirement="required" mb="l">
-  <goa-input name="fullName" width="100%"></goa-input>
+        angular: `<goabx-form-item label="Full name" requirement="required" mb="l">
+  <goabx-input name="fullName" width="100%"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Full name" requirement="required" mb="l">
+  <goa-input version="2" name="fullName" width="100%"></goa-input>
 </goa-form-item>`,
       },
     },
@@ -69,11 +69,11 @@ export const formItemConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Middle name" requirement="optional" mb="l">
   <GoabxInput name="middleName" width="100%" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Middle name" requirement="optional" mb="l">
-  <goab-input name="middleName" width="100%"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Middle name" requirement="optional" mb="l">
-  <goa-input name="middleName" width="100%"></goa-input>
+        angular: `<goabx-form-item label="Middle name" requirement="optional" mb="l">
+  <goabx-input name="middleName" width="100%"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Middle name" requirement="optional" mb="l">
+  <goa-input version="2" name="middleName" width="100%"></goa-input>
 </goa-form-item>`,
       },
     },
@@ -85,11 +85,11 @@ export const formItemConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Email address" error="Please enter a valid email address" mb="l">
   <GoabxInput name="email" type="email" error width="100%" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Email address" error="Please enter a valid email address" mb="l">
-  <goab-input name="email" type="email" [error]="true" width="100%"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Email address" error="Please enter a valid email address" mb="l">
-  <goa-input name="email" type="email" error width="100%"></goa-input>
+        angular: `<goabx-form-item label="Email address" error="Please enter a valid email address" mb="l">
+  <goabx-input name="email" type="email" [error]="true" width="100%"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Email address" error="Please enter a valid email address" mb="l">
+  <goa-input version="2" name="email" type="email" error width="100%"></goa-input>
 </goa-form-item>`,
       },
     },
@@ -107,23 +107,23 @@ export const formItemConfigurations: ComponentConfigurations = {
 <GoabxFormItem label="Large label" labelSize="large" mb="l">
   <GoabxInput name="large" width="100%" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Compact label" labelSize="compact" mb="l">
-  <goab-input name="compact" width="100%"></goab-input>
-</goab-form-item>
-<goab-form-item label="Regular label" labelSize="regular" mb="l">
-  <goab-input name="regular" width="100%"></goab-input>
-</goab-form-item>
-<goab-form-item label="Large label" labelSize="large" mb="l">
-  <goab-input name="large" width="100%"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Compact label" labelsize="compact" mb="l">
-  <goa-input name="compact" width="100%"></goa-input>
+        angular: `<goabx-form-item label="Compact label" labelSize="compact" mb="l">
+  <goabx-input name="compact" width="100%"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Regular label" labelSize="regular" mb="l">
+  <goabx-input name="regular" width="100%"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Large label" labelSize="large" mb="l">
+  <goabx-input name="large" width="100%"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Compact label" labelsize="compact" mb="l">
+  <goa-input version="2" name="compact" width="100%"></goa-input>
 </goa-form-item>
-<goa-form-item label="Regular label" labelsize="regular" mb="l">
-  <goa-input name="regular" width="100%"></goa-input>
+<goa-form-item version="2" label="Regular label" labelsize="regular" mb="l">
+  <goa-input version="2" name="regular" width="100%"></goa-input>
 </goa-form-item>
-<goa-form-item label="Large label" labelsize="large" mb="l">
-  <goa-input name="large" width="100%"></goa-input>
+<goa-form-item version="2" label="Large label" labelsize="large" mb="l">
+  <goa-input version="2" name="large" width="100%"></goa-input>
 </goa-form-item>`,
       },
     },

--- a/docs/src/data/configurations/form-item.ts
+++ b/docs/src/data/configurations/form-item.ts
@@ -18,9 +18,9 @@ export const formItemConfigurations: ComponentConfigurations = {
       name: 'Basic example',
       description: 'Form item with label wrapping an input',
       code: {
-        react: `<GoabFormItem label="Email address" mb="l">
-  <GoabInput name="email" type="email" width="100%" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Email address" mb="l">
+  <GoabxInput name="email" type="email" width="100%" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Email address" mb="l">
   <goab-input name="email" type="email" width="100%"></goab-input>
 </goab-form-item>`,
@@ -34,9 +34,9 @@ export const formItemConfigurations: ComponentConfigurations = {
       name: 'With help text',
       description: 'Form item with additional guidance',
       code: {
-        react: `<GoabFormItem label="Password" helpText="Must be at least 8 characters" mb="l">
-  <GoabInput name="password" type="password" width="100%" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Password" helpText="Must be at least 8 characters" mb="l">
+  <GoabxInput name="password" type="password" width="100%" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Password" helpText="Must be at least 8 characters" mb="l">
   <goab-input name="password" type="password" width="100%"></goab-input>
 </goab-form-item>`,
@@ -50,9 +50,9 @@ export const formItemConfigurations: ComponentConfigurations = {
       name: 'Required field',
       description: 'Form item marked as required',
       code: {
-        react: `<GoabFormItem label="Full name" requirement="required" mb="l">
-  <GoabInput name="fullName" width="100%" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Full name" requirement="required" mb="l">
+  <GoabxInput name="fullName" width="100%" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Full name" requirement="required" mb="l">
   <goab-input name="fullName" width="100%"></goab-input>
 </goab-form-item>`,
@@ -66,9 +66,9 @@ export const formItemConfigurations: ComponentConfigurations = {
       name: 'Optional field',
       description: 'Form item marked as optional',
       code: {
-        react: `<GoabFormItem label="Middle name" requirement="optional" mb="l">
-  <GoabInput name="middleName" width="100%" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Middle name" requirement="optional" mb="l">
+  <GoabxInput name="middleName" width="100%" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Middle name" requirement="optional" mb="l">
   <goab-input name="middleName" width="100%"></goab-input>
 </goab-form-item>`,
@@ -82,9 +82,9 @@ export const formItemConfigurations: ComponentConfigurations = {
       name: 'With error',
       description: 'Form item showing validation error',
       code: {
-        react: `<GoabFormItem label="Email address" error="Please enter a valid email address" mb="l">
-  <GoabInput name="email" type="email" error width="100%" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Email address" error="Please enter a valid email address" mb="l">
+  <GoabxInput name="email" type="email" error width="100%" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Email address" error="Please enter a valid email address" mb="l">
   <goab-input name="email" type="email" [error]="true" width="100%"></goab-input>
 </goab-form-item>`,
@@ -98,15 +98,15 @@ export const formItemConfigurations: ComponentConfigurations = {
       name: 'Label sizes',
       description: 'Different label size options',
       code: {
-        react: `<GoabFormItem label="Compact label" labelSize="compact" mb="l">
-  <GoabInput name="compact" width="100%" />
-</GoabFormItem>
-<GoabFormItem label="Regular label" labelSize="regular" mb="l">
-  <GoabInput name="regular" width="100%" />
-</GoabFormItem>
-<GoabFormItem label="Large label" labelSize="large" mb="l">
-  <GoabInput name="large" width="100%" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Compact label" labelSize="compact" mb="l">
+  <GoabxInput name="compact" width="100%" />
+</GoabxFormItem>
+<GoabxFormItem label="Regular label" labelSize="regular" mb="l">
+  <GoabxInput name="regular" width="100%" />
+</GoabxFormItem>
+<GoabxFormItem label="Large label" labelSize="large" mb="l">
+  <GoabxInput name="large" width="100%" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Compact label" labelSize="compact" mb="l">
   <goab-input name="compact" width="100%"></goab-input>
 </goab-form-item>

--- a/docs/src/data/configurations/form.ts
+++ b/docs/src/data/configurations/form.ts
@@ -18,14 +18,14 @@ export const formConfigurations: ComponentConfigurations = {
       description: 'Simple form wrapper',
       code: {
         react: `<GoabForm onSubmit={handleSubmit}>
-  <GoabFormItem label="Name" mb="l">
-    <GoabInput name="name" width="100%" />
-  </GoabFormItem>
-  <GoabFormItem label="Email" mb="l">
-    <GoabInput name="email" type="email" width="100%" />
-  </GoabFormItem>
+  <GoabxFormItem label="Name" mb="l">
+    <GoabxInput name="name" width="100%" />
+  </GoabxFormItem>
+  <GoabxFormItem label="Email" mb="l">
+    <GoabxInput name="email" type="email" width="100%" />
+  </GoabxFormItem>
   <GoabButtonGroup mt="l">
-    <GoabButton type="submit">Submit</GoabButton>
+    <GoabxButton type="submit">Submit</GoabxButton>
   </GoabButtonGroup>
 </GoabForm>`,
         angular: `<goab-form (_submit)="handleSubmit($event)">

--- a/docs/src/data/configurations/form.ts
+++ b/docs/src/data/configurations/form.ts
@@ -29,25 +29,25 @@ export const formConfigurations: ComponentConfigurations = {
   </GoabButtonGroup>
 </GoabForm>`,
         angular: `<goab-form (_submit)="handleSubmit($event)">
-  <goab-form-item label="Name" mb="l">
-    <goab-input name="name" width="100%"></goab-input>
-  </goab-form-item>
-  <goab-form-item label="Email" mb="l">
-    <goab-input name="email" type="email" width="100%"></goab-input>
-  </goab-form-item>
+  <goabx-form-item label="Name" mb="l">
+    <goabx-input name="name" width="100%"></goabx-input>
+  </goabx-form-item>
+  <goabx-form-item label="Email" mb="l">
+    <goabx-input name="email" type="email" width="100%"></goabx-input>
+  </goabx-form-item>
   <goab-button-group mt="l">
-    <goab-button type="submit">Submit</goab-button>
+    <goabx-button type="submit">Submit</goabx-button>
   </goab-button-group>
 </goab-form>`,
         webComponents: `<goa-form>
-  <goa-form-item label="Name" mb="l">
-    <goa-input name="name" width="100%"></goa-input>
+  <goa-form-item version="2" label="Name" mb="l">
+    <goa-input version="2" name="name" width="100%"></goa-input>
   </goa-form-item>
-  <goa-form-item label="Email" mb="l">
-    <goa-input name="email" type="email" width="100%"></goa-input>
+  <goa-form-item version="2" label="Email" mb="l">
+    <goa-input version="2" name="email" type="email" width="100%"></goa-input>
   </goa-form-item>
   <goa-button-group mt="l">
-    <goa-button type="submit">Submit</goa-button>
+    <goa-button version="2" type="submit">Submit</goa-button>
   </goa-button-group>
 </goa-form>`,
       },

--- a/docs/src/data/configurations/hero-banner.ts
+++ b/docs/src/data/configurations/hero-banner.ts
@@ -49,8 +49,8 @@ export const heroBannerConfigurations: ComponentConfigurations = {
         react: `<GoabHeroBanner heading="Start your application">
   <p>Apply for government services quickly and easily online.</p>
   <GoabButtonGroup mt="l">
-    <GoabButton>Get started</GoabButton>
-    <GoabButton type="secondary">Learn more</GoabButton>
+    <GoabxButton>Get started</GoabxButton>
+    <GoabxButton type="secondary">Learn more</GoabxButton>
   </GoabButtonGroup>
 </GoabHeroBanner>`,
         angular: `<goab-hero-banner heading="Start your application">

--- a/docs/src/data/configurations/hero-banner.ts
+++ b/docs/src/data/configurations/hero-banner.ts
@@ -56,15 +56,15 @@ export const heroBannerConfigurations: ComponentConfigurations = {
         angular: `<goab-hero-banner heading="Start your application">
   <p>Apply for government services quickly and easily online.</p>
   <goab-button-group mt="l">
-    <goab-button>Get started</goab-button>
-    <goab-button type="secondary">Learn more</goab-button>
+    <goabx-button>Get started</goabx-button>
+    <goabx-button type="secondary">Learn more</goabx-button>
   </goab-button-group>
 </goab-hero-banner>`,
         webComponents: `<goa-hero-banner heading="Start your application">
   <p>Apply for government services quickly and easily online.</p>
   <goa-button-group mt="l">
-    <goa-button>Get started</goa-button>
-    <goa-button type="secondary">Learn more</goa-button>
+    <goa-button version="2">Get started</goa-button>
+    <goa-button version="2" type="secondary">Learn more</goa-button>
   </goa-button-group>
 </goa-hero-banner>`,
       },

--- a/docs/src/data/configurations/input.ts
+++ b/docs/src/data/configurations/input.ts
@@ -21,11 +21,11 @@ export const inputConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Full name" mb="l">
   <GoabxInput name="fullName" width="100%" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Full name" mb="l">
-  <goab-input name="fullName" width="100%"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Full name" mb="l">
-  <goa-input name="fullName" width="100%"></goa-input>
+        angular: `<goabx-form-item label="Full name" mb="l">
+  <goabx-input name="fullName" width="100%"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Full name" mb="l">
+  <goa-input version="2" name="fullName" width="100%"></goa-input>
 </goa-form-item>`,
       },
     },
@@ -46,29 +46,29 @@ export const inputConfigurations: ComponentConfigurations = {
 <GoabxFormItem label="Age" mb="l">
   <GoabxInput name="age" type="number" width="3ch" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Email address" mb="l">
-  <goab-input name="email" type="email" width="100%"></goab-input>
-</goab-form-item>
-<goab-form-item label="Password" mb="l">
-  <goab-input name="password" type="password" width="100%"></goab-input>
-</goab-form-item>
-<goab-form-item label="Date of birth" mb="l">
-  <goab-input name="dob" type="date"></goab-input>
-</goab-form-item>
-<goab-form-item label="Age" mb="l">
-  <goab-input name="age" type="number" width="3ch"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Email address" mb="l">
-  <goa-input name="email" type="email" width="100%"></goa-input>
+        angular: `<goabx-form-item label="Email address" mb="l">
+  <goabx-input name="email" type="email" width="100%"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Password" mb="l">
+  <goabx-input name="password" type="password" width="100%"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Date of birth" mb="l">
+  <goabx-input name="dob" type="date"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Age" mb="l">
+  <goabx-input name="age" type="number" width="3ch"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Email address" mb="l">
+  <goa-input version="2" name="email" type="email" width="100%"></goa-input>
 </goa-form-item>
-<goa-form-item label="Password" mb="l">
-  <goa-input name="password" type="password" width="100%"></goa-input>
+<goa-form-item version="2" label="Password" mb="l">
+  <goa-input version="2" name="password" type="password" width="100%"></goa-input>
 </goa-form-item>
-<goa-form-item label="Date of birth" mb="l">
-  <goa-input name="dob" type="date"></goa-input>
+<goa-form-item version="2" label="Date of birth" mb="l">
+  <goa-input version="2" name="dob" type="date"></goa-input>
 </goa-form-item>
-<goa-form-item label="Age" mb="l">
-  <goa-input name="age" type="number" width="3ch"></goa-input>
+<goa-form-item version="2" label="Age" mb="l">
+  <goa-input version="2" name="age" type="number" width="3ch"></goa-input>
 </goa-form-item>`,
       },
     },
@@ -83,17 +83,17 @@ export const inputConfigurations: ComponentConfigurations = {
 <GoabxFormItem label="Website" mb="l">
   <GoabxInput name="website" trailingIcon="open" width="100%" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Search" mb="l">
-  <goab-input name="search" leadingIcon="search" width="100%"></goab-input>
-</goab-form-item>
-<goab-form-item label="Website" mb="l">
-  <goab-input name="website" trailingIcon="open" width="100%"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Search" mb="l">
-  <goa-input name="search" leading-icon="search" width="100%"></goa-input>
+        angular: `<goabx-form-item label="Search" mb="l">
+  <goabx-input name="search" leadingIcon="search" width="100%"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Website" mb="l">
+  <goabx-input name="website" trailingIcon="open" width="100%"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Search" mb="l">
+  <goa-input version="2" name="search" leading-icon="search" width="100%"></goa-input>
 </goa-form-item>
-<goa-form-item label="Website" mb="l">
-  <goa-input name="website" trailing-icon="open" width="100%"></goa-input>
+<goa-form-item version="2" label="Website" mb="l">
+  <goa-input version="2" name="website" trailing-icon="open" width="100%"></goa-input>
 </goa-form-item>`,
       },
     },
@@ -111,23 +111,23 @@ export const inputConfigurations: ComponentConfigurations = {
 <GoabxFormItem label="SIN" mb="l">
   <GoabxInput name="sin" width="11ch" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Postal code" mb="l">
-  <goab-input name="postalCode" width="7ch"></goab-input>
-</goab-form-item>
-<goab-form-item label="Year" mb="l">
-  <goab-input name="year" type="number" width="4ch"></goab-input>
-</goab-form-item>
-<goab-form-item label="SIN" mb="l">
-  <goab-input name="sin" width="11ch"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Postal code" mb="l">
-  <goa-input name="postalCode" width="7ch"></goa-input>
+        angular: `<goabx-form-item label="Postal code" mb="l">
+  <goabx-input name="postalCode" width="7ch"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Year" mb="l">
+  <goabx-input name="year" type="number" width="4ch"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="SIN" mb="l">
+  <goabx-input name="sin" width="11ch"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Postal code" mb="l">
+  <goa-input version="2" name="postalCode" width="7ch"></goa-input>
 </goa-form-item>
-<goa-form-item label="Year" mb="l">
-  <goa-input name="year" type="number" width="4ch"></goa-input>
+<goa-form-item version="2" label="Year" mb="l">
+  <goa-input version="2" name="year" type="number" width="4ch"></goa-input>
 </goa-form-item>
-<goa-form-item label="SIN" mb="l">
-  <goa-input name="sin" width="11ch"></goa-input>
+<goa-form-item version="2" label="SIN" mb="l">
+  <goa-input version="2" name="sin" width="11ch"></goa-input>
 </goa-form-item>`,
       },
     },
@@ -142,17 +142,17 @@ export const inputConfigurations: ComponentConfigurations = {
 <GoabxFormItem label="Weight" mb="l">
   <GoabxInput name="weight" type="number" width="10ch" trailingContent="kg" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Price" mb="l">
-  <goab-input name="price" type="number" width="10ch" leadingContent="$"></goab-input>
-</goab-form-item>
-<goab-form-item label="Weight" mb="l">
-  <goab-input name="weight" type="number" width="10ch" trailingContent="kg"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Price" mb="l">
-  <goa-input name="price" type="number" width="10ch" leading-content="$"></goa-input>
+        angular: `<goabx-form-item label="Price" mb="l">
+  <goabx-input name="price" type="number" width="10ch" leadingContent="$"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Weight" mb="l">
+  <goabx-input name="weight" type="number" width="10ch" trailingContent="kg"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Price" mb="l">
+  <goa-input version="2" name="price" type="number" width="10ch" leading-content="$"></goa-input>
 </goa-form-item>
-<goa-form-item label="Weight" mb="l">
-  <goa-input name="weight" type="number" width="10ch" trailing-content="kg"></goa-input>
+<goa-form-item version="2" label="Weight" mb="l">
+  <goa-input version="2" name="weight" type="number" width="10ch" trailing-content="kg"></goa-input>
 </goa-form-item>`,
       },
     },
@@ -170,23 +170,23 @@ export const inputConfigurations: ComponentConfigurations = {
 <GoabxFormItem label="Input with error" error="This field is required" mb="l">
   <GoabxInput name="error" error width="100%" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Disabled input" mb="l">
-  <goab-input name="disabled" [disabled]="true" value="Cannot edit" width="100%"></goab-input>
-</goab-form-item>
-<goab-form-item label="Read-only input" mb="l">
-  <goab-input name="readonly" [readOnly]="true" value="View only" width="100%"></goab-input>
-</goab-form-item>
-<goab-form-item label="Input with error" error="This field is required" mb="l">
-  <goab-input name="error" [error]="true" width="100%"></goab-input>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Disabled input" mb="l">
-  <goa-input name="disabled" disabled value="Cannot edit" width="100%"></goa-input>
+        angular: `<goabx-form-item label="Disabled input" mb="l">
+  <goabx-input name="disabled" [disabled]="true" value="Cannot edit" width="100%"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Read-only input" mb="l">
+  <goabx-input name="readonly" [readOnly]="true" value="View only" width="100%"></goabx-input>
+</goabx-form-item>
+<goabx-form-item label="Input with error" error="This field is required" mb="l">
+  <goabx-input name="error" [error]="true" width="100%"></goabx-input>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Disabled input" mb="l">
+  <goa-input version="2" name="disabled" disabled value="Cannot edit" width="100%"></goa-input>
 </goa-form-item>
-<goa-form-item label="Read-only input" mb="l">
-  <goa-input name="readonly" read-only value="View only" width="100%"></goa-input>
+<goa-form-item version="2" label="Read-only input" mb="l">
+  <goa-input version="2" name="readonly" read-only value="View only" width="100%"></goa-input>
 </goa-form-item>
-<goa-form-item label="Input with error" error="This field is required" mb="l">
-  <goa-input name="error" error width="100%"></goa-input>
+<goa-form-item version="2" label="Input with error" error="This field is required" mb="l">
+  <goa-input version="2" name="error" error width="100%"></goa-input>
 </goa-form-item>`,
       },
     },

--- a/docs/src/data/configurations/input.ts
+++ b/docs/src/data/configurations/input.ts
@@ -18,9 +18,9 @@ export const inputConfigurations: ComponentConfigurations = {
       name: 'Basic example',
       description: 'Text input wrapped in FormItem with label',
       code: {
-        react: `<GoabFormItem label="Full name" mb="l">
-  <GoabInput name="fullName" width="100%" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Full name" mb="l">
+  <GoabxInput name="fullName" width="100%" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Full name" mb="l">
   <goab-input name="fullName" width="100%"></goab-input>
 </goab-form-item>`,
@@ -34,18 +34,18 @@ export const inputConfigurations: ComponentConfigurations = {
       name: 'Input types',
       description: 'Different input types for various data formats',
       code: {
-        react: `<GoabFormItem label="Email address" mb="l">
-  <GoabInput name="email" type="email" width="100%" />
-</GoabFormItem>
-<GoabFormItem label="Password" mb="l">
-  <GoabInput name="password" type="password" width="100%" />
-</GoabFormItem>
-<GoabFormItem label="Date of birth" mb="l">
-  <GoabInput name="dob" type="date" />
-</GoabFormItem>
-<GoabFormItem label="Age" mb="l">
-  <GoabInput name="age" type="number" width="3ch" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Email address" mb="l">
+  <GoabxInput name="email" type="email" width="100%" />
+</GoabxFormItem>
+<GoabxFormItem label="Password" mb="l">
+  <GoabxInput name="password" type="password" width="100%" />
+</GoabxFormItem>
+<GoabxFormItem label="Date of birth" mb="l">
+  <GoabxInput name="dob" type="date" />
+</GoabxFormItem>
+<GoabxFormItem label="Age" mb="l">
+  <GoabxInput name="age" type="number" width="3ch" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Email address" mb="l">
   <goab-input name="email" type="email" width="100%"></goab-input>
 </goab-form-item>
@@ -77,12 +77,12 @@ export const inputConfigurations: ComponentConfigurations = {
       name: 'With icons',
       description: 'Inputs with leading or trailing icons',
       code: {
-        react: `<GoabFormItem label="Search" mb="l">
-  <GoabInput name="search" leadingIcon="search" width="100%" />
-</GoabFormItem>
-<GoabFormItem label="Website" mb="l">
-  <GoabInput name="website" trailingIcon="open" width="100%" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Search" mb="l">
+  <GoabxInput name="search" leadingIcon="search" width="100%" />
+</GoabxFormItem>
+<GoabxFormItem label="Website" mb="l">
+  <GoabxInput name="website" trailingIcon="open" width="100%" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Search" mb="l">
   <goab-input name="search" leadingIcon="search" width="100%"></goab-input>
 </goab-form-item>
@@ -102,15 +102,15 @@ export const inputConfigurations: ComponentConfigurations = {
       name: 'Fixed widths',
       description: 'Inputs sized for specific data types',
       code: {
-        react: `<GoabFormItem label="Postal code" mb="l">
-  <GoabInput name="postalCode" width="7ch" />
-</GoabFormItem>
-<GoabFormItem label="Year" mb="l">
-  <GoabInput name="year" type="number" width="4ch" />
-</GoabFormItem>
-<GoabFormItem label="SIN" mb="l">
-  <GoabInput name="sin" width="11ch" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Postal code" mb="l">
+  <GoabxInput name="postalCode" width="7ch" />
+</GoabxFormItem>
+<GoabxFormItem label="Year" mb="l">
+  <GoabxInput name="year" type="number" width="4ch" />
+</GoabxFormItem>
+<GoabxFormItem label="SIN" mb="l">
+  <GoabxInput name="sin" width="11ch" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Postal code" mb="l">
   <goab-input name="postalCode" width="7ch"></goab-input>
 </goab-form-item>
@@ -136,12 +136,12 @@ export const inputConfigurations: ComponentConfigurations = {
       name: 'With leading or trailing content',
       description: 'Inputs with text content before or after the input field',
       code: {
-        react: `<GoabFormItem label="Price" mb="l">
-  <GoabInput name="price" type="number" width="10ch" leadingContent="$" />
-</GoabFormItem>
-<GoabFormItem label="Weight" mb="l">
-  <GoabInput name="weight" type="number" width="10ch" trailingContent="kg" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Price" mb="l">
+  <GoabxInput name="price" type="number" width="10ch" leadingContent="$" />
+</GoabxFormItem>
+<GoabxFormItem label="Weight" mb="l">
+  <GoabxInput name="weight" type="number" width="10ch" trailingContent="kg" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Price" mb="l">
   <goab-input name="price" type="number" width="10ch" leadingContent="$"></goab-input>
 </goab-form-item>
@@ -161,15 +161,15 @@ export const inputConfigurations: ComponentConfigurations = {
       name: 'States',
       description: 'Disabled, readonly, and error states',
       code: {
-        react: `<GoabFormItem label="Disabled input" mb="l">
-  <GoabInput name="disabled" disabled value="Cannot edit" width="100%" />
-</GoabFormItem>
-<GoabFormItem label="Read-only input" mb="l">
-  <GoabInput name="readonly" readOnly value="View only" width="100%" />
-</GoabFormItem>
-<GoabFormItem label="Input with error" error="This field is required" mb="l">
-  <GoabInput name="error" error width="100%" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Disabled input" mb="l">
+  <GoabxInput name="disabled" disabled value="Cannot edit" width="100%" />
+</GoabxFormItem>
+<GoabxFormItem label="Read-only input" mb="l">
+  <GoabxInput name="readonly" readOnly value="View only" width="100%" />
+</GoabxFormItem>
+<GoabxFormItem label="Input with error" error="This field is required" mb="l">
+  <GoabxInput name="error" error width="100%" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Disabled input" mb="l">
   <goab-input name="disabled" [disabled]="true" value="Cannot edit" width="100%"></goab-input>
 </goab-form-item>

--- a/docs/src/data/configurations/link.ts
+++ b/docs/src/data/configurations/link.ts
@@ -18,7 +18,7 @@ export const linkConfigurations: ComponentConfigurations = {
       description: 'Simple text link',
       code: {
         react: `<GoabxLink href="/about">Learn more about our services</GoabxLink>`,
-        angular: `<goab-link href="/about">Learn more about our services</goab-link>`,
+        angular: `<goabx-link href="/about">Learn more about our services</goabx-link>`,
         webComponents: `<goa-link href="/about">Learn more about our services</goa-link>`,
       },
     },
@@ -30,9 +30,9 @@ export const linkConfigurations: ComponentConfigurations = {
         react: `<GoabxLink href="https://www.alberta.ca">
   Visit Alberta.ca
 </GoabxLink>`,
-        angular: `<goab-link href="https://www.alberta.ca">
+        angular: `<goabx-link href="https://www.alberta.ca">
   Visit Alberta.ca
-</goab-link>`,
+</goabx-link>`,
         webComponents: `<goa-link href="https://www.alberta.ca">
   Visit Alberta.ca
 </goa-link>`,
@@ -47,7 +47,7 @@ export const linkConfigurations: ComponentConfigurations = {
   <GoabxLink href="/contact" color="light">Contact us</GoabxLink>
 </div>`,
         angular: `<div style="background-color: #333; padding: 1rem">
-  <goab-link href="/contact" color="light">Contact us</goab-link>
+  <goabx-link href="/contact" color="light">Contact us</goabx-link>
 </div>`,
         webComponents: `<div style="background-color: #333; padding: 1rem">
   <goa-link href="/contact" color="light">Contact us</goa-link>
@@ -62,9 +62,9 @@ export const linkConfigurations: ComponentConfigurations = {
         react: `<GoabxLink href="/download" leadingIcon="download">
   Download form
 </GoabxLink>`,
-        angular: `<goab-link href="/download" leadingIcon="download">
+        angular: `<goabx-link href="/download" leadingIcon="download">
   Download form
-</goab-link>`,
+</goabx-link>`,
         webComponents: `<goa-link href="/download" leadingicon="download">
   Download form
 </goa-link>`,
@@ -78,9 +78,9 @@ export const linkConfigurations: ComponentConfigurations = {
         react: `<GoabxLink href="/next" trailingIcon="arrow-forward">
   Continue to next step
 </GoabxLink>`,
-        angular: `<goab-link href="/next" trailingIcon="arrow-forward">
+        angular: `<goabx-link href="/next" trailingIcon="arrow-forward">
   Continue to next step
-</goab-link>`,
+</goabx-link>`,
         webComponents: `<goa-link href="/next" trailingicon="arrow-forward">
   Continue to next step
 </goa-link>`,

--- a/docs/src/data/configurations/link.ts
+++ b/docs/src/data/configurations/link.ts
@@ -17,7 +17,7 @@ export const linkConfigurations: ComponentConfigurations = {
       name: 'Basic link',
       description: 'Simple text link',
       code: {
-        react: `<GoabLink href="/about">Learn more about our services</GoabLink>`,
+        react: `<GoabxLink href="/about">Learn more about our services</GoabxLink>`,
         angular: `<goab-link href="/about">Learn more about our services</goab-link>`,
         webComponents: `<goa-link href="/about">Learn more about our services</goa-link>`,
       },
@@ -27,9 +27,9 @@ export const linkConfigurations: ComponentConfigurations = {
       name: 'External link',
       description: 'Link to external website (icon added automatically)',
       code: {
-        react: `<GoabLink href="https://www.alberta.ca">
+        react: `<GoabxLink href="https://www.alberta.ca">
   Visit Alberta.ca
-</GoabLink>`,
+</GoabxLink>`,
         angular: `<goab-link href="https://www.alberta.ca">
   Visit Alberta.ca
 </goab-link>`,
@@ -44,7 +44,7 @@ export const linkConfigurations: ComponentConfigurations = {
       description: 'Link for dark backgrounds',
       code: {
         react: `<div style={{ backgroundColor: '#333', padding: '1rem' }}>
-  <GoabLink href="/contact" color="light">Contact us</GoabLink>
+  <GoabxLink href="/contact" color="light">Contact us</GoabxLink>
 </div>`,
         angular: `<div style="background-color: #333; padding: 1rem">
   <goab-link href="/contact" color="light">Contact us</goab-link>
@@ -59,9 +59,9 @@ export const linkConfigurations: ComponentConfigurations = {
       name: 'With leading icon',
       description: 'Link with an icon before text',
       code: {
-        react: `<GoabLink href="/download" leadingIcon="download">
+        react: `<GoabxLink href="/download" leadingIcon="download">
   Download form
-</GoabLink>`,
+</GoabxLink>`,
         angular: `<goab-link href="/download" leadingIcon="download">
   Download form
 </goab-link>`,
@@ -75,9 +75,9 @@ export const linkConfigurations: ComponentConfigurations = {
       name: 'With trailing icon',
       description: 'Link with an icon after text',
       code: {
-        react: `<GoabLink href="/next" trailingIcon="arrow-forward">
+        react: `<GoabxLink href="/next" trailingIcon="arrow-forward">
   Continue to next step
-</GoabLink>`,
+</GoabxLink>`,
         angular: `<goab-link href="/next" trailingIcon="arrow-forward">
   Continue to next step
 </goab-link>`,

--- a/docs/src/data/configurations/menu-button.ts
+++ b/docs/src/data/configurations/menu-button.ts
@@ -24,13 +24,13 @@ export const menuButtonConfigurations: ComponentConfigurations = {
   <GoabMenuItem label="Delete" onClick={() => {}} />
 </GoabMenuButton>`,
         angular: `<goab-menu-button>
-  <goab-button slot="trigger">Actions</goab-button>
+  <goabx-button slot="trigger">Actions</goabx-button>
   <goab-menu-item label="Edit" (_click)="handleEdit()"></goab-menu-item>
   <goab-menu-item label="Copy" (_click)="handleCopy()"></goab-menu-item>
   <goab-menu-item label="Delete" (_click)="handleDelete()"></goab-menu-item>
 </goab-menu-button>`,
         webComponents: `<goa-menu-button>
-  <goa-button slot="trigger">Actions</goa-button>
+  <goa-button version="2" slot="trigger">Actions</goa-button>
   <goa-menu-item label="Edit"></goa-menu-item>
   <goa-menu-item label="Copy"></goa-menu-item>
   <goa-menu-item label="Delete"></goa-menu-item>
@@ -74,13 +74,13 @@ export const menuButtonConfigurations: ComponentConfigurations = {
   <GoabMenuItem label="Print" icon="print" onClick={() => {}} />
 </GoabMenuButton>`,
         angular: `<goab-menu-button>
-  <goab-button slot="trigger">Options</goab-button>
+  <goabx-button slot="trigger">Options</goabx-button>
   <goab-menu-item label="Download" icon="download" (_click)="handleDownload()"></goab-menu-item>
   <goab-menu-item label="Share" icon="share" (_click)="handleShare()"></goab-menu-item>
   <goab-menu-item label="Print" icon="print" (_click)="handlePrint()"></goab-menu-item>
 </goab-menu-button>`,
         webComponents: `<goa-menu-button>
-  <goa-button slot="trigger">Options</goa-button>
+  <goa-button version="2" slot="trigger">Options</goa-button>
   <goa-menu-item label="Download" icon="download"></goa-menu-item>
   <goa-menu-item label="Share" icon="share"></goa-menu-item>
   <goa-menu-item label="Print" icon="print"></goa-menu-item>

--- a/docs/src/data/configurations/menu-button.ts
+++ b/docs/src/data/configurations/menu-button.ts
@@ -18,7 +18,7 @@ export const menuButtonConfigurations: ComponentConfigurations = {
       description: 'Button with dropdown menu',
       code: {
         react: `<GoabMenuButton>
-  <GoabButton slot="trigger">Actions</GoabButton>
+  <GoabxButton slot="trigger">Actions</GoabxButton>
   <GoabMenuItem label="Edit" onClick={() => {}} />
   <GoabMenuItem label="Copy" onClick={() => {}} />
   <GoabMenuItem label="Delete" onClick={() => {}} />
@@ -68,7 +68,7 @@ export const menuButtonConfigurations: ComponentConfigurations = {
       description: 'Menu items with leading icons',
       code: {
         react: `<GoabMenuButton>
-  <GoabButton slot="trigger">Options</GoabButton>
+  <GoabxButton slot="trigger">Options</GoabxButton>
   <GoabMenuItem label="Download" icon="download" onClick={() => {}} />
   <GoabMenuItem label="Share" icon="share" onClick={() => {}} />
   <GoabMenuItem label="Print" icon="print" onClick={() => {}} />

--- a/docs/src/data/configurations/modal.ts
+++ b/docs/src/data/configurations/modal.ts
@@ -40,19 +40,19 @@ export const modalConfigurations: ComponentConfigurations = {
     <GoabxButton size="compact" onClick={handleConfirm}>Confirm</GoabxButton>
   </GoabButtonGroup>
 </GoabxModal>`,
-        angular: `<goab-modal heading="Confirm action" [open]="isOpen" [closable]="true" (_close)="handleClose()">
+        angular: `<goabx-modal heading="Confirm action" [open]="isOpen" [closable]="true" (_close)="handleClose()">
   <p>Are you sure you want to proceed with this action?</p>
   <goab-button-group alignment="end" mt="l">
-    <goab-button type="secondary" size="compact" (_click)="handleClose()">Cancel</goab-button>
-    <goab-button size="compact" (_click)="handleConfirm()">Confirm</goab-button>
+    <goabx-button type="secondary" size="compact" (_click)="handleClose()">Cancel</goabx-button>
+    <goabx-button size="compact" (_click)="handleConfirm()">Confirm</goabx-button>
   </goab-button-group>
-</goab-modal>`,
-        webComponents: `<goa-button id="open-modal">Open modal</goa-button>
-<goa-modal id="demo-modal" heading="Confirm action" closable>
+</goabx-modal>`,
+        webComponents: `<goa-button version="2" id="open-modal">Open modal</goa-button>
+<goa-modal version="2" id="demo-modal" heading="Confirm action" closable>
   <p>Are you sure you want to proceed with this action?</p>
   <goa-button-group alignment="end" mt="l">
-    <goa-button type="secondary" size="compact">Cancel</goa-button>
-    <goa-button size="compact">Confirm</goa-button>
+    <goa-button version="2" type="secondary" size="compact">Cancel</goa-button>
+    <goa-button version="2" size="compact">Confirm</goa-button>
   </goa-button-group>
 </goa-modal>
 <script>${modalScript}</script>`,
@@ -66,11 +66,11 @@ export const modalConfigurations: ComponentConfigurations = {
         react: `<GoabxModal heading="Animated modal" open={isOpen} transition="fast" closable onClose={handleClose}>
   <p>This modal animates when opening and closing.</p>
 </GoabxModal>`,
-        angular: `<goab-modal heading="Animated modal" [open]="isOpen" transition="fast" [closable]="true" (_close)="handleClose()">
+        angular: `<goabx-modal heading="Animated modal" [open]="isOpen" transition="fast" [closable]="true" (_close)="handleClose()">
   <p>This modal animates when opening and closing.</p>
-</goab-modal>`,
-        webComponents: `<goa-button id="open-modal">Open modal</goa-button>
-<goa-modal id="demo-modal" heading="Animated modal" transition="fast" closable>
+</goabx-modal>`,
+        webComponents: `<goa-button version="2" id="open-modal">Open modal</goa-button>
+<goa-modal version="2" id="demo-modal" heading="Animated modal" transition="fast" closable>
   <p>This modal animates when opening and closing.</p>
 </goa-modal>
 <script>${modalScript}</script>`,
@@ -84,11 +84,11 @@ export const modalConfigurations: ComponentConfigurations = {
         react: `<GoabxModal heading="Wide modal" open={isOpen} maxWidth="80ch" closable onClose={handleClose}>
   <p>This modal has a wider maximum width for more content.</p>
 </GoabxModal>`,
-        angular: `<goab-modal heading="Wide modal" [open]="isOpen" maxWidth="80ch" [closable]="true" (_close)="handleClose()">
+        angular: `<goabx-modal heading="Wide modal" [open]="isOpen" maxWidth="80ch" [closable]="true" (_close)="handleClose()">
   <p>This modal has a wider maximum width for more content.</p>
-</goab-modal>`,
-        webComponents: `<goa-button id="open-modal">Open modal</goa-button>
-<goa-modal id="demo-modal" heading="Wide modal" maxwidth="80ch" closable>
+</goabx-modal>`,
+        webComponents: `<goa-button version="2" id="open-modal">Open modal</goa-button>
+<goa-modal version="2" id="demo-modal" heading="Wide modal" maxwidth="80ch" closable>
   <p>This modal has a wider maximum width for more content.</p>
 </goa-modal>
 <script>${modalScript}</script>`,
@@ -106,19 +106,19 @@ export const modalConfigurations: ComponentConfigurations = {
     <GoabxButton variant="destructive" size="compact" onClick={handleDelete}>Delete</GoabxButton>
   </GoabButtonGroup>
 </GoabxModal>`,
-        angular: `<goab-modal heading="Are you sure you want to delete this item?" [open]="isOpen" [closable]="true" (_close)="handleClose()">
+        angular: `<goabx-modal heading="Are you sure you want to delete this item?" [open]="isOpen" [closable]="true" (_close)="handleClose()">
   <p>This action cannot be undone. The item will be permanently removed.</p>
   <goab-button-group alignment="end" mt="l">
-    <goab-button type="secondary" size="compact" (_click)="handleClose()">Cancel</goab-button>
-    <goab-button variant="destructive" size="compact" (_click)="handleDelete()">Delete</goab-button>
+    <goabx-button type="secondary" size="compact" (_click)="handleClose()">Cancel</goabx-button>
+    <goabx-button variant="destructive" size="compact" (_click)="handleDelete()">Delete</goabx-button>
   </goab-button-group>
-</goab-modal>`,
-        webComponents: `<goa-button id="open-modal">Open modal</goa-button>
-<goa-modal id="demo-modal" heading="Are you sure you want to delete this item?" closable>
+</goabx-modal>`,
+        webComponents: `<goa-button version="2" id="open-modal">Open modal</goa-button>
+<goa-modal version="2" id="demo-modal" heading="Are you sure you want to delete this item?" closable>
   <p>This action cannot be undone. The item will be permanently removed.</p>
   <goa-button-group alignment="end" mt="l">
-    <goa-button type="secondary" size="compact">Cancel</goa-button>
-    <goa-button variant="destructive" size="compact">Delete</goa-button>
+    <goa-button version="2" type="secondary" size="compact">Cancel</goa-button>
+    <goa-button version="2" variant="destructive" size="compact">Delete</goa-button>
   </goa-button-group>
 </goa-modal>
 <script>${modalScript}</script>`,

--- a/docs/src/data/configurations/modal.ts
+++ b/docs/src/data/configurations/modal.ts
@@ -33,13 +33,13 @@ export const modalConfigurations: ComponentConfigurations = {
       name: 'Basic modal',
       description: 'Simple modal with heading and content',
       code: {
-        react: `<GoabModal heading="Confirm action" open={isOpen} closable onClose={handleClose}>
+        react: `<GoabxModal heading="Confirm action" open={isOpen} closable onClose={handleClose}>
   <p>Are you sure you want to proceed with this action?</p>
   <GoabButtonGroup alignment="end" mt="l">
-    <GoabButton type="secondary" size="compact" onClick={handleClose}>Cancel</GoabButton>
-    <GoabButton size="compact" onClick={handleConfirm}>Confirm</GoabButton>
+    <GoabxButton type="secondary" size="compact" onClick={handleClose}>Cancel</GoabxButton>
+    <GoabxButton size="compact" onClick={handleConfirm}>Confirm</GoabxButton>
   </GoabButtonGroup>
-</GoabModal>`,
+</GoabxModal>`,
         angular: `<goab-modal heading="Confirm action" [open]="isOpen" [closable]="true" (_close)="handleClose()">
   <p>Are you sure you want to proceed with this action?</p>
   <goab-button-group alignment="end" mt="l">
@@ -63,9 +63,9 @@ export const modalConfigurations: ComponentConfigurations = {
       name: 'With transition',
       description: 'Modal with animated opening/closing',
       code: {
-        react: `<GoabModal heading="Animated modal" open={isOpen} transition="fast" closable onClose={handleClose}>
+        react: `<GoabxModal heading="Animated modal" open={isOpen} transition="fast" closable onClose={handleClose}>
   <p>This modal animates when opening and closing.</p>
-</GoabModal>`,
+</GoabxModal>`,
         angular: `<goab-modal heading="Animated modal" [open]="isOpen" transition="fast" [closable]="true" (_close)="handleClose()">
   <p>This modal animates when opening and closing.</p>
 </goab-modal>`,
@@ -81,9 +81,9 @@ export const modalConfigurations: ComponentConfigurations = {
       name: 'Custom width',
       description: 'Modal with specified maximum width',
       code: {
-        react: `<GoabModal heading="Wide modal" open={isOpen} maxWidth="80ch" closable onClose={handleClose}>
+        react: `<GoabxModal heading="Wide modal" open={isOpen} maxWidth="80ch" closable onClose={handleClose}>
   <p>This modal has a wider maximum width for more content.</p>
-</GoabModal>`,
+</GoabxModal>`,
         angular: `<goab-modal heading="Wide modal" [open]="isOpen" maxWidth="80ch" [closable]="true" (_close)="handleClose()">
   <p>This modal has a wider maximum width for more content.</p>
 </goab-modal>`,
@@ -99,13 +99,13 @@ export const modalConfigurations: ComponentConfigurations = {
       name: 'Destructive action',
       description: 'Confirmation modal for destructive actions',
       code: {
-        react: `<GoabModal heading="Are you sure you want to delete this item?" open={isOpen} closable onClose={handleClose}>
+        react: `<GoabxModal heading="Are you sure you want to delete this item?" open={isOpen} closable onClose={handleClose}>
   <p>This action cannot be undone. The item will be permanently removed.</p>
   <GoabButtonGroup alignment="end" mt="l">
-    <GoabButton type="secondary" size="compact" onClick={handleClose}>Cancel</GoabButton>
-    <GoabButton variant="destructive" size="compact" onClick={handleDelete}>Delete</GoabButton>
+    <GoabxButton type="secondary" size="compact" onClick={handleClose}>Cancel</GoabxButton>
+    <GoabxButton variant="destructive" size="compact" onClick={handleDelete}>Delete</GoabxButton>
   </GoabButtonGroup>
-</GoabModal>`,
+</GoabxModal>`,
         angular: `<goab-modal heading="Are you sure you want to delete this item?" [open]="isOpen" [closable]="true" (_close)="handleClose()">
   <p>This action cannot be undone. The item will be permanently removed.</p>
   <goab-button-group alignment="end" mt="l">

--- a/docs/src/data/configurations/notification.ts
+++ b/docs/src/data/configurations/notification.ts
@@ -20,10 +20,10 @@ export const notificationConfigurations: ComponentConfigurations = {
         react: `<GoabxNotification type="information">
   Your application has been received and is being processed.
 </GoabxNotification>`,
-        angular: `<goab-notification type="information">
+        angular: `<goabx-notification type="information">
   Your application has been received and is being processed.
-</goab-notification>`,
-        webComponents: `<goa-notification type="information">
+</goabx-notification>`,
+        webComponents: `<goa-notification version="2" type="information">
   Your application has been received and is being processed.
 </goa-notification>`,
       },
@@ -45,28 +45,28 @@ export const notificationConfigurations: ComponentConfigurations = {
 <GoabxNotification type="event">
   Event: Upcoming deadline or scheduled event.
 </GoabxNotification>`,
-        angular: `<goab-notification type="information">
+        angular: `<goabx-notification type="information">
   Information: General updates for the user.
-</goab-notification>
-<goab-notification type="important">
+</goabx-notification>
+<goabx-notification type="important">
   Important: Action may be required.
-</goab-notification>
-<goab-notification type="emergency">
+</goabx-notification>
+<goabx-notification type="emergency">
   Emergency: Critical issue requiring attention.
-</goab-notification>
-<goab-notification type="event">
+</goabx-notification>
+<goabx-notification type="event">
   Event: Upcoming deadline or scheduled event.
-</goab-notification>`,
-        webComponents: `<goa-notification type="information">
+</goabx-notification>`,
+        webComponents: `<goa-notification version="2" type="information">
   Information: General updates for the user.
 </goa-notification>
-<goa-notification type="important">
+<goa-notification version="2" type="important">
   Important: Action may be required.
 </goa-notification>
-<goa-notification type="emergency">
+<goa-notification version="2" type="emergency">
   Emergency: Critical issue requiring attention.
 </goa-notification>
-<goa-notification type="event">
+<goa-notification version="2" type="event">
   Event: Upcoming deadline or scheduled event.
 </goa-notification>`,
       },
@@ -79,10 +79,10 @@ export const notificationConfigurations: ComponentConfigurations = {
         react: `<GoabxNotification type="information" onDismiss={() => setVisible(false)}>
   This notification can be dismissed by clicking the close button.
 </GoabxNotification>`,
-        angular: `<goab-notification type="information" (_dismiss)="handleDismiss()">
+        angular: `<goabx-notification type="information" (_dismiss)="handleDismiss()">
   This notification can be dismissed by clicking the close button.
-</goab-notification>`,
-        webComponents: `<goa-notification type="information" dismissable>
+</goabx-notification>`,
+        webComponents: `<goa-notification version="2" type="information" dismissable>
   This notification can be dismissed by clicking the close button.
 </goa-notification>`,
       },
@@ -95,10 +95,10 @@ export const notificationConfigurations: ComponentConfigurations = {
         react: `<GoabxNotification type="information" maxWidth="600px">
   This notification has a maximum width for narrower layouts.
 </GoabxNotification>`,
-        angular: `<goab-notification type="information" maxWidth="600px">
+        angular: `<goabx-notification type="information" maxWidth="600px">
   This notification has a maximum width for narrower layouts.
-</goab-notification>`,
-        webComponents: `<goa-notification type="information" maxwidth="600px">
+</goabx-notification>`,
+        webComponents: `<goa-notification version="2" type="information" maxwidth="600px">
   This notification has a maximum width for narrower layouts.
 </goa-notification>`,
       },

--- a/docs/src/data/configurations/notification.ts
+++ b/docs/src/data/configurations/notification.ts
@@ -17,9 +17,9 @@ export const notificationConfigurations: ComponentConfigurations = {
       name: 'Information notification',
       description: 'Default informational notification',
       code: {
-        react: `<GoabNotification type="information">
+        react: `<GoabxNotification type="information">
   Your application has been received and is being processed.
-</GoabNotification>`,
+</GoabxNotification>`,
         angular: `<goab-notification type="information">
   Your application has been received and is being processed.
 </goab-notification>`,
@@ -33,18 +33,18 @@ export const notificationConfigurations: ComponentConfigurations = {
       name: 'Notification types',
       description: 'Different notification types for various contexts',
       code: {
-        react: `<GoabNotification type="information">
+        react: `<GoabxNotification type="information">
   Information: General updates for the user.
-</GoabNotification>
-<GoabNotification type="important">
+</GoabxNotification>
+<GoabxNotification type="important">
   Important: Action may be required.
-</GoabNotification>
-<GoabNotification type="emergency">
+</GoabxNotification>
+<GoabxNotification type="emergency">
   Emergency: Critical issue requiring attention.
-</GoabNotification>
-<GoabNotification type="event">
+</GoabxNotification>
+<GoabxNotification type="event">
   Event: Upcoming deadline or scheduled event.
-</GoabNotification>`,
+</GoabxNotification>`,
         angular: `<goab-notification type="information">
   Information: General updates for the user.
 </goab-notification>
@@ -76,9 +76,9 @@ export const notificationConfigurations: ComponentConfigurations = {
       name: 'Dismissable',
       description: 'Notification that can be closed',
       code: {
-        react: `<GoabNotification type="information" onDismiss={() => setVisible(false)}>
+        react: `<GoabxNotification type="information" onDismiss={() => setVisible(false)}>
   This notification can be dismissed by clicking the close button.
-</GoabNotification>`,
+</GoabxNotification>`,
         angular: `<goab-notification type="information" (_dismiss)="handleDismiss()">
   This notification can be dismissed by clicking the close button.
 </goab-notification>`,
@@ -92,9 +92,9 @@ export const notificationConfigurations: ComponentConfigurations = {
       name: 'With max width',
       description: 'Notification with constrained width',
       code: {
-        react: `<GoabNotification type="information" maxWidth="600px">
+        react: `<GoabxNotification type="information" maxWidth="600px">
   This notification has a maximum width for narrower layouts.
-</GoabNotification>`,
+</GoabxNotification>`,
         angular: `<goab-notification type="information" maxWidth="600px">
   This notification has a maximum width for narrower layouts.
 </goab-notification>`,

--- a/docs/src/data/configurations/pagination.ts
+++ b/docs/src/data/configurations/pagination.ts
@@ -17,7 +17,7 @@ export const paginationConfigurations: ComponentConfigurations = {
       name: 'Basic pagination',
       description: 'Simple pagination with page numbers',
       code: {
-        react: `<GoabPagination
+        react: `<GoabxPagination
   page={1}
   itemCount={100}
   perPageCount={10}
@@ -41,13 +41,13 @@ export const paginationConfigurations: ComponentConfigurations = {
       name: 'Variants',
       description: 'Different pagination styles',
       code: {
-        react: `<GoabPagination
+        react: `<GoabxPagination
   page={1}
   itemCount={50}
   perPageCount={10}
   variant="all"
 />
-<GoabPagination
+<GoabxPagination
   page={1}
   itemCount={50}
   perPageCount={10}
@@ -84,7 +84,7 @@ export const paginationConfigurations: ComponentConfigurations = {
       name: 'Middle page',
       description: 'Pagination showing middle page selected',
       code: {
-        react: `<GoabPagination
+        react: `<GoabxPagination
   page={5}
   itemCount={100}
   perPageCount={10}

--- a/docs/src/data/configurations/pagination.ts
+++ b/docs/src/data/configurations/pagination.ts
@@ -23,13 +23,13 @@ export const paginationConfigurations: ComponentConfigurations = {
   perPageCount={10}
   onChange={handlePageChange}
 />`,
-        angular: `<goab-pagination
+        angular: `<goabx-pagination
   [page]="1"
   [itemCount]="100"
   [perPageCount]="10"
   (_change)="handlePageChange($event)">
-</goab-pagination>`,
-        webComponents: `<goa-pagination
+</goabx-pagination>`,
+        webComponents: `<goa-pagination version="2"
   page="1"
   itemcount="100"
   perpagecount="10">
@@ -53,25 +53,25 @@ export const paginationConfigurations: ComponentConfigurations = {
   perPageCount={10}
   variant="links-only"
 />`,
-        angular: `<goab-pagination
+        angular: `<goabx-pagination
   [page]="1"
   [itemCount]="50"
   [perPageCount]="10"
   variant="all">
-</goab-pagination>
-<goab-pagination
+</goabx-pagination>
+<goabx-pagination
   [page]="1"
   [itemCount]="50"
   [perPageCount]="10"
   variant="links-only">
-</goab-pagination>`,
-        webComponents: `<goa-pagination
+</goabx-pagination>`,
+        webComponents: `<goa-pagination version="2"
   page="1"
   itemcount="50"
   perpagecount="10"
   variant="all">
 </goa-pagination>
-<goa-pagination
+<goa-pagination version="2"
   page="1"
   itemcount="50"
   perpagecount="10"
@@ -90,13 +90,13 @@ export const paginationConfigurations: ComponentConfigurations = {
   perPageCount={10}
   onChange={handlePageChange}
 />`,
-        angular: `<goab-pagination
+        angular: `<goabx-pagination
   [page]="5"
   [itemCount]="100"
   [perPageCount]="10"
   (_change)="handlePageChange($event)">
-</goab-pagination>`,
-        webComponents: `<goa-pagination
+</goabx-pagination>`,
+        webComponents: `<goa-pagination version="2"
   page="5"
   itemcount="100"
   perpagecount="10">

--- a/docs/src/data/configurations/popover.ts
+++ b/docs/src/data/configurations/popover.ts
@@ -18,7 +18,7 @@ export const popoverConfigurations: ComponentConfigurations = {
       description: 'Simple popover with content',
       code: {
         react: `<GoabPopover>
-  <GoabButton slot="target">Open popover</GoabButton>
+  <GoabxButton slot="target">Open popover</GoabxButton>
   <p>Popover content goes here. It can contain any content.</p>
 </GoabPopover>`,
         angular: `<goab-popover>
@@ -37,19 +37,19 @@ export const popoverConfigurations: ComponentConfigurations = {
       description: 'Popover placement options',
       code: {
         react: `<GoabPopover position="top">
-  <GoabButton slot="target">Top</GoabButton>
+  <GoabxButton slot="target">Top</GoabxButton>
   <p>Content above the trigger.</p>
 </GoabPopover>
 <GoabPopover position="bottom">
-  <GoabButton slot="target">Bottom</GoabButton>
+  <GoabxButton slot="target">Bottom</GoabxButton>
   <p>Content below the trigger.</p>
 </GoabPopover>
 <GoabPopover position="left">
-  <GoabButton slot="target">Left</GoabButton>
+  <GoabxButton slot="target">Left</GoabxButton>
   <p>Content to the left.</p>
 </GoabPopover>
 <GoabPopover position="right">
-  <GoabButton slot="target">Right</GoabButton>
+  <GoabxButton slot="target">Right</GoabxButton>
   <p>Content to the right.</p>
 </GoabPopover>`,
         angular: `<goab-popover position="top">
@@ -92,7 +92,7 @@ export const popoverConfigurations: ComponentConfigurations = {
       description: 'Popover with custom padding',
       code: {
         react: `<GoabPopover padded>
-  <GoabButton slot="target">Show details</GoabButton>
+  <GoabxButton slot="target">Show details</GoabxButton>
   <p>Content with default padding applied.</p>
 </GoabPopover>`,
         angular: `<goab-popover [padded]="true">
@@ -111,7 +111,7 @@ export const popoverConfigurations: ComponentConfigurations = {
       description: 'Popover with constrained width',
       code: {
         react: `<GoabPopover maxWidth="300px">
-  <GoabButton slot="target">More info</GoabButton>
+  <GoabxButton slot="target">More info</GoabxButton>
   <p>This popover has a maximum width of 300 pixels to control content width.</p>
 </GoabPopover>`,
         angular: `<goab-popover maxWidth="300px">

--- a/docs/src/data/configurations/popover.ts
+++ b/docs/src/data/configurations/popover.ts
@@ -22,11 +22,11 @@ export const popoverConfigurations: ComponentConfigurations = {
   <p>Popover content goes here. It can contain any content.</p>
 </GoabPopover>`,
         angular: `<goab-popover>
-  <goab-button slot="target">Open popover</goab-button>
+  <goabx-button slot="target">Open popover</goabx-button>
   <p>Popover content goes here. It can contain any content.</p>
 </goab-popover>`,
         webComponents: `<goa-popover>
-  <goa-button slot="target">Open popover</goa-button>
+  <goa-button version="2" slot="target">Open popover</goa-button>
   <p>Popover content goes here. It can contain any content.</p>
 </goa-popover>`,
       },
@@ -53,35 +53,35 @@ export const popoverConfigurations: ComponentConfigurations = {
   <p>Content to the right.</p>
 </GoabPopover>`,
         angular: `<goab-popover position="top">
-  <goab-button slot="target">Top</goab-button>
+  <goabx-button slot="target">Top</goabx-button>
   <p>Content above the trigger.</p>
 </goab-popover>
 <goab-popover position="bottom">
-  <goab-button slot="target">Bottom</goab-button>
+  <goabx-button slot="target">Bottom</goabx-button>
   <p>Content below the trigger.</p>
 </goab-popover>
 <goab-popover position="left">
-  <goab-button slot="target">Left</goab-button>
+  <goabx-button slot="target">Left</goabx-button>
   <p>Content to the left.</p>
 </goab-popover>
 <goab-popover position="right">
-  <goab-button slot="target">Right</goab-button>
+  <goabx-button slot="target">Right</goabx-button>
   <p>Content to the right.</p>
 </goab-popover>`,
         webComponents: `<goa-popover position="top">
-  <goa-button slot="target">Top</goa-button>
+  <goa-button version="2" slot="target">Top</goa-button>
   <p>Content above the trigger.</p>
 </goa-popover>
 <goa-popover position="bottom">
-  <goa-button slot="target">Bottom</goa-button>
+  <goa-button version="2" slot="target">Bottom</goa-button>
   <p>Content below the trigger.</p>
 </goa-popover>
 <goa-popover position="left">
-  <goa-button slot="target">Left</goa-button>
+  <goa-button version="2" slot="target">Left</goa-button>
   <p>Content to the left.</p>
 </goa-popover>
 <goa-popover position="right">
-  <goa-button slot="target">Right</goa-button>
+  <goa-button version="2" slot="target">Right</goa-button>
   <p>Content to the right.</p>
 </goa-popover>`,
       },
@@ -96,11 +96,11 @@ export const popoverConfigurations: ComponentConfigurations = {
   <p>Content with default padding applied.</p>
 </GoabPopover>`,
         angular: `<goab-popover [padded]="true">
-  <goab-button slot="target">Show details</goab-button>
+  <goabx-button slot="target">Show details</goabx-button>
   <p>Content with default padding applied.</p>
 </goab-popover>`,
         webComponents: `<goa-popover padded>
-  <goa-button slot="target">Show details</goa-button>
+  <goa-button version="2" slot="target">Show details</goa-button>
   <p>Content with default padding applied.</p>
 </goa-popover>`,
       },
@@ -115,11 +115,11 @@ export const popoverConfigurations: ComponentConfigurations = {
   <p>This popover has a maximum width of 300 pixels to control content width.</p>
 </GoabPopover>`,
         angular: `<goab-popover maxWidth="300px">
-  <goab-button slot="target">More info</goab-button>
+  <goabx-button slot="target">More info</goabx-button>
   <p>This popover has a maximum width of 300 pixels to control content width.</p>
 </goab-popover>`,
         webComponents: `<goa-popover maxwidth="300px">
-  <goa-button slot="target">More info</goa-button>
+  <goa-button version="2" slot="target">More info</goa-button>
   <p>This popover has a maximum width of 300 pixels to control content width.</p>
 </goa-popover>`,
       },

--- a/docs/src/data/configurations/radio-group.ts
+++ b/docs/src/data/configurations/radio-group.ts
@@ -24,15 +24,15 @@ export const radioGroupConfigurations: ComponentConfigurations = {
     <GoabxRadioItem value="mail" label="Mail" />
   </GoabxRadioGroup>
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Contact preference" mb="l">
-  <goab-radio-group name="contact" value="">
-    <goab-radio-item value="email" label="Email"></goab-radio-item>
-    <goab-radio-item value="phone" label="Phone"></goab-radio-item>
-    <goab-radio-item value="mail" label="Mail"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Contact preference" mb="l">
-  <goa-radio-group name="contact" value="">
+        angular: `<goabx-form-item label="Contact preference" mb="l">
+  <goabx-radio-group name="contact" value="">
+    <goabx-radio-item value="email" label="Email"></goabx-radio-item>
+    <goabx-radio-item value="phone" label="Phone"></goabx-radio-item>
+    <goabx-radio-item value="mail" label="Mail"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Contact preference" mb="l">
+  <goa-radio-group version="2" name="contact" value="">
     <goa-radio-item value="email" label="Email"></goa-radio-item>
     <goa-radio-item value="phone" label="Phone"></goa-radio-item>
     <goa-radio-item value="mail" label="Mail"></goa-radio-item>
@@ -52,15 +52,15 @@ export const radioGroupConfigurations: ComponentConfigurations = {
     <GoabxRadioItem value="large" label="Large" />
   </GoabxRadioGroup>
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Size" mb="l">
-  <goab-radio-group name="size" value="" orientation="horizontal">
-    <goab-radio-item value="small" label="Small"></goab-radio-item>
-    <goab-radio-item value="medium" label="Medium"></goab-radio-item>
-    <goab-radio-item value="large" label="Large"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Size" mb="l">
-  <goa-radio-group name="size" value="" orientation="horizontal">
+        angular: `<goabx-form-item label="Size" mb="l">
+  <goabx-radio-group name="size" value="" orientation="horizontal">
+    <goabx-radio-item value="small" label="Small"></goabx-radio-item>
+    <goabx-radio-item value="medium" label="Medium"></goabx-radio-item>
+    <goabx-radio-item value="large" label="Large"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Size" mb="l">
+  <goa-radio-group version="2" name="size" value="" orientation="horizontal">
     <goa-radio-item value="small" label="Small"></goa-radio-item>
     <goa-radio-item value="medium" label="Medium"></goa-radio-item>
     <goa-radio-item value="large" label="Large"></goa-radio-item>
@@ -80,15 +80,15 @@ export const radioGroupConfigurations: ComponentConfigurations = {
     <GoabxRadioItem value="overnight" label="Overnight" description="Next business day" />
   </GoabxRadioGroup>
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Shipping method" mb="l">
-  <goab-radio-group name="shipping" value="">
-    <goab-radio-item value="standard" label="Standard" description="5-7 business days"></goab-radio-item>
-    <goab-radio-item value="express" label="Express" description="2-3 business days"></goab-radio-item>
-    <goab-radio-item value="overnight" label="Overnight" description="Next business day"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Shipping method" mb="l">
-  <goa-radio-group name="shipping" value="">
+        angular: `<goabx-form-item label="Shipping method" mb="l">
+  <goabx-radio-group name="shipping" value="">
+    <goabx-radio-item value="standard" label="Standard" description="5-7 business days"></goabx-radio-item>
+    <goabx-radio-item value="express" label="Express" description="2-3 business days"></goabx-radio-item>
+    <goabx-radio-item value="overnight" label="Overnight" description="Next business day"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Shipping method" mb="l">
+  <goa-radio-group version="2" name="shipping" value="">
     <goa-radio-item value="standard" label="Standard" description="5-7 business days"></goa-radio-item>
     <goa-radio-item value="express" label="Express" description="2-3 business days"></goa-radio-item>
     <goa-radio-item value="overnight" label="Overnight" description="Next business day"></goa-radio-item>
@@ -108,15 +108,15 @@ export const radioGroupConfigurations: ComponentConfigurations = {
     <GoabxRadioItem value="weekly" label="Weekly summary" />
   </GoabxRadioGroup>
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Notification frequency" mb="l">
-  <goab-radio-group name="frequency" value="daily">
-    <goab-radio-item value="realtime" label="Real-time"></goab-radio-item>
-    <goab-radio-item value="daily" label="Daily digest"></goab-radio-item>
-    <goab-radio-item value="weekly" label="Weekly summary"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Notification frequency" mb="l">
-  <goa-radio-group name="frequency" value="daily">
+        angular: `<goabx-form-item label="Notification frequency" mb="l">
+  <goabx-radio-group name="frequency" value="daily">
+    <goabx-radio-item value="realtime" label="Real-time"></goabx-radio-item>
+    <goabx-radio-item value="daily" label="Daily digest"></goabx-radio-item>
+    <goabx-radio-item value="weekly" label="Weekly summary"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Notification frequency" mb="l">
+  <goa-radio-group version="2" name="frequency" value="daily">
     <goa-radio-item value="realtime" label="Real-time"></goa-radio-item>
     <goa-radio-item value="daily" label="Daily digest"></goa-radio-item>
     <goa-radio-item value="weekly" label="Weekly summary"></goa-radio-item>
@@ -135,14 +135,14 @@ export const radioGroupConfigurations: ComponentConfigurations = {
     <GoabxRadioItem value="premium" label="Premium" />
   </GoabxRadioGroup>
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Account type" mb="l">
-  <goab-radio-group name="accountType" value="basic" [disabled]="true">
-    <goab-radio-item value="basic" label="Basic"></goab-radio-item>
-    <goab-radio-item value="premium" label="Premium"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Account type" mb="l">
-  <goa-radio-group name="accountType" value="basic" disabled>
+        angular: `<goabx-form-item label="Account type" mb="l">
+  <goabx-radio-group name="accountType" value="basic" [disabled]="true">
+    <goabx-radio-item value="basic" label="Basic"></goabx-radio-item>
+    <goabx-radio-item value="premium" label="Premium"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Account type" mb="l">
+  <goa-radio-group version="2" name="accountType" value="basic" disabled>
     <goa-radio-item value="basic" label="Basic"></goa-radio-item>
     <goa-radio-item value="premium" label="Premium"></goa-radio-item>
   </goa-radio-group>
@@ -161,15 +161,15 @@ export const radioGroupConfigurations: ComponentConfigurations = {
     <GoabxRadioItem value="bank" label="Bank transfer" />
   </GoabxRadioGroup>
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Payment method" error="Please select a payment method" mb="l">
-  <goab-radio-group name="payment" value="" [error]="true">
-    <goab-radio-item value="credit" label="Credit card"></goab-radio-item>
-    <goab-radio-item value="debit" label="Debit card"></goab-radio-item>
-    <goab-radio-item value="bank" label="Bank transfer"></goab-radio-item>
-  </goab-radio-group>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Payment method" error="Please select a payment method" mb="l">
-  <goa-radio-group name="payment" value="" error>
+        angular: `<goabx-form-item label="Payment method" error="Please select a payment method" mb="l">
+  <goabx-radio-group name="payment" value="" [error]="true">
+    <goabx-radio-item value="credit" label="Credit card"></goabx-radio-item>
+    <goabx-radio-item value="debit" label="Debit card"></goabx-radio-item>
+    <goabx-radio-item value="bank" label="Bank transfer"></goabx-radio-item>
+  </goabx-radio-group>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Payment method" error="Please select a payment method" mb="l">
+  <goa-radio-group version="2" name="payment" value="" error>
     <goa-radio-item value="credit" label="Credit card"></goa-radio-item>
     <goa-radio-item value="debit" label="Debit card"></goa-radio-item>
     <goa-radio-item value="bank" label="Bank transfer"></goa-radio-item>

--- a/docs/src/data/configurations/radio-group.ts
+++ b/docs/src/data/configurations/radio-group.ts
@@ -17,13 +17,13 @@ export const radioGroupConfigurations: ComponentConfigurations = {
       name: 'Basic example',
       description: 'Radio group with vertical layout',
       code: {
-        react: `<GoabFormItem label="Contact preference" mb="l">
-  <GoabRadioGroup name="contact" value="">
-    <GoabRadioItem value="email" label="Email" />
-    <GoabRadioItem value="phone" label="Phone" />
-    <GoabRadioItem value="mail" label="Mail" />
-  </GoabRadioGroup>
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Contact preference" mb="l">
+  <GoabxRadioGroup name="contact" value="">
+    <GoabxRadioItem value="email" label="Email" />
+    <GoabxRadioItem value="phone" label="Phone" />
+    <GoabxRadioItem value="mail" label="Mail" />
+  </GoabxRadioGroup>
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Contact preference" mb="l">
   <goab-radio-group name="contact" value="">
     <goab-radio-item value="email" label="Email"></goab-radio-item>
@@ -45,13 +45,13 @@ export const radioGroupConfigurations: ComponentConfigurations = {
       name: 'Horizontal layout',
       description: 'Radio group arranged horizontally',
       code: {
-        react: `<GoabFormItem label="Size" mb="l">
-  <GoabRadioGroup name="size" value="" orientation="horizontal">
-    <GoabRadioItem value="small" label="Small" />
-    <GoabRadioItem value="medium" label="Medium" />
-    <GoabRadioItem value="large" label="Large" />
-  </GoabRadioGroup>
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Size" mb="l">
+  <GoabxRadioGroup name="size" value="" orientation="horizontal">
+    <GoabxRadioItem value="small" label="Small" />
+    <GoabxRadioItem value="medium" label="Medium" />
+    <GoabxRadioItem value="large" label="Large" />
+  </GoabxRadioGroup>
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Size" mb="l">
   <goab-radio-group name="size" value="" orientation="horizontal">
     <goab-radio-item value="small" label="Small"></goab-radio-item>
@@ -73,13 +73,13 @@ export const radioGroupConfigurations: ComponentConfigurations = {
       name: 'With descriptions',
       description: 'Radio items with additional description text',
       code: {
-        react: `<GoabFormItem label="Shipping method" mb="l">
-  <GoabRadioGroup name="shipping" value="">
-    <GoabRadioItem value="standard" label="Standard" description="5-7 business days" />
-    <GoabRadioItem value="express" label="Express" description="2-3 business days" />
-    <GoabRadioItem value="overnight" label="Overnight" description="Next business day" />
-  </GoabRadioGroup>
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Shipping method" mb="l">
+  <GoabxRadioGroup name="shipping" value="">
+    <GoabxRadioItem value="standard" label="Standard" description="5-7 business days" />
+    <GoabxRadioItem value="express" label="Express" description="2-3 business days" />
+    <GoabxRadioItem value="overnight" label="Overnight" description="Next business day" />
+  </GoabxRadioGroup>
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Shipping method" mb="l">
   <goab-radio-group name="shipping" value="">
     <goab-radio-item value="standard" label="Standard" description="5-7 business days"></goab-radio-item>
@@ -101,13 +101,13 @@ export const radioGroupConfigurations: ComponentConfigurations = {
       name: 'Preselected',
       description: 'Radio group with default selection',
       code: {
-        react: `<GoabFormItem label="Notification frequency" mb="l">
-  <GoabRadioGroup name="frequency" value="daily">
-    <GoabRadioItem value="realtime" label="Real-time" />
-    <GoabRadioItem value="daily" label="Daily digest" />
-    <GoabRadioItem value="weekly" label="Weekly summary" />
-  </GoabRadioGroup>
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Notification frequency" mb="l">
+  <GoabxRadioGroup name="frequency" value="daily">
+    <GoabxRadioItem value="realtime" label="Real-time" />
+    <GoabxRadioItem value="daily" label="Daily digest" />
+    <GoabxRadioItem value="weekly" label="Weekly summary" />
+  </GoabxRadioGroup>
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Notification frequency" mb="l">
   <goab-radio-group name="frequency" value="daily">
     <goab-radio-item value="realtime" label="Real-time"></goab-radio-item>
@@ -129,12 +129,12 @@ export const radioGroupConfigurations: ComponentConfigurations = {
       name: 'Disabled',
       description: 'Radio group in disabled state',
       code: {
-        react: `<GoabFormItem label="Account type" mb="l">
-  <GoabRadioGroup name="accountType" value="basic" disabled>
-    <GoabRadioItem value="basic" label="Basic" />
-    <GoabRadioItem value="premium" label="Premium" />
-  </GoabRadioGroup>
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Account type" mb="l">
+  <GoabxRadioGroup name="accountType" value="basic" disabled>
+    <GoabxRadioItem value="basic" label="Basic" />
+    <GoabxRadioItem value="premium" label="Premium" />
+  </GoabxRadioGroup>
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Account type" mb="l">
   <goab-radio-group name="accountType" value="basic" [disabled]="true">
     <goab-radio-item value="basic" label="Basic"></goab-radio-item>
@@ -154,13 +154,13 @@ export const radioGroupConfigurations: ComponentConfigurations = {
       name: 'Error state',
       description: 'Radio group showing validation error',
       code: {
-        react: `<GoabFormItem label="Payment method" error="Please select a payment method" mb="l">
-  <GoabRadioGroup name="payment" value="" error>
-    <GoabRadioItem value="credit" label="Credit card" />
-    <GoabRadioItem value="debit" label="Debit card" />
-    <GoabRadioItem value="bank" label="Bank transfer" />
-  </GoabRadioGroup>
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Payment method" error="Please select a payment method" mb="l">
+  <GoabxRadioGroup name="payment" value="" error>
+    <GoabxRadioItem value="credit" label="Credit card" />
+    <GoabxRadioItem value="debit" label="Debit card" />
+    <GoabxRadioItem value="bank" label="Bank transfer" />
+  </GoabxRadioGroup>
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Payment method" error="Please select a payment method" mb="l">
   <goab-radio-group name="payment" value="" [error]="true">
     <goab-radio-item value="credit" label="Credit card"></goab-radio-item>

--- a/docs/src/data/configurations/radio-item.ts
+++ b/docs/src/data/configurations/radio-item.ts
@@ -17,11 +17,11 @@ export const radioItemConfigurations: ComponentConfigurations = {
       name: 'Basic radio item',
       description: 'Single radio option within RadioGroup',
       code: {
-        react: `<GoabRadioGroup name="option" value="">
-  <GoabRadioItem value="opt1" label="Option 1" />
-  <GoabRadioItem value="opt2" label="Option 2" />
-  <GoabRadioItem value="opt3" label="Option 3" />
-</GoabRadioGroup>`,
+        react: `<GoabxRadioGroup name="option" value="">
+  <GoabxRadioItem value="opt1" label="Option 1" />
+  <GoabxRadioItem value="opt2" label="Option 2" />
+  <GoabxRadioItem value="opt3" label="Option 3" />
+</GoabxRadioGroup>`,
         angular: `<goab-radio-group name="option" value="">
   <goab-radio-item value="opt1" label="Option 1"></goab-radio-item>
   <goab-radio-item value="opt2" label="Option 2"></goab-radio-item>
@@ -39,10 +39,10 @@ export const radioItemConfigurations: ComponentConfigurations = {
       name: 'With description',
       description: 'Radio item with additional text',
       code: {
-        react: `<GoabRadioGroup name="plan" value="">
-  <GoabRadioItem value="basic" label="Basic" description="Free tier with limited features" />
-  <GoabRadioItem value="pro" label="Professional" description="Full access to all features" />
-</GoabRadioGroup>`,
+        react: `<GoabxRadioGroup name="plan" value="">
+  <GoabxRadioItem value="basic" label="Basic" description="Free tier with limited features" />
+  <GoabxRadioItem value="pro" label="Professional" description="Full access to all features" />
+</GoabxRadioGroup>`,
         angular: `<goab-radio-group name="plan" value="">
   <goab-radio-item value="basic" label="Basic" description="Free tier with limited features"></goab-radio-item>
   <goab-radio-item value="pro" label="Professional" description="Full access to all features"></goab-radio-item>

--- a/docs/src/data/configurations/radio-item.ts
+++ b/docs/src/data/configurations/radio-item.ts
@@ -22,12 +22,12 @@ export const radioItemConfigurations: ComponentConfigurations = {
   <GoabxRadioItem value="opt2" label="Option 2" />
   <GoabxRadioItem value="opt3" label="Option 3" />
 </GoabxRadioGroup>`,
-        angular: `<goab-radio-group name="option" value="">
-  <goab-radio-item value="opt1" label="Option 1"></goab-radio-item>
-  <goab-radio-item value="opt2" label="Option 2"></goab-radio-item>
-  <goab-radio-item value="opt3" label="Option 3"></goab-radio-item>
-</goab-radio-group>`,
-        webComponents: `<goa-radio-group name="option" value="">
+        angular: `<goabx-radio-group name="option" value="">
+  <goabx-radio-item value="opt1" label="Option 1"></goabx-radio-item>
+  <goabx-radio-item value="opt2" label="Option 2"></goabx-radio-item>
+  <goabx-radio-item value="opt3" label="Option 3"></goabx-radio-item>
+</goabx-radio-group>`,
+        webComponents: `<goa-radio-group version="2" name="option" value="">
   <goa-radio-item value="opt1" label="Option 1"></goa-radio-item>
   <goa-radio-item value="opt2" label="Option 2"></goa-radio-item>
   <goa-radio-item value="opt3" label="Option 3"></goa-radio-item>
@@ -43,11 +43,11 @@ export const radioItemConfigurations: ComponentConfigurations = {
   <GoabxRadioItem value="basic" label="Basic" description="Free tier with limited features" />
   <GoabxRadioItem value="pro" label="Professional" description="Full access to all features" />
 </GoabxRadioGroup>`,
-        angular: `<goab-radio-group name="plan" value="">
-  <goab-radio-item value="basic" label="Basic" description="Free tier with limited features"></goab-radio-item>
-  <goab-radio-item value="pro" label="Professional" description="Full access to all features"></goab-radio-item>
-</goab-radio-group>`,
-        webComponents: `<goa-radio-group name="plan" value="">
+        angular: `<goabx-radio-group name="plan" value="">
+  <goabx-radio-item value="basic" label="Basic" description="Free tier with limited features"></goabx-radio-item>
+  <goabx-radio-item value="pro" label="Professional" description="Full access to all features"></goabx-radio-item>
+</goabx-radio-group>`,
+        webComponents: `<goa-radio-group version="2" name="plan" value="">
   <goa-radio-item value="basic" label="Basic" description="Free tier with limited features"></goa-radio-item>
   <goa-radio-item value="pro" label="Professional" description="Full access to all features"></goa-radio-item>
 </goa-radio-group>`,

--- a/docs/src/data/configurations/side-menu-group.ts
+++ b/docs/src/data/configurations/side-menu-group.ts
@@ -17,17 +17,17 @@ export const sideMenuGroupConfigurations: ComponentConfigurations = {
       name: 'Basic side menu group',
       description: 'Collapsible group within SideMenu',
       code: {
-        react: `<GoabSideMenu>
-  <GoabSideMenuGroup heading="Applications">
+        react: `<GoabxSideMenu>
+  <GoabxSideMenuGroup heading="Applications">
     <a href="/apps/active">Active</a>
     <a href="/apps/pending">Pending</a>
     <a href="/apps/archived">Archived</a>
-  </GoabSideMenuGroup>
-  <GoabSideMenuGroup heading="Reports">
+  </GoabxSideMenuGroup>
+  <GoabxSideMenuGroup heading="Reports">
     <a href="/reports/monthly">Monthly</a>
     <a href="/reports/annual">Annual</a>
-  </GoabSideMenuGroup>
-</GoabSideMenu>`,
+  </GoabxSideMenuGroup>
+</GoabxSideMenu>`,
         angular: `<goab-side-menu>
   <goab-side-menu-group heading="Applications">
     <a href="/apps/active">Active</a>

--- a/docs/src/data/configurations/side-menu-group.ts
+++ b/docs/src/data/configurations/side-menu-group.ts
@@ -28,24 +28,24 @@ export const sideMenuGroupConfigurations: ComponentConfigurations = {
     <a href="/reports/annual">Annual</a>
   </GoabxSideMenuGroup>
 </GoabxSideMenu>`,
-        angular: `<goab-side-menu>
-  <goab-side-menu-group heading="Applications">
+        angular: `<goabx-side-menu>
+  <goabx-side-menu-group heading="Applications">
     <a href="/apps/active">Active</a>
     <a href="/apps/pending">Pending</a>
     <a href="/apps/archived">Archived</a>
-  </goab-side-menu-group>
-  <goab-side-menu-group heading="Reports">
+  </goabx-side-menu-group>
+  <goabx-side-menu-group heading="Reports">
     <a href="/reports/monthly">Monthly</a>
     <a href="/reports/annual">Annual</a>
-  </goab-side-menu-group>
-</goab-side-menu>`,
-        webComponents: `<goa-side-menu>
-  <goa-side-menu-group heading="Applications">
+  </goabx-side-menu-group>
+</goabx-side-menu>`,
+        webComponents: `<goa-side-menu version="2">
+  <goa-side-menu-group version="2" heading="Applications">
     <a href="/apps/active">Active</a>
     <a href="/apps/pending">Pending</a>
     <a href="/apps/archived">Archived</a>
   </goa-side-menu-group>
-  <goa-side-menu-group heading="Reports">
+  <goa-side-menu-group version="2" heading="Reports">
     <a href="/reports/monthly">Monthly</a>
     <a href="/reports/annual">Annual</a>
   </goa-side-menu-group>

--- a/docs/src/data/configurations/side-menu-heading.ts
+++ b/docs/src/data/configurations/side-menu-heading.ts
@@ -17,14 +17,14 @@ export const sideMenuHeadingConfigurations: ComponentConfigurations = {
       name: 'Basic side menu heading',
       description: 'Section heading within SideMenu',
       code: {
-        react: `<GoabSideMenu>
-  <GoabSideMenuHeading>Main Menu</GoabSideMenuHeading>
+        react: `<GoabxSideMenu>
+  <GoabxSideMenuHeading>Main Menu</GoabxSideMenuHeading>
   <a href="/dashboard">Dashboard</a>
   <a href="/reports">Reports</a>
-  <GoabSideMenuHeading>Settings</GoabSideMenuHeading>
+  <GoabxSideMenuHeading>Settings</GoabxSideMenuHeading>
   <a href="/profile">Profile</a>
   <a href="/preferences">Preferences</a>
-</GoabSideMenu>`,
+</GoabxSideMenu>`,
         angular: `<goab-side-menu>
   <goab-side-menu-heading>Main Menu</goab-side-menu-heading>
   <a href="/dashboard">Dashboard</a>

--- a/docs/src/data/configurations/side-menu-heading.ts
+++ b/docs/src/data/configurations/side-menu-heading.ts
@@ -25,19 +25,19 @@ export const sideMenuHeadingConfigurations: ComponentConfigurations = {
   <a href="/profile">Profile</a>
   <a href="/preferences">Preferences</a>
 </GoabxSideMenu>`,
-        angular: `<goab-side-menu>
-  <goab-side-menu-heading>Main Menu</goab-side-menu-heading>
+        angular: `<goabx-side-menu>
+  <goabx-side-menu-heading>Main Menu</goabx-side-menu-heading>
   <a href="/dashboard">Dashboard</a>
   <a href="/reports">Reports</a>
-  <goab-side-menu-heading>Settings</goab-side-menu-heading>
+  <goabx-side-menu-heading>Settings</goabx-side-menu-heading>
   <a href="/profile">Profile</a>
   <a href="/preferences">Preferences</a>
-</goab-side-menu>`,
-        webComponents: `<goa-side-menu>
-  <goa-side-menu-heading>Main Menu</goa-side-menu-heading>
+</goabx-side-menu>`,
+        webComponents: `<goa-side-menu version="2">
+  <goa-side-menu-heading version="2">Main Menu</goa-side-menu-heading>
   <a href="/dashboard">Dashboard</a>
   <a href="/reports">Reports</a>
-  <goa-side-menu-heading>Settings</goa-side-menu-heading>
+  <goa-side-menu-heading version="2">Settings</goa-side-menu-heading>
   <a href="/profile">Profile</a>
   <a href="/preferences">Preferences</a>
 </goa-side-menu>`,

--- a/docs/src/data/configurations/side-menu.ts
+++ b/docs/src/data/configurations/side-menu.ts
@@ -25,14 +25,14 @@ export const sideMenuConfigurations: ComponentConfigurations = {
   </GoabxSideMenu>
 </div>`,
         angular: `<div style="width: 200px">
-  <goab-side-menu heading="My Application" url="/">
+  <goabx-side-menu heading="My Application" url="/">
     <a href="/overview">Overview</a>
     <a href="/details">Details</a>
     <a href="/settings">Settings</a>
-  </goab-side-menu>
+  </goabx-side-menu>
 </div>`,
         webComponents: `<div style="width: 200px">
-  <goa-side-menu heading="My Application" url="/">
+  <goa-side-menu version="2" heading="My Application" url="/">
     <a href="/overview">Overview</a>
     <a href="/details">Details</a>
     <a href="/settings">Settings</a>
@@ -56,21 +56,21 @@ export const sideMenuConfigurations: ComponentConfigurations = {
   </GoabxSideMenu>
 </div>`,
         angular: `<div style="width: 200px">
-  <goab-side-menu heading="My Application" url="/">
-    <goab-side-menu-heading>Main</goab-side-menu-heading>
+  <goabx-side-menu heading="My Application" url="/">
+    <goabx-side-menu-heading>Main</goabx-side-menu-heading>
     <a href="/dashboard">Dashboard</a>
     <a href="/reports">Reports</a>
-    <goab-side-menu-heading>Settings</goab-side-menu-heading>
+    <goabx-side-menu-heading>Settings</goabx-side-menu-heading>
     <a href="/profile">Profile</a>
     <a href="/preferences">Preferences</a>
-  </goab-side-menu>
+  </goabx-side-menu>
 </div>`,
         webComponents: `<div style="width: 200px">
-  <goa-side-menu heading="My Application" url="/">
-    <goa-side-menu-heading>Main</goa-side-menu-heading>
+  <goa-side-menu version="2" heading="My Application" url="/">
+    <goa-side-menu-heading version="2">Main</goa-side-menu-heading>
     <a href="/dashboard">Dashboard</a>
     <a href="/reports">Reports</a>
-    <goa-side-menu-heading>Settings</goa-side-menu-heading>
+    <goa-side-menu-heading version="2">Settings</goa-side-menu-heading>
     <a href="/profile">Profile</a>
     <a href="/preferences">Preferences</a>
   </goa-side-menu>
@@ -96,26 +96,26 @@ export const sideMenuConfigurations: ComponentConfigurations = {
   </GoabxSideMenu>
 </div>`,
         angular: `<div style="width: 200px">
-  <goab-side-menu heading="My Application" url="/">
-    <goab-side-menu-group heading="Applications">
+  <goabx-side-menu heading="My Application" url="/">
+    <goabx-side-menu-group heading="Applications">
       <a href="/apps/active">Active</a>
       <a href="/apps/pending">Pending</a>
       <a href="/apps/archived">Archived</a>
-    </goab-side-menu-group>
-    <goab-side-menu-group heading="Reports">
+    </goabx-side-menu-group>
+    <goabx-side-menu-group heading="Reports">
       <a href="/reports/monthly">Monthly</a>
       <a href="/reports/annual">Annual</a>
-    </goab-side-menu-group>
-  </goab-side-menu>
+    </goabx-side-menu-group>
+  </goabx-side-menu>
 </div>`,
         webComponents: `<div style="width: 200px">
-  <goa-side-menu heading="My Application" url="/">
-    <goa-side-menu-group heading="Applications">
+  <goa-side-menu version="2" heading="My Application" url="/">
+    <goa-side-menu-group version="2" heading="Applications">
       <a href="/apps/active">Active</a>
       <a href="/apps/pending">Pending</a>
       <a href="/apps/archived">Archived</a>
     </goa-side-menu-group>
-    <goa-side-menu-group heading="Reports">
+    <goa-side-menu-group version="2" heading="Reports">
       <a href="/reports/monthly">Monthly</a>
       <a href="/reports/annual">Annual</a>
     </goa-side-menu-group>

--- a/docs/src/data/configurations/side-menu.ts
+++ b/docs/src/data/configurations/side-menu.ts
@@ -18,11 +18,11 @@ export const sideMenuConfigurations: ComponentConfigurations = {
       description: 'Simple navigation menu',
       code: {
         react: `<div style={{ width: '200px' }}>
-  <GoabSideMenu heading="My Application" url="/">
+  <GoabxSideMenu heading="My Application" url="/">
     <a href="/overview">Overview</a>
     <a href="/details">Details</a>
     <a href="/settings">Settings</a>
-  </GoabSideMenu>
+  </GoabxSideMenu>
 </div>`,
         angular: `<div style="width: 200px">
   <goab-side-menu heading="My Application" url="/">
@@ -46,14 +46,14 @@ export const sideMenuConfigurations: ComponentConfigurations = {
       description: 'Menu items organized into groups',
       code: {
         react: `<div style={{ width: '200px' }}>
-  <GoabSideMenu heading="My Application" url="/">
-    <GoabSideMenuHeading>Main</GoabSideMenuHeading>
+  <GoabxSideMenu heading="My Application" url="/">
+    <GoabxSideMenuHeading>Main</GoabxSideMenuHeading>
     <a href="/dashboard">Dashboard</a>
     <a href="/reports">Reports</a>
-    <GoabSideMenuHeading>Settings</GoabSideMenuHeading>
+    <GoabxSideMenuHeading>Settings</GoabxSideMenuHeading>
     <a href="/profile">Profile</a>
     <a href="/preferences">Preferences</a>
-  </GoabSideMenu>
+  </GoabxSideMenu>
 </div>`,
         angular: `<div style="width: 200px">
   <goab-side-menu heading="My Application" url="/">
@@ -83,17 +83,17 @@ export const sideMenuConfigurations: ComponentConfigurations = {
       description: 'Collapsible menu sections',
       code: {
         react: `<div style={{ width: '200px' }}>
-  <GoabSideMenu heading="My Application" url="/">
-    <GoabSideMenuGroup heading="Applications">
+  <GoabxSideMenu heading="My Application" url="/">
+    <GoabxSideMenuGroup heading="Applications">
       <a href="/apps/active">Active</a>
       <a href="/apps/pending">Pending</a>
       <a href="/apps/archived">Archived</a>
-    </GoabSideMenuGroup>
-    <GoabSideMenuGroup heading="Reports">
+    </GoabxSideMenuGroup>
+    <GoabxSideMenuGroup heading="Reports">
       <a href="/reports/monthly">Monthly</a>
       <a href="/reports/annual">Annual</a>
-    </GoabSideMenuGroup>
-  </GoabSideMenu>
+    </GoabxSideMenuGroup>
+  </GoabxSideMenu>
 </div>`,
         angular: `<div style="width: 200px">
   <goab-side-menu heading="My Application" url="/">

--- a/docs/src/data/configurations/tab.ts
+++ b/docs/src/data/configurations/tab.ts
@@ -17,14 +17,14 @@ export const tabConfigurations: ComponentConfigurations = {
       name: 'Basic tab',
       description: 'Single tab within Tabs component',
       code: {
-        react: `<GoabTabs>
+        react: `<GoabxTabs>
   <GoabTab heading="First tab">
     Content for the first tab.
   </GoabTab>
   <GoabTab heading="Second tab">
     Content for the second tab.
   </GoabTab>
-</GoabTabs>`,
+</GoabxTabs>`,
         angular: `<goab-tabs>
   <goab-tab heading="First tab">
     Content for the first tab.

--- a/docs/src/data/configurations/tab.ts
+++ b/docs/src/data/configurations/tab.ts
@@ -25,15 +25,15 @@ export const tabConfigurations: ComponentConfigurations = {
     Content for the second tab.
   </GoabTab>
 </GoabxTabs>`,
-        angular: `<goab-tabs>
+        angular: `<goabx-tabs>
   <goab-tab heading="First tab">
     Content for the first tab.
   </goab-tab>
   <goab-tab heading="Second tab">
     Content for the second tab.
   </goab-tab>
-</goab-tabs>`,
-        webComponents: `<goa-tabs>
+</goabx-tabs>`,
+        webComponents: `<goa-tabs version="2">
   <goa-tab heading="First tab">
     Content for the first tab.
   </goa-tab>

--- a/docs/src/data/configurations/table.ts
+++ b/docs/src/data/configurations/table.ts
@@ -38,7 +38,7 @@ export const tableConfigurations: ComponentConfigurations = {
     </tr>
   </tbody>
 </GoabxTable>`,
-        angular: `<goab-table>
+        angular: `<goabx-table>
   <thead>
     <tr>
       <th>Name</th>
@@ -58,8 +58,8 @@ export const tableConfigurations: ComponentConfigurations = {
       <td>Jan 16, 2024</td>
     </tr>
   </tbody>
-</goab-table>`,
-        webComponents: `<goa-table>
+</goabx-table>`,
+        webComponents: `<goa-table version="2">
   <table>
     <thead>
       <tr>
@@ -115,7 +115,7 @@ export const tableConfigurations: ComponentConfigurations = {
     </tr>
   </tbody>
 </GoabxTable>`,
-        angular: `<goab-table [striped]="true">
+        angular: `<goabx-table [striped]="true">
   <thead>
     <tr>
       <th>Item</th>
@@ -140,8 +140,8 @@ export const tableConfigurations: ComponentConfigurations = {
       <td>$10.00</td>
     </tr>
   </tbody>
-</goab-table>`,
-        webComponents: `<goa-table striped>
+</goabx-table>`,
+        webComponents: `<goa-table version="2" striped>
   <table>
     <thead>
       <tr>
@@ -194,7 +194,7 @@ export const tableConfigurations: ComponentConfigurations = {
     </tr>
   </tbody>
 </GoabxTable>`,
-        angular: `<goab-table variant="relaxed">
+        angular: `<goabx-table variant="relaxed">
   <thead>
     <tr>
       <th>Service</th>
@@ -211,8 +211,8 @@ export const tableConfigurations: ComponentConfigurations = {
       <td>Register a new or used vehicle</td>
     </tr>
   </tbody>
-</goab-table>`,
-        webComponents: `<goa-table variant="relaxed">
+</goabx-table>`,
+        webComponents: `<goa-table version="2" variant="relaxed">
   <table>
     <thead>
       <tr>
@@ -265,7 +265,7 @@ export const tableConfigurations: ComponentConfigurations = {
     </tr>
   </tbody>
 </GoabxTable>`,
-        angular: `<goab-table [stickyHeader]="true" width="100%">
+        angular: `<goabx-table [stickyHeader]="true" width="100%">
   <thead>
     <tr>
       <th>ID</th>
@@ -290,8 +290,8 @@ export const tableConfigurations: ComponentConfigurations = {
       <td>Finance</td>
     </tr>
   </tbody>
-</goab-table>`,
-        webComponents: `<goa-table stickyheader width="100%">
+</goabx-table>`,
+        webComponents: `<goa-table version="2" stickyheader width="100%">
   <table>
     <thead>
       <tr>
@@ -350,7 +350,7 @@ export const tableConfigurations: ComponentConfigurations = {
     </tr>
   </tbody>
 </GoabxTable>`,
-        angular: `<goab-table width="100%" [striped]="true">
+        angular: `<goabx-table width="100%" [striped]="true">
   <thead>
     <tr>
       <th>Application ID</th>
@@ -373,8 +373,8 @@ export const tableConfigurations: ComponentConfigurations = {
       <td>Jan 14, 2024</td>
     </tr>
   </tbody>
-</goab-table>`,
-        webComponents: `<goa-table width="100%" striped>
+</goabx-table>`,
+        webComponents: `<goa-table version="2" width="100%" striped>
   <table>
     <thead>
       <tr>

--- a/docs/src/data/configurations/table.ts
+++ b/docs/src/data/configurations/table.ts
@@ -17,7 +17,7 @@ export const tableConfigurations: ComponentConfigurations = {
       name: 'Basic table',
       description: 'Simple table with data',
       code: {
-        react: `<GoabTable>
+        react: `<GoabxTable>
   <thead>
     <tr>
       <th>Name</th>
@@ -37,7 +37,7 @@ export const tableConfigurations: ComponentConfigurations = {
       <td>Jan 16, 2024</td>
     </tr>
   </tbody>
-</GoabTable>`,
+</GoabxTable>`,
         angular: `<goab-table>
   <thead>
     <tr>
@@ -89,7 +89,7 @@ export const tableConfigurations: ComponentConfigurations = {
       name: 'Striped rows',
       description: 'Alternating row colors for readability',
       code: {
-        react: `<GoabTable striped>
+        react: `<GoabxTable striped>
   <thead>
     <tr>
       <th>Item</th>
@@ -114,7 +114,7 @@ export const tableConfigurations: ComponentConfigurations = {
       <td>$10.00</td>
     </tr>
   </tbody>
-</GoabTable>`,
+</GoabxTable>`,
         angular: `<goab-table [striped]="true">
   <thead>
     <tr>
@@ -176,7 +176,7 @@ export const tableConfigurations: ComponentConfigurations = {
       name: 'Relaxed variant',
       description: 'More vertical padding for comfortable reading',
       code: {
-        react: `<GoabTable variant="relaxed">
+        react: `<GoabxTable variant="relaxed">
   <thead>
     <tr>
       <th>Service</th>
@@ -193,7 +193,7 @@ export const tableConfigurations: ComponentConfigurations = {
       <td>Register a new or used vehicle</td>
     </tr>
   </tbody>
-</GoabTable>`,
+</GoabxTable>`,
         angular: `<goab-table variant="relaxed">
   <thead>
     <tr>
@@ -239,7 +239,7 @@ export const tableConfigurations: ComponentConfigurations = {
       name: 'Sticky header',
       description: 'Header stays visible when scrolling',
       code: {
-        react: `<GoabTable stickyHeader width="100%">
+        react: `<GoabxTable stickyHeader width="100%">
   <thead>
     <tr>
       <th>ID</th>
@@ -264,7 +264,7 @@ export const tableConfigurations: ComponentConfigurations = {
       <td>Finance</td>
     </tr>
   </tbody>
-</GoabTable>`,
+</GoabxTable>`,
         angular: `<goab-table [stickyHeader]="true" width="100%">
   <thead>
     <tr>
@@ -326,7 +326,7 @@ export const tableConfigurations: ComponentConfigurations = {
       name: 'Full width',
       description: 'Table that spans container width',
       code: {
-        react: `<GoabTable width="100%" striped>
+        react: `<GoabxTable width="100%" striped>
   <thead>
     <tr>
       <th>Application ID</th>
@@ -349,7 +349,7 @@ export const tableConfigurations: ComponentConfigurations = {
       <td>Jan 14, 2024</td>
     </tr>
   </tbody>
-</GoabTable>`,
+</GoabxTable>`,
         angular: `<goab-table width="100%" [striped]="true">
   <thead>
     <tr>

--- a/docs/src/data/configurations/tabs.ts
+++ b/docs/src/data/configurations/tabs.ts
@@ -28,7 +28,7 @@ export const tabsConfigurations: ComponentConfigurations = {
     <p>Historical data goes here.</p>
   </GoabTab>
 </GoabxTabs>`,
-        angular: `<goab-tabs [initialTab]="1">
+        angular: `<goabx-tabs [initialTab]="1">
   <goab-tab heading="Overview">
     <p>Overview content goes here.</p>
   </goab-tab>
@@ -38,8 +38,8 @@ export const tabsConfigurations: ComponentConfigurations = {
   <goab-tab heading="History">
     <p>Historical data goes here.</p>
   </goab-tab>
-</goab-tabs>`,
-        webComponents: `<goa-tabs initialtab="1">
+</goabx-tabs>`,
+        webComponents: `<goa-tabs version="2" initialtab="1">
   <goa-tab heading="Overview">
     <p>Overview content goes here.</p>
   </goa-tab>
@@ -62,12 +62,12 @@ export const tabsConfigurations: ComponentConfigurations = {
   <GoabTab heading="Second">Second tab content (initially shown).</GoabTab>
   <GoabTab heading="Third">Third tab content.</GoabTab>
 </GoabxTabs>`,
-        angular: `<goab-tabs [initialTab]="2">
+        angular: `<goabx-tabs [initialTab]="2">
   <goab-tab heading="First">First tab content.</goab-tab>
   <goab-tab heading="Second">Second tab content (initially shown).</goab-tab>
   <goab-tab heading="Third">Third tab content.</goab-tab>
-</goab-tabs>`,
-        webComponents: `<goa-tabs initialtab="2">
+</goabx-tabs>`,
+        webComponents: `<goa-tabs version="2" initialtab="2">
   <goa-tab heading="First">First tab content.</goa-tab>
   <goa-tab heading="Second">Second tab content (initially shown).</goa-tab>
   <goa-tab heading="Third">Third tab content.</goa-tab>
@@ -84,12 +84,12 @@ export const tabsConfigurations: ComponentConfigurations = {
   <GoabTab heading="Week">Weekly view</GoabTab>
   <GoabTab heading="Month">Monthly view</GoabTab>
 </GoabxTabs>`,
-        angular: `<goab-tabs variant="segmented">
+        angular: `<goabx-tabs variant="segmented">
   <goab-tab heading="Day">Daily view</goab-tab>
   <goab-tab heading="Week">Weekly view</goab-tab>
   <goab-tab heading="Month">Monthly view</goab-tab>
-</goab-tabs>`,
-        webComponents: `<goa-tabs variant="segmented">
+</goabx-tabs>`,
+        webComponents: `<goa-tabs version="2" variant="segmented">
   <goa-tab heading="Day">Daily view</goa-tab>
   <goa-tab heading="Week">Weekly view</goa-tab>
   <goa-tab heading="Month">Monthly view</goa-tab>
@@ -105,11 +105,11 @@ export const tabsConfigurations: ComponentConfigurations = {
   <GoabTab heading="Settings">Settings panel</GoabTab>
   <GoabTab heading="Preferences">Preferences panel</GoabTab>
 </GoabxTabs>`,
-        angular: `<goab-tabs [initialTab]="1" [updateUrl]="false">
+        angular: `<goabx-tabs [initialTab]="1" [updateUrl]="false">
   <goab-tab heading="Settings">Settings panel</goab-tab>
   <goab-tab heading="Preferences">Preferences panel</goab-tab>
-</goab-tabs>`,
-        webComponents: `<goa-tabs initialtab="1" updateurl="false">
+</goabx-tabs>`,
+        webComponents: `<goa-tabs version="2" initialtab="1" updateurl="false">
   <goa-tab heading="Settings">Settings panel</goa-tab>
   <goa-tab heading="Preferences">Preferences panel</goa-tab>
 </goa-tabs>`,
@@ -125,12 +125,12 @@ export const tabsConfigurations: ComponentConfigurations = {
   <GoabTab heading="Tab 2">Content 2</GoabTab>
   <GoabTab heading="Tab 3">Content 3</GoabTab>
 </GoabxTabs>`,
-        angular: `<goab-tabs [initialTab]="1" [stackOnMobile]="false">
+        angular: `<goabx-tabs [initialTab]="1" [stackOnMobile]="false">
   <goab-tab heading="Tab 1">Content 1</goab-tab>
   <goab-tab heading="Tab 2">Content 2</goab-tab>
   <goab-tab heading="Tab 3">Content 3</goab-tab>
-</goab-tabs>`,
-        webComponents: `<goa-tabs initialtab="1" stackonmobile="false">
+</goabx-tabs>`,
+        webComponents: `<goa-tabs version="2" initialtab="1" stackonmobile="false">
   <goa-tab heading="Tab 1">Content 1</goa-tab>
   <goa-tab heading="Tab 2">Content 2</goa-tab>
   <goa-tab heading="Tab 3">Content 3</goa-tab>

--- a/docs/src/data/configurations/tabs.ts
+++ b/docs/src/data/configurations/tabs.ts
@@ -17,7 +17,7 @@ export const tabsConfigurations: ComponentConfigurations = {
       name: 'Basic tabs',
       description: 'Simple tab navigation',
       code: {
-        react: `<GoabTabs initialTab={1}>
+        react: `<GoabxTabs initialTab={1}>
   <GoabTab heading="Overview">
     <p>Overview content goes here.</p>
   </GoabTab>
@@ -27,7 +27,7 @@ export const tabsConfigurations: ComponentConfigurations = {
   <GoabTab heading="History">
     <p>Historical data goes here.</p>
   </GoabTab>
-</GoabTabs>`,
+</GoabxTabs>`,
         angular: `<goab-tabs [initialTab]="1">
   <goab-tab heading="Overview">
     <p>Overview content goes here.</p>
@@ -57,11 +57,11 @@ export const tabsConfigurations: ComponentConfigurations = {
       name: 'Initial tab',
       description: 'Start with a specific tab selected',
       code: {
-        react: `<GoabTabs initialTab={2}>
+        react: `<GoabxTabs initialTab={2}>
   <GoabTab heading="First">First tab content.</GoabTab>
   <GoabTab heading="Second">Second tab content (initially shown).</GoabTab>
   <GoabTab heading="Third">Third tab content.</GoabTab>
-</GoabTabs>`,
+</GoabxTabs>`,
         angular: `<goab-tabs [initialTab]="2">
   <goab-tab heading="First">First tab content.</goab-tab>
   <goab-tab heading="Second">Second tab content (initially shown).</goab-tab>
@@ -79,11 +79,11 @@ export const tabsConfigurations: ComponentConfigurations = {
       name: 'Segmented variant',
       description: 'Pill/button style tabs',
       code: {
-        react: `<GoabTabs variant="segmented">
+        react: `<GoabxTabs variant="segmented">
   <GoabTab heading="Day">Daily view</GoabTab>
   <GoabTab heading="Week">Weekly view</GoabTab>
   <GoabTab heading="Month">Monthly view</GoabTab>
-</GoabTabs>`,
+</GoabxTabs>`,
         angular: `<goab-tabs variant="segmented">
   <goab-tab heading="Day">Daily view</goab-tab>
   <goab-tab heading="Week">Weekly view</goab-tab>
@@ -101,10 +101,10 @@ export const tabsConfigurations: ComponentConfigurations = {
       name: 'Without URL update',
       description: 'Tabs that do not update browser URL',
       code: {
-        react: `<GoabTabs initialTab={1} updateUrl={false}>
+        react: `<GoabxTabs initialTab={1} updateUrl={false}>
   <GoabTab heading="Settings">Settings panel</GoabTab>
   <GoabTab heading="Preferences">Preferences panel</GoabTab>
-</GoabTabs>`,
+</GoabxTabs>`,
         angular: `<goab-tabs [initialTab]="1" [updateUrl]="false">
   <goab-tab heading="Settings">Settings panel</goab-tab>
   <goab-tab heading="Preferences">Preferences panel</goab-tab>
@@ -120,11 +120,11 @@ export const tabsConfigurations: ComponentConfigurations = {
       name: 'Horizontal on mobile',
       description: 'Tabs stay horizontal on small screens',
       code: {
-        react: `<GoabTabs initialTab={1} stackOnMobile={false}>
+        react: `<GoabxTabs initialTab={1} stackOnMobile={false}>
   <GoabTab heading="Tab 1">Content 1</GoabTab>
   <GoabTab heading="Tab 2">Content 2</GoabTab>
   <GoabTab heading="Tab 3">Content 3</GoabTab>
-</GoabTabs>`,
+</GoabxTabs>`,
         angular: `<goab-tabs [initialTab]="1" [stackOnMobile]="false">
   <goab-tab heading="Tab 1">Content 1</goab-tab>
   <goab-tab heading="Tab 2">Content 2</goab-tab>

--- a/docs/src/data/configurations/text-area.ts
+++ b/docs/src/data/configurations/text-area.ts
@@ -20,11 +20,11 @@ export const textAreaConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Comments" mb="l">
   <GoabxTextArea name="comments" />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Comments" mb="l">
-  <goab-textarea name="comments"></goab-textarea>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Comments" mb="l">
-  <goa-textarea name="comments"></goa-textarea>
+        angular: `<goabx-form-item label="Comments" mb="l">
+  <goabx-textarea name="comments"></goabx-textarea>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Comments" mb="l">
+  <goa-textarea version="2" name="comments"></goa-textarea>
 </goa-form-item>`,
       },
     },
@@ -36,11 +36,11 @@ export const textAreaConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Feedback" mb="l">
   <GoabxTextArea name="feedback" placeholder="Enter your feedback here..." />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Feedback" mb="l">
-  <goab-textarea name="feedback" placeholder="Enter your feedback here..."></goab-textarea>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Feedback" mb="l">
-  <goa-textarea name="feedback" placeholder="Enter your feedback here..."></goa-textarea>
+        angular: `<goabx-form-item label="Feedback" mb="l">
+  <goabx-textarea name="feedback" placeholder="Enter your feedback here..."></goabx-textarea>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Feedback" mb="l">
+  <goa-textarea version="2" name="feedback" placeholder="Enter your feedback here..."></goa-textarea>
 </goa-form-item>`,
       },
     },
@@ -52,11 +52,11 @@ export const textAreaConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Description" mb="l">
   <GoabxTextArea name="description" rows={6} />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Description" mb="l">
-  <goab-textarea name="description" [rows]="6"></goab-textarea>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Description" mb="l">
-  <goa-textarea name="description" rows="6"></goa-textarea>
+        angular: `<goabx-form-item label="Description" mb="l">
+  <goabx-textarea name="description" [rows]="6"></goabx-textarea>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Description" mb="l">
+  <goa-textarea version="2" name="description" rows="6"></goa-textarea>
 </goa-form-item>`,
       },
     },
@@ -68,11 +68,11 @@ export const textAreaConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Bio" helpText="Maximum 200 characters" mb="l">
   <GoabxTextArea name="bio" countBy="character" maxCount={200} />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Bio" helpText="Maximum 200 characters" mb="l">
-  <goab-textarea name="bio" countby="character" [maxCount]="200"></goab-textarea>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Bio" helpText="Maximum 200 characters" mb="l">
-  <goa-textarea name="bio" countby="character" maxcount="200"></goa-textarea>
+        angular: `<goabx-form-item label="Bio" helpText="Maximum 200 characters" mb="l">
+  <goabx-textarea name="bio" countby="character" [maxCount]="200"></goabx-textarea>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Bio" helpText="Maximum 200 characters" mb="l">
+  <goa-textarea version="2" name="bio" countby="character" maxcount="200"></goa-textarea>
 </goa-form-item>`,
       },
     },
@@ -84,11 +84,11 @@ export const textAreaConfigurations: ComponentConfigurations = {
         react: `<GoabxFormItem label="Essay" helpText="Maximum 500 words" mb="l">
   <GoabxTextArea name="essay" countBy="word" maxCount={500} rows={8} />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Essay" helpText="Maximum 500 words" mb="l">
-  <goab-textarea name="essay" countby="word" [maxCount]="500" [rows]="8"></goab-textarea>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Essay" helpText="Maximum 500 words" mb="l">
-  <goa-textarea name="essay" countby="word" maxcount="500" rows="8"></goa-textarea>
+        angular: `<goabx-form-item label="Essay" helpText="Maximum 500 words" mb="l">
+  <goabx-textarea name="essay" countby="word" [maxCount]="500" [rows]="8"></goabx-textarea>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Essay" helpText="Maximum 500 words" mb="l">
+  <goa-textarea version="2" name="essay" countby="word" maxcount="500" rows="8"></goa-textarea>
 </goa-form-item>`,
       },
     },
@@ -106,23 +106,23 @@ export const textAreaConfigurations: ComponentConfigurations = {
 <GoabxFormItem label="With error" error="This field is required" mb="l">
   <GoabxTextArea name="error" error />
 </GoabxFormItem>`,
-        angular: `<goab-form-item label="Disabled" mb="l">
-  <goab-textarea name="disabled" [disabled]="true" value="Cannot edit this content"></goab-textarea>
-</goab-form-item>
-<goab-form-item label="Read-only" mb="l">
-  <goab-textarea name="readonly" [readOnly]="true" value="View only content"></goab-textarea>
-</goab-form-item>
-<goab-form-item label="With error" error="This field is required" mb="l">
-  <goab-textarea name="error" [error]="true"></goab-textarea>
-</goab-form-item>`,
-        webComponents: `<goa-form-item label="Disabled" mb="l">
-  <goa-textarea name="disabled" disabled value="Cannot edit this content"></goa-textarea>
+        angular: `<goabx-form-item label="Disabled" mb="l">
+  <goabx-textarea name="disabled" [disabled]="true" value="Cannot edit this content"></goabx-textarea>
+</goabx-form-item>
+<goabx-form-item label="Read-only" mb="l">
+  <goabx-textarea name="readonly" [readOnly]="true" value="View only content"></goabx-textarea>
+</goabx-form-item>
+<goabx-form-item label="With error" error="This field is required" mb="l">
+  <goabx-textarea name="error" [error]="true"></goabx-textarea>
+</goabx-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Disabled" mb="l">
+  <goa-textarea version="2" name="disabled" disabled value="Cannot edit this content"></goa-textarea>
 </goa-form-item>
-<goa-form-item label="Read-only" mb="l">
-  <goa-textarea name="readonly" readonly value="View only content"></goa-textarea>
+<goa-form-item version="2" label="Read-only" mb="l">
+  <goa-textarea version="2" name="readonly" readonly value="View only content"></goa-textarea>
 </goa-form-item>
-<goa-form-item label="With error" error="This field is required" mb="l">
-  <goa-textarea name="error" error></goa-textarea>
+<goa-form-item version="2" label="With error" error="This field is required" mb="l">
+  <goa-textarea version="2" name="error" error></goa-textarea>
 </goa-form-item>`,
       },
     },

--- a/docs/src/data/configurations/text-area.ts
+++ b/docs/src/data/configurations/text-area.ts
@@ -17,9 +17,9 @@ export const textAreaConfigurations: ComponentConfigurations = {
       name: 'Basic example',
       description: 'Text area wrapped in FormItem with label',
       code: {
-        react: `<GoabFormItem label="Comments" mb="l">
-  <GoabTextArea name="comments" />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Comments" mb="l">
+  <GoabxTextArea name="comments" />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Comments" mb="l">
   <goab-textarea name="comments"></goab-textarea>
 </goab-form-item>`,
@@ -33,9 +33,9 @@ export const textAreaConfigurations: ComponentConfigurations = {
       name: 'With placeholder',
       description: 'Text area with placeholder text',
       code: {
-        react: `<GoabFormItem label="Feedback" mb="l">
-  <GoabTextArea name="feedback" placeholder="Enter your feedback here..." />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Feedback" mb="l">
+  <GoabxTextArea name="feedback" placeholder="Enter your feedback here..." />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Feedback" mb="l">
   <goab-textarea name="feedback" placeholder="Enter your feedback here..."></goab-textarea>
 </goab-form-item>`,
@@ -49,9 +49,9 @@ export const textAreaConfigurations: ComponentConfigurations = {
       name: 'Custom rows',
       description: 'Text area with custom height',
       code: {
-        react: `<GoabFormItem label="Description" mb="l">
-  <GoabTextArea name="description" rows={6} />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Description" mb="l">
+  <GoabxTextArea name="description" rows={6} />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Description" mb="l">
   <goab-textarea name="description" [rows]="6"></goab-textarea>
 </goab-form-item>`,
@@ -65,9 +65,9 @@ export const textAreaConfigurations: ComponentConfigurations = {
       name: 'Character count',
       description: 'Text area with character limit',
       code: {
-        react: `<GoabFormItem label="Bio" helpText="Maximum 200 characters" mb="l">
-  <GoabTextArea name="bio" countBy="character" maxCount={200} />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Bio" helpText="Maximum 200 characters" mb="l">
+  <GoabxTextArea name="bio" countBy="character" maxCount={200} />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Bio" helpText="Maximum 200 characters" mb="l">
   <goab-textarea name="bio" countby="character" [maxCount]="200"></goab-textarea>
 </goab-form-item>`,
@@ -81,9 +81,9 @@ export const textAreaConfigurations: ComponentConfigurations = {
       name: 'Word count',
       description: 'Text area with word limit',
       code: {
-        react: `<GoabFormItem label="Essay" helpText="Maximum 500 words" mb="l">
-  <GoabTextArea name="essay" countBy="word" maxCount={500} rows={8} />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Essay" helpText="Maximum 500 words" mb="l">
+  <GoabxTextArea name="essay" countBy="word" maxCount={500} rows={8} />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Essay" helpText="Maximum 500 words" mb="l">
   <goab-textarea name="essay" countby="word" [maxCount]="500" [rows]="8"></goab-textarea>
 </goab-form-item>`,
@@ -97,15 +97,15 @@ export const textAreaConfigurations: ComponentConfigurations = {
       name: 'States',
       description: 'Disabled, readonly, and error states',
       code: {
-        react: `<GoabFormItem label="Disabled" mb="l">
-  <GoabTextArea name="disabled" disabled value="Cannot edit this content" />
-</GoabFormItem>
-<GoabFormItem label="Read-only" mb="l">
-  <GoabTextArea name="readonly" readOnly value="View only content" />
-</GoabFormItem>
-<GoabFormItem label="With error" error="This field is required" mb="l">
-  <GoabTextArea name="error" error />
-</GoabFormItem>`,
+        react: `<GoabxFormItem label="Disabled" mb="l">
+  <GoabxTextArea name="disabled" disabled value="Cannot edit this content" />
+</GoabxFormItem>
+<GoabxFormItem label="Read-only" mb="l">
+  <GoabxTextArea name="readonly" readOnly value="View only content" />
+</GoabxFormItem>
+<GoabxFormItem label="With error" error="This field is required" mb="l">
+  <GoabxTextArea name="error" error />
+</GoabxFormItem>`,
         angular: `<goab-form-item label="Disabled" mb="l">
   <goab-textarea name="disabled" [disabled]="true" value="Cannot edit this content"></goab-textarea>
 </goab-form-item>

--- a/docs/src/data/configurations/tooltip.ts
+++ b/docs/src/data/configurations/tooltip.ts
@@ -18,7 +18,7 @@ export const tooltipConfigurations: ComponentConfigurations = {
       description: 'Simple tooltip on hover',
       code: {
         react: `<GoabTooltip content="Additional information about this item">
-  <GoabButton>Hover me</GoabButton>
+  <GoabxButton>Hover me</GoabxButton>
 </GoabTooltip>`,
         angular: `<goab-tooltip content="Additional information about this item">
   <goab-button>Hover me</goab-button>
@@ -34,16 +34,16 @@ export const tooltipConfigurations: ComponentConfigurations = {
       description: 'Tooltip placement options',
       code: {
         react: `<GoabTooltip content="Top tooltip" position="top">
-  <GoabButton>Top</GoabButton>
+  <GoabxButton>Top</GoabxButton>
 </GoabTooltip>
 <GoabTooltip content="Bottom tooltip" position="bottom">
-  <GoabButton>Bottom</GoabButton>
+  <GoabxButton>Bottom</GoabxButton>
 </GoabTooltip>
 <GoabTooltip content="Left tooltip" position="left">
-  <GoabButton>Left</GoabButton>
+  <GoabxButton>Left</GoabxButton>
 </GoabTooltip>
 <GoabTooltip content="Right tooltip" position="right">
-  <GoabButton>Right</GoabButton>
+  <GoabxButton>Right</GoabxButton>
 </GoabTooltip>`,
         angular: `<goab-tooltip content="Top tooltip" position="top">
   <goab-button>Top</goab-button>
@@ -93,7 +93,7 @@ export const tooltipConfigurations: ComponentConfigurations = {
       description: 'Tooltip with custom hover delay',
       code: {
         react: `<GoabTooltip content="This appears after 500ms" hoverDelay={500}>
-  <GoabButton>Delayed tooltip</GoabButton>
+  <GoabxButton>Delayed tooltip</GoabxButton>
 </GoabTooltip>`,
         angular: `<goab-tooltip content="This appears after 500ms" [hoverDelay]="500">
   <goab-button>Delayed tooltip</goab-button>

--- a/docs/src/data/configurations/tooltip.ts
+++ b/docs/src/data/configurations/tooltip.ts
@@ -21,10 +21,10 @@ export const tooltipConfigurations: ComponentConfigurations = {
   <GoabxButton>Hover me</GoabxButton>
 </GoabTooltip>`,
         angular: `<goab-tooltip content="Additional information about this item">
-  <goab-button>Hover me</goab-button>
+  <goabx-button>Hover me</goabx-button>
 </goab-tooltip>`,
         webComponents: `<goa-tooltip content="Additional information about this item">
-  <goa-button>Hover me</goa-button>
+  <goa-button version="2">Hover me</goa-button>
 </goa-tooltip>`,
       },
     },
@@ -46,28 +46,28 @@ export const tooltipConfigurations: ComponentConfigurations = {
   <GoabxButton>Right</GoabxButton>
 </GoabTooltip>`,
         angular: `<goab-tooltip content="Top tooltip" position="top">
-  <goab-button>Top</goab-button>
+  <goabx-button>Top</goabx-button>
 </goab-tooltip>
 <goab-tooltip content="Bottom tooltip" position="bottom">
-  <goab-button>Bottom</goab-button>
+  <goabx-button>Bottom</goabx-button>
 </goab-tooltip>
 <goab-tooltip content="Left tooltip" position="left">
-  <goab-button>Left</goab-button>
+  <goabx-button>Left</goabx-button>
 </goab-tooltip>
 <goab-tooltip content="Right tooltip" position="right">
-  <goab-button>Right</goab-button>
+  <goabx-button>Right</goabx-button>
 </goab-tooltip>`,
         webComponents: `<goa-tooltip content="Top tooltip" position="top">
-  <goa-button>Top</goa-button>
+  <goa-button version="2">Top</goa-button>
 </goa-tooltip>
 <goa-tooltip content="Bottom tooltip" position="bottom">
-  <goa-button>Bottom</goa-button>
+  <goa-button version="2">Bottom</goa-button>
 </goa-tooltip>
 <goa-tooltip content="Left tooltip" position="left">
-  <goa-button>Left</goa-button>
+  <goa-button version="2">Left</goa-button>
 </goa-tooltip>
 <goa-tooltip content="Right tooltip" position="right">
-  <goa-button>Right</goa-button>
+  <goa-button version="2">Right</goa-button>
 </goa-tooltip>`,
       },
     },
@@ -96,10 +96,10 @@ export const tooltipConfigurations: ComponentConfigurations = {
   <GoabxButton>Delayed tooltip</GoabxButton>
 </GoabTooltip>`,
         angular: `<goab-tooltip content="This appears after 500ms" [hoverDelay]="500">
-  <goab-button>Delayed tooltip</goab-button>
+  <goabx-button>Delayed tooltip</goabx-button>
 </goab-tooltip>`,
         webComponents: `<goa-tooltip content="This appears after 500ms" hoverdelay="500">
-  <goa-button>Delayed tooltip</goa-button>
+  <goa-button version="2">Delayed tooltip</goa-button>
 </goa-tooltip>`,
       },
     },

--- a/docs/src/data/configurations/work-side-menu.ts
+++ b/docs/src/data/configurations/work-side-menu.ts
@@ -17,15 +17,15 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
       name: 'Basic work side menu',
       description: 'Side navigation for internal apps',
       code: {
-        react: `<GoabWorkSideMenu
+        react: `<GoabxWorkSideMenu
   heading="My Application"
   url="/"
   primaryContent={
     <>
-      <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-      <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-      <GoabWorkSideMenuItem icon="document" label="Reports" url="/reports" />
-      <GoabWorkSideMenuItem icon="settings" label="Admin" url="/admin" />
+      <GoabxWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+      <GoabxWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+      <GoabxWorkSideMenuItem icon="document" label="Reports" url="/reports" />
+      <GoabxWorkSideMenuItem icon="settings" label="Admin" url="/admin" />
     </>
   }
 />`,
@@ -50,18 +50,18 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
       name: 'With nested items',
       description: 'Work menu with expandable sub-items',
       code: {
-        react: `<GoabWorkSideMenu
+        react: `<GoabxWorkSideMenu
   heading="My Application"
   url="/"
   primaryContent={
     <>
-      <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-      <GoabWorkSideMenuItem icon="document" label="Documents" url="/documents">
-        <GoabWorkSideMenuItem label="Invoices" url="/documents/invoices" />
-        <GoabWorkSideMenuItem label="Contracts" url="/documents/contracts" />
-        <GoabWorkSideMenuItem label="Reports" url="/documents/reports" />
-      </GoabWorkSideMenuItem>
-      <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+      <GoabxWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+      <GoabxWorkSideMenuItem icon="document" label="Documents" url="/documents">
+        <GoabxWorkSideMenuItem label="Invoices" url="/documents/invoices" />
+        <GoabxWorkSideMenuItem label="Contracts" url="/documents/contracts" />
+        <GoabxWorkSideMenuItem label="Reports" url="/documents/reports" />
+      </GoabxWorkSideMenuItem>
+      <GoabxWorkSideMenuItem icon="list" label="Cases" url="/cases" />
     </>
   }
 />`,

--- a/docs/src/data/configurations/work-side-menu.ts
+++ b/docs/src/data/configurations/work-side-menu.ts
@@ -29,14 +29,14 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
     </>
   }
 />`,
-        angular: `<goab-work-side-menu heading="My Application" url="/">
+        angular: `<goabx-work-side-menu heading="My Application" url="/">
   <div slot="primary-content">
-    <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="document" label="Reports" url="/reports"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="settings" label="Admin" url="/admin"></goab-work-side-menu-item>
+    <goabx-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goabx-work-side-menu-item>
+    <goabx-work-side-menu-item icon="list" label="Cases" url="/cases"></goabx-work-side-menu-item>
+    <goabx-work-side-menu-item icon="document" label="Reports" url="/reports"></goabx-work-side-menu-item>
+    <goabx-work-side-menu-item icon="settings" label="Admin" url="/admin"></goabx-work-side-menu-item>
   </div>
-</goab-work-side-menu>`,
+</goabx-work-side-menu>`,
         webComponents: `<goa-work-side-menu heading="My Application" url="/" open="true">
   <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
   <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
@@ -65,17 +65,17 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
     </>
   }
 />`,
-        angular: `<goab-work-side-menu heading="My Application" url="/">
+        angular: `<goabx-work-side-menu heading="My Application" url="/">
   <div slot="primary-content">
-    <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="document" label="Documents" url="/documents">
-      <goab-work-side-menu-item label="Invoices" url="/documents/invoices"></goab-work-side-menu-item>
-      <goab-work-side-menu-item label="Contracts" url="/documents/contracts"></goab-work-side-menu-item>
-      <goab-work-side-menu-item label="Reports" url="/documents/reports"></goab-work-side-menu-item>
-    </goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
+    <goabx-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goabx-work-side-menu-item>
+    <goabx-work-side-menu-item icon="document" label="Documents" url="/documents">
+      <goabx-work-side-menu-item label="Invoices" url="/documents/invoices"></goabx-work-side-menu-item>
+      <goabx-work-side-menu-item label="Contracts" url="/documents/contracts"></goabx-work-side-menu-item>
+      <goabx-work-side-menu-item label="Reports" url="/documents/reports"></goabx-work-side-menu-item>
+    </goabx-work-side-menu-item>
+    <goabx-work-side-menu-item icon="list" label="Cases" url="/cases"></goabx-work-side-menu-item>
   </div>
-</goab-work-side-menu>`,
+</goabx-work-side-menu>`,
         webComponents: `<goa-work-side-menu heading="My Application" url="/" open="true">
   <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
   <goa-work-side-menu-item slot="primary" icon="document" label="Documents" url="/documents">

--- a/docs/src/global.d.ts
+++ b/docs/src/global.d.ts
@@ -3,61 +3,62 @@
  *
  * These declarations allow using goa-* web components directly in JSX
  * without TypeScript errors.
+ *
+ * Each entry here represents a gap in the React wrappers. When the wrapper
+ * is fixed, remove the corresponding entry and update the component code.
  */
 
-import 'react';
+import "react";
 
-declare module 'react' {
+declare module "react" {
   namespace JSX {
     interface IntrinsicElements {
-      'goa-icon': React.DetailedHTMLProps<
+      // TODO: Remove when GoabxBadge wrapper supports V2 types (dawn, sky, prairie, etc.)
+      // See: https://github.com/GovAlta/ui-components/issues/3385
+      "goa-badge": React.DetailedHTMLProps<
         React.HTMLAttributes<HTMLElement> & {
-          type?: string;
-          size?: string;
           version?: string;
+          type?: string;
+          content?: string;
+          emphasis?: string;
         },
         HTMLElement
       >;
-      'goa-button': React.DetailedHTMLProps<
+      // TODO: Remove when GoabxTable renders V2 styling correctly
+      // See: https://github.com/GovAlta/ui-components/issues/3384
+      "goa-table": React.DetailedHTMLProps<
         React.HTMLAttributes<HTMLElement> & {
-          type?: string;
-          size?: string;
-          variant?: string;
-          disabled?: boolean;
           version?: string;
-          leadingIcon?: string;
-          trailingIcon?: string;
-          // Web component attribute names (lowercase)
-          leadingicon?: string;
-          trailingicon?: string;
-        },
-        HTMLElement
-      >;
-      'goa-input': React.DetailedHTMLProps<
-        React.HTMLAttributes<HTMLElement> & {
-          type?: string;
-          name?: string;
-          value?: string;
-          placeholder?: string;
           width?: string;
-          disabled?: boolean;
-          version?: string;
+          variant?: string;
+          ref?: React.RefObject<HTMLElement>;
         },
         HTMLElement
       >;
-      'goa-dropdown': React.DetailedHTMLProps<
+      // TODO: Remove when GoabxTableSortHeader wrapper exposes sortOrder prop
+      "goa-table-sort-header": React.DetailedHTMLProps<
         React.HTMLAttributes<HTMLElement> & {
+          version?: string;
           name?: string;
-          value?: string;
-          placeholder?: string;
-          version?: string;
+          direction?: string;
         },
         HTMLElement
       >;
-      'goa-dropdown-item': React.DetailedHTMLProps<
+      // TODO: Remove when GoabxTabs wrapper exposes updateUrl and stackOnMobile props
+      "goa-tabs": React.DetailedHTMLProps<
         React.HTMLAttributes<HTMLElement> & {
-          value?: string;
-          label?: string;
+          version?: string;
+          variant?: string;
+          initialtab?: number;
+          updateurl?: string;
+          stackonmobile?: string;
+          ref?: React.RefObject<HTMLElement>;
+        },
+        HTMLElement
+      >;
+      "goa-tab": React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          heading?: string;
         },
         HTMLElement
       >;

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -6,9 +6,10 @@ import '@design-tokens/tokens.css';
 interface Props {
   title: string;
   description?: string;
+  page?: string;
 }
 
-const { title, description } = Astro.props;
+const { title, description, page } = Astro.props;
 ---
 
 <!DOCTYPE html>
@@ -156,14 +157,26 @@ const { title, description } = Astro.props;
       z-index: 50;
       padding: var(--goa-space-m) var(--goa-space-m); /* 16px vertical, 16px horizontal */
       border-bottom: 1px solid var(--goa-color-greyscale-150, #e0e0e0);
-      /* Smooth transition for hide/show */
+      /* Smooth transitions for hide/show and background */
       transform: translateY(0);
-      transition: transform 0.25s ease-out;
+      transition: transform 0.25s ease-out, background 0.2s ease, border-bottom 0.2s ease;
     }
 
     /* Header hidden on scroll down */
     body[data-mobile="true"][data-header-hidden="true"] .mobile-header-container {
       transform: translateY(-100%);
+    }
+
+    /* Homepage: transparent header at top blends with hero */
+    body[data-page="home"][data-mobile="true"][data-scrolled="false"] .mobile-header-container {
+      background: transparent;
+      border-bottom: none;
+    }
+
+    /* Homepage: restore white header when scrolled */
+    body[data-page="home"][data-mobile="true"][data-scrolled="true"] .mobile-header-container {
+      background: white;
+      border-bottom: 1px solid var(--goa-color-greyscale-150, #e0e0e0);
     }
 
     /* Mobile header content layout */
@@ -226,7 +239,7 @@ const { title, description } = Astro.props;
     }
   </style>
 </head>
-<body>
+<body data-page={page}>
   <slot />
 </body>
 </html>

--- a/docs/src/layouts/ComponentPageLayout.astro
+++ b/docs/src/layouts/ComponentPageLayout.astro
@@ -75,7 +75,7 @@ const { title, description, currentSlug, category } = Astro.props;
     top: 0;
     height: 100vh;
     background: var(--goa-color-greyscale-50);
-    z-index: 5;
+    z-index: 2; /* Above content (1) for tooltips, below modals (998+) */
   }
 
   .main-content {

--- a/docs/src/layouts/DocumentationPageLayout.astro
+++ b/docs/src/layouts/DocumentationPageLayout.astro
@@ -99,7 +99,7 @@ const {
     top: 0;
     height: 100vh;
     background: var(--goa-color-greyscale-50);
-    z-index: 5;
+    z-index: 2; /* Above content (1) for tooltips, below modals (998+) */
   }
 
   .main-content {
@@ -122,6 +122,8 @@ const {
     display: grid;
     grid-template-columns: 1fr;
     gap: var(--goa-space-2xl);
+    max-width: 960px;
+    margin: 0 auto;
   }
 
   .content-grid.with-toc {
@@ -131,6 +133,7 @@ const {
   /* Prose typography */
   .prose-content {
     max-width: 70ch;
+    min-width: 0; /* Allow shrinking in grid to prevent overflow */
   }
 
   /* Page title */

--- a/docs/src/layouts/ExamplesPageLayout.astro
+++ b/docs/src/layouts/ExamplesPageLayout.astro
@@ -70,7 +70,7 @@ const { title, description, currentSlug } = Astro.props;
     top: 0;
     height: 100vh;
     background: var(--goa-color-greyscale-50);
-    z-index: 5;
+    z-index: 2; /* Above content (1) for tooltips, below modals (998+) */
   }
 
   .main-content {

--- a/docs/src/layouts/HomeLayout.astro
+++ b/docs/src/layouts/HomeLayout.astro
@@ -23,7 +23,7 @@ interface Props {
 const { title, description } = Astro.props;
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} page="home">
   <!-- Full-width grey background wrapper -->
   <div class="layout-wrapper">
     <div class="layout-container">
@@ -68,7 +68,7 @@ const { title, description } = Astro.props;
     top: 0;
     height: 100vh;
     background: var(--goa-color-greyscale-50);
-    z-index: 5;
+    z-index: 2; /* Above content (1) for tooltips, below modals (998+) */
   }
 
   .main-content {
@@ -118,6 +118,8 @@ const { title, description } = Astro.props;
       border-radius: 0;
       border: none;
       min-height: auto;
+      /* Pull content up behind transparent header (header is ~73px) */
+      margin-top: -73px;
     }
   }
 

--- a/docs/src/layouts/TokensLayout.astro
+++ b/docs/src/layouts/TokensLayout.astro
@@ -68,7 +68,7 @@ const { title, description } = Astro.props;
     top: 0;
     height: 100vh;
     background: var(--goa-color-greyscale-50);
-    z-index: 5;
+    z-index: 2; /* Above content (1) for tooltips, below modals (998+) */
   }
 
   .main-content {

--- a/docs/src/lib/content-queries.ts
+++ b/docs/src/lib/content-queries.ts
@@ -39,7 +39,7 @@ export interface ComponentApi {
  */
 export async function getComponentApi(slug: string): Promise<ComponentApi | null> {
   try {
-    const apiPath = path.join(process.cwd(), 'generated', 'component-apis', `${slug}.json`);
+    const apiPath = new URL(`../../generated/component-apis/${slug}.json`, import.meta.url).pathname;
     const content = await fs.readFile(apiPath, 'utf-8');
     return JSON.parse(content) as ComponentApi;
   } catch (error) {

--- a/docs/src/lib/content-queries.ts
+++ b/docs/src/lib/content-queries.ts
@@ -1,6 +1,4 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
-import fs from 'node:fs/promises';
-import path from 'node:path';
 
 // Types for extracted API data
 export interface PropDefinition {
@@ -34,18 +32,31 @@ export interface ComponentApi {
   slots: SlotDefinition[];
 }
 
+// Load all component API JSON files at build time using Vite glob import
+const apiModules = import.meta.glob<{ default: ComponentApi }>(
+  '../../generated/component-apis/*.json',
+  { eager: true }
+);
+
+// Build lookup map: slug -> ComponentApi
+const apiBySlug = new Map<string, ComponentApi>();
+for (const [path, module] of Object.entries(apiModules)) {
+  const slug = path.split('/').pop()?.replace('.json', '');
+  if (slug && module.default) {
+    apiBySlug.set(slug, module.default);
+  }
+}
+
 /**
  * Get extracted API data for a component
  */
 export async function getComponentApi(slug: string): Promise<ComponentApi | null> {
-  try {
-    const apiPath = new URL(`../../generated/component-apis/${slug}.json`, import.meta.url).pathname;
-    const content = await fs.readFile(apiPath, 'utf-8');
-    return JSON.parse(content) as ComponentApi;
-  } catch (error) {
+  const api = apiBySlug.get(slug);
+  if (!api) {
     console.warn(`No API data found for component: ${slug}`);
     return null;
   }
+  return api;
 }
 
 /**

--- a/docs/src/lib/example-code.ts
+++ b/docs/src/lib/example-code.ts
@@ -2,9 +2,6 @@
  * Helper functions to read example code files at build time
  */
 
-import fs from 'node:fs/promises';
-import path from 'node:path';
-
 export interface ExampleCode {
   react?: string;
   angular?: {
@@ -14,41 +11,75 @@ export interface ExampleCode {
   webComponents?: string;
 }
 
+// Load all example code files at build time using Vite glob imports
+const reactFiles = import.meta.glob<string>(
+  '../content/examples/*/react.tsx',
+  { eager: true, query: '?raw', import: 'default' }
+);
+const angularTemplates = import.meta.glob<string>(
+  '../content/examples/*/angular.html',
+  { eager: true, query: '?raw', import: 'default' }
+);
+const angularComponents = import.meta.glob<string>(
+  '../content/examples/*/angular.ts',
+  { eager: true, query: '?raw', import: 'default' }
+);
+const webComponentFiles = import.meta.glob<string>(
+  '../content/examples/*/web-components.html',
+  { eager: true, query: '?raw', import: 'default' }
+);
+
+// Helper to extract slug from path like "../content/examples/button-basic/react.tsx"
+function getSlugFromPath(path: string): string {
+  const parts = path.split('/');
+  return parts[parts.length - 2]; // folder name before the filename
+}
+
+// Build lookup maps
+const reactBySlug = new Map<string, string>();
+for (const [path, content] of Object.entries(reactFiles)) {
+  reactBySlug.set(getSlugFromPath(path), content);
+}
+
+const angularTemplateBySlug = new Map<string, string>();
+for (const [path, content] of Object.entries(angularTemplates)) {
+  angularTemplateBySlug.set(getSlugFromPath(path), content);
+}
+
+const angularComponentBySlug = new Map<string, string>();
+for (const [path, content] of Object.entries(angularComponents)) {
+  angularComponentBySlug.set(getSlugFromPath(path), content);
+}
+
+const webComponentBySlug = new Map<string, string>();
+for (const [path, content] of Object.entries(webComponentFiles)) {
+  webComponentBySlug.set(getSlugFromPath(path), content);
+}
+
 /**
- * Read all code files for an example
+ * Get all code files for an example
  * @param exampleSlug - The example folder name (e.g., "button-with-icon")
  * @returns Object with code for each framework
  */
 export async function getExampleCode(exampleSlug: string): Promise<ExampleCode> {
-  const exampleDir = new URL(`../content/examples/${exampleSlug}`, import.meta.url).pathname;
   const code: ExampleCode = {};
 
-  // Read React code
-  try {
-    code.react = await fs.readFile(path.join(exampleDir, 'react.tsx'), 'utf-8');
-  } catch {
-    // File doesn't exist
+  const react = reactBySlug.get(exampleSlug);
+  if (react) {
+    code.react = react;
   }
 
-  // Read Angular code (template + component)
-  try {
-    const template = await fs.readFile(path.join(exampleDir, 'angular.html'), 'utf-8');
-    let component: string | undefined;
-    try {
-      component = await fs.readFile(path.join(exampleDir, 'angular.ts'), 'utf-8');
-    } catch {
-      // Component file is optional
-    }
-    code.angular = { template, component };
-  } catch {
-    // Files don't exist
+  const angularTemplate = angularTemplateBySlug.get(exampleSlug);
+  if (angularTemplate) {
+    code.angular = {
+      template: angularTemplate,
+      component: angularComponentBySlug.get(exampleSlug),
+    };
   }
 
-  // Read Web Components code
-  try {
-    code.webComponents = await fs.readFile(path.join(exampleDir, 'web-components.html'), 'utf-8');
-  } catch {
-    // File doesn't exist
+  const webComponent = webComponentBySlug.get(exampleSlug);
+  if (webComponent) {
+    code.webComponents = webComponent;
   }
 
   return code;

--- a/docs/src/lib/example-code.ts
+++ b/docs/src/lib/example-code.ts
@@ -20,7 +20,7 @@ export interface ExampleCode {
  * @returns Object with code for each framework
  */
 export async function getExampleCode(exampleSlug: string): Promise<ExampleCode> {
-  const exampleDir = path.join(process.cwd(), 'src/content/examples', exampleSlug);
+  const exampleDir = new URL(`../content/examples/${exampleSlug}`, import.meta.url).pathname;
   const code: ExampleCode = {};
 
   // Read React code

--- a/docs/src/lib/framework-preference.ts
+++ b/docs/src/lib/framework-preference.ts
@@ -25,7 +25,7 @@ export function getFrameworkPreference(): Framework {
 }
 
 /**
- * Set the user's framework preference and broadcast to all components
+ * Set the user's framework preference and broadcast to all components.
  */
 export function setFrameworkPreference(framework: Framework): void {
   if (typeof window === 'undefined') return;

--- a/docs/src/pages/components/[slug].astro
+++ b/docs/src/pages/components/[slug].astro
@@ -105,7 +105,8 @@ const githubIssuesUrl = `https://github.com/GovAlta/ui-components/issues?q=is%3A
     </goa-tab>
 
     <!-- Examples Tab -->
-    <goa-tab>
+    <!-- TODO: URL shows "tab-1" instead of "examples" because heading slot overrides heading attribute for URL generation -->
+    <goa-tab heading="Examples">
       <span slot="heading">Examples <goa-badge version="2" type="default" emphasis="subtle" icon="false" content={String(componentExamples.length)}></goa-badge></span>
       <TabContentWrapper tocQuery=".example-preview .example-title">
         {componentExamples.length > 0 ? (

--- a/docs/src/pages/get-started/designers.astro
+++ b/docs/src/pages/get-started/designers.astro
@@ -1,0 +1,149 @@
+---
+/**
+ * Get Started - Designers (Early Adopters)
+ *
+ * Designer onboarding for the early adopters program.
+ * Figma setup, BETA libraries, illustration requests, project updates.
+ * Content from Confluence (Brief 65).
+ */
+import DocumentationPageLayout from '../../layouts/DocumentationPageLayout.astro';
+---
+
+<DocumentationPageLayout
+  title="Get started as a designer"
+  description="Get started with the experimental GoA Design System as a designer"
+  section="get-started"
+>
+  <goa-text version="2" size="heading-xl" mt="none" mb="m">Get started as a designer</goa-text>
+  <goa-text version="2" size="body-l" mt="none" mb="2xl">
+    Onboarding for the early adopters program.
+  </goa-text>
+
+  <goa-callout version="2" type="information" emphasis="low" heading="What you'll do as a designer early adopter" mb="m">
+    <ul style="margin-bottom: 0;">
+      <li>Get access to the experimental Figma libraries.</li>
+      <li>Use experimental libraries to design or evaluate screens in your service context.</li>
+      <li>Provide feedback on what's working, what's not working and what's missing.</li>
+    </ul>
+  </goa-callout>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="setup">Available resources <goa-badge version="2" type="success" icon="false" emphasis="subtle" ml="m" content="Start here" style="vertical-align: middle;"></goa-badge></h2>
+
+  <goa-text version="2" size="heading-xs" mt="xl" mb="s">Figma assets</goa-text>
+  <goa-grid version="2" minchildwidth="300px" gap="xl">
+    <goa-block version="2" gap="s" direction="column">
+      <goa-text version="2" size="body-m" mt="m" mb="2xs"><strong>Production</strong></goa-text>
+      <goa-link version="2"><a href="https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=33054-33175" target="_blank">Component library</a></goa-link>
+      <goa-link version="2"><a href="https://www.figma.com/design/ylmHeuDMfxnDBnP1VaQYz8/%E2%9D%96-Styles--Tokens--Icons--and-Guidelines-%7C-DDD?node-id=12132-379669" target="_blank">Styles, tokens, icons, and guidelines</a></goa-link>
+      <goa-link version="2"><a href="https://www.figma.com/design/aIRjvBzpIUH0GbkffjbL04/%E2%9D%96-Patterns-library-%7C-DDD?node-id=6345-1491163" target="_blank">Patterns library</a></goa-link>
+    </goa-block>
+    <goa-block version="2" gap="s" direction="column">
+      <goa-text version="2" size="body-m" mt="m" mb="2xs"><strong>Beta</strong></goa-text>
+      <goa-link version="2"><a href="https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-BETA-Component-library?node-id=60166-171607" target="_blank">Component library BETA</a></goa-link>
+      <goa-link version="2"><a href="https://www.figma.com/design/1xnHCsSgKHvkQEEDRvEa9y/%E2%9D%96-BETA-Styles-library?node-id=36-7" target="_blank">Styles library BETA</a></goa-link>
+      <goa-link version="2"><a href="https://www.figma.com/design/1DyrNxvQ1yhIEGqtpAtJqp/Illustration-library?node-id=0-1" target="_blank">Illustration library BETA</a></goa-link>
+    </goa-block>
+  </goa-grid>
+
+  <goa-callout version="2" type="information" emphasis="low" mt="l" mb="l">
+    Component names are the same in both libraries, which makes
+    <a href="https://help.figma.com/hc/en-us/articles/4404856784663-Swap-style-and-component-libraries" target="_blank">library swapping</a>
+    possible. Be aware this can make it harder to tell which library a component came from once
+    it's on the canvas.
+  </goa-callout>
+
+  <h3 id="illustrations" style="margin-top: var(--goa-space-xl);">Illustrations</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    The illustration library is a collection of custom GoA illustrations to be used at various
+    points throughout a service. We will continue to update it regularly, so start by checking what's already
+    available.
+  </goa-text>
+  <goa-container version="2" type="non-interactive" padding="compact" mb="m">
+    Can't find an existing illustration that fits your scenario? Need a new
+    composition combining existing illustration elements?
+    <br /><br />
+    <goa-button version="2" type="tertiary" size="compact">Request an illustration</goa-button>
+  </goa-container>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    If you're unsure, ask in
+    <a href="https://goa-dio.slack.com/archives/C0A9SN3JM7E" target="_blank"><strong>#design-system-early-adopters</strong></a>
+    or bring it to drop-in hours — we'll help you decide the best path.
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="start-designing">Designing with the BETA libraries in Figma</h2>
+
+  <h3 id="new-designs">Starting a new design</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    We recommend starting from <a href="https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-BETA-Component-library?node-id=58855-81995" target="_blank">DS 2.0 templates</a>.
+  </goa-text>
+
+  <h3 id="existing-files">Starting from an existing design</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li><strong>Library swap</strong> — If your goal is to convert the whole file to DS 2.0, consider trying the library swap approach.</li>
+      <li><strong>Manual rebuild</strong> — The slowest approach, but gives you the most control. Consider using starter templates as a base for rebuilding your pages.</li>
+    </ul>
+  </goa-text>
+
+  <goa-callout version="2" type="important" emphasis="low" mt="none" mb="m">
+    <a href="https://help.figma.com/hc/en-us/articles/4404856784663-Swap-style-and-component-libraries" target="_blank">Library swap</a> results can vary. We recommend creating a copy of the file before attempting
+    a library swap.
+  </goa-callout>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="update-existing">Updating an existing project</h2>
+
+  <h3 id="developer-first">Developer-first</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    A developer creates a new branch, completes the upgrade steps, and runs the upgraded
+    application. This helps the team quickly see which areas need design updates to align with
+    DS 2.0.
+  </goa-text>
+
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>When reviewing the upgraded branch, watch for:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li>Spacing and layout rhythm</li>
+      <li>Typography scale/weight usage</li>
+      <li>Screens with dense content or constrained layouts (these will often have the highest risk of "breaking" during the update)</li>
+    </ul>
+  </goa-text>
+
+  <h3 id="design-first">Design-first</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ol>
+      <li>Identify custom elements created to support your users' needs.</li>
+      <li>Create an inventory and prioritize items by importance and effort.</li>
+      <li>Redesign the highest priority elements using the visual design values from the Styles library BETA.</li>
+    </ol>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    This can allow design work to proceed ahead of development rather than being blocked by the
+    version update.
+  </goa-text>
+
+  <goa-callout version="2" type="information" emphasis="low" mt="none" mb="m">
+    In most cases we recommend the Developer-First approach.
+  </goa-callout>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="file-location">File location and sharing</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Early adopter Figma files will be collected within the <a href="https://www.figma.com/files/1352057334427203708/project/546230850" target="_blank"><strong>Early adopter project</strong></a>
+    in the Design system workspace to:
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li>Facilitate learning from fellow early adopters and the design system team</li>
+      <li>Avoid confusion / chance encounters of experimental assets by practitioners who are not part of the early adopter program</li>
+    </ul>
+  </goa-text>
+</DocumentationPageLayout>

--- a/docs/src/pages/get-started/developers.astro
+++ b/docs/src/pages/get-started/developers.astro
@@ -1,0 +1,239 @@
+---
+/**
+ * Get Started - Developers (Early Adopters)
+ *
+ * Developer onboarding for the early adopters program.
+ * Package setup, template repo, branches, compatibility, custom components.
+ * Content from Confluence (Brief 65).
+ */
+import DocumentationPageLayout from '../../layouts/DocumentationPageLayout.astro';
+---
+
+<DocumentationPageLayout
+  title="Get started as a developer"
+  description="Get started with the experimental GoA Design System as a developer"
+  section="get-started"
+>
+  <goa-text version="2" size="heading-xl" mt="none" mb="m">Get started as a developer</goa-text>
+  <goa-text version="2" size="body-l" mt="none" mb="2xl">
+    Onboarding for the early adopters program.
+  </goa-text>
+
+  <goa-callout version="2" type="information" emphasis="low" heading="Key differences from v1" mb="m">
+    Early adopters use the same design system packages you're already familiar with, but opt into
+    experimental DS v2 by:
+    <ul style="margin-bottom: 0;">
+      <li>Importing Goabx components</li>
+      <li>Using the experimental prefix (<code>goab</code> &rarr; <code>goabx</code>)</li>
+      <li>Installing and applying <a href="https://www.npmjs.com/package/@abgov/design-tokens" target="_blank">design tokens</a></li>
+    </ul>
+  </goa-callout>
+
+  <goa-callout version="2" type="important" emphasis="low" mt="none" mb="m">
+    Angular 21 has not been formally tested by the design system team. A couple of teams have
+    used it successfully, but we can't guarantee full compatibility.
+  </goa-callout>
+
+  <!-- TODO: Add video walkthrough link when available -->
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="choose-how">Using design system v2</h2>
+
+  <h3 id="option-a">A) Try it in your existing app <goa-badge version="2" type="success" icon="false" emphasis="subtle" ml="m" content="Recommended" style="vertical-align: middle;"></goa-badge></h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    See what changes in your context before committing to a full upgrade.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ol>
+      <li>Create a branch in your repo</li>
+      <li>Apply the initial DS v2 setup changes (imports, prefix, tokens v2)</li>
+      <li>Run the app and review the changes</li>
+      <li>Start with one page and share back with your team — don't try to fix the entire app on day one</li>
+    </ol>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Why this approach works well:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <ul>
+      <li>Quick feedback on impact and risk</li>
+      <li>Easy to abandon (don't merge the branch)</li>
+    </ul>
+  </goa-text>
+
+  <h3 id="option-b" style="margin-top: var(--goa-space-xl);">B) Try the workspace template repo</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Understand the workspace pattern and DS v2 structure before applying it to your product.
+  </goa-text>
+
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ol>
+      <li>
+        Open the template repo for your framework:
+        <ul>
+          <li><a href="#">React</a></li>
+          <li><a href="#">Angular</a></li>
+        </ul>
+      </li>
+      <li>Click <strong>Use this template</strong></li>
+      <li>Choose <strong>Create a new repository</strong></li>
+      <li>Select an owner + repo name</li>
+      <li>Choose <strong>Public</strong> or <strong>Private</strong></li>
+      <li>Click <strong>Create repository from template</strong></li>
+      <li>Clone the repo locally</li>
+      <li>
+        Install and run, go into the directory you created and run the following commands (in order):
+        <ol>
+          <li><code>npm i</code></li>
+          <li><code>npm run build</code></li>
+          <li><code>npm run start</code> (Angular) or <code>npm run dev</code> (React)</li>
+        </ol>
+      </li>
+      <li>Go to the listed port number of your localhost</li>
+    </ol>
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="receive-updates">Choose how you receive updates</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    Consider your tolerance for changes.
+  </goa-text>
+
+  <h3 id="next-branch">Next branch <goa-badge version="2" type="success" icon="false" emphasis="subtle" ml="m" content="Recommended" style="vertical-align: middle;"></goa-badge></h3>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    Best balance of stability and the latest changes. You get changes once they have been reviewed
+    and tested.
+  </goa-text>
+
+  <h3 id="dev-branch">Dev branch <goa-badge version="2" type="warning" icon="false" emphasis="subtle" ml="m" content="Most current" style="vertical-align: middle;"></goa-badge></h3>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    Fastest access to new fixes and improvements. Expect more churn and occasional breaking
+    changes.
+  </goa-text>
+
+  <h3 id="production-branch">Production branch <goa-badge version="2" type="midtone" icon="false" emphasis="subtle" ml="m" content="Most stable" style="vertical-align: middle;"></goa-badge></h3>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    Least change over time. Not ideal for early adopters, since fixes and improvements arrive later.
+  </goa-text>
+
+  <goa-callout version="2" type="information" emphasis="low" mt="none" mb="m">
+    If you're unsure, start on "Next." Move to Dev if you need fixes sooner, or to
+    Production if you need more stability.
+  </goa-callout>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="compatibility">Compatibility and mixing rules</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    DS v2 experimental isn't "fully backward compatible" in practice because tokens v2 can
+    visually impact DS 1.0 components.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li>You'll get the best results when tokens and components are upgraded together.</li>
+      <li>Mixing experimental and production components in one app may be possible, but is not recommended.</li>
+    </ul>
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="plan-upgrade">Plan your upgrade scope</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li>If possible, start with a small/simple application while you're learning the new system.</li>
+      <li>For most teams with a monorepo setup, you will need to update the import statements and add the design tokens to the specific project you're upgrading.</li>
+    </ul>
+  </goa-text>
+
+  <goa-callout version="2" type="information" emphasis="low" mt="none" mb="m">
+    Monorepo setups can vary, which may affect the exact update steps. If you have
+    any questions, book a drop-in hours session.
+    <!-- TODO: Add drop-in hours booking link -->
+  </goa-callout>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="custom-components">Updating your custom components</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Most DDD services have custom UI alongside design system components. Set aside time to
+    review and adjust custom elements to align with DS v2 styles.
+  </goa-text>
+
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li>Start by identifying where you have custom UI (a quick inventory is enough to begin).</li>
+      <li>
+        Replace hard-coded values in your custom UI with the corresponding Tokens v2
+        values, such as:
+        <ul>
+          <li>Spacing (padding, margin, gaps)</li>
+          <li>Typography (font, size, weight, line height)</li>
+          <li>Color (text, background, borders)</li>
+          <li>Elevation / shadow (surfaces)</li>
+        </ul>
+      </li>
+    </ul>
+  </goa-text>
+
+  <h3 id="token-gaps">When tokens v2 values don't cover what you need</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li>Identify gaps where Tokens v2 don't cover what you need.</li>
+      <li>Where needed, create custom styles to bridge those gaps, while keeping them consistent with the DS v2 look and feel.</li>
+    </ul>
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="getting-help">Getting help and reporting issues</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Use the <a href="https://goa-dio.slack.com/archives/C0A9SN3JM7E" target="_blank"><strong>#design-system-early-adopters</strong></a> Slack channel first so the cohort benefits
+    and the design system team can clarify details before a GitHub issue is created.
+  </goa-text>
+  <goa-callout version="2" type="important" emphasis="low" mb="m">
+    Avoid DMs to individual design system team members, and avoid the standard
+    #design-system-support channel. Use the early adopters channel so all
+    participants can benefit.
+  </goa-callout>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Drop-in hours are the best option for deeper troubleshooting, debugging, or
+    talking through bugs and features.
+  </goa-text>
+  <goa-block version="2" gap="s" direction="row" alignment="center" mb="m">
+    <goa-link version="2"><a href="#">Book drop-in hours</a></goa-link>
+    <goa-text version="2" size="body-s" mt="none" mb="none">(Tuesdays + Fridays, 1–3 PM MT)</goa-text>
+  </goa-block>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="rollback">Rollback and branching strategy</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li>The simplest rollback is to reverse the setup steps.</li>
+      <li>If you're working in a branch, rollback can be as simple as not merging the branch.</li>
+      <li>Rollback becomes harder once you've made many manual updates to custom components.</li>
+    </ul>
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="end-of-program">End of program expectations</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li>
+        Moving to production at the end of the early adopter program (end of March 2026) includes
+        switching <code>goabx</code> &rarr; <code>goab</code>.
+      </li>
+      <li>
+        Once the early adopter program ends:
+        <ul>
+          <li>The experimental library will no longer be updated</li>
+          <li>Design system team effort will shift to the production libraries and packages</li>
+          <li>Web components continue to be updated</li>
+        </ul>
+      </li>
+    </ul>
+  </goa-text>
+</DocumentationPageLayout>

--- a/docs/src/pages/get-started/developers.astro
+++ b/docs/src/pages/get-started/developers.astro
@@ -23,9 +23,20 @@ import DocumentationPageLayout from '../../layouts/DocumentationPageLayout.astro
     Early adopters use the same design system packages you're already familiar with, but opt into
     experimental DS v2 by:
     <ul style="margin-bottom: 0;">
-      <li>Importing Goabx components</li>
-      <li>Using the experimental prefix (<code>goab</code> &rarr; <code>goabx</code>)</li>
-      <li>Installing and applying <a href="https://www.npmjs.com/package/@abgov/design-tokens" target="_blank">design tokens</a></li>
+      <li>Importing Goabx components
+        <ul>
+          <li>Angular: <a href="https://www.npmjs.com/package/@abgov/angular-components/v/4.10.0-next.1" target="_blank">4.10.0-next.1</a> or later</li>
+          <li>React: <a href="https://www.npmjs.com/package/@abgov/react-components/v/6.10.0-next.1" target="_blank">6.10.0-next.1</a> or later</li>
+          <li>Web: <a href="https://www.npmjs.com/package/@abgov/web-components/v/1.40.0-next.1" target="_blank">1.40.0-next.1</a> or later</li>
+          <li>ui-components-common: <a href="https://www.npmjs.com/package/@abgov/ui-components-common/v/1.10.0-next.1" target="_blank">1.10.0-next.1</a> or later</li>
+        </ul>
+      </li>
+      <li>Using the experimental prefix (<code>goab</code> &rarr; <code>goabx</code>)
+        <ul>
+          <li><a href="https://gist.github.com/vanessatran-ddi/29ec983351144bc3eb328c2a4d835a2b" target="_blank">Modified components reference</a></li>
+        </ul>
+      </li>
+      <li>Installing and applying <a href="https://www.npmjs.com/package/@abgov/design-tokens" target="_blank">tokens v2</a> (<code>designtokens2</code>)</li>
     </ul>
   </goa-callout>
 
@@ -34,7 +45,9 @@ import DocumentationPageLayout from '../../layouts/DocumentationPageLayout.astro
     used it successfully, but we can't guarantee full compatibility.
   </goa-callout>
 
-  <!-- TODO: Add video walkthrough link when available -->
+  <goa-button version="2" type="tertiary" size="compact" mt="m" mb="m">
+    <a href="https://jam.dev/c/e9bbd0f4-47a4-405a-b591-9b144f57a496" target="_blank" style="text-decoration: none; color: inherit;">View setup walkthrough video</a>
+  </goa-button>
 
   <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
 

--- a/docs/src/pages/get-started/developers.astro
+++ b/docs/src/pages/get-started/developers.astro
@@ -20,8 +20,8 @@ import DocumentationPageLayout from '../../layouts/DocumentationPageLayout.astro
   </goa-text>
 
   <goa-callout version="2" type="information" emphasis="low" heading="Key differences from v1" mb="m">
-    Early adopters use the same design system packages you're already familiar with, but opt into
-    experimental DS v2 by:
+    <p style="margin: 0;">Early adopters use the same design system packages you're already familiar with, but opt into
+    experimental DS v2 by:</p>
     <ul style="margin-bottom: 0;">
       <li>Importing Goabx components
         <ul>
@@ -36,7 +36,11 @@ import DocumentationPageLayout from '../../layouts/DocumentationPageLayout.astro
           <li><a href="https://gist.github.com/vanessatran-ddi/29ec983351144bc3eb328c2a4d835a2b" target="_blank">Modified components reference</a></li>
         </ul>
       </li>
-      <li>Installing and applying <a href="https://www.npmjs.com/package/@abgov/design-tokens" target="_blank">tokens v2</a> (<code>designtokens2</code>)</li>
+      <li>Installing and applying <a href="https://www.npmjs.com/package/@abgov/design-tokens" target="_blank">tokens v2</a> (<code>designtokens2</code>)
+        <ul>
+          <li>Import <code>@abgov/design-tokens/dist/tokens.css</code> in the global CSS of your app, below where you import <code>@abgov/web-components/index.css</code></li>
+        </ul>
+      </li>
     </ul>
   </goa-callout>
 

--- a/docs/src/pages/get-started/index.astro
+++ b/docs/src/pages/get-started/index.astro
@@ -55,15 +55,16 @@ import DocumentationPageLayout from '../../layouts/DocumentationPageLayout.astro
   <h2 id="before-you-start">Before you start</h2>
 
   <goa-callout version="2" type="important" emphasis="low" mb="m">
-    Be on the latest version of the current (production) design system before
+    Be on the latest version of the current next branch of the design system before
     attempting the experimental update.
   </goa-callout>
   <goa-text version="2" size="heading-xs" mt="none" mb="s">Minimum versions</goa-text>
   <goa-text version="2" size="body-m" mt="none" mb="m">
     <ul>
-      <li>Web components: TBD</li>
-      <li>React: TBD</li>
-      <li>Angular: TBD</li>
+      <li>Angular: <a href="https://www.npmjs.com/package/@abgov/angular-components/v/4.10.0-next.1" target="_blank">4.10.0-next.1</a> or later</li>
+      <li>React: <a href="https://www.npmjs.com/package/@abgov/react-components/v/6.10.0-next.1" target="_blank">6.10.0-next.1</a> or later</li>
+      <li>Web: <a href="https://www.npmjs.com/package/@abgov/web-components/v/1.40.0-next.1" target="_blank">1.40.0-next.1</a> or later</li>
+      <li>ui-components-common: <a href="https://www.npmjs.com/package/@abgov/ui-components-common/v/1.10.0-next.1" target="_blank">1.10.0-next.1</a> or later</li>
     </ul>
   </goa-text>
 

--- a/docs/src/pages/get-started/index.astro
+++ b/docs/src/pages/get-started/index.astro
@@ -1,121 +1,101 @@
 ---
 /**
- * Get Started - Landing Page
+ * Get Started - Landing Page (Early Adopters Program)
  *
- * Placeholder demonstrating the DocumentationPageLayout template.
- * Content will be migrated from existing documentation in Brief 30.
+ * Helps early adopter teams start using the experimental (pre-production)
+ * version of the design system. Content from Confluence (Brief 65).
  */
 import DocumentationPageLayout from '../../layouts/DocumentationPageLayout.astro';
 ---
 
 <DocumentationPageLayout
-  title="Get started"
-  description="Start building with the Government of Alberta Design System"
+  title="Early adopters program: Get started"
+  description="Get started with the experimental version of the GoA Design System"
   section="get-started"
 >
-  <goa-text version="2" size="heading-xl" mt="none" mb="m">Get started with the design system</goa-text>
+  <goa-text version="2" size="heading-xl" mt="none" mb="m">Early adopters program: Get started</goa-text>
   <goa-text version="2" size="body-l" mt="none" mb="2xl">
-    Start with the design system to build on the research and experience of other service teams
-    and avoid repeating work that's already been done.
+    This page helps early adopter teams start using the experimental (pre-production) version of
+    the design system.
   </goa-text>
 
-  <goa-callout version="2" type="information" heading="Documentation placeholder">
-    This page demonstrates the documentation template. Actual content from the current
-    design system website will be migrated here in a future update.
+  <goa-callout version="2" type="information" emphasis="low" heading="What &quot;experimental&quot; means" mb="m">
+    DS 2.0 pre-production components and templates available for early adopters to use and test
+    before the production release. Properties and visual design may change as the library
+    receives feedback and matures.
     <br /><br />
-    <a href="https://design.alberta.ca/get-started" target="_blank">View current Get Started documentation</a>
+    Early adopters should expect more change (and occasional rough edges) than production assets.
   </goa-callout>
 
-  <h2 id="why-design-system">Why use the design system?</h2>
-  <goa-text version="2" size="body-m" mt="none" mb="m">
-    The design system can save you time and effort getting to a better service, allowing you to
-    focus on other high-value work. By starting with the design system, you can:
-  </goa-text>
-  <goa-text version="2" size="body-m" mt="none" mb="l">
-    <ul>
-      <li>
-        <strong>Streamline collaboration:</strong> Your developers can use the corresponding coded
-        design system components.
-      </li>
-      <li>
-        <strong>Ensure better accessibility:</strong> Accessibility is built into the components
-        from both design and code.
-      </li>
-      <li>
-        <strong>Save time on testing:</strong> Components have been rigorously tested across
-        various devices, browsers, and service contexts.
-      </li>
-      <li>
-        <strong>Maintain consistency:</strong> Components are coordinated with the rest of the
-        system for a cohesive experience.
-      </li>
-    </ul>
-  </goa-text>
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
 
-  <h3 id="time-for-high-value">More time for high-value work</h3>
-  <goa-text version="2" size="body-m" mt="none" mb="m">
-    Leveraging what exists in the design system saves you time, enabling you to spend more time
-    on other high-value tasks such as:
-  </goa-text>
-  <goa-text version="2" size="body-m" mt="none" mb="l">
-    <ul>
-      <li>Usability testing</li>
-      <li>User research</li>
-      <li>Content design</li>
-      <li>Accessibility auditing</li>
-      <li>Design integrity of the product</li>
-      <li>Low fidelity design and testing</li>
-    </ul>
-  </goa-text>
+  <h2 id="choose-your-path">Choose your path</h2>
 
-  <h2 id="how-to-use">How do I use the design system?</h2>
-  <goa-text version="2" size="body-m" mt="none" mb="m">
-    Start by using the design system <a href="/components">components</a> and
-    <a href="/examples">patterns</a>. You should expect that this will cover about 80% of your
-    needs in a service. When usability testing shows that a new solution is needed, design a
-    better solution.
-  </goa-text>
-  <goa-text version="2" size="body-m" mt="none" mb="l">
-    <ol>
-      <li>Use the design system as the default first solution in design and development</li>
-      <li>Identify any needs that don't exist in the design system through user testing</li>
-      <li>Talk to the design system team to see what's available and what other teams have done</li>
-      <li>Test a better solution with users</li>
-      <li>Share learnings from design and development back to the design system</li>
-    </ol>
-  </goa-text>
-
-  <h3 id="for-designers">For designers</h3>
-  <goa-text version="2" size="body-m" mt="none" mb="m">
-    Get started by connecting to the GoA Figma libraries. The component library contains all
-    design system components with their variants and states. Use these components in your designs
-    to maintain consistency and enable smooth developer handoff.
-  </goa-text>
-  <goa-container version="2" type="interactive">
-    <goa-text version="2" size="heading-s" mt="none" mb="m">Figma resources</goa-text>
-    <goa-text version="2" size="body-m" mt="none" mb="none">
-      Connect to the GoA Styles Library and Component Library in Figma to access all design
-      system assets.
-    </goa-text>
+  <goa-container version="2" type="non-interactive" accent="thick" padding="compact" mb="m">
+    <span slot="title">A: Upgrade an existing service</span>
+    Best if your team wants to use DS 2.0 experimental components and templates to update an
+    existing product to the new look and feel. This gives you a head start on migration and
+    produces the most actionable feedback.
   </goa-container>
 
-  <h3 id="for-developers">For developers</h3>
+  <goa-container version="2" type="non-interactive" accent="thick" padding="compact" mb="m">
+    <span slot="title">B: Build a new service</span>
+    Best if your team is starting a new product or major feature and wants to build with DS 2.0
+    from the beginning. This is the cleanest path (no updating custom elements).
+  </goa-container>
+
+  <goa-container version="2" type="non-interactive" accent="thick" padding="compact" mb="m">
+    <span slot="title">C: Test in a sample project</span>
+    Best if your team wants to get a high level understanding of how DS 2.0 works and test the
+    setup process.
+  </goa-container>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="before-you-start">Before you start</h2>
+
+  <goa-callout version="2" type="important" emphasis="low" mb="m">
+    Be on the latest version of the current (production) design system before
+    attempting the experimental update.
+  </goa-callout>
+  <goa-text version="2" size="heading-xs" mt="none" mb="s">Minimum versions</goa-text>
   <goa-text version="2" size="body-m" mt="none" mb="m">
-    Install the design system packages for your framework. The design system supports React,
-    Angular, and Web Components.
-  </goa-text>
-  <pre><code>npm install @abgov/react-components @abgov/design-tokens</code></pre>
-  <goa-text version="2" size="body-m" mt="none" mb="l">
-    Import the design tokens CSS and start using components. All components follow the naming
-    convention <code>Goab*</code> for React and <code>goa-*</code> for Web Components.
+    <ul>
+      <li>Web components: TBD</li>
+      <li>React: TBD</li>
+      <li>Angular: TBD</li>
+    </ul>
   </goa-text>
 
-  <h2 id="governance">Governance process</h2>
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="getting-help">Getting help and reporting issues</h2>
   <goa-text version="2" size="body-m" mt="none" mb="m">
-    When you need something that doesn't exist in the design system, follow the governance
-    process to either request an addition or document your custom solution.
+    Use the <a href="https://goa-dio.slack.com/archives/C0A9SN3JM7E" target="_blank"><strong>#design-system-early-adopters</strong></a> Slack channel first so the whole
+    cohort can learn from questions and answers, and so the design system team can ask
+    clarifying questions before a GitHub issue is created.
   </goa-text>
-  <goa-callout version="2" type="information" heading="Remember">
-    Avoid custom solutions without a genuine user need to prevent unnecessary work and save time.
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    When reporting an issue, include any relevant screenshots, links, version details, or
+    reproduction steps.
+  </goa-text>
+  <goa-callout version="2" type="important" emphasis="low" mb="m">
+    Avoid DMs to individual design system team members, use the Slack channel so all
+    participants can benefit from the questions and answers.
   </goa-callout>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="useful-links">Useful links</h2>
+  <goa-block version="2" gap="s" direction="column">
+    <goa-link version="2"><a href="/get-started/designers">Designers: Get started</a></goa-link>
+    <goa-link version="2"><a href="/get-started/developers">Developers: Get started</a></goa-link>
+    <goa-link version="2"><a href="#">Workspace template repo</a></goa-link>
+    <goa-link version="2"><a href="#">Deployed workspace demo</a></goa-link>
+    <goa-link version="2"><a href="https://goa-dio.slack.com/archives/C0A9SN3JM7E" target="_blank">Early adopter Slack channel</a></goa-link>
+    <goa-block version="2" gap="s" direction="row" alignment="center">
+      <goa-link version="2"><a href="#">Book Drop-in hours</a></goa-link>
+      <goa-text version="2" size="body-s" mt="none" mb="none">(Tuesday and Friday 1-3 PM MST)</goa-text>
+    </goa-block>
+  </goa-block>
 </DocumentationPageLayout>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -17,9 +17,9 @@ import CardLite from '../components/CardLite.astro';
         <img src="/images/home/hero-banner-graphic.svg" alt="" />
       </div>
       <div class="hero-text">
-        <h1>Introducing the New Design System</h1>
+        <h1>A design system for Alberta government digital services</h1>
         <p class="hero-description">
-          Build on the research and experience of other service teams by using the DDD components and templates.
+          Build on the research and experience of other service teams by using shared components, examples, tokens, and templates.
         </p>
       </div>
     </div>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -252,6 +252,10 @@ import CardLite from '../components/CardLite.astro';
     margin-bottom: var(--goa-space-4xl);
   }
 
+  .card-grid:last-child {
+    margin-bottom: 0;
+  }
+
   .card-grid.two-col {
     grid-template-columns: repeat(2, 1fr);
   }
@@ -268,8 +272,8 @@ import CardLite from '../components/CardLite.astro';
 
     .hero-content {
       flex-direction: column;
-      text-align: center;
-      align-items: center;
+      text-align: left;
+      align-items: flex-start;
     }
 
     .hero-image {
@@ -303,6 +307,10 @@ import CardLite from '../components/CardLite.astro';
       font: var(--goa-typography-heading-xl);
     }
 
+    .hero-image {
+      max-width: 220px;
+    }
+
     .cta-text h2,
     .section-heading {
       font: var(--goa-typography-heading-l);
@@ -317,6 +325,8 @@ import CardLite from '../components/CardLite.astro';
       flex-direction: column;
       border-radius: 0;
       padding: 0 var(--goa-space-xs);
+      /* Extra top padding to account for header overlay (~73px) */
+      padding-top: 73px;
     }
 
     .hero-content {

--- a/docs/src/scripts/mobile-bridge.ts
+++ b/docs/src/scripts/mobile-bridge.ts
@@ -8,6 +8,7 @@
  * - data-mobile: "true" | "false" (viewport width < 624px)
  * - data-menu-open: "true" | "false" (sidebar menu state)
  * - data-header-hidden: "true" | "false" (header hidden on scroll down)
+ * - data-scrolled: "true" | "false" (page scrolled from top)
  *
  * Custom events listened for:
  * - goa-menu-change: { detail: { isOpen: boolean } }
@@ -19,6 +20,7 @@ const SIDEBAR_EXPANDED = 280;
 const SIDEBAR_COLLAPSED = 72;
 const SCROLL_UP_THRESHOLD = 10; // pixels of upward scroll to show header
 const SCROLL_DOWN_THRESHOLD = 50; // pixels from top before header can hide
+const SCROLLED_THRESHOLD = 80; // pixels before header background changes (after header hides)
 
 let lastScrollY = 0;
 let headerHidden = false;
@@ -56,10 +58,18 @@ function updateMobileState(): void {
  * - Scrolling up (any amount): show header
  */
 function handleScroll(): void {
-  // Only apply on mobile
-  if (window.innerWidth >= MOBILE_BREAKPOINT) return;
-
   const currentScrollY = window.scrollY;
+
+  // Track scrolled state (applies to all viewports, used for header transparency)
+  const isScrolled = currentScrollY > SCROLLED_THRESHOLD;
+  document.body.setAttribute('data-scrolled', String(isScrolled));
+
+  // Header hide/show only applies on mobile
+  if (window.innerWidth >= MOBILE_BREAKPOINT) {
+    lastScrollY = currentScrollY;
+    return;
+  }
+
   const scrollDelta = currentScrollY - lastScrollY;
 
   // Near top of page - always show header
@@ -112,6 +122,7 @@ function init(): void {
   updateMobileState();
   document.body.setAttribute('data-menu-open', 'false');
   document.body.setAttribute('data-header-hidden', 'false');
+  document.body.setAttribute('data-scrolled', String(window.scrollY > SCROLLED_THRESHOLD));
   lastScrollY = window.scrollY;
 
   // Listen for viewport changes


### PR DESCRIPTION
## Summary

- Upgrade root design tokens from `^1.8.0` to `^2.0.0` (backward compatible — same token names, updated V2 values)
- Migrate docs grid components to `Goabx*` experimental wrappers where available
- Use web components directly for Table, Tabs, Badge where wrappers don't pass `version` prop or are missing props
- Clean up `global.d.ts` to 5 tracked workaround entries (each with TODO comments for when to remove)
- Fixed expand button disappearing
- Added framework preference sync
- Fixed checkbox-list and text JSDoc not showing all props correctly

## Known workarounds (tracked in global.d.ts)

- `goa-table` — #3384 (V2 styling bug)
- `goa-table-sort-header` — wrapper missing `sortOrder` prop
- `goa-tabs` / `goa-tab` — wrapper missing `updateUrl`, `stackOnMobile`
- `goa-badge` — wrapper needs V2 types (`dawn`, `sky`, etc.)

---
 **Note:** Some files also include formatting changes (single → double quotes) applied by the repo's shared `formatOnSave` setting. 

_Created with the help of Claude_