### PR TITLE
 fix(#3385): fix v2 subtle badge borders

### DIFF
--- a/libs/web-components/src/components/badge/Badge.svelte
+++ b/libs/web-components/src/components/badge/Badge.svelte
@@ -419,37 +419,37 @@
 
   .v2.badge-subtle.badge-sky {
     background-color: var(--goa-color-extended-sky-light);
-    box-shadow: var(--goa-color-extended-sky-subtle-border);
+    box-shadow: var(--goa-badge-sky-subtle-border);
     color: var(--goa-color-extended-sky-text);
   }
 
   .v2.badge-subtle.badge-prairie {
     background-color: var(--goa-color-extended-prairie-light);
-    box-shadow: var(--goa-color-extended-prairie-subtle-border);
+    box-shadow: var(--goa-badge-prairie-subtle-border);
     color: var(--goa-color-extended-prairie-text);
   }
 
   .v2.badge-subtle.badge-lilac {
     background-color: var(--goa-color-extended-lilac-light);
-    box-shadow: var(--goa-color-extended-lilac-subtle-border);
+    box-shadow: var(--goa-badge-lilac-subtle-border);
     color: var(--goa-color-extended-lilac-text);
   }
 
   .v2.badge-subtle.badge-pasture {
     background-color: var(--goa-color-extended-pasture-light);
-    box-shadow: var(--goa-color-extended-pasture-subtle-border);
+    box-shadow: var(--goa-badge-pasture-subtle-border);
     color: var(--goa-color-extended-pasture-text);
   }
 
   .v2.badge-subtle.badge-sunset {
     background-color: var(--goa-color-extended-sunset-light);
-    box-shadow: var(--goa-color-extended-sunset-subtle-border);
+    box-shadow: var(--goa-badge-sunset-subtle-border);
     color: var(--goa-color-extended-sunset-text);
   }
 
   .v2.badge-subtle.badge-dawn {
     background-color: var(--goa-color-extended-dawn-light);
-    box-shadow: var(--goa-color-extended-dawn-subtle-border);
+    box-shadow: var(--goa-badge-dawn-subtle-border);
     color: var(--goa-color-extended-dawn-text);
   }
 


### PR DESCRIPTION
This PR fixes the issue of missing borders for v2 subtle badges. It uses the new design tokens from the related PR: https://github.com/GovAlta/design-tokens/pull/132

### Before

The subtle badges with extended colour types have no borders. 😢 

<img width="1466" height="164" alt="image" src="https://github.com/user-attachments/assets/cc24fcb8-ee85-4dfe-af58-4093b00700c0" />

### After

The subtle badges with extended colour types have borders! 🎉 

<img width="1459" height="193" alt="image" src="https://github.com/user-attachments/assets/8304ecdb-d5b2-4de7-9506-b4e1b0f80b8a" />
