### PR TITLE
fix(#3384): add v2 table border

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -56,6 +56,7 @@
           <a href="/bugs/3281">3281</a>
           <a href="/bugs/3337">3337 - Autocomplete styling</a>
           <a href="/bugs/3279">3279</a>
+          <a href="/bugs/3384">3384 Table v2 sample</a>
         </goab-side-menu-group>
         <goab-side-menu-group heading="Features">
           <a href="/features/1328">1328</a>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -42,6 +42,7 @@ import { Bug3275Component } from "../routes/bugs/3275/bug3275.component";
 import { Bug3281Component } from "../routes/bugs/3281/bug3281.component";
 import { Bug3337Component } from "../routes/bugs/3337/bug3337.component";
 import { Bug3279Component } from "../routes/bugs/3279/bug3279.component";
+import { Bug3384Component } from "../routes/bugs/3384/bug3384.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -112,6 +113,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3281", component: Bug3281Component },
   { path: "bugs/3337", component: Bug3337Component },
   { path: "bugs/3279", component: Bug3279Component },
+  { path: "bugs/3384", component: Bug3384Component },
 
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1383", component: Feat1383Component },

--- a/apps/prs/angular/src/routes/bugs/3384/bug3384.component.html
+++ b/apps/prs/angular/src/routes/bugs/3384/bug3384.component.html
@@ -1,0 +1,24 @@
+<goab-block direction="column" gap="l">
+  <goab-text tag="h1">Bug 3384 - Goabx Table Border</goab-text>
+
+  <goab-text tag="p"> The below table should have a border and border radius.</goab-text>
+
+  <goabx-table width="100%">
+    <thead>
+      <tr>
+        <th>Service</th>
+        <th>Status</th>
+        <th class="Goab-table-number-header">Requests</th>
+        <th>Updated</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let row of rows">
+        <td>{{ row.service }}</td>
+        <td>{{ row.status }}</td>
+        <td class="Goab-table-number-cell">{{ row.requests }}</td>
+        <td>{{ row.updated }}</td>
+      </tr>
+    </tbody>
+  </goabx-table>
+</goab-block>

--- a/apps/prs/angular/src/routes/bugs/3384/bug3384.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3384/bug3384.component.ts
@@ -1,0 +1,34 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { GoabBlock, GoabText, GoabxTable } from "@abgov/angular-components";
+
+type Row = {
+  service: string;
+  status: string;
+  requests: number;
+  updated: string;
+};
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3384",
+  templateUrl: "./bug3384.component.html",
+  imports: [CommonModule, GoabBlock, GoabText, GoabxTable],
+})
+export class Bug3384Component {
+  readonly rows: Row[] = [
+    {
+      service: "Alberta.ca Accounts",
+      status: "Operational",
+      requests: 128,
+      updated: "2026-02-05",
+    },
+    { service: "Payments", status: "Degraded", requests: 42, updated: "2026-02-04" },
+    {
+      service: "Notifications",
+      status: "Maintenance",
+      requests: 7,
+      updated: "2026-02-03",
+    },
+  ];
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -66,6 +66,7 @@ export function App() {
               <Link to="/bugs/3281">3281 GoabText p tag margin issues</Link>
               <Link to="/bugs/3337">3337 Input autocomplete styling</Link>
               <Link to="/bugs/3279">3279 Work Side Menu Key Nav</Link>
+              <Link to="/bugs/3384">3384 v2 Table Border</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Features">
               <Link to="/features/1383">1383 Button Filled Icons</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -44,6 +44,7 @@ import { Bug3275Route } from "./routes/bugs/bug3275";
 import { Bug3322Route } from "./routes/bugs/bug3322";
 import { Bug3281Route } from "./routes/bugs/bug3281";
 import { Bug3337Route } from "./routes/bugs/bug3337";
+import { Bug3384Route } from "./routes/bugs/bug3384";
 
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
@@ -123,6 +124,7 @@ root.render(
           <Route path="bugs/3322" element={<Bug3322Route />} />
           <Route path="bugs/3281" element={<Bug3281Route />} />
           <Route path="bugs/3337" element={<Bug3337Route />} />
+          <Route path="bugs/3384" element={<Bug3384Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3384.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3384.tsx
@@ -1,0 +1,45 @@
+import { GoabBlock, GoabText } from "@abgov/react-components";
+import { GoabxTable } from "@abgov/react-components/experimental";
+
+export function Bug3384Route() {
+  return (
+    <GoabBlock direction="column" gap="l">
+      <GoabText tag="h1">Bug 3384 - GoabxTable Border</GoabText>
+
+      <GoabText tag="p">
+        The below table should have a border with a border radius.
+      </GoabText>
+
+      <GoabxTable width="100%">
+        <thead>
+          <tr>
+            <th>Service</th>
+            <th>Status</th>
+            <th className="Goab-table-number-header">Requests</th>
+            <th>Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Alberta.ca Accounts</td>
+            <td>Operational</td>
+            <td className="Goab-table-number-cell">128</td>
+            <td>2026-02-05</td>
+          </tr>
+          <tr>
+            <td>Payments</td>
+            <td>Degraded</td>
+            <td className="Goab-table-number-cell">42</td>
+            <td>2026-02-04</td>
+          </tr>
+          <tr>
+            <td>Notifications</td>
+            <td>Maintenance</td>
+            <td className="Goab-table-number-cell">7</td>
+            <td>2026-02-03</td>
+          </tr>
+        </tbody>
+      </GoabxTable>
+    </GoabBlock>
+  );
+}

--- a/libs/web-components/src/assets/css/components.css
+++ b/libs/web-components/src/assets/css/components.css
@@ -39,6 +39,11 @@ goa-table table {
   border-collapse: collapse;
 }
 
+goa-table[version="2"] table {
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
 goa-table.sticky thead {
   position: sticky;
   top: 0;

--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -170,9 +170,7 @@
   }
 
   /* V2 Border and Border-Radius */
-  .v2 table {
-    border-collapse: separate;
-    border-spacing: 0;
+  .v2.goatable {
     border: var(--goa-table-container-border, 1px solid #e7e7e7);
     border-radius: var(--goa-table-border-radius-container, 16px);
     overflow: hidden;


### PR DESCRIPTION
This PR fixes the v2 table border.

# Before (the change)

The v2 Table doesn't have a border. 😢 

<img width="685" height="248" alt="image" src="https://github.com/user-attachments/assets/e5136d11-69f2-483a-b66e-e2406eb2be5d" />

# After (the change)

The v2 Table has a border! 🎉 

<img width="687" height="239" alt="image" src="https://github.com/user-attachments/assets/08609a0f-fb48-457d-9cb2-1ff783de3439" />
