### PR TITLE
fix(#3337): Fixed styling for input using autocomplete

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -54,6 +54,7 @@
           <a href="/bugs/3248">3248</a>
           <a href="/bugs/3275">3275 Can't unset month</a>
           <a href="/bugs/3281">3281</a>
+          <a href="/bugs/3337">3337 - Autocomplete styling</a>
         </goab-side-menu-group>
         <goab-side-menu-group heading="Features">
           <a href="/features/1328">1328</a>
@@ -67,6 +68,7 @@
           <a href="/features/2361">2361</a>
           <a href="/features/2440">2440</a>
           <a href="/features/2492">2492</a>
+          <a href="/features/2609">2609</a>
           <a href="/features/2611">2611</a>
           <a href="/features/2611-tabs-disabled">2611-tabs-disabled</a>
           <a href="/features/2682">2682</a>
@@ -74,13 +76,10 @@
           <a href="/features/2730">2730</a>
           <a href="/features/2829">2829</a>
           <a href="/features/3102">3102</a>
-          <a href="/features/3306">3306</a>
-          <a href="/features/1908">1908</a>
-          <a href="/features/2609">2609</a>
-          <a href="/features/3241">3241</a>
-          <a href="/features/v2-icons">v2 header icons</a>
           <a href="/features/3137">3137</a>
-          <a href="/features/1908">1908</a>
+          <a href="/features/3241">3241</a>
+          <a href="/features/3306">3306</a>
+          <a href="/features/v2-icons">v2 header icons</a>
         </goab-side-menu-group>
       </goab-side-menu>
     </section>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Route } from "@angular/router";
 
 import { EverythingComponent } from "./everything.component";
+
 import { Bug2152Component } from "../routes/bugs/2152/bug2152.component";
 import { Bug2331Component } from "../routes/bugs/2331/bug2331.component";
 import { Bug2393Component } from "../routes/bugs/2393/bug2393.component";
@@ -39,17 +40,20 @@ import { Bug3215Component } from "../routes/bugs/3215/bug3215.component";
 import { Bug3248Component } from "../routes/bugs/3248/bug3248.component";
 import { Bug3275Component } from "../routes/bugs/3275/bug3275.component";
 import { Bug3281Component } from "../routes/bugs/3281/bug3281.component";
+import { Bug3337Component } from "../routes/bugs/3337/bug3337.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
 import { Feat1547Component } from "../routes/features/feat1547/feat1547.component";
 import { Feat1813Component } from "../routes/features/feat1813/feat1813.component";
+import { Feat1908Component } from "../routes/features/feat1908/feat1908.component";
 import { Feat2054Component } from "../routes/features/feat2054/feat2054.component";
 import { Feat2267Component } from "../routes/features/feat2267/feat2267.component";
 import { Feat2328Component } from "../routes/features/feat2328/feat2328.component";
 import { Feat2361Component } from "../routes/features/feat2361/feat2361.component";
 import { Feat2440Component } from "../routes/features/feat2440/feat2440.component";
 import { Feat2492Component } from "../routes/features/feat2492/feat2492.component";
+import { Feat2609Component } from "../routes/features/feat2609/feat2609.component";
 import { Feat2611Component } from "../routes/features/feat2611/feat2611.component";
 import { Feat2611TabsDisabledComponent } from "../routes/features/feat2611-tabs-disabled/feat2611-tabs-disabled.component";
 import { Feat2682Component } from "../routes/features/feat2682/feat2682.component";
@@ -57,11 +61,9 @@ import { Feat2722Component } from "../routes/features/feat2722/feat2722.componen
 import { Feat2730Component } from "../routes/features/feat2730/feat2730.component";
 import { Feat2829Component } from "../routes/features/feat2829/feat2829.component";
 import { Feat3102Component } from "../routes/features/feat3102/feat3102.component";
-import { Feat1908Component } from "../routes/features/feat1908/feat1908.component";
-import { Feat2609Component } from "../routes/features/feat2609/feat2609.component";
-import { Feat3241Component } from "../routes/features/feat3241/feat3241.component";
 import { FeatV2IconsComponent } from "../routes/features/featV2Icons/feat-v2-icons.component";
 import { Feat3137Component } from "../routes/features/feat3137/feat3137.component";
+import { Feat3241Component } from "../routes/features/feat3241/feat3241.component";
 import { Feat3306Component } from "../routes/features/feat3306/feat3306.component";
 
 export const appRoutes: Route[] = [
@@ -105,6 +107,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3248", component: Bug3248Component },
   { path: "bugs/3275", component: Bug3275Component },
   { path: "bugs/3281", component: Bug3281Component },
+  { path: "bugs/3337", component: Bug3337Component },
 
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1383", component: Feat1383Component },
@@ -117,6 +120,7 @@ export const appRoutes: Route[] = [
   { path: "features/2361", component: Feat2361Component },
   { path: "features/2440", component: Feat2440Component },
   { path: "features/2492", component: Feat2492Component },
+  { path: "features/2609", component: Feat2609Component },
   { path: "features/2611", component: Feat2611Component },
   { path: "features/2611-tabs-disabled", component: Feat2611TabsDisabledComponent },
   { path: "features/2682", component: Feat2682Component },
@@ -124,10 +128,8 @@ export const appRoutes: Route[] = [
   { path: "features/2730", component: Feat2730Component },
   { path: "features/2829", component: Feat2829Component },
   { path: "features/3102", component: Feat3102Component },
-  { path: "features/2609", component: Feat2609Component },
+  { path: "features/3137", component: Feat3137Component },
   { path: "features/3241", component: Feat3241Component },
   { path: "features/v2-icons", component: FeatV2IconsComponent },
-  { path: "features/3137", component: Feat3137Component },
-  { path: "features/1908", component: Feat1908Component },
   { path: "features/3306", component: Feat3306Component },
 ];

--- a/apps/prs/angular/src/routes/bugs/3337/bug3337.component.html
+++ b/apps/prs/angular/src/routes/bugs/3337/bug3337.component.html
@@ -1,0 +1,25 @@
+<goab-text tag="h1">Bug 3337 - Input autocomplete default styling</goab-text>
+<goab-text tag="p">
+  Chromium browsers add their own styling to inputs using autocomplete, which overwrites
+  our styling. This is to ensure our styling remains at all times.
+</goab-text>
+
+<goab-form-item label="Autocomplete Input" mb="xl">
+  <goab-input
+    name="autocomplete-test"
+    leadingIcon="search"
+    (onBlur)="inputBlur($event)"
+    [value]="inputValue"
+    autoComplete="name"
+  />
+</goab-form-item>
+<goab-form-item label="Autocomplete Input (Goabx)" mb="xl">
+  <goabx-input
+    name="autocomplete-test-v2"
+    leadingIcon="search"
+    (onBlur)="inputBlur($event)"
+    [value]="inputValue"
+    autoComplete="name"
+  />
+</goab-form-item>
+<goab-button (onClick)="buttonClick()">Click Me</goab-button>

--- a/apps/prs/angular/src/routes/bugs/3337/bug3337.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3337/bug3337.component.ts
@@ -1,0 +1,27 @@
+import { Component } from "@angular/core";
+import {
+  GoabInput,
+  GoabButton,
+  GoabFormItem,
+  GoabText,
+  GoabxInput,
+  GoabInputOnBlurDetail,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3337",
+  templateUrl: "./bug3337.component.html",
+  imports: [GoabInput, GoabxInput, GoabButton, GoabText, GoabFormItem],
+})
+export class Bug3337Component {
+  inputValue = "";
+
+  buttonClick() {
+    console.log("clicked");
+  }
+
+  inputBlur(details: GoabInputOnBlurDetail) {
+    this.inputValue = details.value;
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -64,6 +64,7 @@ export function App() {
               <Link to="/bugs/3275">3275 Can't unset month</Link>
               <Link to="/bugs/3322">3322 App Header Menu Hover</Link>
               <Link to="/bugs/3281">3281 GoabText p tag margin issues</Link>
+              <Link to="/bugs/3337">3337 Input autocomplete styling</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Features">
               <Link to="/features/1383">1383 Button Filled Icons</Link>
@@ -85,9 +86,9 @@ export function App() {
               <Link to="/features/2829">2829 Modal ARIA Live Region</Link>
               <Link to="/features/2877">2877 Badge Types and Custom Icon</Link>
               <Link to="/features/3102">3102 MenuButton Width</Link>
+              <Link to="/features/3137">3137 Work Side Menu Group</Link>
               <Link to="/features/3241">3241 V2 Experimental Wrappers</Link>
               <Link to="/features/v2-icons">v2 header icons</Link>
-              <Link to="/features/3137">3137 Work Side Menu Group</Link>
               <Link to="/features/3306">3306 Custom slug value for tabs</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Everything">

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -42,10 +42,12 @@ import { Bug3248Route } from "./routes/bugs/bug3248";
 import { Bug3275Route } from "./routes/bugs/bug3275";
 import { Bug3322Route } from "./routes/bugs/bug3322";
 import { Bug3281Route } from "./routes/bugs/bug3281";
+import { Bug3337Route } from "./routes/bugs/bug3337";
 
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
-import Feat1383Route from "./routes/features/feat1383";
+
+import { Feat1383Route } from "./routes/features/feat1383";
 import { Feat1547Route } from "./routes/features/feat1547";
 import { Feat1813Route } from "./routes/features/feat1813";
 import { Feat1908Route } from "./routes/features/feat1908";
@@ -67,7 +69,7 @@ import { Feat3102Route } from "./routes/features/feat3102";
 import { Feat3241Route } from "./routes/features/feat3241";
 import { FeatV2IconsRoute } from "./routes/features/featV2Icons";
 import { Feat3137Route } from "./routes/features/feat3137";
-import Feat3306Route from "./routes/features/feat3306";
+import { Feat3306Route } from "./routes/features/feat3306";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 
@@ -116,6 +118,7 @@ root.render(
           <Route path="bugs/3275" element={<Bug3275Route />} />
           <Route path="bugs/3322" element={<Bug3322Route />} />
           <Route path="bugs/3281" element={<Bug3281Route />} />
+          <Route path="bugs/3337" element={<Bug3337Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />
@@ -139,10 +142,9 @@ root.render(
           <Route path="features/2829" element={<Feat2829Route />} />
           <Route path="features/2877" element={<Feat2877Route />} />
           <Route path="features/3102" element={<Feat3102Route />} />
+          <Route path="features/3137" element={<Feat3137Route />} />
           <Route path="features/3241" element={<Feat3241Route />} />
           <Route path="features/v2-icons" element={<FeatV2IconsRoute />} />
-          <Route path="features/3137" element={<Feat3137Route />} />
-          <Route path="features/1908" element={<Feat1908Route />} />
           <Route path="features/3306" element={<Feat3306Route />} />
         </Route>
       </Routes>

--- a/apps/prs/react/src/routes/bugs/bug3337.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3337.tsx
@@ -1,0 +1,46 @@
+import { GoabText, GoabFormItem, GoabInput, GoabButton } from "@abgov/react-components";
+import { GoabxInput } from "@abgov/react-components/experimental";
+import { GoabInputOnBlurDetail } from "@abgov/ui-components-common";
+import { useState } from "react";
+
+export function Bug3337Route() {
+  const [inputValue, setInputValue] = useState<string>("");
+
+  function buttonClick() {
+    console.log("clicked");
+  }
+
+  function inputBlur(details: GoabInputOnBlurDetail) {
+    setInputValue(details.value);
+  }
+
+  return (
+    <>
+      <GoabText tag="h1">Bug 3337 - Input autocomplete default styling</GoabText>
+      <GoabText tag="p">
+        Chromium browsers add their own styling to inputs using autocomplete, which
+        overwrites our styling. This is to ensure our styling remains at all times.
+      </GoabText>
+
+      <GoabFormItem label="Autocomplete Input" mb="xl">
+        <GoabInput
+          name="autocomplete-test"
+          leadingIcon="search"
+          onBlur={(e) => inputBlur(e)}
+          value={inputValue}
+          autoComplete="name"
+        />
+      </GoabFormItem>
+      <GoabFormItem label="Autocomplete Input (Goabx)" mb="xl">
+        <GoabxInput
+          name="autocomplete-test-v2"
+          leadingIcon="search"
+          onBlur={(e) => inputBlur(e)}
+          value={inputValue}
+          autoComplete="name"
+        />
+      </GoabFormItem>
+      <GoabButton onClick={() => buttonClick()}>Click Me</GoabButton>
+    </>
+  );
+}

--- a/apps/prs/react/src/routes/features/feat1383.tsx
+++ b/apps/prs/react/src/routes/features/feat1383.tsx
@@ -304,5 +304,3 @@ export function Feat1383Route() {
     </main>
   );
 }
-
-export default Feat1383Route;

--- a/apps/prs/react/src/routes/features/feat3306.tsx
+++ b/apps/prs/react/src/routes/features/feat3306.tsx
@@ -9,7 +9,7 @@ import {
   GoabButton,
 } from "@abgov/react-components";
 
-export default function Feat3306Component() {
+export function Feat3306Route() {
   const review = [0, 1, 2, 3];
   const complete = [0, 1];
 

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -543,7 +543,9 @@
     );
   }
 
-  .goa-input:not(.error):not(.input--disabled):hover:not(:has(input:focus-visible)) {
+  .goa-input:not(.error):not(.input--disabled):hover:not(
+      :has(input:focus-visible)
+    ) {
     /* hover border */
     box-shadow: var(--goa-text-input-border-hover);
   }
@@ -696,7 +698,9 @@
   }
 
   /* V2: Read-only input field styling (exclude disabled inputs) */
-  .container.v2.goa-input:not(.error)::has(input:read-only:not(:disabled):not(:focus-visible):not(:hover)) {
+  .container.v2.goa-input:not(.error)::has(
+      input:read-only:not(:disabled):not(:focus-visible):not(:hover)
+    ) {
     box-shadow: var(--goa-text-input-border-readonly);
   }
 
@@ -801,7 +805,6 @@
 
   /* Autofill styling - override browser defaults */
   input:autofill {
-    background-color: var(--goa-text-input-color-bg) !important;
-    -webkit-text-fill-color: var(--goa-text-input-color-text) !important;
+    transition: all 0s 5000s;
   }
 </style>


### PR DESCRIPTION
# Before (the change)

Before, whenever you hovered over an autocomplete option, or selected an autocomplete option, the input component would look like this:

<img width="1667" height="636" alt="image" src="https://github.com/user-attachments/assets/264019ea-a286-440d-998a-58e1dd33e656" />

# After (the change)

Now, when you select an autocomplete option, the Input component should look how the Input component always looks. The only catch, is when you hover over an autocomplete option, the font style still changes.

**NOTE:** I didn't add any tests beyond the PR tests, because this is a purely visual issue. There are a couple things about this fix. As far as I'm aware and have tried, it is completely impossible to override browser native styles. So the best option I could figure out how to do is hide the style change using the `transition` CSS property. This seems to work in at least Chromium browsers, but testing needs to happen for Firefox and for Safari. This also means I can't do anything about the change in font style on hover. If you have any ideas you want me to try, please let me know, but keep in mind I've tried a lot of options.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the PR created for both Angular and React, Bug 3337. Please update design-tokens to 2.0.0 on your local machine to test the Goabx component.
