### PR TITLE
fix: Adding TableSortHeader to Angular experimental wrappers

### DIFF
--- a/apps/prs/angular/src/routes/features/feat3241/feat3241.component.html
+++ b/apps/prs/angular/src/routes/features/feat3241/feat3241.component.html
@@ -411,62 +411,78 @@
 <goab-grid minChildWidth="500px" gap="xl" mb="xl">
   <div>
     <goab-text tag="h3" mb="m">GoabxTable</goab-text>
-    <goabx-table>
+    <goabx-table (onSort)="handleSort($event)">
       <thead>
         <tr>
-          <th>Service</th>
-          <th>Status</th>
+          <th>
+            <goabx-table-sort-header name="firstName">First name</goabx-table-sort-header>
+          </th>
+          <th>
+            <goabx-table-sort-header name="lastName">Last name</goabx-table-sort-header>
+          </th>
+          <th>
+            <goabx-table-sort-header name="age" direction="asc"
+              >Age</goabx-table-sort-header
+            >
+          </th>
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td>Payments</td>
-          <td>Active</td>
-        </tr>
-        <tr>
-          <td>Reporting</td>
-          <td>Pending</td>
-        </tr>
+        @for (user of users; track $index) {
+          <tr>
+            <td>{{ user.firstName }}</td>
+            <td>{{ user.lastName }}</td>
+            <td>{{ user.age }}</td>
+          </tr>
+        }
       </tbody>
     </goabx-table>
     <goab-text tag="h3" mb="m">GoabxTable - Striped = true</goab-text>
     <goabx-table [striped]="true">
       <thead>
         <tr>
-          <th>Service</th>
-          <th>Status</th>
+          <th>First name</th>
+          <th>Last name</th>
+          <th>Age</th>
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td>Payments</td>
-          <td>Active</td>
-        </tr>
-        <tr>
-          <td>Reporting</td>
-          <td>Pending</td>
-        </tr>
+        @for (user of users; track $index) {
+          <tr>
+            <td>{{ user.firstName }}</td>
+            <td>{{ user.lastName }}</td>
+            <td>{{ user.age }}</td>
+          </tr>
+        }
       </tbody>
     </goabx-table>
   </div>
   <div>
     <goab-text tag="h3" mb="m">GoabTable</goab-text>
-    <goab-table>
+    <goab-table (onSort)="handleSort($event)">
       <thead>
         <tr>
-          <th>Service</th>
-          <th>Status</th>
+          <th>
+            <goab-table-sort-header name="firstName">First name</goab-table-sort-header>
+          </th>
+          <th>
+            <goab-table-sort-header name="lastName">Last name</goab-table-sort-header>
+          </th>
+          <th>
+            <goab-table-sort-header name="age" direction="asc"
+              >Age</goab-table-sort-header
+            >
+          </th>
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td>Payments</td>
-          <td>Active</td>
-        </tr>
-        <tr>
-          <td>Reporting</td>
-          <td>Pending</td>
-        </tr>
+        @for (user of users; track $index) {
+          <tr>
+            <td>{{ user.firstName }}</td>
+            <td>{{ user.lastName }}</td>
+            <td>{{ user.age }}</td>
+          </tr>
+        }
       </tbody>
     </goab-table>
   </div>

--- a/apps/prs/angular/src/routes/features/feat3241/feat3241.component.ts
+++ b/apps/prs/angular/src/routes/features/feat3241/feat3241.component.ts
@@ -29,6 +29,7 @@ import {
   GoabSideMenuHeading,
   GoabTab,
   GoabTable,
+  GoabTableSortHeader,
   GoabTabs,
   GoabText,
   GoabTextArea,
@@ -57,6 +58,7 @@ import {
   GoabxSideMenuGroup,
   GoabxSideMenuHeading,
   GoabxTable,
+  GoabxTableSortHeader,
   GoabxTabs,
   GoabxTextArea,
   GoabDatePicker,
@@ -67,7 +69,14 @@ import {
 import {
   GoabPaginationOnChangeDetail,
   GoabTabsOnChangeDetail,
+  GoabTableOnSortDetail,
 } from "@abgov/ui-components-common";
+
+interface User {
+  firstName: string;
+  lastName: string;
+  age: number;
+}
 
 @Component({
   standalone: true,
@@ -105,6 +114,7 @@ import {
     GoabSideMenuHeading,
     GoabTab,
     GoabTable,
+    GoabTableSortHeader,
     GoabTabs,
     GoabText,
     GoabTextArea,
@@ -135,6 +145,7 @@ import {
     GoabxSideMenuGroup,
     GoabxSideMenuHeading,
     GoabxTable,
+    GoabxTableSortHeader,
     GoabxTabs,
     GoabxTextArea,
   ],
@@ -156,6 +167,38 @@ export class Feat3241Component {
 
   goabxNotificationStatus = "No dismiss action yet.";
   goabNotificationStatus = "No dismiss action yet.";
+
+  users: User[] = [];
+
+  constructor() {
+    this.users = [
+      {
+        firstName: "Christian",
+        lastName: "Batz",
+        age: 18,
+      },
+      {
+        firstName: "Brain",
+        lastName: "Wisozk",
+        age: 19,
+      },
+      {
+        firstName: "Neha",
+        lastName: "Jones",
+        age: 23,
+      },
+      {
+        firstName: "Tristin",
+        lastName: "Buckridge",
+        age: 31,
+      },
+    ];
+  }
+
+  handleSort(event: GoabTableOnSortDetail) {
+    const { sortBy, sortDir } = event;
+    this.users.sort((a: any, b: any) => (a[sortBy] > b[sortBy] ? 1 : -1) * sortDir);
+  }
 
   openGoabxDrawer() {
     this.goabxDrawerOpen = true;

--- a/apps/prs/react/src/routes/features/feat3241.tsx
+++ b/apps/prs/react/src/routes/features/feat3241.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   GoabAppFooter,
   GoabAppFooterMetaSection,
@@ -30,6 +30,7 @@ import {
   GoabSideMenuHeading,
   GoabTab,
   GoabTable,
+  GoabTableSortHeader,
   GoabTabs,
   GoabText,
   GoabTextArea,
@@ -62,15 +63,45 @@ import {
   GoabxSideMenuGroup,
   GoabxSideMenuHeading,
   GoabxTable,
+  GoabxTableSortHeader,
   GoabxTabs,
   GoabxTextArea,
 } from "@abgov/react-components/experimental";
 import type {
   GoabPaginationOnChangeDetail,
+  GoabTableOnSortDetail,
   GoabTabsOnChangeDetail,
 } from "@abgov/ui-components-common";
 
+interface User {
+  firstName: string;
+  lastName: string;
+  age: number;
+}
+
 export function Feat3241Route() {
+  const [users, setUsers] = useState<User[]>([
+    {
+      firstName: "Christian",
+      lastName: "Batz",
+      age: 18,
+    },
+    {
+      firstName: "Brain",
+      lastName: "Wisozk",
+      age: 19,
+    },
+    {
+      firstName: "Neha",
+      lastName: "Jones",
+      age: 23,
+    },
+    {
+      firstName: "Tristin",
+      lastName: "Buckridge",
+      age: 31,
+    },
+  ]);
   const [goabxDrawerOpen, setGoabxDrawerOpen] = useState(false);
   const [goabDrawerOpen, setGoabDrawerOpen] = useState(false);
   const [goabxModalOpen, setGoabxModalOpen] = useState(false);
@@ -123,6 +154,15 @@ export function Feat3241Route() {
   const noop = () => {
     /* nothing */
   };
+
+  function sortData(event: GoabTableOnSortDetail) {
+    console.log("sorting");
+    const _users = [...users];
+    _users.sort((a: any, b: any) => {
+      return (a[event.sortBy] > b[event.sortBy] ? 1 : -1) * event.sortDir;
+    });
+    setUsers(_users);
+  }
 
   return (
     <>
@@ -700,22 +740,30 @@ export function Feat3241Route() {
           <GoabText tag="h3" mb="m">
             GoabxTable
           </GoabText>
-          <GoabxTable>
+          <GoabxTable onSort={sortData}>
             <thead>
               <tr>
-                <th>Service</th>
-                <th>Status</th>
+                <th>
+                  <GoabxTableSortHeader name="firstName">First name</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="lastName">Last name</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="age" direction="asc">
+                    Age
+                  </GoabxTableSortHeader>
+                </th>
               </tr>
             </thead>
             <tbody>
-              <tr>
-                <td>Payments</td>
-                <td>Active</td>
-              </tr>
-              <tr>
-                <td>Reporting</td>
-                <td>Pending</td>
-              </tr>
+              {users.map((user) => (
+                <tr key={user.firstName}>
+                  <td>{user.firstName}</td>
+                  <td>{user.lastName}</td>
+                  <td>{user.age}</td>
+                </tr>
+              ))}
             </tbody>
           </GoabxTable>
           <GoabText tag="h3" mb="m">
@@ -724,19 +772,19 @@ export function Feat3241Route() {
           <GoabxTable striped>
             <thead>
               <tr>
-                <th>Service</th>
-                <th>Status</th>
+                <th>First name</th>
+                <th>Last name</th>
+                <th>Age</th>
               </tr>
             </thead>
             <tbody>
-              <tr>
-                <td>Payments</td>
-                <td>Active</td>
-              </tr>
-              <tr>
-                <td>Reporting</td>
-                <td>Pending</td>
-              </tr>
+              {users.map((user) => (
+                <tr key={user.firstName}>
+                  <td>{user.firstName}</td>
+                  <td>{user.lastName}</td>
+                  <td>{user.age}</td>
+                </tr>
+              ))}
             </tbody>
           </GoabxTable>
         </div>
@@ -744,22 +792,30 @@ export function Feat3241Route() {
           <GoabText tag="h3" mb="m">
             GoabTable
           </GoabText>
-          <GoabTable>
+          <GoabTable onSort={sortData}>
             <thead>
               <tr>
-                <th>Service</th>
-                <th>Status</th>
+                <th>
+                  <GoabTableSortHeader name="firstName">First name</GoabTableSortHeader>
+                </th>
+                <th>
+                  <GoabTableSortHeader name="lastName">Last name</GoabTableSortHeader>
+                </th>
+                <th>
+                  <GoabTableSortHeader name="age" direction="asc">
+                    Age
+                  </GoabTableSortHeader>
+                </th>
               </tr>
             </thead>
             <tbody>
-              <tr>
-                <td>Payments</td>
-                <td>Active</td>
-              </tr>
-              <tr>
-                <td>Reporting</td>
-                <td>Pending</td>
-              </tr>
+              {users.map((user) => (
+                <tr key={user.firstName}>
+                  <td>{user.firstName}</td>
+                  <td>{user.lastName}</td>
+                  <td>{user.age}</td>
+                </tr>
+              ))}
             </tbody>
           </GoabTable>
         </div>

--- a/libs/angular-components/src/experimental/index.ts
+++ b/libs/angular-components/src/experimental/index.ts
@@ -25,6 +25,7 @@ export * from "./side-menu/side-menu";
 export * from "./side-menu-group/side-menu-group";
 export * from "./side-menu-heading/side-menu-heading";
 export * from "./table/table";
+export * from "./table-sort-header/table-sort-header";
 export * from "./textarea/textarea";
 export * from "./tabs/tabs";
 export * from "./work-side-menu/work-side-menu";

--- a/libs/angular-components/src/experimental/table-sort-header/table-sort-header.spec.ts
+++ b/libs/angular-components/src/experimental/table-sort-header/table-sort-header.spec.ts
@@ -1,0 +1,41 @@
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { GoabxTableSortHeader } from "./table-sort-header";
+
+@Component({
+  standalone: true,
+  imports: [GoabxTableSortHeader],
+  template: `
+    <th>
+      <goabx-table-sort-header name="firstName" direction="asc">
+        First name and really long header
+      </goabx-table-sort-header>
+    </th>
+  `,
+})
+class TestTableSortHeaderComponent {
+  /** do nothing **/
+}
+
+describe("GoABTableSortHeader", () => {
+  let fixture: ComponentFixture<TestTableSortHeaderComponent>;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [GoabxTableSortHeader, TestTableSortHeaderComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestTableSortHeaderComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+  }));
+
+  it("should render", () => {
+    const el = fixture.nativeElement.querySelector("goa-table-sort-header");
+    expect(el?.getAttribute("direction")).toBe("asc");
+    expect(el?.getAttribute("name")).toBe("firstName");
+    expect(el?.textContent).toContain("First name and really long header");
+  });
+});

--- a/libs/angular-components/src/experimental/table-sort-header/table-sort-header.ts
+++ b/libs/angular-components/src/experimental/table-sort-header/table-sort-header.ts
@@ -1,0 +1,39 @@
+import { GoabTableSortDirection } from "@abgov/ui-components-common";
+import {
+  CUSTOM_ELEMENTS_SCHEMA,
+  Component,
+  Input,
+  OnInit,
+  ChangeDetectorRef,
+} from "@angular/core";
+import { CommonModule } from "@angular/common";
+
+@Component({
+  standalone: true,
+  selector: "goabx-table-sort-header",
+  template: `
+    <goa-table-sort-header
+      *ngIf="isReady"
+      [attr.name]="name"
+      [attr.direction]="direction"
+    >
+      <ng-content />
+    </goa-table-sort-header>
+  `,
+  imports: [CommonModule],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class GoabxTableSortHeader implements OnInit {
+  isReady = false;
+  @Input() name?: string;
+  @Input() direction?: GoabTableSortDirection = "none";
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.isReady = true;
+      this.cdr.detectChanges();
+    });
+  }
+}


### PR DESCRIPTION
# Before (the change)

TableSortHeader didn't exist in experimental Angular wrappers, but was available for React experimental wrappers.

# After (the change)

This brings Angular up to date with React by adding GoabxTableSortHeader

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

PR Feat3241 has been updated to use GoabTableSortHeader and GoabxTableSortHeader, ctrl+f for GoabxTable.
