### PR TITLE
feat(#3407): add prop to tabs to not stack on mobile, and skip focus on initial load

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -85,6 +85,8 @@
           <a href="/features/3370">3370</a>
           <a href="/features/v2-icons">v2 header icons</a>
           <a href="/features/3396">3396 Text heading-2xs size</a>
+          <a href="/features/3407-skip-on-focus-tab">3407 Skip Focus on Tab</a>
+          <a href="/features/3407-stack-on-mobile">3407 Tabs Orientation</a>
         </goab-side-menu-group>
       </goab-side-menu>
     </section>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -54,6 +54,7 @@ import { Feat2267Component } from "../routes/features/feat2267/feat2267.componen
 import { Feat2328Component } from "../routes/features/feat2328/feat2328.component";
 import { Feat2361Component } from "../routes/features/feat2361/feat2361.component";
 import { Feat2440Component } from "../routes/features/feat2440/feat2440.component";
+import { Feat2469Component } from "../routes/features/feat2469/feat2469.component";
 import { Feat2492Component } from "../routes/features/feat2492/feat2492.component";
 import { Feat2609Component } from "../routes/features/feat2609/feat2609.component";
 import { Feat2611Component } from "../routes/features/feat2611/feat2611.component";
@@ -66,14 +67,15 @@ import { Feat3102Component } from "../routes/features/feat3102/feat3102.componen
 import { Feat3137Component } from "../routes/features/feat3137/feat3137.component";
 import { Feat3241Component } from "../routes/features/feat3241/feat3241.component";
 import { Feat3306Component } from "../routes/features/feat3306/feat3306.component";
-import { Feat2469Component } from "../routes/features/feat2469/feat2469.component";
 import { Feat3370Component } from "../routes/features/feat3370/feat3370.component";
+import { Feat3407SkipOnFocusTabComponent } from "../routes/features/feat3407SkipOnFocusTab/feat3407-skip-on-focus-tab.component";
+import { Feat3407StackOnMobileComponent } from "../routes/features/feat3407StackOnMobile/feat3407-stack-on-mobile.component";
 import { FeatV2IconsComponent } from "../routes/features/featV2Icons/feat-v2-icons.component";
 import { Feat3396Component } from "../routes/features/feat3396/feat3396.component";
 
 export const appRoutes: Route[] = [
   { path: "everything", component: EverythingComponent },
-
+  // Bug routes
   { path: "bugs/2152", component: Bug2152Component },
   { path: "bugs/2331", component: Bug2331Component },
   { path: "bugs/2393", component: Bug2393Component },
@@ -115,7 +117,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3337", component: Bug3337Component },
   { path: "bugs/3279", component: Bug3279Component },
   { path: "bugs/3384", component: Bug3384Component },
-
+  // Feature routes
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1383", component: Feat1383Component },
   { path: "features/1547", component: Feat1547Component },
@@ -143,4 +145,6 @@ export const appRoutes: Route[] = [
   { path: "features/3306", component: Feat3306Component },
   { path: "features/3370", component: Feat3370Component },
   { path: "features/3396", component: Feat3396Component },
+  { path: "features/3407-skip-on-focus-tab", component: Feat3407SkipOnFocusTabComponent },
+  { path: "features/3407-stack-on-mobile", component: Feat3407StackOnMobileComponent },
 ];

--- a/apps/prs/angular/src/routes/features/feat3407SkipOnFocusTab/feat3407-skip-on-focus-tab.component.html
+++ b/apps/prs/angular/src/routes/features/feat3407SkipOnFocusTab/feat3407-skip-on-focus-tab.component.html
@@ -1,0 +1,49 @@
+<main>
+  <goab-text tag="h1" mt="m">#3407: Skip Focus on Initial Tab Load</goab-text>
+  <goab-text tag="p">
+    Testing skipFocus on initial page load (no visible focus ring) and
+    segmented tabpanel fixes (no focus ring or tab stop on empty content).
+  </goab-text>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <goab-block direction="column" gap="xl">
+    <goab-block direction="column" gap="s">
+      <goab-text tag="h2">Test 1: Skip focus on initial load</goab-text>
+      <goab-text tag="p">
+        When the page loads, the active tab should NOT have a visible focus
+        ring. Reload the page and confirm no tab shows a focus outline
+        until you interact via keyboard.
+      </goab-text>
+      <goab-tabs [initialTab]="2">
+        <goab-tab heading="First">
+          <goab-text tag="p">Not initially selected.</goab-text>
+        </goab-tab>
+        <goab-tab heading="Second (initial)">
+          <goab-text tag="p">
+            This tab is initially active via initialTab=2. It should NOT
+            have a focus ring on page load.
+          </goab-text>
+        </goab-tab>
+        <goab-tab heading="Third">
+          <goab-text tag="p">Not initially selected.</goab-text>
+        </goab-tab>
+      </goab-tabs>
+    </goab-block>
+
+    <goab-block direction="column" gap="s">
+      <goab-text tag="h2">Test 2: When no initialize Tabs</goab-text>
+      <goab-tabs>
+        <goab-tab heading="Overview">
+          <goab-text tag="p">Default tabs — check URL changes when clicking tabs.</goab-text>
+        </goab-tab>
+        <goab-tab heading="Details">
+          <goab-text tag="p">The URL hash should update to reflect the active tab.</goab-text>
+        </goab-tab>
+        <goab-tab heading="Settings">
+          <goab-text tag="p">Resize browser to mobile width — tabs should stack vertically.</goab-text>
+        </goab-tab>
+      </goab-tabs>
+    </goab-block>
+  </goab-block>
+</main>

--- a/apps/prs/angular/src/routes/features/feat3407SkipOnFocusTab/feat3407-skip-on-focus-tab.component.ts
+++ b/apps/prs/angular/src/routes/features/feat3407SkipOnFocusTab/feat3407-skip-on-focus-tab.component.ts
@@ -1,0 +1,16 @@
+import { Component } from "@angular/core";
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabTabs,
+  GoabTab,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat3407-skip-on-focus-tab",
+  templateUrl: "./feat3407-skip-on-focus-tab.component.html",
+  imports: [GoabBlock, GoabText, GoabDivider, GoabTabs, GoabTab],
+})
+export class Feat3407SkipOnFocusTabComponent {}

--- a/apps/prs/angular/src/routes/features/feat3407StackOnMobile/feat3407-stack-on-mobile.component.html
+++ b/apps/prs/angular/src/routes/features/feat3407StackOnMobile/feat3407-stack-on-mobile.component.html
@@ -1,0 +1,79 @@
+<main>
+  <goab-text tag="h1" mt="m">#3407: orientation Prop</goab-text>
+  <goab-text tag="p">
+    Testing orientation prop (controls mobile stacking behavior). orientation is
+    only available on goabx-tabs (experimental).
+  </goab-text>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <goab-block direction="column" gap="xl">
+    <goab-block direction="column" gap="s">
+      <goab-text tag="h2">
+        Test 1: Experimental Tabs + orientation="auto" (default)
+      </goab-text>
+      <goab-text tag="p">
+        Experimental (v2) tabs that stack vertically on mobile (default behavior).
+        Resize browser to mobile width to verify tabs stack.
+      </goab-text>
+      <goabx-tabs>
+        <goabx-tab heading="Overview">
+          <goab-text tag="p">These tabs should stack vertically on mobile.</goab-text>
+        </goabx-tab>
+        <goabx-tab heading="Details">
+          <goab-text tag="p">Vertical stacking on narrow screens.</goab-text>
+        </goabx-tab>
+        <goabx-tab heading="Settings">
+          <goab-text tag="p">Compare with Test 2 below.</goab-text>
+        </goabx-tab>
+      </goabx-tabs>
+    </goab-block>
+
+    <goab-block direction="column" gap="s">
+      <goab-text tag="h2">Test 2: Experimental Tabs + orientation="horizontal"</goab-text>
+      <goab-text tag="p">
+        Experimental (v2) tabs that stay horizontal on mobile. Resize browser to
+        mobile width to verify tabs remain in a row.
+      </goab-text>
+      <goabx-tabs orientation="horizontal">
+        <goabx-tab heading="Overview">
+          <goab-text tag="p">These tabs should stay horizontal on mobile.</goab-text>
+        </goabx-tab>
+        <goabx-tab heading="Details">
+          <goab-text tag="p">No vertical stacking on narrow screens.</goab-text>
+        </goabx-tab>
+        <goabx-tab heading="Settings">
+          <goab-text tag="p">Useful when horizontal space is preferred.</goab-text>
+        </goabx-tab>
+      </goabx-tabs>
+    </goab-block>
+
+    <goab-block direction="column" gap="s">
+      <goab-text tag="h2">
+        Test 3: Segmented variant (always not stacked on mobile)
+      </goab-text>
+      <goab-text tag="p">
+        Segmented tabs stay horizontal on mobile by default (no prop needed). Resize
+        to mobile width to verify.
+      </goab-text>
+      <goabx-tabs variant="segmented">
+        <goabx-tab heading="Active"></goabx-tab>
+        <goabx-tab heading="Completed"></goabx-tab>
+        <goabx-tab heading="Archived"></goabx-tab>
+      </goabx-tabs>
+    </goab-block>
+
+    <goab-block direction="column" gap="s">
+      <goab-text tag="h2">Test 4: Segmented + orientation="horizontal"</goab-text>
+      <goab-text tag="p">
+        Segmented tabs with orientation explicitly set to "horizontal". Should remain
+        horizontal on mobile (same as default segmented behavior).
+      </goab-text>
+      <goabx-tabs variant="segmented" orientation="horizontal">
+        <goabx-tab heading="All"></goabx-tab>
+        <goabx-tab heading="Open"></goabx-tab>
+        <goabx-tab heading="Closed"></goabx-tab>
+      </goabx-tabs>
+    </goab-block>
+  </goab-block>
+</main>

--- a/apps/prs/angular/src/routes/features/feat3407StackOnMobile/feat3407-stack-on-mobile.component.ts
+++ b/apps/prs/angular/src/routes/features/feat3407StackOnMobile/feat3407-stack-on-mobile.component.ts
@@ -1,0 +1,16 @@
+import { Component } from "@angular/core";
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabxTabs,
+  GoabxTab,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat3407-stack-on-mobile",
+  templateUrl: "./feat3407-stack-on-mobile.component.html",
+  imports: [GoabBlock, GoabText, GoabDivider, GoabxTabs, GoabxTab],
+})
+export class Feat3407StackOnMobileComponent {}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -92,6 +92,8 @@ export function App() {
               <Link to="/features/3137">3137 Work Side Menu Group</Link>
               <Link to="/features/3241">3241 V2 Experimental Wrappers</Link>
               <Link to="/features/v2-icons">v2 header icons</Link>
+              <Link to="/features/3407-skip-on-focus-tab">3407 Skip Focus on Tab</Link>
+              <Link to="/features/3407-stack-on-mobile">3407 Tabs Orientation</Link>
               <Link to="/features/3306">3306 Custom slug value for tabs</Link>
               <Link to="/features/3370">3370 Clear calendar day selection</Link>
               <Link to="/features/3396">3396 Text heading-2xs size</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -70,6 +70,8 @@ import { Feat2877Route } from "./routes/features/feat2877";
 import { Feat3102Route } from "./routes/features/feat3102";
 import { Feat3241Route } from "./routes/features/feat3241";
 import { FeatV2IconsRoute } from "./routes/features/featV2Icons";
+import { Feat3407SkipOnFocusTabRoute } from "./routes/features/feat3407SkipOnFocusTab";
+import { Feat3407StackOnMobileRoute } from "./routes/features/feat3407StackOnMobile";
 import { Feat3137Route } from "./routes/features/feat3137";
 import { Feat3306Route } from "./routes/features/feat3306";
 import { Feat2469Route } from "./routes/features/feat2469";
@@ -153,7 +155,8 @@ root.render(
           <Route path="features/3137" element={<Feat3137Route />} />
           <Route path="features/3241" element={<Feat3241Route />} />
           <Route path="features/v2-icons" element={<FeatV2IconsRoute />} />
-          <Route path="features/3137" element={<Feat3137Route />} />
+          <Route path="features/3407-skip-on-focus-tab" element={<Feat3407SkipOnFocusTabRoute />} />
+          <Route path="features/3407-stack-on-mobile" element={<Feat3407StackOnMobileRoute />} />
           <Route path="features/3306" element={<Feat3306Route />} />
           <Route path="features/3370" element={<Feat3370Route />} />
           <Route path="features/3396" element={<Feat3396Route />} />

--- a/apps/prs/react/src/routes/features/feat3407SkipOnFocusTab.tsx
+++ b/apps/prs/react/src/routes/features/feat3407SkipOnFocusTab.tsx
@@ -1,0 +1,67 @@
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabTabs,
+  GoabTab,
+} from "@abgov/react-components";
+import type { JSX } from "react";
+
+export function Feat3407SkipOnFocusTabRoute(): JSX.Element {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        #3407: Skip Focus on Initial Tab Load
+      </GoabText>
+      <GoabText tag="p">
+        Testing skipFocus on initial page load (no visible focus ring) and
+        segmented tabpanel fixes (no focus ring or tab stop on empty content).
+      </GoabText>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabBlock direction="column" gap="xl">
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="h2">Test 1: Skip focus on initial load</GoabText>
+          <GoabText tag="p">
+            When the page loads, the active tab should NOT have a visible focus
+            ring. Reload the page and confirm no tab shows a focus outline
+            until you interact via keyboard.
+          </GoabText>
+          <GoabTabs initialTab={2}>
+            <GoabTab heading="First">
+              <GoabText tag="p">Not initially selected.</GoabText>
+            </GoabTab>
+            <GoabTab heading="Second (initial)">
+              <GoabText tag="p">
+                This tab is initially active via initialTab=2. It should NOT
+                have a focus ring on page load.
+              </GoabText>
+            </GoabTab>
+            <GoabTab heading="Third">
+              <GoabText tag="p">Not initially selected.</GoabText>
+            </GoabTab>
+          </GoabTabs>
+        </GoabBlock>
+
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="h2">Test 2: When no initialize Tabs</GoabText>
+          <GoabTabs>
+            <GoabTab heading="Overview">
+              <GoabText tag="p">Default tabs — check URL changes when clicking tabs.</GoabText>
+            </GoabTab>
+            <GoabTab heading="Details">
+              <GoabText tag="p">The URL hash should update to reflect the active tab.</GoabText>
+            </GoabTab>
+            <GoabTab heading="Settings">
+              <GoabText tag="p">Resize browser to mobile width — tabs should stack vertically.</GoabText>
+            </GoabTab>
+          </GoabTabs>
+        </GoabBlock>
+
+      </GoabBlock>
+    </div>
+  );
+}
+
+export default Feat3407SkipOnFocusTabRoute;

--- a/apps/prs/react/src/routes/features/feat3407StackOnMobile.tsx
+++ b/apps/prs/react/src/routes/features/feat3407StackOnMobile.tsx
@@ -1,0 +1,105 @@
+import { GoabBlock, GoabText, GoabDivider } from "@abgov/react-components";
+import { GoabxTabs, GoabxTab } from "@abgov/react-components/experimental";
+import { useEffect, type JSX } from "react";
+// ?url suffix tells Vite to resolve the path without injecting the CSS
+import v2TokensUrl from "@abgov/design-tokens-v2/dist/tokens.css?url";
+
+export function Feat3407StackOnMobileRoute(): JSX.Element {
+  // Dynamically load v2 design tokens only while this page is mounted,
+  // so they don't leak into other routes in the SPA.
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = v2TokensUrl;
+    document.head.appendChild(link);
+    return () => {
+      document.head.removeChild(link);
+    };
+  }, []);
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        #3407: orientation Prop
+      </GoabText>
+      <GoabText tag="p">
+        Testing orientation prop (controls mobile stacking behavior). orientation is
+        only available on GoabxTabs (experimental).
+      </GoabText>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabBlock direction="column" gap="xl">
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="h2">
+            Test 1: Experimental Tabs + orientation="auto" (default)
+          </GoabText>
+          <GoabText tag="p">
+            Experimental (v2) tabs that stack vertically on mobile (default behavior).
+            Resize browser to mobile width to verify tabs stack.
+          </GoabText>
+          <GoabxTabs>
+            <GoabxTab heading="Overview">
+              <GoabText tag="p">These tabs should stack vertically on mobile.</GoabText>
+            </GoabxTab>
+            <GoabxTab heading="Details">
+              <GoabText tag="p">Vertical stacking on narrow screens.</GoabText>
+            </GoabxTab>
+            <GoabxTab heading="Settings">
+              <GoabText tag="p">Compare with Test 2 below.</GoabText>
+            </GoabxTab>
+          </GoabxTabs>
+        </GoabBlock>
+
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="h2">Test 2: Experimental Tabs + orientation="horizontal"</GoabText>
+          <GoabText tag="p">
+            Experimental (v2) tabs that stay horizontal on mobile. Resize browser to
+            mobile width to verify tabs remain in a row.
+          </GoabText>
+          <GoabxTabs orientation="horizontal">
+            <GoabxTab heading="Overview">
+              <GoabText tag="p">These tabs should stay horizontal on mobile.</GoabText>
+            </GoabxTab>
+            <GoabxTab heading="Details">
+              <GoabText tag="p">No vertical stacking on narrow screens.</GoabText>
+            </GoabxTab>
+            <GoabxTab heading="Settings">
+              <GoabText tag="p">Useful when horizontal space is preferred.</GoabText>
+            </GoabxTab>
+          </GoabxTabs>
+        </GoabBlock>
+
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="h2">
+            Test 3: Segmented variant (always not stacked on mobile)
+          </GoabText>
+          <GoabText tag="p">
+            Segmented tabs stay horizontal on mobile by default (no prop needed). Resize
+            to mobile width to verify.
+          </GoabText>
+          <GoabxTabs variant="segmented">
+            <GoabxTab heading="Active">{""}</GoabxTab>
+            <GoabxTab heading="Completed">{""}</GoabxTab>
+            <GoabxTab heading="Archived">{""}</GoabxTab>
+          </GoabxTabs>
+        </GoabBlock>
+
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="h2">Test 4: Segmented + orientation="horizontal"</GoabText>
+          <GoabText tag="p">
+            Segmented tabs with orientation explicitly set to "horizontal". Should remain
+            horizontal on mobile (same as default segmented behavior).
+          </GoabText>
+          <GoabxTabs variant="segmented" orientation="horizontal">
+            <GoabxTab heading="All">{""}</GoabxTab>
+            <GoabxTab heading="Open">{""}</GoabxTab>
+            <GoabxTab heading="Closed">{""}</GoabxTab>
+          </GoabxTabs>
+        </GoabBlock>
+      </GoabBlock>
+    </div>
+  );
+}
+
+export default Feat3407StackOnMobileRoute;

--- a/docs/generated/component-apis/tabs.json
+++ b/docs/generated/component-apis/tabs.json
@@ -26,7 +26,15 @@
       ],
       "required": false,
       "default": "default",
-      "description": ""
+      "description": "Sets the visual style of tabs. 'segmented' shows pill/button style tabs."
+    },
+    {
+      "name": "orientation",
+      "type": "\"auto\" | \"horizontal\"",
+      "values": ["auto", "horizontal"],
+      "required": false,
+      "default": "auto",
+      "description": "Tab layout orientation. 'auto' stacks vertically on mobile, 'horizontal' keeps horizontal on all screen sizes."
     }
   ],
   "events": [

--- a/docs/src/components/CodeSnippet.tsx
+++ b/docs/src/components/CodeSnippet.tsx
@@ -217,8 +217,8 @@ export function CodeSnippet({
   // Get available frameworks
   const availableFrameworks = hasFrameworkSwitcher
     ? (Object.keys(frameworkCode).filter(
-        (k) => frameworkCode[k as Framework],
-      ) as Framework[])
+      (k) => frameworkCode[k as Framework],
+    ) as Framework[])
     : [];
 
   // Subscribe to global framework preference changes from other components.
@@ -254,7 +254,7 @@ export function CodeSnippet({
                 new CustomEvent("tabs:set-open", {
                   composed: true,
                   detail: { open: i === targetIndex },
-                })
+                }),
               );
             });
           }
@@ -440,7 +440,7 @@ export function CodeSnippet({
   const renderBlocksForFramework = (fw: Framework) => {
     if (!extractParts) {
       const rawCode = getFrameworkRawCode(frameworkCode, fw);
-      const lang = fw === 'react' ? 'tsx' : 'html';
+      const lang = fw === "react" ? "tsx" : "html";
       return (
         <SingleCodeBlock
           code={rawCode}
@@ -452,11 +452,11 @@ export function CodeSnippet({
     }
 
     switch (fw) {
-      case 'react':
+      case "react":
         return renderReactBlocks(frameworkCode.react);
-      case 'angular':
+      case "angular":
         return renderAngularBlocks(frameworkCode.angular);
-      case 'webComponents':
+      case "webComponents":
         return renderWebComponentsBlocks(frameworkCode.webComponents);
       default:
         return null;
@@ -471,13 +471,12 @@ export function CodeSnippet({
           <GoabxTabs
             variant="segmented"
             initialTab={availableFrameworks.indexOf(selectedFramework) + 1}
+            orientation="horizontal"
           >
             {availableFrameworks.map((fw) => (
               <GoabTab key={fw} heading={FRAMEWORK_LABELS[fw]}>
                 <div className="code-snippet">
-                  <div className="code-blocks">
-                    {renderBlocksForFramework(fw)}
-                  </div>
+                  <div className="code-blocks">{renderBlocksForFramework(fw)}</div>
                 </div>
               </GoabTab>
             ))}
@@ -486,9 +485,7 @@ export function CodeSnippet({
       ) : (
         // Single framework - no tabs needed
         <div className="code-snippet">
-          <div className="code-blocks">
-            {renderFrameworkBlocks()}
-          </div>
+          <div className="code-blocks">{renderFrameworkBlocks()}</div>
         </div>
       )}
 

--- a/docs/src/components/ComponentsGrid.tsx
+++ b/docs/src/components/ComponentsGrid.tsx
@@ -39,11 +39,11 @@ export interface Component {
     description?: string;
     status: "stable" | "beta" | "deprecated" | "experimental";
     category:
-      | "inputs-and-actions"
-      | "content-layout"
-      | "structure-and-navigation"
-      | "feedback-and-alerts"
-      | "utilities";
+    | "inputs-and-actions"
+    | "content-layout"
+    | "structure-and-navigation"
+    | "feedback-and-alerts"
+    | "utilities";
     tags?: string[];
     relatedComponents?: string[];
     webComponentTag?: string;
@@ -164,7 +164,6 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
     defaultLayout: "card", // 'card' = grid view
     defaultColumns: DEFAULT_VISIBLE_COLUMNS,
   });
-
 
   // Listen for table sort events (from goa-table web component)
   // Also explicitly set version="2" attribute since React may not set it correctly on custom elements
@@ -589,9 +588,8 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
               ref={tabsRef}
               version="2"
               variant="segmented"
-              initialtab={viewMode === "card" ? 1 : 2}
-              updateurl="false"
-              stackonmobile="false"
+              initialTab={viewMode === "card" ? 1 : 2}
+              orientation="horizontal"
             >
               <goa-tab heading="Grid">
                 <span />
@@ -735,35 +733,35 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
               <tbody>
                 {groupedComponents
                   ? groupedComponents.map((group) => (
-                      <React.Fragment key={group.key}>
-                        <tr
-                          className="components-group-row"
-                          onClick={() => toggleGroup(group.key)}
-                        >
-                          <td colSpan={4}>
-                            <div className="components-group-header">
-                              <GoabIcon
-                                type={
-                                  expandedGroups.has(group.key)
-                                    ? "chevron-down"
-                                    : "chevron-forward"
-                                }
-                                size="small"
-                              />
-                              <strong>{group.label}</strong>
-                              <goa-badge
-                                version="2"
-                                type="default"
-                                content={String(group.components.length)}
-                                emphasis="subtle"
-                              />
-                            </div>
-                          </td>
-                        </tr>
-                        {expandedGroups.has(group.key) &&
-                          group.components.map(renderTableRow)}
-                      </React.Fragment>
-                    ))
+                    <React.Fragment key={group.key}>
+                      <tr
+                        className="components-group-row"
+                        onClick={() => toggleGroup(group.key)}
+                      >
+                        <td colSpan={4}>
+                          <div className="components-group-header">
+                            <GoabIcon
+                              type={
+                                expandedGroups.has(group.key)
+                                  ? "chevron-down"
+                                  : "chevron-forward"
+                              }
+                              size="small"
+                            />
+                            <strong>{group.label}</strong>
+                            <goa-badge
+                              version="2"
+                              type="default"
+                              content={String(group.components.length)}
+                              emphasis="subtle"
+                            />
+                          </div>
+                        </td>
+                      </tr>
+                      {expandedGroups.has(group.key) &&
+                        group.components.map(renderTableRow)}
+                    </React.Fragment>
+                  ))
                   : filteredComponents.map(renderTableRow)}
               </tbody>
             </table>

--- a/docs/src/components/ExamplesGrid.tsx
+++ b/docs/src/components/ExamplesGrid.tsx
@@ -647,9 +647,8 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
               ref={tabsRef}
               version="2"
               variant="segmented"
-              initialtab={viewMode === "card" ? 1 : 2}
-              updateurl="false"
-              stackonmobile="false"
+              initialTab={viewMode === "card" ? 1 : 2}
+              orientation="horizontal"
             >
               <goa-tab heading="Grid">
                 <span />
@@ -811,35 +810,35 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
               <tbody>
                 {groupedExamples
                   ? groupedExamples.map((group) => (
-                      <React.Fragment key={group.key}>
-                        <tr
-                          className="examples-group-row"
-                          onClick={() => toggleGroup(group.key)}
-                        >
-                          <td colSpan={5}>
-                            <div className="examples-group-header">
-                              <GoabIcon
-                                type={
-                                  expandedGroups.has(group.key)
-                                    ? "chevron-down"
-                                    : "chevron-forward"
-                                }
-                                size="small"
-                              />
-                              <strong>{group.label}</strong>
-                              <goa-badge
-                                version="2"
-                                type="default"
-                                content={String(group.examples.length)}
-                                emphasis="subtle"
-                              />
-                            </div>
-                          </td>
-                        </tr>
-                        {expandedGroups.has(group.key) &&
-                          group.examples.map(renderTableRow)}
-                      </React.Fragment>
-                    ))
+                    <React.Fragment key={group.key}>
+                      <tr
+                        className="examples-group-row"
+                        onClick={() => toggleGroup(group.key)}
+                      >
+                        <td colSpan={5}>
+                          <div className="examples-group-header">
+                            <GoabIcon
+                              type={
+                                expandedGroups.has(group.key)
+                                  ? "chevron-down"
+                                  : "chevron-forward"
+                              }
+                              size="small"
+                            />
+                            <strong>{group.label}</strong>
+                            <goa-badge
+                              version="2"
+                              type="default"
+                              content={String(group.examples.length)}
+                              emphasis="subtle"
+                            />
+                          </div>
+                        </td>
+                      </tr>
+                      {expandedGroups.has(group.key) &&
+                        group.examples.map(renderTableRow)}
+                    </React.Fragment>
+                  ))
                   : filteredExamples.map(renderTableRow)}
               </tbody>
             </table>
@@ -975,19 +974,19 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
           {(pendingFilters.category.length > 0 ||
             pendingFilters.scale.length > 0 ||
             pendingFilters.userType.length > 0) && (
-            <>
-              <GoabDivider />
-              <GoabxButton
-                type="tertiary"
-                size="compact"
-                onClick={() =>
-                  setPendingFilters({ category: [], scale: [], userType: [] })
-                }
-              >
-                Clear all filters
-              </GoabxButton>
-            </>
-          )}
+              <>
+                <GoabDivider />
+                <GoabxButton
+                  type="tertiary"
+                  size="compact"
+                  onClick={() =>
+                    setPendingFilters({ category: [], scale: [], userType: [] })
+                  }
+                >
+                  Clear all filters
+                </GoabxButton>
+              </>
+            )}
         </div>
       </GoabxDrawer>
 

--- a/docs/src/components/TokensGrid.tsx
+++ b/docs/src/components/TokensGrid.tsx
@@ -436,9 +436,8 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
               ref={tabsRef}
               version="2"
               variant="segmented"
-              initialtab={tokenSyntax === "css" ? 1 : 2}
-              updateurl="false"
-              stackonmobile="false"
+              initialTab={tokenSyntax === "css" ? 1 : 2}
+              orientation="horizontal"
             >
               <goa-tab heading="CSS">
                 <span />

--- a/docs/src/data/configurations/tabs.ts
+++ b/docs/src/data/configurations/tabs.ts
@@ -4,18 +4,18 @@
  * Tabs organize content into separate views.
  */
 
-import type { ComponentConfigurations } from './types';
+import type { ComponentConfigurations } from "./types";
 
 export const tabsConfigurations: ComponentConfigurations = {
-  componentSlug: 'tabs',
-  componentName: 'Tabs',
-  defaultConfigurationId: 'basic',
+  componentSlug: "tabs",
+  componentName: "Tabs",
+  defaultConfigurationId: "basic",
 
   configurations: [
     {
-      id: 'basic',
-      name: 'Basic tabs',
-      description: 'Simple tab navigation',
+      id: "basic",
+      name: "Basic tabs",
+      description: "Simple tab navigation",
       code: {
         react: `<GoabxTabs initialTab={1}>
   <GoabTab heading="Overview">
@@ -53,9 +53,9 @@ export const tabsConfigurations: ComponentConfigurations = {
       },
     },
     {
-      id: 'initial-tab',
-      name: 'Initial tab',
-      description: 'Start with a specific tab selected',
+      id: "initial-tab",
+      name: "Initial tab",
+      description: "Start with a specific tab selected",
       code: {
         react: `<GoabxTabs initialTab={2}>
   <GoabTab heading="First">First tab content.</GoabTab>
@@ -75,9 +75,9 @@ export const tabsConfigurations: ComponentConfigurations = {
       },
     },
     {
-      id: 'segmented',
-      name: 'Segmented variant',
-      description: 'Pill/button style tabs',
+      id: "segmented",
+      name: "Segmented variant",
+      description: "Pill/button style tabs",
       code: {
         react: `<GoabxTabs variant="segmented">
   <GoabTab heading="Day">Daily view</GoabTab>
@@ -97,9 +97,9 @@ export const tabsConfigurations: ComponentConfigurations = {
       },
     },
     {
-      id: 'no-url-update',
-      name: 'Without URL update',
-      description: 'Tabs that do not update browser URL',
+      id: "no-url-update",
+      name: "Without URL update",
+      description: "Tabs that do not update browser URL",
       code: {
         react: `<GoabxTabs initialTab={1} updateUrl={false}>
   <GoabTab heading="Settings">Settings panel</GoabTab>
@@ -116,21 +116,21 @@ export const tabsConfigurations: ComponentConfigurations = {
       },
     },
     {
-      id: 'no-stack-mobile',
-      name: 'Horizontal on mobile',
-      description: 'Tabs stay horizontal on small screens',
+      id: "horizontal-on-mobile",
+      name: "Horizontal on mobile",
+      description: "Tabs stay horizontal on small screens",
       code: {
-        react: `<GoabxTabs initialTab={1} stackOnMobile={false}>
-  <GoabTab heading="Tab 1">Content 1</GoabTab>
-  <GoabTab heading="Tab 2">Content 2</GoabTab>
-  <GoabTab heading="Tab 3">Content 3</GoabTab>
+        react: `<GoabxTabs initialTab={1} orientation="horizontal">
+  <GoabxTab heading="Tab 1">Content 1</GoabxTab>
+  <GoabxTab heading="Tab 2">Content 2</GoabxTab>
+  <GoabxTab heading="Tab 3">Content 3</GoabxTab>
 </GoabxTabs>`,
-        angular: `<goabx-tabs [initialTab]="1" [stackOnMobile]="false">
-  <goab-tab heading="Tab 1">Content 1</goab-tab>
-  <goab-tab heading="Tab 2">Content 2</goab-tab>
-  <goab-tab heading="Tab 3">Content 3</goab-tab>
+        angular: `<goabx-tabs [initialTab]="1" orientation="horizontal">
+  <goabx-tab heading="Tab 1">Content 1</goabx-tab>
+  <goabx-tab heading="Tab 2">Content 2</goabx-tab>
+  <goabx-tab heading="Tab 3">Content 3</goabx-tab>
 </goabx-tabs>`,
-        webComponents: `<goa-tabs version="2" initialtab="1" stackonmobile="false">
+        webComponents: `<goa-tabs initialtab="1" orientation="horizontal">
   <goa-tab heading="Tab 1">Content 1</goa-tab>
   <goa-tab heading="Tab 2">Content 2</goa-tab>
   <goa-tab heading="Tab 3">Content 3</goa-tab>

--- a/libs/angular-components/src/experimental/index.ts
+++ b/libs/angular-components/src/experimental/index.ts
@@ -27,6 +27,7 @@ export * from "./side-menu-heading/side-menu-heading";
 export * from "./table/table";
 export * from "./table-sort-header/table-sort-header";
 export * from "./textarea/textarea";
+export * from "./tab/tab";
 export * from "./tabs/tabs";
 export * from "./work-side-menu/work-side-menu";
 export * from "./work-side-menu-item/work-side-menu-item";

--- a/libs/angular-components/src/experimental/tab/tab.ts
+++ b/libs/angular-components/src/experimental/tab/tab.ts
@@ -1,0 +1,56 @@
+import {
+  CUSTOM_ELEMENTS_SCHEMA,
+  Component,
+  Input,
+  TemplateRef,
+  OnInit,
+  ChangeDetectorRef,
+  booleanAttribute,
+} from "@angular/core";
+import { NgTemplateOutlet, CommonModule } from "@angular/common";
+
+@Component({
+  standalone: true,
+  selector: "goabx-tab",
+  template: `
+    <goa-tab
+      *ngIf="isReady"
+      [attr.slug]="slug"
+      [attr.disabled]="disabled || null"
+      [attr.heading]="getHeadingAsString()"
+    >
+      <ng-content />
+      @if (typeof heading !== "string") {
+        <div slot="heading">
+          <ng-container [ngTemplateOutlet]="getHeadingAsTemplate()"></ng-container>
+        </div>
+      }
+    </goa-tab>
+  `,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [NgTemplateOutlet, CommonModule],
+})
+export class GoabxTab implements OnInit {
+  isReady = false;
+  @Input() heading!: string | TemplateRef<any>;
+  @Input({ transform: booleanAttribute }) disabled?: boolean;
+  @Input() slug?: string;
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.isReady = true;
+      this.cdr.detectChanges();
+    });
+  }
+
+  getHeadingAsString(): string {
+    return this.heading instanceof TemplateRef ? "" : this.heading;
+  }
+
+  getHeadingAsTemplate(): TemplateRef<any> | null {
+    if (!this.heading) return null;
+    return this.heading instanceof TemplateRef ? this.heading : null;
+  }
+}

--- a/libs/angular-components/src/experimental/tabs/tabs.ts
+++ b/libs/angular-components/src/experimental/tabs/tabs.ts
@@ -9,7 +9,7 @@ import {
   ChangeDetectorRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { GoabTabsOnChangeDetail, GoabTabsVariant } from "@abgov/ui-components-common";
+import { GoabTabsOnChangeDetail, GoabTabsOrientation, GoabTabsVariant } from "@abgov/ui-components-common";
 
 @Component({
   standalone: true,
@@ -21,6 +21,7 @@ import { GoabTabsOnChangeDetail, GoabTabsVariant } from "@abgov/ui-components-co
       [attr.initialtab]="initialTab"
       [attr.testid]="testId"
       [attr.variant]="variant"
+      [attr.orientation]="orientation"
       (_change)="_onChange($event)"
     >
       <ng-content />
@@ -35,6 +36,8 @@ export class GoabxTabs implements OnInit {
   @Input({ transform: numberAttribute }) initialTab?: number;
   @Input() testId?: string;
   @Input() variant?: GoabTabsVariant;
+  /** Tab layout orientation. "auto" stacks vertically on mobile (default), "horizontal" keeps horizontal on all screen sizes. */
+  @Input() orientation?: GoabTabsOrientation;
 
   constructor(private cdr: ChangeDetectorRef) {}
 

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -219,10 +219,12 @@ export type GoabTextAreaOnBlurDetail = {
 // Tabs
 
 export type GoabTabsVariant = "default" | "segmented";
+export type GoabTabsOrientation = "auto" | "horizontal";
 
 export interface GoabTabsProps {
   initialTab?: number;
   variant?: GoabTabsVariant;
+  orientation?: GoabTabsOrientation;
 }
 
 export type GoabTabsOnChangeDetail = {

--- a/libs/react-components/specs/tabs.browser.spec.tsx
+++ b/libs/react-components/specs/tabs.browser.spec.tsx
@@ -1,7 +1,9 @@
 import { render } from "vitest-browser-react";
 
 import { GoabTabs, GoabTab } from "../src";
+import { GoabxTabs, GoabxTab } from "../src/experimental";
 import { expect, describe, it, vi } from "vitest";
+import { page } from "@vitest/browser/context";
 import { GoabBadge } from "../src/lib/badge/badge";
 
 describe("Tabs Browser Tests", () => {
@@ -521,9 +523,7 @@ describe("Tabs Browser Tests", () => {
       const Component = () => {
         return (
           <GoabTabs testId="test-tabs">
-            <GoabTab heading="Review pending">
-              Review content
-            </GoabTab>
+            <GoabTab heading="Review pending">Review content</GoabTab>
             <GoabTab
               heading={
                 <>
@@ -633,7 +633,6 @@ describe("Tabs Browser Tests", () => {
         );
       };
 
-
       const { getByText, getByRole } = render(<Component />);
       const tabs = getByRole("tab");
 
@@ -693,12 +692,124 @@ describe("Tabs Browser Tests", () => {
       // pass and the vitest would see that as a fully passing test. The logic below ensure that
       // is passes all the time.
       const hashes = new Set();
-      await vi.waitFor(() => {
-        hashes.add(window.location.hash);
-      }, { timeout: 500 });
+      await vi.waitFor(
+        () => {
+          hashes.add(window.location.hash);
+        },
+        { timeout: 500 },
+      );
 
       expect(hashes.size).toBe(1);
       expect(hashes.has("#active-tasks")).toBe(true);
-    })
+    });
+  });
+
+  describe("skip focus on initial load", () => {
+    it("should not focus any tab on initial page load", async () => {
+      const Component = () => {
+        return (
+          <GoabTabs testId="test-tabs">
+            <GoabTab heading="Tab 1">Content 1</GoabTab>
+            <GoabTab heading="Tab 2">Content 2</GoabTab>
+            <GoabTab heading="Tab 3">Content 3</GoabTab>
+          </GoabTabs>
+        );
+      };
+
+      const { getByRole } = render(<Component />);
+      const tabs = getByRole("tab");
+
+      await vi.waitFor(() => {
+        expect(tabs.elements().length).toBe(3);
+      });
+
+      // No tab should be focus-visible on initial page load
+      tabs.elements().forEach((tab) => {
+        expect(tab.matches(":focus-visible")).toBe(false);
+      });
+    });
+
+    it("should not focus any tab when initialTab is set", async () => {
+      const Component = () => {
+        return (
+          <GoabTabs testId="test-tabs" initialTab={2}>
+            <GoabTab heading="Tab 1">Content 1</GoabTab>
+            <GoabTab heading="Tab 2">Content 2</GoabTab>
+            <GoabTab heading="Tab 3">Content 3</GoabTab>
+          </GoabTabs>
+        );
+      };
+
+      const { getByRole } = render(<Component />);
+      const tabs = getByRole("tab");
+
+      // The second goa-tab should be open (active)
+      await vi.waitFor(() => {
+        const goaTabs = document.querySelectorAll("goa-tab");
+        expect(goaTabs[1].getAttribute("open")).toBe("true");
+      });
+
+      // But it should NOT be focus-visible
+      await vi.waitFor(() => {
+        expect(tabs.elements().length).toBe(3);
+      });
+
+      const secondTab = tabs.elements()[1];
+      expect(secondTab.matches(":focus-visible")).toBe(false);
+    });
+  });
+
+  describe("orientation (experimental)", () => {
+    it("should stack tabs vertically on mobile by default (orientation='auto')", async () => {
+      // Simulate mobile viewport (iPhone SE dimensions)
+      await page.viewport(375, 667);
+
+      const Component = () => {
+        return (
+          <GoabxTabs testId="test-tabs">
+            <GoabxTab heading="Tab 1">Content 1</GoabxTab>
+            <GoabxTab heading="Tab 2">Content 2</GoabxTab>
+          </GoabxTabs>
+        );
+      };
+
+      const { getByRole } = render(<Component />);
+      const tabs = getByRole("tab");
+
+      await vi.waitFor(() => {
+        const els = tabs.elements();
+        expect(els.length).toBe(2);
+      });
+
+      const tabsDiv = tabs.elements()[0].parentElement!;
+      const borderLeft = getComputedStyle(tabsDiv).borderLeftStyle;
+      expect(borderLeft).not.toBe("none"); // on mobile css, we have border left while desktop we don't
+    });
+
+    it("should keep tabs horizontal on mobile when orientation is 'horizontal'", async () => {
+      // Simulate mobile viewport (iPhone SE dimensions)
+      await page.viewport(375, 667);
+
+      const Component = () => {
+        return (
+          <GoabxTabs testId="test-tabs" orientation="horizontal">
+            <GoabxTab heading="Tab 1">Content 1</GoabxTab>
+            <GoabxTab heading="Tab 2">Content 2</GoabxTab>
+          </GoabxTabs>
+        );
+      };
+
+      const { getByRole } = render(<Component />);
+      const tabs = getByRole("tab");
+
+      await vi.waitFor(() => {
+        const els = tabs.elements();
+        expect(els.length).toBe(2);
+      });
+
+      const tabsDiv = tabs.elements()[0].parentElement!;
+      const borderLeft = getComputedStyle(tabsDiv).borderLeftStyle;
+      expect(borderLeft).toBe("none");
+    });
   });
 });

--- a/libs/react-components/src/experimental/index.ts
+++ b/libs/react-components/src/experimental/index.ts
@@ -25,6 +25,7 @@ export * from "./side-menu-group/side-menu-group";
 export * from "./side-menu-heading/side-menu-heading";
 export * from "./table/table";
 export * from "./table/table-sort-header";
+export * from "./tab/tab";
 export * from "./tabs/tabs";
 export * from "./textarea/textarea";
 export * from "./work-side-menu/work-side-menu";

--- a/libs/react-components/src/experimental/tab/tab.tsx
+++ b/libs/react-components/src/experimental/tab/tab.tsx
@@ -1,0 +1,36 @@
+import type { JSX } from "react";
+
+interface WCProps {
+  heading?: React.ReactNode;
+  disabled?: string;
+  slug?: string;
+}
+
+declare module "react" {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      "goa-tab": WCProps & React.HTMLAttributes<HTMLElement>;
+    }
+  }
+}
+
+export interface GoabxTabItemProps {
+  heading?: React.ReactNode;
+  disabled?: boolean;
+  children?: React.ReactNode;
+  slug?: string;
+}
+
+export function GoabxTab({ heading, disabled, slug, children }: GoabxTabItemProps): JSX.Element {
+  return (
+    <goa-tab
+      slug={slug}
+      disabled={disabled ? "true" : undefined}
+      heading={typeof heading === "string" ? heading : undefined}
+    >
+      {typeof heading !== "string" && <span slot="heading">{heading}</span>}
+      {children}
+    </goa-tab>
+  );
+}

--- a/libs/react-components/src/experimental/tabs/tabs.tsx
+++ b/libs/react-components/src/experimental/tabs/tabs.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, type JSX } from "react";
-import { GoabTabsOnChangeDetail, GoabTabsVariant } from "@abgov/ui-components-common";
+import { GoabTabsOnChangeDetail, GoabTabsOrientation, GoabTabsVariant } from "@abgov/ui-components-common";
 
 interface WCProps {
   initialtab?: number;
@@ -8,6 +8,7 @@ interface WCProps {
   testid?: string;
   variant?: GoabTabsVariant;
   version?: string;
+  orientation?: string;
 }
 
 declare module "react" {
@@ -24,8 +25,9 @@ export interface GoabxTabsProps {
   children?: React.ReactNode;
   testId?: string;
   variant?: GoabTabsVariant;
+  /** Tab layout orientation. "auto" stacks vertically on mobile (default), "horizontal" keeps horizontal on all screen sizes. */
+  orientation?: GoabTabsOrientation;
   onChange?: (detail: GoabTabsOnChangeDetail) => void;
-  version?: string;
 }
 
 export function GoabxTabs({
@@ -34,7 +36,7 @@ export function GoabxTabs({
   testId,
   onChange,
   variant,
-  version = "2",
+  orientation,
 }: GoabxTabsProps): JSX.Element {
   const ref = useRef<HTMLElement>(null);
 
@@ -58,7 +60,8 @@ export function GoabxTabs({
       initialtab={initialTab}
       testid={testId}
       variant={variant}
-      version={version}
+      version="2"
+      orientation={orientation}
     >
       {children}
     </goa-tabs>

--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -1,8 +1,16 @@
-<svelte:options customElement="goa-tabs" />
+<svelte:options
+  customElement={{
+    tag: "goa-tabs",
+  }}
+/>
 
 <script lang="ts">
   import { onDestroy, onMount, tick } from "svelte";
-  import { clamp, ensureSlotExists, fromBoolean } from "../../common/utils";
+  import {
+    clamp,
+    ensureSlotExists,
+    fromBoolean,
+  } from "../../common/utils";
   import { GoATabProps } from "../tab/Tab.svelte";
 
   /** The initially active tab (1-based index). If not set, the first tab is active. */
@@ -11,9 +19,12 @@
   export let testid: string = "";
   /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
+  /** Visual style variant. "segmented" shows pill-style tabs with animation. */
   export let variant: "default" | "segmented" = "default";
+  /** Tab layout orientation. "auto" stacks vertically on mobile, "horizontal" keeps horizontal on all screen sizes. */
+  export let orientation: "auto" | "horizontal" = "auto";
 
- // Private
+  // Private
   let _rootEl: HTMLElement;
   let _tabsEl: HTMLElement;
   let _slotEl: HTMLElement;
@@ -132,7 +143,7 @@
             targetTab = getFirstEnabledTab();
           }
 
-          setCurrentTab(targetTab);
+          setCurrentTab(targetTab, { skipFocus: true });
           _initialLoad = false;
         }
       }, 1);
@@ -248,7 +259,11 @@
    * Updates the segmented indicator position with velocity-based animation.
    * @param withAnimation - Whether to animate the transition (false on first load, true on tab change)
    */
-  function updateSegmentedIndicatorPosition({ withAnimation }: { withAnimation: boolean }) {
+  function updateSegmentedIndicatorPosition({
+    withAnimation,
+  }: {
+    withAnimation: boolean;
+  }) {
     if (!_tabsEl || variant !== "segmented") return;
 
     const tabs = _tabsEl.querySelectorAll('[role="tab"]');
@@ -262,9 +277,13 @@
     if (withAnimation) {
       const previousTab = tabs[_previousTabIndex - 1] as HTMLElement;
       if (previousTab) {
-        const tabDistance = Math.abs(selectedRect.left - previousTab.getBoundingClientRect().left);
-        const calculatedDuration = MIN_TRANSITION_DURATION + DURATION_PER_PIXEL * tabDistance;
-        _segmentedTransitionDuration = Math.min(calculatedDuration, MAX_TRANSITION_DURATION) / 1000;
+        const tabDistance = Math.abs(
+          selectedRect.left - previousTab.getBoundingClientRect().left,
+        );
+        const calculatedDuration =
+          MIN_TRANSITION_DURATION + DURATION_PER_PIXEL * tabDistance;
+        _segmentedTransitionDuration =
+          Math.min(calculatedDuration, MAX_TRANSITION_DURATION) / 1000;
       } else {
         _segmentedTransitionDuration = 0;
       }
@@ -279,7 +298,8 @@
     _previousTabIndex = _currentTab;
   }
 
-  function setCurrentTab(tab: number) {
+  function setCurrentTab(tab: number, options: { skipFocus?: boolean } = {}) {
+    const { skipFocus = false } = options;
     if (!_tabsEl) return;
 
     const previousTab = _currentTab;
@@ -309,7 +329,9 @@
 
       if (isCurrent) {
         currentLocation = (el as HTMLLinkElement).href;
-        el.focus();
+        if (!skipFocus) {
+          el.focus();
+        }
       }
     });
 
@@ -327,24 +349,30 @@
     _slotEl.setAttribute("aria-labelledby", `tab-${_currentTab}`);
     _slotEl.setAttribute("id", `tabpanel-${_currentTab}`);
 
-    // update the browswers url with the new hash
+    // update the browser's url with the new hash
     if (currentLocation) {
       const url = new URL(currentLocation);
       // to make sure we preserve multiple #, for example /#tab-1#example
-      const allHashes = window.location.href.split('#').slice(1);
-      const otherHashes = allHashes.filter(hash => !hash.startsWith('tab-')); // #example
+      const allHashes = window.location.href.split("#").slice(1);
+      const otherHashes = allHashes.filter((hash) => !hash.startsWith("tab-")); // #example
       const uniqHashes = [...new Set([url.hash.substring(1), ...otherHashes])];
-      const newHash = uniqHashes.filter(Boolean).join('#');
+      const newHash = uniqHashes.filter(Boolean).join("#");
 
-      history.replaceState({}, "", url.pathname + url.search + (newHash ? '#' + newHash : ''));
+      history.replaceState(
+        {},
+        "",
+        url.pathname + url.search + (newHash ? "#" + newHash : ""),
+      );
 
       if (_initialLoad) {
         const anchorHash = otherHashes[0];
         if (anchorHash) {
           tick().then(() => {
-            const element = document.getElementById(anchorHash) || document.querySelector(`[name="${anchorHash}"]`);
+            const element =
+              document.getElementById(anchorHash) ||
+              document.querySelector(`[name="${anchorHash}"]`);
             if (element) {
-              element.scrollIntoView({ behavior: 'smooth' });
+              element.scrollIntoView({ behavior: "smooth" });
             }
           });
         }
@@ -406,7 +434,7 @@
   /** Converts the input string to a kebab format url encoded string */
   function toSlug(input: string): string {
     const parts = input.toLowerCase().split(" ");
-    const str = parts.map(val => val.toLowerCase()).join("-");
+    const str = parts.map((val) => val.toLowerCase()).join("-");
     return encodeURIComponent(str);
   }
 </script>
@@ -417,6 +445,7 @@
   role="tablist"
   bind:this={_rootEl}
   class:v2={version === "2"}
+  class:horizontal={orientation === "horizontal"}
   class:segmented={variant === "segmented"}
   data-testid={testid}
 >
@@ -429,13 +458,17 @@
       <div class="segmented-indicator"></div>
     {/if}
   </div>
-  <div class="tabpanel" tabindex="0" bind:this={_slotEl} role="tabpanel">
+  <div
+    class="tabpanel"
+    tabindex={variant === "segmented" ? -1 : 0}
+    bind:this={_slotEl}
+    role="tabpanel"
+  >
     <slot />
   </div>
 </div>
 
 <style>
-
   :host {
     box-sizing: border-box;
     font: var(--goa-tab-typography);
@@ -489,6 +522,9 @@
     outline: var(--goa-tab-border-focus);
     outline-offset: 4px;
   }
+  .segmented .tabpanel:focus-visible {
+    outline: none;
+  }
 
   @media (--not-mobile) {
     .tabs {
@@ -525,7 +561,10 @@
       display: flex;
       flex-direction: column;
       gap: var(--goa-tabs-gap-small-screen);
-      padding-bottom: var(--goa-tabs-padding-bottom-small-screen, var(--goa-space-m));
+      padding-bottom: var(
+        --goa-tabs-padding-bottom-small-screen,
+        var(--goa-space-m)
+      );
     }
     :global([role="tab"]) {
       padding: var(--goa-tab-padding-mobile);
@@ -549,6 +588,40 @@
     :global([role="tab"][aria-disabled="true"]) {
       border-left: var(--goa-tab-border-not-selected);
     }
+
+    /* horizontal: override mobile styles to use desktop layout */
+    .horizontal .tabs {
+      border-left: none;
+      border-bottom: var(--goa-tabs-bottom-border);
+      flex-direction: row;
+      gap: var(--goa-tabs-gap);
+      padding-bottom: 0;
+      margin-bottom: var(--goa-space-xl);
+    }
+    .horizontal :global([role="tab"]) {
+      padding: var(--goa-tab-padding);
+      border-left: none;
+      border-bottom: var(--goa-tab-border-not-selected);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: var(--goa-space-2xl);
+      justify-content: center;
+    }
+    .horizontal :global([role="tab"][aria-selected="true"]) {
+      border-left: none;
+      border-bottom: var(--goa-tab-border-selected);
+      background: transparent;
+    }
+    .horizontal
+      :global(
+        [role="tab"]:hover:not([aria-selected="true"]):not(
+            [aria-disabled="true"]
+          )
+      ) {
+      border-left: none;
+      border-bottom: var(--goa-tab-border-hover);
+      background: transparent;
+    }
   }
 
   .v2 :global([role="tab"]) {
@@ -563,7 +636,7 @@
     :global(
       [role="tab"]:hover:not([aria-selected="true"]):not([aria-disabled="true"])
     ) {
-    border-bottom: none; /* Remove V1 border on hover */
+    border-bottom: none;
   }
 
   @media (--not-mobile) {
@@ -580,10 +653,13 @@
       right: 0;
       height: var(--goa-tab-indicator-width, 3px);
       background: transparent;
-      border-radius: var(--goa-tab-indicator-border-radius-desktop, 6px 6px 0 0);
+      border-radius: var(
+        --goa-tab-indicator-border-radius-desktop,
+        6px 6px 0 0
+      );
     }
     .v2 :global([role="tab"][aria-selected="true"]::after) {
-      background: var(--goa-tab-indicator-color-active, #0070C4);
+      background: var(--goa-tab-indicator-color-active, #0070c4);
     }
     .v2
       :global(
@@ -599,6 +675,17 @@
     .v2 :global([role="tab"]) {
       border-left: none; /* Remove V1 border, replaced with ::after */
     }
+    .v2 :global([role="tab"][aria-selected="true"]) {
+      border-left: none;
+    }
+    .v2
+      :global(
+        [role="tab"]:hover:not([aria-selected="true"]):not(
+            [aria-disabled="true"]
+          )
+      ) {
+      border-left: none;
+    }
 
     /* V2 uses ::after pseudo-element for rounded corner indicators */
     .v2 :global([role="tab"]::after) {
@@ -609,10 +696,13 @@
       bottom: 0;
       width: var(--goa-tab-indicator-width, 3px);
       background: transparent;
-      border-radius: var(--goa-tab-indicator-border-radius-small-screen, 0 6px 6px 0);
+      border-radius: var(
+        --goa-tab-indicator-border-radius-small-screen,
+        0 6px 6px 0
+      );
     }
     .v2 :global([role="tab"][aria-selected="true"]::after) {
-      background: var(--goa-tab-indicator-color-active, #0070C4);
+      background: var(--goa-tab-indicator-color-active, #0070c4);
     }
     .v2
       :global(
@@ -621,6 +711,35 @@
           )::after
       ) {
       background: var(--goa-tab-indicator-color-hover, #dcdcdc);
+    }
+
+    /* V2 horizontal on mobile: remove V1 borders, use ::after bottom indicator instead */
+    .horizontal.v2 :global([role="tab"]) {
+      border-bottom: none;
+    }
+    .horizontal.v2 :global([role="tab"][aria-selected="true"]) {
+      border-bottom: none;
+    }
+    .horizontal.v2
+      :global(
+        [role="tab"]:hover:not([aria-selected="true"]):not(
+            [aria-disabled="true"]
+          )
+      ) {
+      border-bottom: none;
+    }
+    /* V2 horizontal: switch ::after from left indicator to bottom indicator */
+    .horizontal.v2 :global([role="tab"]::after) {
+      top: auto;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      width: auto;
+      height: var(--goa-tab-indicator-width, 3px);
+      border-radius: var(
+        --goa-tab-indicator-border-radius-desktop,
+        6px 6px 0 0
+      );
     }
   }
 
@@ -651,7 +770,8 @@
     width: var(--segmented-indicator-width, 0);
     height: var(--segmented-indicator-height, 30px);
     background: var(--goa-color-greyscale-white, #ffffff);
-    border: var(--goa-border-width-s) solid var(--goa-color-greyscale-150, #dcdcdc);
+    border: var(--goa-border-width-s) solid
+      var(--goa-color-greyscale-150, #dcdcdc);
     border-radius: var(--goa-border-radius-xl);
     pointer-events: none;
     z-index: 0;


### PR DESCRIPTION
## Summary

- Add `stackOnMobile` prop to keep default tabs horizontal on mobile
- Skip focus on initial page load to avoid visible focus ring when `initialTab` is set
- Remove tabpanel from tab order for segmented variant (`tabindex=-1`)
- Remove focus outline on segmented tabpanel (no content to focus)

## Test plan

- [ ] Run playground: `npm run serve:prs:react` → navigate to "V2 Tabs" in features
- [ ] Test 1: Reload page - no focus ring on "Second (initial)" tab
- [ ] Test 2: Default tabs stack on mobile (resize browser)
- [ ] Test 3: Default tabs with `stackOnMobile={false}` stay horizontal on mobile
- [ ] Test 4: Segmented tabs have no tabpanel focus when tabbing
- [ ] Test 5: Segmented tabs stay horizontal on mobile by default

## Closes

Closes #3407
Closes #2996
Closes #3268