### PR TITLE
feat(#3344): add multi-column sorting to Table and TableSortHeader

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -112,6 +112,7 @@
           <a href="/features/3306">3306</a>
           <a href="/features/3370">3370</a>
           <a href="/features/v2-icons">v2 header icons</a>
+          <a href="/features/3344">3344 Table Multi-Sort</a>
           <a href="/features/3396">3396 Text heading-2xs size</a>
           <a href="/features/3407-skip-on-focus-tab">3407 Skip Focus on Tab</a>
           <a href="/features/3407-stack-on-mobile">3407 Tabs Orientation</a>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -67,6 +67,7 @@ import { Feat2722Component } from "../routes/features/feat2722/feat2722.componen
 import { Feat2730Component } from "../routes/features/feat2730/feat2730.component";
 import { Feat2829Component } from "../routes/features/feat2829/feat2829.component";
 import { Feat3102Component } from "../routes/features/feat3102/feat3102.component";
+import { Feat3344Component } from "../routes/features/feat3344/feat3344.component";
 import { Feat3137Component } from "../routes/features/feat3137/feat3137.component";
 import { Feat3211Component } from "../routes/features/feat3211/feat3211.component";
 import { Feat3241Component } from "../routes/features/feat3241/feat3241.component";
@@ -152,6 +153,7 @@ export const appRoutes: Route[] = [
   { path: "features/3211", component: Feat3211Component },
   { path: "features/3241", component: Feat3241Component },
   { path: "features/v2-icons", component: FeatV2IconsComponent },
+  { path: "features/3344", component: Feat3344Component },
   { path: "features/3137", component: Feat3137Component },
   { path: "features/3229", component: Feat3229Component },
   { path: "features/3306", component: Feat3306Component },

--- a/apps/prs/angular/src/routes/features/feat3344/feat3344.component.html
+++ b/apps/prs/angular/src/routes/features/feat3344/feat3344.component.html
@@ -1,0 +1,111 @@
+<h1>PR 4: Table & TableSortHeader V2</h1>
+
+<goab-block>
+  <goab-details heading="Changes in this PR">
+    <p>
+      <strong>TableSortHeader:</strong><br />
+      - Always-visible sort icon (chevron-expand when unsorted)<br />
+      - Arrow-up/arrow-down for sorted states<br />
+      - sortOrder prop shows "1", "2" for multi-column sort<br />
+      <br />
+      <strong>Table:</strong><br />
+      - sortMode="single" (default) or "multi" (up to 2 columns)<br />
+      - Initial sort declared on headers via direction + sortOrder<br />
+      - onSort callback with sortBy, sortDir, and sorts array
+    </p>
+  </goab-details>
+</goab-block>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<h2>Test 1: Single-Column Sort (Default)</h2>
+<p>Click column headers to sort. Only one column sorts at a time (default behavior).</p>
+<p><small>Current sort: {{ formatSorts(currentSorts) }}</small></p>
+
+<goabx-table mt="m" (onSort)="onSingleSortChange($event)">
+  <thead>
+    <tr>
+      <th>
+        <goabx-table-sort-header name="name">Name</goabx-table-sort-header>
+      </th>
+      <th>
+        <goabx-table-sort-header name="department">Department</goabx-table-sort-header>
+      </th>
+      <th class="goa-table-cell--numeric">
+        <goabx-table-sort-header name="salary">Salary</goabx-table-sort-header>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (row of singleSorted; track row.id) {
+    <tr>
+      <td>{{ row.name }}</td>
+      <td>{{ row.department }}</td>
+      <td class="goa-table-cell--numeric">{{ formatCurrency(row.salary) }}</td>
+    </tr>
+    }
+  </tbody>
+</goabx-table>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<h2>Test 2: Multi-Column Sort</h2>
+<p>With sortMode="multi", click columns to add them to sort order (up to 2).</p>
+<p><small>Current sort: {{ formatSorts(multiSorts) }}</small></p>
+
+<goabx-table mt="m" sortMode="multi" (onMultiSort)="onMultiSortChange($event)">
+  <thead>
+    <tr>
+      <th>
+        <goabx-table-sort-header name="name">Name</goabx-table-sort-header>
+      </th>
+      <th>
+        <goabx-table-sort-header name="department">Department</goabx-table-sort-header>
+      </th>
+      <th class="goa-table-cell--numeric">
+        <goabx-table-sort-header name="salary">Salary</goabx-table-sort-header>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (row of multiSorted; track row.id) {
+    <tr>
+      <td>{{ row.name }}</td>
+      <td>{{ row.department }}</td>
+      <td class="goa-table-cell--numeric">{{ formatCurrency(row.salary) }}</td>
+    </tr>
+    }
+  </tbody>
+</goabx-table>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<h2>Test 3: Multi Initial Sort (declarative)</h2>
+<p>Two initial sorts declared on headers: Department ascending (primary), Salary descending (secondary).
+Use direction + sortOrder on each header to set priority.</p>
+<p><small>Current sort: {{ formatSorts(test3Sorts) }}</small></p>
+
+<goabx-table mt="m" sortMode="multi" (onMultiSort)="onTest3SortChange($event)">
+  <thead>
+    <tr>
+      <th>
+        <goabx-table-sort-header name="name">Name</goabx-table-sort-header>
+      </th>
+      <th>
+        <goabx-table-sort-header name="department" direction="asc" [sortOrder]="1">Department</goabx-table-sort-header>
+      </th>
+      <th class="goa-table-cell--numeric">
+        <goabx-table-sort-header name="salary" direction="desc" [sortOrder]="2">Salary</goabx-table-sort-header>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (row of test3Sorted; track row.id) {
+    <tr>
+      <td>{{ row.name }}</td>
+      <td>{{ row.department }}</td>
+      <td class="goa-table-cell--numeric">{{ formatCurrency(row.salary) }}</td>
+    </tr>
+    }
+  </tbody>
+</goabx-table>

--- a/apps/prs/angular/src/routes/features/feat3344/feat3344.component.ts
+++ b/apps/prs/angular/src/routes/features/feat3344/feat3344.component.ts
@@ -1,0 +1,100 @@
+import { Component, OnInit, OnDestroy } from "@angular/core";
+import {
+  GoabBlock,
+  GoabDivider,
+  GoabDetails,
+  GoabxTable,
+  GoabxTableSortHeader,
+} from "@abgov/angular-components";
+import { GoabTableOnSortDetail, GoabTableOnMultiSortDetail, GoabTableSortEntry } from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat3344",
+  templateUrl: "./feat3344.component.html",
+  imports: [
+    GoabBlock,
+    GoabDivider,
+    GoabDetails,
+    GoabxTable,
+    GoabxTableSortHeader,
+  ],
+})
+export class Feat3344Component implements OnInit, OnDestroy {
+  private v2TokensLink: HTMLLinkElement | null = null;
+
+  currentSorts: GoabTableSortEntry[] = [];
+  multiSorts: GoabTableSortEntry[] = [];
+  test3Sorts: GoabTableSortEntry[] = [];
+
+  data = [
+    { id: 1, name: "Alice Johnson", department: "Engineering", salary: 95000 },
+    { id: 2, name: "Bob Smith", department: "Marketing", salary: 72000 },
+    { id: 3, name: "Carol Williams", department: "Engineering", salary: 105000 },
+    { id: 4, name: "David Brown", department: "Sales", salary: 68000 },
+    { id: 5, name: "Eve Davis", department: "Marketing", salary: 78000 },
+  ];
+
+  singleSorted = [...this.data];
+  multiSorted = [...this.data];
+  test3Sorted = [...this.data];
+
+  ngOnInit() {
+    this.v2TokensLink = document.createElement("link");
+    this.v2TokensLink.rel = "stylesheet";
+    this.v2TokensLink.href = "/v2-tokens/tokens.css";
+    document.head.appendChild(this.v2TokensLink);
+  }
+
+  ngOnDestroy() {
+    if (this.v2TokensLink) {
+      document.head.removeChild(this.v2TokensLink);
+      this.v2TokensLink = null;
+    }
+  }
+
+  onSingleSortChange(detail: GoabTableOnSortDetail) {
+    this.currentSorts = [{ column: detail.sortBy, direction: detail.sortDir === 1 ? "asc" : "desc" }];
+    this.singleSorted = this.sortData(this.data, this.currentSorts);
+  }
+
+  onMultiSortChange(detail: GoabTableOnMultiSortDetail) {
+    this.multiSorts = detail.sorts;
+    this.multiSorted = this.sortData(this.data, this.multiSorts);
+  }
+
+  onTest3SortChange(detail: GoabTableOnMultiSortDetail) {
+    this.test3Sorts = detail.sorts;
+    this.test3Sorted = this.sortData(this.data, this.test3Sorts);
+  }
+
+  formatSorts(sorts: GoabTableSortEntry[]): string {
+    if (sorts.length === 0) return "None";
+    return sorts.map((s, i) => `${i + 1}. ${s.column} (${s.direction})`).join(", ");
+  }
+
+  formatCurrency(value: number): string {
+    return "$" + value.toLocaleString();
+  }
+
+  private sortData(
+    data: typeof this.data,
+    sorts: GoabTableSortEntry[],
+  ): typeof this.data {
+    if (sorts.length === 0) return [...data];
+    return [...data].sort((a, b) => {
+      for (const { column, direction } of sorts) {
+        const aVal = a[column as keyof typeof a];
+        const bVal = b[column as keyof typeof b];
+        let cmp = 0;
+        if (typeof aVal === "string" && typeof bVal === "string") {
+          cmp = aVal.localeCompare(bVal);
+        } else {
+          cmp = (aVal as number) - (bVal as number);
+        }
+        if (cmp !== 0) return direction === "asc" ? cmp : -cmp;
+      }
+      return 0;
+    });
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -123,13 +123,14 @@ export function App() {
               <Link to="/features/3137">3137 Work Side Menu Group</Link>
               <Link to="/features/3241">3241 V2 Experimental Wrappers</Link>
               <Link to="/features/v2-icons">v2 header icons</Link>
-              <Link to="/features/3407-skip-on-focus-tab">3407 Skip Focus on Tab</Link>
-              <Link to="/features/3407-stack-on-mobile">3407 Tabs Orientation</Link>
               <Link to="/features/3229">3229 V2 Menu Button vs size and icon-only</Link>
+              <Link to="/features/3344">3344 Table Multi-Sort</Link>
               <Link to="/features/3306">3306 Custom slug value for tabs</Link>
               <Link to="/features/3370">3370 Clear calendar day selection</Link>
               <Link to="/features/3396">3396 Text heading-2xs size</Link>
               <Link to="/features/v2-checkbox">3399 V2 Checkbox Spacing</Link>
+              <Link to="/features/3407-skip-on-focus-tab">3407 Skip Focus on Tab</Link>
+              <Link to="/features/3407-stack-on-mobile">3407 Tabs Orientation</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Everything">
               <Link to="/everything">A</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -75,6 +75,7 @@ import { Feat3241Route } from "./routes/features/feat3241";
 import { FeatV2IconsRoute } from "./routes/features/featV2Icons";
 import { Feat3407SkipOnFocusTabRoute } from "./routes/features/feat3407SkipOnFocusTab";
 import { Feat3407StackOnMobileRoute } from "./routes/features/feat3407StackOnMobile";
+import { Feat3344Route } from "./routes/features/feat3344";
 import { Feat3137Route } from "./routes/features/feat3137";
 import { Feat3306Route } from "./routes/features/feat3306";
 import { Feat2469Route } from "./routes/features/feat2469";
@@ -165,6 +166,7 @@ root.render(
           <Route path="features/v2-icons" element={<FeatV2IconsRoute />} />
           <Route path="features/3137" element={<Feat3137Route />} />
           <Route path="features/3229" element={<Feat3229Route />} />
+          <Route path="features/3344" element={<Feat3344Route />} />
           <Route path="features/3306" element={<Feat3306Route />} />
           <Route path="features/3370" element={<Feat3370Route />} />
           <Route path="features/3396" element={<Feat3396Route />} />

--- a/apps/prs/react/src/routes/features/feat3344.tsx
+++ b/apps/prs/react/src/routes/features/feat3344.tsx
@@ -1,0 +1,200 @@
+/**
+ * PR 4: Table & TableSortHeader V2 Updates
+ *
+ * Tests:
+ * - TableSortHeader with chevron-expand icon (unsorted state)
+ * - TableSortHeader with arrow-up/arrow-down (sorted states)
+ * - Built-in single and multi-column sorting
+ * - sortOrder numbers for multi-column sort priority
+ * - V2 focus ring on icon only (not whole button)
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  GoabBlock,
+  GoabDivider,
+  GoabDetails,
+} from "@abgov/react-components";
+// ?url suffix tells Vite to resolve the path without injecting the CSS
+import v2TokensUrl from "@abgov/design-tokens-v2/dist/tokens.css?url";
+import { GoabxTable, GoabxTableSortHeader } from "@abgov/react-components/experimental";
+import type { GoabTableSortEntry } from "@abgov/ui-components-common";
+
+type RowData = { id: number; name: string; department: string; salary: number };
+
+const initialData: RowData[] = [
+  { id: 1, name: "Alice Johnson", department: "Engineering", salary: 95000 },
+  { id: 2, name: "Bob Smith", department: "Marketing", salary: 72000 },
+  { id: 3, name: "Carol Williams", department: "Engineering", salary: 105000 },
+  { id: 4, name: "David Brown", department: "Sales", salary: 68000 },
+  { id: 5, name: "Eve Davis", department: "Marketing", salary: 78000 },
+];
+
+function sortData(data: RowData[], sorts: GoabTableSortEntry[]): RowData[] {
+  if (sorts.length === 0) return data;
+  return [...data].sort((a, b) => {
+    for (const { column, direction } of sorts) {
+      const aVal = a[column as keyof RowData];
+      const bVal = b[column as keyof RowData];
+      let cmp = 0;
+      if (typeof aVal === "string" && typeof bVal === "string") {
+        cmp = aVal.localeCompare(bVal);
+      } else {
+        cmp = (aVal as number) - (bVal as number);
+      }
+      if (cmp !== 0) return direction === "asc" ? cmp : -cmp;
+    }
+    return 0;
+  });
+}
+
+export function Feat3344Route() {
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = v2TokensUrl;
+    document.head.appendChild(link);
+    return () => {
+      document.head.removeChild(link);
+    };
+  }, []);
+
+  const [currentSorts, setCurrentSorts] = useState<GoabTableSortEntry[]>([]);
+  const [multiSorts, setMultiSorts] = useState<GoabTableSortEntry[]>([]);
+  const [test3Sorts, setTest3Sorts] = useState<GoabTableSortEntry[]>([]);
+
+  const singleSorted = useMemo(() => sortData(initialData, currentSorts), [currentSorts]);
+  const multiSorted = useMemo(() => sortData(initialData, multiSorts), [multiSorts]);
+  const test3Sorted = useMemo(() => sortData(initialData, test3Sorts), [test3Sorts]);
+
+  const formatSorts = (sorts: GoabTableSortEntry[]): string => {
+    if (sorts.length === 0) return "None";
+    return sorts.map((s, i) => `${i + 1}. ${s.column} (${s.direction})`).join(", ");
+  };
+
+  return (
+    <div>
+      <h1>PR 4: Table & TableSortHeader V2</h1>
+
+      <GoabBlock>
+        <GoabDetails heading="Changes in this PR">
+          <p>
+            <strong>TableSortHeader:</strong><br />
+            - Always-visible sort icon (chevron-expand when unsorted)<br />
+            - Arrow-up/arrow-down for sorted states<br />
+            - sortOrder prop shows "1", "2" for multi-column sort<br />
+            <br />
+            <strong>Table:</strong><br />
+            - sortMode="single" (default) or "multi" (up to 2 columns)<br />
+            - Initial sort declared on headers via direction + sortOrder<br />
+            - onSort callback with sortBy, sortDir, and sorts array
+          </p>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <h2>Test 1: Single-Column Sort (Default)</h2>
+      <p>Click column headers to sort. Only one column sorts at a time (default behavior).</p>
+      <p><small>Current sort: {formatSorts(currentSorts)}</small></p>
+
+      <GoabxTable mt="m" onSort={(detail) => setCurrentSorts([{ column: detail.sortBy, direction: detail.sortDir === 1 ? "asc" : "desc" }])}>
+        <thead>
+          <tr>
+            <th>
+              <GoabxTableSortHeader name="name">Name</GoabxTableSortHeader>
+            </th>
+            <th>
+              <GoabxTableSortHeader name="department">Department</GoabxTableSortHeader>
+            </th>
+            <th className="goa-table-cell--numeric">
+              <GoabxTableSortHeader name="salary">Salary</GoabxTableSortHeader>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {singleSorted.map((row) => (
+            <tr key={row.id}>
+              <td>{row.name}</td>
+              <td>{row.department}</td>
+              <td className="goa-table-cell--numeric">${row.salary.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </GoabxTable>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <h2>Test 2: Multi-Column Sort</h2>
+      <p>With sortMode="multi", click columns to add them to sort order (up to 2).</p>
+      <p><small>Current sort: {formatSorts(multiSorts)}</small></p>
+
+      <GoabxTable mt="m" sortMode="multi" onMultiSort={(detail) => setMultiSorts(detail.sorts)}>
+        <thead>
+          <tr>
+            <th>
+              <GoabxTableSortHeader name="name">Name</GoabxTableSortHeader>
+            </th>
+            <th>
+              <GoabxTableSortHeader name="department">Department</GoabxTableSortHeader>
+            </th>
+            <th className="goa-table-cell--numeric">
+              <GoabxTableSortHeader name="salary">Salary</GoabxTableSortHeader>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {multiSorted.map((row) => (
+            <tr key={row.id}>
+              <td>{row.name}</td>
+              <td>{row.department}</td>
+              <td className="goa-table-cell--numeric">${row.salary.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </GoabxTable>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <h2>Test 3: Multi Initial Sort (declarative)</h2>
+      <p>Two initial sorts declared on headers: Department ascending (primary), Salary
+        descending (secondary). Use direction + sortOrder on each header to set priority.</p>
+      <p><small>Current sort: {formatSorts(test3Sorts)}</small></p>
+
+      <GoabxTable
+        mt="m"
+        sortMode="multi"
+        onMultiSort={(detail) => setTest3Sorts(detail.sorts)}
+      >
+        <thead>
+          <tr>
+            <th>
+              <GoabxTableSortHeader name="name">Name</GoabxTableSortHeader>
+            </th>
+            <th>
+              <GoabxTableSortHeader name="department" direction="asc" sortOrder={1}>
+                Department
+              </GoabxTableSortHeader>
+            </th>
+            <th className="goa-table-cell--numeric">
+              <GoabxTableSortHeader name="salary" direction="desc" sortOrder={2}>
+                Salary
+              </GoabxTableSortHeader>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {test3Sorted.map((row) => (
+            <tr key={row.id}>
+              <td>{row.name}</td>
+              <td>{row.department}</td>
+              <td className="goa-table-cell--numeric">${row.salary.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </GoabxTable>
+    </div>
+  );
+}
+
+export default Feat3344Route;

--- a/docs/generated/component-apis/table-sort-header.json
+++ b/docs/generated/component-apis/table-sort-header.json
@@ -1,0 +1,41 @@
+{
+  "componentSlug": "table-sort-header",
+  "extractedFrom": "libs/web-components/src/components/table/TableSortHeader.svelte",
+  "extractedAt": "2026-02-26T00:00:00.000Z",
+  "props": [
+    {
+      "name": "name",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Column name identifier for sorting."
+    },
+    {
+      "name": "direction",
+      "type": "\"asc\" | \"desc\" | \"none\"",
+      "typeLabel": "GoabTableSortDirection",
+      "values": [
+        "asc",
+        "desc",
+        "none"
+      ],
+      "required": false,
+      "default": "none",
+      "description": "Sets the sort direction indicator."
+    },
+    {
+      "name": "sortOrder",
+      "type": "number",
+      "required": false,
+      "default": 0,
+      "description": "Sort order number for multi-column sort display (1, 2, etc)."
+    }
+  ],
+  "events": [],
+  "slots": [
+    {
+      "name": "default",
+      "description": ""
+    }
+  ]
+}

--- a/docs/generated/component-apis/table.json
+++ b/docs/generated/component-apis/table.json
@@ -37,6 +37,18 @@
       "description": "A relaxed variant of the table with more vertical padding for the cells."
     },
     {
+      "name": "sortMode",
+      "type": "\"single\" | \"multi\"",
+      "typeLabel": "GoabTableSortMode",
+      "values": [
+        "single",
+        "multi"
+      ],
+      "required": false,
+      "default": "single",
+      "description": "Sort mode: \"single\" allows one column, \"multi\" allows up to 2 columns."
+    },
+    {
       "name": "testId",
       "type": "string",
       "required": false,
@@ -79,8 +91,8 @@
   "events": [
     {
       "name": "onSort",
-      "type": "(event: Event) => void",
-      "description": "",
+      "type": "(detail: GoabTableOnSortDetail) => void",
+      "description": "Called when sort state changes in single-sort mode. Receives { sortBy, sortDir }.",
       "frameworks": [
         "react"
       ]
@@ -88,7 +100,23 @@
     {
       "name": "_sort",
       "type": "CustomEvent",
-      "description": "",
+      "description": "Dispatched when sort state changes in single-sort mode. Detail contains { sortBy, sortDir }.",
+      "frameworks": [
+        "angular"
+      ]
+    },
+    {
+      "name": "onMultiSort",
+      "type": "(detail: GoabTableOnMultiSortDetail) => void",
+      "description": "Called when sort state changes in multi-sort mode. Receives { sorts: GoabTableSortEntry[] }.",
+      "frameworks": [
+        "react"
+      ]
+    },
+    {
+      "name": "_multisort",
+      "type": "CustomEvent",
+      "description": "Dispatched when sort state changes in multi-sort mode. Detail contains { sorts: GoabTableSortEntry[] }.",
       "frameworks": [
         "angular"
       ]

--- a/docs/src/data/configurations/index.ts
+++ b/docs/src/data/configurations/index.ts
@@ -73,6 +73,7 @@ export { cardContentConfigurations } from './card-content';
 export { cardImageConfigurations } from './card-image';
 export { cardActionsConfigurations } from './card-actions';
 export { tableConfigurations } from './table';
+export { tableSortHeaderConfigurations } from './table-sort-header';
 export { dataGridConfigurations } from './data-grid';
 export { modalConfigurations } from './modal';
 export { drawerConfigurations } from './drawer';
@@ -147,6 +148,7 @@ import { cardContentConfigurations } from './card-content';
 import { cardImageConfigurations } from './card-image';
 import { cardActionsConfigurations } from './card-actions';
 import { tableConfigurations } from './table';
+import { tableSortHeaderConfigurations } from './table-sort-header';
 import { dataGridConfigurations } from './data-grid';
 import { modalConfigurations } from './modal';
 import { drawerConfigurations } from './drawer';
@@ -231,6 +233,7 @@ export const configurationRegistry: ConfigurationRegistry = {
   'card-image': cardImageConfigurations,
   'card-actions': cardActionsConfigurations,
   table: tableConfigurations,
+  'table-sort-header': tableSortHeaderConfigurations,
   'data-grid': dataGridConfigurations,
   modal: modalConfigurations,
   drawer: drawerConfigurations,

--- a/docs/src/data/configurations/table-sort-header.ts
+++ b/docs/src/data/configurations/table-sort-header.ts
@@ -1,0 +1,48 @@
+/**
+ * TableSortHeader Component Configurations
+ *
+ * Sort headers for table columns, used within Table's thead.
+ */
+
+import type { ComponentConfigurations } from './types';
+
+export const tableSortHeaderConfigurations: ComponentConfigurations = {
+  componentSlug: 'table-sort-header',
+  componentName: 'TableSortHeader',
+  defaultConfigurationId: 'basic',
+
+  configurations: [
+    {
+      id: 'basic',
+      name: 'Basic sort header',
+      description: 'Sortable column header with name and direction',
+      code: {
+        react: `<GoabxTableSortHeader name="name" direction="asc">
+  Name
+</GoabxTableSortHeader>`,
+        angular: `<goabx-table-sort-header name="name" direction="asc">
+  Name
+</goabx-table-sort-header>`,
+        webComponents: `<goa-table-sort-header name="name" direction="asc">
+  Name
+</goa-table-sort-header>`,
+      },
+    },
+    {
+      id: 'sort-order',
+      name: 'With sort order',
+      description: 'Sort header with sortOrder for multi-column sort priority display',
+      code: {
+        react: `<GoabxTableSortHeader name="name" direction="asc" sortOrder={1}>
+  Name
+</GoabxTableSortHeader>`,
+        angular: `<goabx-table-sort-header name="name" direction="asc" [sortOrder]="1">
+  Name
+</goabx-table-sort-header>`,
+        webComponents: `<goa-table-sort-header name="name" direction="asc" sort-order="1">
+  Name
+</goa-table-sort-header>`,
+      },
+    },
+  ],
+};

--- a/docs/src/data/configurations/table.ts
+++ b/docs/src/data/configurations/table.ts
@@ -402,5 +402,173 @@ export const tableConfigurations: ComponentConfigurations = {
 </goa-table>`,
       },
     },
+    {
+      id: 'single-sort',
+      name: 'Single-column sorting',
+      description: 'Sortable columns using TableSortHeader (default single sort mode)',
+      code: {
+        react: `<GoabxTable onSort={(detail) => console.log(detail)}>
+  <thead>
+    <tr>
+      <th>
+        <GoabxTableSortHeader name="name" direction="asc">Name</GoabxTableSortHeader>
+      </th>
+      <th>
+        <GoabxTableSortHeader name="status">Status</GoabxTableSortHeader>
+      </th>
+      <th>
+        <GoabxTableSortHeader name="date">Date</GoabxTableSortHeader>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>John Smith</td>
+      <td>Active</td>
+      <td>Jan 15, 2024</td>
+    </tr>
+    <tr>
+      <td>Jane Doe</td>
+      <td>Pending</td>
+      <td>Jan 16, 2024</td>
+    </tr>
+  </tbody>
+</GoabxTable>`,
+        angular: `<goabx-table (onSort)="onSort($event)">
+  <thead>
+    <tr>
+      <th>
+        <goabx-table-sort-header name="name" direction="asc">Name</goabx-table-sort-header>
+      </th>
+      <th>
+        <goabx-table-sort-header name="status">Status</goabx-table-sort-header>
+      </th>
+      <th>
+        <goabx-table-sort-header name="date">Date</goabx-table-sort-header>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>John Smith</td>
+      <td>Active</td>
+      <td>Jan 15, 2024</td>
+    </tr>
+    <tr>
+      <td>Jane Doe</td>
+      <td>Pending</td>
+      <td>Jan 16, 2024</td>
+    </tr>
+  </tbody>
+</goabx-table>`,
+        webComponents: `<goa-table version="2">
+  <table>
+    <thead>
+      <tr>
+        <th><goa-table-sort-header name="name" direction="asc">Name</goa-table-sort-header></th>
+        <th><goa-table-sort-header name="status">Status</goa-table-sort-header></th>
+        <th><goa-table-sort-header name="date">Date</goa-table-sort-header></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>John Smith</td>
+        <td>Active</td>
+        <td>Jan 15, 2024</td>
+      </tr>
+      <tr>
+        <td>Jane Doe</td>
+        <td>Pending</td>
+        <td>Jan 16, 2024</td>
+      </tr>
+    </tbody>
+  </table>
+</goa-table>`,
+      },
+    },
+    {
+      id: 'multi-sort',
+      name: 'Multi-column sorting',
+      description: 'Sort by multiple columns with sortMode="multi" and sortOrder for priority',
+      code: {
+        react: `<GoabxTable sortMode="multi" onMultiSort={(detail) => console.log(detail.sorts)}>
+  <thead>
+    <tr>
+      <th>
+        <GoabxTableSortHeader name="name" direction="asc" sortOrder={1}>Name</GoabxTableSortHeader>
+      </th>
+      <th>
+        <GoabxTableSortHeader name="status" direction="desc" sortOrder={2}>Status</GoabxTableSortHeader>
+      </th>
+      <th>
+        <GoabxTableSortHeader name="date">Date</GoabxTableSortHeader>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>John Smith</td>
+      <td>Active</td>
+      <td>Jan 15, 2024</td>
+    </tr>
+    <tr>
+      <td>Jane Doe</td>
+      <td>Pending</td>
+      <td>Jan 16, 2024</td>
+    </tr>
+  </tbody>
+</GoabxTable>`,
+        angular: `<goabx-table sortMode="multi" (onMultiSort)="onMultiSort($event)">
+  <thead>
+    <tr>
+      <th>
+        <goabx-table-sort-header name="name" direction="asc" [sortOrder]="1">Name</goabx-table-sort-header>
+      </th>
+      <th>
+        <goabx-table-sort-header name="status" direction="desc" [sortOrder]="2">Status</goabx-table-sort-header>
+      </th>
+      <th>
+        <goabx-table-sort-header name="date">Date</goabx-table-sort-header>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>John Smith</td>
+      <td>Active</td>
+      <td>Jan 15, 2024</td>
+    </tr>
+    <tr>
+      <td>Jane Doe</td>
+      <td>Pending</td>
+      <td>Jan 16, 2024</td>
+    </tr>
+  </tbody>
+</goabx-table>`,
+        webComponents: `<goa-table version="2" sort-mode="multi">
+  <table>
+    <thead>
+      <tr>
+        <th><goa-table-sort-header name="name" direction="asc" sort-order="1">Name</goa-table-sort-header></th>
+        <th><goa-table-sort-header name="status" direction="desc" sort-order="2">Status</goa-table-sort-header></th>
+        <th><goa-table-sort-header name="date">Date</goa-table-sort-header></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>John Smith</td>
+        <td>Active</td>
+        <td>Jan 15, 2024</td>
+      </tr>
+      <tr>
+        <td>Jane Doe</td>
+        <td>Pending</td>
+        <td>Jan 16, 2024</td>
+      </tr>
+    </tbody>
+  </table>
+</goa-table>`,
+      },
+    },
   ],
 };

--- a/libs/angular-components/src/experimental/table-sort-header/table-sort-header.spec.ts
+++ b/libs/angular-components/src/experimental/table-sort-header/table-sort-header.spec.ts
@@ -17,6 +17,21 @@ class TestTableSortHeaderComponent {
   /** do nothing **/
 }
 
+@Component({
+  standalone: true,
+  imports: [GoabxTableSortHeader],
+  template: `
+    <th>
+      <goabx-table-sort-header name="salary" direction="desc" [sortOrder]="2">
+        Salary
+      </goabx-table-sort-header>
+    </th>
+  `,
+})
+class TestTableSortHeaderWithSortOrderComponent {
+  /** do nothing **/
+}
+
 describe("GoABTableSortHeader", () => {
   let fixture: ComponentFixture<TestTableSortHeaderComponent>;
 
@@ -37,5 +52,28 @@ describe("GoABTableSortHeader", () => {
     expect(el?.getAttribute("direction")).toBe("asc");
     expect(el?.getAttribute("name")).toBe("firstName");
     expect(el?.textContent).toContain("First name and really long header");
+  });
+});
+
+describe("GoABTableSortHeader with sortOrder", () => {
+  let fixture: ComponentFixture<TestTableSortHeaderWithSortOrderComponent>;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [GoabxTableSortHeader, TestTableSortHeaderWithSortOrderComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestTableSortHeaderWithSortOrderComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+  }));
+
+  it("should render sort-order attribute", () => {
+    const el = fixture.nativeElement.querySelector("goa-table-sort-header");
+    expect(el?.getAttribute("sort-order")).toBe("2");
+    expect(el?.getAttribute("direction")).toBe("desc");
+    expect(el?.getAttribute("name")).toBe("salary");
   });
 });

--- a/libs/angular-components/src/experimental/table-sort-header/table-sort-header.ts
+++ b/libs/angular-components/src/experimental/table-sort-header/table-sort-header.ts
@@ -1,4 +1,4 @@
-import { GoabTableSortDirection } from "@abgov/ui-components-common";
+import { GoabTableSortDirection, GoabTableSortOrder } from "@abgov/ui-components-common";
 import {
   CUSTOM_ELEMENTS_SCHEMA,
   Component,
@@ -12,7 +12,11 @@ import {
   selector: "goabx-table-sort-header",
   template: `
     @if (isReady) {
-      <goa-table-sort-header [attr.name]="name" [attr.direction]="direction">
+      <goa-table-sort-header
+        [attr.name]="name"
+        [attr.direction]="direction"
+        [attr.sort-order]="sortOrder"
+      >
         <ng-content />
       </goa-table-sort-header>
     }
@@ -24,6 +28,7 @@ export class GoabxTableSortHeader implements OnInit {
   isReady = false;
   @Input() name?: string;
   @Input() direction?: GoabTableSortDirection = "none";
+  @Input() sortOrder?: GoabTableSortOrder;
 
   constructor(private cdr: ChangeDetectorRef) {}
 

--- a/libs/angular-components/src/experimental/table/table.spec.ts
+++ b/libs/angular-components/src/experimental/table/table.spec.ts
@@ -3,6 +3,8 @@ import { GoabxTable } from "./table";
 import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import {
   GoabTableOnSortDetail,
+  GoabTableOnMultiSortDetail,
+  GoabTableSortMode,
   GoabTableVariant,
   Spacing,
 } from "@abgov/ui-components-common";
@@ -15,12 +17,15 @@ import { fireEvent } from "@testing-library/dom";
     <goabx-table
       [width]="width"
       [variant]="variant"
+      [sortMode]="sortMode"
+      [striped]="striped"
       [testId]="testId"
       [mt]="mt"
       [mb]="mb"
       [mr]="mr"
       [ml]="ml"
       (onSort)="onSort($event)"
+      (onMultiSort)="onMultiSort($event)"
     >
       <thead>
         <tr>
@@ -38,13 +43,19 @@ import { fireEvent } from "@testing-library/dom";
 class TestTableComponent {
   width?: string;
   variant?: GoabTableVariant;
+  sortMode?: GoabTableSortMode;
+  striped?: boolean;
   testId?: string;
   mt?: Spacing;
   mb?: Spacing;
   mr?: Spacing;
   ml?: Spacing;
 
-  onSort(event: GoabTableOnSortDetail) {
+  onSort(_event: GoabTableOnSortDetail) {
+    /** do nothing **/
+  }
+
+  onMultiSort(_event: GoabTableOnMultiSortDetail) {
     /** do nothing **/
   }
 }
@@ -64,6 +75,8 @@ describe("GoabxTable", () => {
 
     component.width = "200px";
     component.variant = "relaxed";
+    component.sortMode = "multi";
+    component.striped = true;
     component.testId = "foo";
     component.mt = "s" as Spacing;
     component.mb = "xl" as Spacing;
@@ -77,8 +90,11 @@ describe("GoabxTable", () => {
 
   it("should render", () => {
     const el = fixture.nativeElement.querySelector("goa-table");
+    expect(el?.getAttribute("version")).toBe("2");
     expect(el?.getAttribute("width")).toBe(component.width);
     expect(el?.getAttribute("variant")).toBe(component.variant);
+    expect(el?.getAttribute("sort-mode")).toBe(component.sortMode);
+    expect(el?.getAttribute("striped")).toBe("true");
     expect(el?.getAttribute("testid")).toBe(component.testId);
     expect(el?.getAttribute("mt")).toBe(component.mt);
     expect(el?.getAttribute("mb")).toBe(component.mb);
@@ -95,13 +111,32 @@ describe("GoabxTable", () => {
   it("should dispatch _sort", () => {
     const onSort = jest.spyOn(component, "onSort");
     const el = fixture.nativeElement.querySelector("goa-table");
+    const detail = {
+      sortBy: "column1",
+      sortDir: 1,
+    };
     fireEvent(
       el,
-      new CustomEvent("_sort", {
-        detail: { sortBy: "column1", sortDir: 1 },
-      }),
+      new CustomEvent("_sort", { detail }),
     );
 
-    expect(onSort).toHaveBeenCalledWith({ sortBy: "column1", sortDir: 1 });
+    expect(onSort).toHaveBeenCalledWith(detail);
+  });
+
+  it("should dispatch _multisort", () => {
+    const onMultiSort = jest.spyOn(component, "onMultiSort");
+    const el = fixture.nativeElement.querySelector("goa-table");
+    const detail = {
+      sorts: [
+        { column: "column1", direction: "asc" },
+        { column: "column2", direction: "desc" },
+      ],
+    };
+    fireEvent(
+      el,
+      new CustomEvent("_multisort", { detail }),
+    );
+
+    expect(onMultiSort).toHaveBeenCalledWith(detail);
   });
 });

--- a/libs/angular-components/src/experimental/table/table.ts
+++ b/libs/angular-components/src/experimental/table/table.ts
@@ -1,4 +1,9 @@
-import { GoabTableOnSortDetail, GoabTableVariant } from "@abgov/ui-components-common";
+import {
+  GoabTableOnSortDetail,
+  GoabTableOnMultiSortDetail,
+  GoabTableSortMode,
+  GoabTableVariant,
+} from "@abgov/ui-components-common";
 import {
   CUSTOM_ELEMENTS_SCHEMA,
   Component,
@@ -21,6 +26,7 @@ import { GoabBaseComponent } from "../base.component";
         [attr.version]="version"
         [attr.width]="width"
         [attr.variant]="variant"
+        [attr.sort-mode]="sortMode"
         [attr.striped]="striped"
         [attr.testid]="testId"
         [attr.mt]="mt"
@@ -28,6 +34,7 @@ import { GoabBaseComponent } from "../base.component";
         [attr.ml]="ml"
         [attr.mr]="mr"
         (_sort)="_onSort($event)"
+        (_multisort)="_onMultiSort($event)"
       >
         <table style="width: 100%;">
           <ng-content />
@@ -43,6 +50,7 @@ export class GoabxTable extends GoabBaseComponent implements OnInit {
   version = "2";
   @Input() width?: string;
   @Input() variant?: GoabTableVariant;
+  @Input() sortMode?: GoabTableSortMode;
   @Input({ transform: booleanAttribute }) striped?: boolean;
 
   constructor(private cdr: ChangeDetectorRef) {
@@ -57,9 +65,15 @@ export class GoabxTable extends GoabBaseComponent implements OnInit {
   }
 
   @Output() onSort = new EventEmitter<GoabTableOnSortDetail>();
+  @Output() onMultiSort = new EventEmitter<GoabTableOnMultiSortDetail>();
 
   _onSort(e: Event) {
     const detail = (e as CustomEvent<GoabTableOnSortDetail>).detail;
     this.onSort.emit(detail);
+  }
+
+  _onMultiSort(e: Event) {
+    const detail = (e as CustomEvent<GoabTableOnMultiSortDetail>).detail;
+    this.onMultiSort.emit(detail);
   }
 }

--- a/libs/angular-components/src/lib/components/table-sort-header/table-sort-header.ts
+++ b/libs/angular-components/src/lib/components/table-sort-header/table-sort-header.ts
@@ -12,7 +12,10 @@ import {
   selector: "goab-table-sort-header",
   template: `
     @if (isReady) {
-      <goa-table-sort-header [attr.name]="name" [attr.direction]="direction">
+      <goa-table-sort-header
+        [attr.name]="name"
+        [attr.direction]="direction"
+      >
         <ng-content />
       </goa-table-sort-header>
     }
@@ -24,7 +27,6 @@ export class GoabTableSortHeader implements OnInit {
   isReady = false;
   @Input() name?: string;
   @Input() direction?: GoabTableSortDirection = "none";
-
   constructor(private cdr: ChangeDetectorRef) {}
 
   ngOnInit(): void {

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -242,9 +242,21 @@ export interface GoabTableProps extends Margins {
   testId?: string;
 }
 
+export type GoabTableSortMode = "single" | "multi";
+export type GoabTableSortOrder = 1 | 2;
+
+export type GoabTableSortEntry = {
+  column: string;
+  direction: "asc" | "desc";
+};
+
 export type GoabTableOnSortDetail = {
   sortBy: string;
   sortDir: number;
+};
+
+export type GoabTableOnMultiSortDetail = {
+  sorts: GoabTableSortEntry[];
 };
 
 // Spacer

--- a/libs/react-components/specs/table.browser.spec.tsx
+++ b/libs/react-components/specs/table.browser.spec.tsx
@@ -1,0 +1,531 @@
+import { render } from "vitest-browser-react";
+import { vi, describe, it, expect } from "vitest";
+import { useState, useMemo } from "react";
+import { GoabxTable, GoabxTableSortHeader } from "../src/experimental";
+
+type SortEntry = { column: string; direction: "asc" | "desc" };
+type RowData = { id: number; name: string; department: string; salary: number };
+
+const initialData: RowData[] = [
+  { id: 1, name: "Alice Johnson", department: "Engineering", salary: 95000 },
+  { id: 2, name: "Bob Smith", department: "Marketing", salary: 72000 },
+  { id: 3, name: "Carol Williams", department: "Engineering", salary: 105000 },
+  { id: 4, name: "David Brown", department: "Sales", salary: 68000 },
+  { id: 5, name: "Eve Davis", department: "Marketing", salary: 78000 },
+];
+
+function sortData(data: RowData[], sorts: SortEntry[]): RowData[] {
+  if (sorts.length === 0) return data;
+  return [...data].sort((a, b) => {
+    for (const { column, direction } of sorts) {
+      const aVal = a[column as keyof RowData];
+      const bVal = b[column as keyof RowData];
+      let cmp = 0;
+      if (typeof aVal === "string" && typeof bVal === "string") {
+        cmp = aVal.localeCompare(bVal);
+      } else {
+        cmp = (aVal as number) - (bVal as number);
+      }
+      if (cmp !== 0) return direction === "asc" ? cmp : -cmp;
+    }
+    return 0;
+  });
+}
+
+/** Query row names from the light DOM render container (not shadow DOM). */
+function getRowNames(container: HTMLElement): string[] {
+  const rows = container.querySelectorAll("tbody tr");
+  return Array.from(rows).map((row) => row.querySelector("td")!.textContent!.trim());
+}
+
+/** Get the shadow DOM button inside a goa-table-sort-header, queried from the light DOM container. */
+function getSortHeaderButton(container: HTMLElement, name: string): HTMLElement {
+  const header = container.querySelector(`goa-table-sort-header[name="${name}"]`);
+  return header!.shadowRoot!.querySelector("button")!;
+}
+
+/** Wait for sort headers to be mounted and their shadow roots to be ready. */
+async function waitForHeaders(container: HTMLElement, count: number) {
+  await vi.waitFor(
+    () => {
+      const headers = container.querySelectorAll("goa-table-sort-header");
+      expect(headers.length).toBe(count);
+      // Ensure shadow roots are ready
+      headers.forEach((h) => {
+        expect(h.shadowRoot).toBeTruthy();
+        expect(h.shadowRoot!.querySelector("button")).toBeTruthy();
+      });
+    },
+    { timeout: 3000 },
+  );
+}
+
+describe("GoabxTable Browser Tests", () => {
+  describe("single-column sorting", () => {
+    it("should sort by name ascending on first click", async () => {
+      const onSort = vi.fn();
+
+      const Component = () => {
+        const [sorts, setSorts] = useState<SortEntry[]>([]);
+        const sorted = useMemo(() => sortData(initialData, sorts), [sorts]);
+
+        return (
+          <GoabxTable
+            testId="single-sort-table"
+            onSort={(detail) => {
+              setSorts([{ column: detail.sortBy, direction: detail.sortDir === 1 ? "asc" : "desc" }]);
+              onSort(detail);
+            }}
+          >
+            <thead>
+              <tr>
+                <th>
+                  <GoabxTableSortHeader name="name">Name</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="department">Department</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="salary">Salary</GoabxTableSortHeader>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr key={row.id}>
+                  <td>{row.name}</td>
+                  <td>{row.department}</td>
+                  <td>${row.salary.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </GoabxTable>
+        );
+      };
+
+      const { container } = render(<Component />);
+      await waitForHeaders(container, 3);
+
+      // Initial order should be the original data order
+      expect(getRowNames(container)).toEqual([
+        "Alice Johnson",
+        "Bob Smith",
+        "Carol Williams",
+        "David Brown",
+        "Eve Davis",
+      ]);
+
+      // Click Name header to sort ascending
+      getSortHeaderButton(container, "name").click();
+
+      await vi.waitFor(() => {
+        expect(onSort).toHaveBeenCalled();
+        expect(getRowNames(container)).toEqual([
+          "Alice Johnson",
+          "Bob Smith",
+          "Carol Williams",
+          "David Brown",
+          "Eve Davis",
+        ]);
+      });
+    });
+
+    it("should toggle sort direction on subsequent clicks", async () => {
+      const Component = () => {
+        const [sorts, setSorts] = useState<SortEntry[]>([]);
+        const sorted = useMemo(() => sortData(initialData, sorts), [sorts]);
+
+        return (
+          <GoabxTable
+            testId="toggle-sort-table"
+            onSort={(detail) => {
+              setSorts([{ column: detail.sortBy, direction: detail.sortDir === 1 ? "asc" : "desc" }]);
+            }}
+          >
+            <thead>
+              <tr>
+                <th>
+                  <GoabxTableSortHeader name="name">Name</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="salary">Salary</GoabxTableSortHeader>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr key={row.id}>
+                  <td>{row.name}</td>
+                  <td>${row.salary.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </GoabxTable>
+        );
+      };
+
+      const { container } = render(<Component />);
+      await waitForHeaders(container, 2);
+
+      // First click — sort ascending
+      getSortHeaderButton(container, "name").click();
+      await vi.waitFor(() => {
+        expect(getRowNames(container)).toEqual([
+          "Alice Johnson",
+          "Bob Smith",
+          "Carol Williams",
+          "David Brown",
+          "Eve Davis",
+        ]);
+      });
+
+      // Second click — sort descending
+      getSortHeaderButton(container, "name").click();
+      await vi.waitFor(() => {
+        expect(getRowNames(container)).toEqual([
+          "Eve Davis",
+          "David Brown",
+          "Carol Williams",
+          "Bob Smith",
+          "Alice Johnson",
+        ]);
+      });
+    });
+
+    it("should switch sort column when clicking a different header", async () => {
+      const Component = () => {
+        const [sorts, setSorts] = useState<SortEntry[]>([]);
+        const sorted = useMemo(() => sortData(initialData, sorts), [sorts]);
+
+        return (
+          <GoabxTable
+            testId="switch-col-table"
+            onSort={(detail) => {
+              setSorts([{ column: detail.sortBy, direction: detail.sortDir === 1 ? "asc" : "desc" }]);
+            }}
+          >
+            <thead>
+              <tr>
+                <th>
+                  <GoabxTableSortHeader name="name">Name</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="salary">Salary</GoabxTableSortHeader>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr key={row.id}>
+                  <td>{row.name}</td>
+                  <td>${row.salary.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </GoabxTable>
+        );
+      };
+
+      const { container } = render(<Component />);
+      await waitForHeaders(container, 2);
+
+      // Sort by name first
+      getSortHeaderButton(container, "name").click();
+      await vi.waitFor(() => {
+        expect(getRowNames(container)[0]).toBe("Alice Johnson");
+      });
+
+      // Now click salary — should sort by salary ascending, replacing name sort
+      getSortHeaderButton(container, "salary").click();
+      await vi.waitFor(() => {
+        // Salary asc: 68000, 72000, 78000, 95000, 105000
+        expect(getRowNames(container)).toEqual([
+          "David Brown",
+          "Bob Smith",
+          "Eve Davis",
+          "Alice Johnson",
+          "Carol Williams",
+        ]);
+      });
+    });
+  });
+
+  describe("multi-column sorting", () => {
+    it("should sort by two columns when clicking sequentially", async () => {
+      const Component = () => {
+        const [sorts, setSorts] = useState<SortEntry[]>([]);
+        const sorted = useMemo(() => sortData(initialData, sorts), [sorts]);
+
+        return (
+          <GoabxTable
+            testId="multi-sort-table"
+            sortMode="multi"
+            onMultiSort={(detail) => {
+              setSorts(detail.sorts);
+            }}
+          >
+            <thead>
+              <tr>
+                <th>
+                  <GoabxTableSortHeader name="name">Name</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="department">Department</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="salary">Salary</GoabxTableSortHeader>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr key={row.id}>
+                  <td>{row.name}</td>
+                  <td>{row.department}</td>
+                  <td>${row.salary.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </GoabxTable>
+        );
+      };
+
+      const { container } = render(<Component />);
+      await waitForHeaders(container, 3);
+
+      // Click department to sort ascending
+      getSortHeaderButton(container, "department").click();
+      await vi.waitFor(() => {
+        // Department asc: Engineering (Alice, Carol), Marketing (Bob, Eve), Sales (David)
+        const names = getRowNames(container);
+        expect(names[0]).toBe("Alice Johnson"); // Engineering
+        expect(names[4]).toBe("David Brown"); // Sales
+      });
+
+      // Click salary as secondary sort
+      getSortHeaderButton(container, "salary").click();
+      await vi.waitFor(() => {
+        // Dept asc then salary asc within each dept
+        // Engineering: Alice (95k), Carol (105k)
+        // Marketing: Bob (72k), Eve (78k)
+        // Sales: David (68k)
+        expect(getRowNames(container)).toEqual([
+          "Alice Johnson",
+          "Carol Williams",
+          "Bob Smith",
+          "Eve Davis",
+          "David Brown",
+        ]);
+      });
+    });
+  });
+
+  describe("declarative initial sort (multi)", () => {
+    it("should apply initial sort from direction and sortOrder props", async () => {
+      const onSort = vi.fn();
+
+      const Component = () => {
+        const [sorts, setSorts] = useState<SortEntry[]>([]);
+        const sorted = useMemo(() => sortData(initialData, sorts), [sorts]);
+
+        return (
+          <GoabxTable
+            testId="initial-sort-table"
+            sortMode="multi"
+            onMultiSort={(detail) => {
+              setSorts(detail.sorts);
+              onSort(detail);
+            }}
+          >
+            <thead>
+              <tr>
+                <th>
+                  <GoabxTableSortHeader name="name">Name</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="department" direction="asc" sortOrder={1}>
+                    Department
+                  </GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="salary" direction="desc" sortOrder={2}>
+                    Salary
+                  </GoabxTableSortHeader>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr key={row.id}>
+                  <td>{row.name}</td>
+                  <td>{row.department}</td>
+                  <td>${row.salary.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </GoabxTable>
+        );
+      };
+
+      const { container } = render(<Component />);
+
+      // Wait for initial sort to be applied
+      await vi.waitFor(
+        () => {
+          // Dept asc, then salary desc within each dept
+          // Engineering: Carol (105k), Alice (95k)
+          // Marketing: Eve (78k), Bob (72k)
+          // Sales: David (68k)
+          expect(getRowNames(container)).toEqual([
+            "Carol Williams",
+            "Alice Johnson",
+            "Eve Davis",
+            "Bob Smith",
+            "David Brown",
+          ]);
+        },
+        { timeout: 3000 },
+      );
+
+      // Verify the initial onMultiSort was dispatched
+      expect(onSort).toHaveBeenCalled();
+      const lastCall = onSort.mock.calls[onSort.mock.calls.length - 1][0];
+      expect(lastCall.sorts).toEqual([
+        { column: "department", direction: "asc" },
+        { column: "salary", direction: "desc" },
+      ]);
+    });
+
+    it("should update sort when clicking a header after initial sort", async () => {
+      const Component = () => {
+        const [sorts, setSorts] = useState<SortEntry[]>([]);
+        const sorted = useMemo(() => sortData(initialData, sorts), [sorts]);
+
+        return (
+          <GoabxTable
+            testId="initial-then-click-table"
+            sortMode="multi"
+            onMultiSort={(detail) => {
+              setSorts(detail.sorts);
+            }}
+          >
+            <thead>
+              <tr>
+                <th>
+                  <GoabxTableSortHeader name="name">Name</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="department" direction="asc" sortOrder={1}>
+                    Department
+                  </GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="salary" direction="desc" sortOrder={2}>
+                    Salary
+                  </GoabxTableSortHeader>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr key={row.id}>
+                  <td>{row.name}</td>
+                  <td>{row.department}</td>
+                  <td>${row.salary.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </GoabxTable>
+        );
+      };
+
+      const { container } = render(<Component />);
+
+      // Wait for initial sort to apply
+      await vi.waitFor(
+        () => {
+          expect(getRowNames(container)[0]).toBe("Carol Williams");
+        },
+        { timeout: 3000 },
+      );
+
+      // Click Name header — should add name as a sort column (replacing secondary since max is 2)
+      getSortHeaderButton(container, "name").click();
+
+      await vi.waitFor(() => {
+        // Department asc is primary, name asc replaces salary as secondary
+        // Engineering: Alice, Carol
+        // Marketing: Bob, Eve
+        // Sales: David
+        expect(getRowNames(container)).toEqual([
+          "Alice Johnson",
+          "Carol Williams",
+          "Bob Smith",
+          "Eve Davis",
+          "David Brown",
+        ]);
+      });
+    });
+  });
+
+  describe("sort header direction attribute", () => {
+    it("should update direction attribute on sort header after clicking", async () => {
+      const Component = () => {
+        return (
+          <GoabxTable testId="direction-attr-table" onSort={() => { /* noop */ }}>
+            <thead>
+              <tr>
+                <th>
+                  <GoabxTableSortHeader name="name">Name</GoabxTableSortHeader>
+                </th>
+                <th>
+                  <GoabxTableSortHeader name="department">Department</GoabxTableSortHeader>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>Engineering</td>
+              </tr>
+            </tbody>
+          </GoabxTable>
+        );
+      };
+
+      const { container } = render(<Component />);
+      await waitForHeaders(container, 2);
+
+      const nameHeader = container.querySelector('goa-table-sort-header[name="name"]')!;
+      const deptHeader = container.querySelector('goa-table-sort-header[name="department"]')!;
+
+      // Initially both should be "none"
+      expect(nameHeader.getAttribute("direction")).toBe("none");
+      expect(deptHeader.getAttribute("direction")).toBe("none");
+
+      // Click name header
+      getSortHeaderButton(container, "name").click();
+
+      await vi.waitFor(() => {
+        expect(nameHeader.getAttribute("direction")).toBe("asc");
+        expect(deptHeader.getAttribute("direction")).toBe("none");
+      });
+
+      // Click again for descending
+      getSortHeaderButton(container, "name").click();
+
+      await vi.waitFor(() => {
+        expect(nameHeader.getAttribute("direction")).toBe("desc");
+        expect(deptHeader.getAttribute("direction")).toBe("none");
+      });
+
+      // Click department — name should reset to none
+      getSortHeaderButton(container, "department").click();
+
+      await vi.waitFor(() => {
+        expect(nameHeader.getAttribute("direction")).toBe("none");
+        expect(deptHeader.getAttribute("direction")).toBe("asc");
+      });
+    });
+  });
+});

--- a/libs/react-components/src/experimental/index.ts
+++ b/libs/react-components/src/experimental/index.ts
@@ -27,7 +27,7 @@ export * from "./side-menu/side-menu";
 export * from "./side-menu-group/side-menu-group";
 export * from "./side-menu-heading/side-menu-heading";
 export * from "./table/table";
-export * from "./table/table-sort-header";
+export * from "./table-sort-header/table-sort-header";
 export * from "./tab/tab";
 export * from "./tabs/tabs";
 export * from "./textarea/textarea";

--- a/libs/react-components/src/experimental/table-sort-header/table-sort-header.spec.tsx
+++ b/libs/react-components/src/experimental/table-sort-header/table-sort-header.spec.tsx
@@ -19,4 +19,12 @@ describe("GoabxTableSortHeader", () => {
     const el = document.querySelector("goa-table-sort-header");
     expect(el?.getAttribute("data-grid")).toBe("cell");
   });
+
+  it("should render sort-order attribute", () => {
+    render(<GoabxTableSortHeader name="salary" direction="desc" sortOrder={2} />);
+    const el = document.querySelector("goa-table-sort-header");
+    expect(el?.getAttribute("sort-order")).toBe("2");
+    expect(el?.getAttribute("name")).toBe("salary");
+    expect(el?.getAttribute("direction")).toBe("desc");
+  });
 });

--- a/libs/react-components/src/experimental/table-sort-header/table-sort-header.tsx
+++ b/libs/react-components/src/experimental/table-sort-header/table-sort-header.tsx
@@ -1,11 +1,11 @@
-import { DataAttributes, GoabTableSortDirection } from "@abgov/ui-components-common";
+import { DataAttributes, GoabTableSortDirection, GoabTableSortOrder } from "@abgov/ui-components-common";
 
 import type { JSX } from "react";
-import { transformProps, lowercase } from "../../lib/common/extract-props";
 
 interface WCProps {
   name?: string;
   direction?: GoabTableSortDirection;
+  "sort-order"?: GoabTableSortOrder;
 }
 
 declare module "react" {
@@ -21,16 +21,22 @@ declare module "react" {
 export interface GoabxTableSortProps extends DataAttributes {
   name?: string;
   direction?: GoabTableSortDirection;
+  sortOrder?: GoabTableSortOrder;
   children?: React.ReactNode;
 }
 
 export function GoabxTableSortHeader({
+  name,
+  direction = "none",
+  sortOrder,
   children,
   ...rest
 }: GoabxTableSortProps): JSX.Element {
-  const _props = transformProps<WCProps>(rest, lowercase);
-
-  return <goa-table-sort-header {..._props}>{children}</goa-table-sort-header>;
+  return (
+    <goa-table-sort-header name={name} direction={direction} sort-order={sortOrder} {...rest}>
+      {children}
+    </goa-table-sort-header>
+  );
 }
 
 export default GoabxTableSortHeader;

--- a/libs/react-components/src/experimental/table/table.spec.tsx
+++ b/libs/react-components/src/experimental/table/table.spec.tsx
@@ -12,13 +12,11 @@ describe("GoabxTable", () => {
   });
 
   it("should render with properties", () => {
-    const { baseElement } = render(<GoabxTable stickyHeader striped />);
+    const { baseElement } = render(<GoabxTable striped sortMode="multi" />);
 
     const table = baseElement.querySelector("goa-table");
-    expect(table?.getAttribute("stickyHeader")).toBeNull();
     expect(table?.getAttribute("striped")).toBe("true");
-    // TODO: Enable this later if needed
-    // expect(table?.getAttribute("stickyHeader")).toBe("true");
+    expect(table?.getAttribute("sort-mode")).toBe("multi");
   });
 
   it("should call onSort when _sort event is triggered", () => {
@@ -26,11 +24,11 @@ describe("GoabxTable", () => {
     const { baseElement } = render(<GoabxTable onSort={onSort} />);
 
     const table = baseElement.querySelector("goa-table");
-    const event: GoabTableOnSortDetail = { sortBy: "name", sortDir: 1 };
+    const detail: GoabTableOnSortDetail = { sortBy: "name", sortDir: 1 };
     expect(table).toBeTruthy();
 
-    table && fireEvent(table, new CustomEvent("_sort", { detail: event }));
-    expect(onSort).toHaveBeenCalledWith(event);
+    table && fireEvent(table, new CustomEvent("_sort", { detail }));
+    expect(onSort).toHaveBeenCalledWith(detail);
   });
 
   it("should handle _sort event gracefully when no onSort prop is passed", () => {

--- a/libs/react-components/src/experimental/table/table.tsx
+++ b/libs/react-components/src/experimental/table/table.tsx
@@ -1,5 +1,7 @@
 import {
   GoabTableOnSortDetail,
+  GoabTableOnMultiSortDetail,
+  GoabTableSortMode,
   GoabTableVariant,
   Margins,
 } from "@abgov/ui-components-common";
@@ -10,6 +12,7 @@ interface WCProps extends Margins {
   width?: string;
   stickyheader?: string;
   variant?: GoabTableVariant;
+  "sort-mode"?: GoabTableSortMode;
   testid?: string;
   striped?: string;
   version?: string;
@@ -28,6 +31,8 @@ declare module "react" {
 export interface GoabxTableProps extends Margins {
   width?: string;
   onSort?: (detail: GoabTableOnSortDetail) => void;
+  onMultiSort?: (detail: GoabTableOnMultiSortDetail) => void;
+  sortMode?: GoabTableSortMode;
   // stickyHeader?: boolean; TODO: enable this later
   variant?: GoabTableVariant;
   striped?: boolean;
@@ -39,7 +44,7 @@ export interface GoabxTableProps extends Margins {
 // legacy name
 export type TableProps = GoabxTableProps;
 
-export function GoabxTable({ onSort, version = "2", ...props }: GoabxTableProps) {
+export function GoabxTable({ onSort, onMultiSort, sortMode, version = "2", ...props }: GoabxTableProps) {
   const ref = useRef<HTMLTableElement>(null);
   useEffect(() => {
     if (!ref.current) {
@@ -50,12 +55,18 @@ export function GoabxTable({ onSort, version = "2", ...props }: GoabxTableProps)
       const detail = (e as CustomEvent<GoabTableOnSortDetail>).detail;
       onSort?.(detail);
     };
+    const multiSortListener = (e: unknown) => {
+      const detail = (e as CustomEvent<GoabTableOnMultiSortDetail>).detail;
+      onMultiSort?.(detail);
+    };
 
     current.addEventListener("_sort", sortListener);
+    current.addEventListener("_multisort", multiSortListener);
     return () => {
       current.removeEventListener("_sort", sortListener);
+      current.removeEventListener("_multisort", multiSortListener);
     };
-  }, [ref, onSort]);
+  }, [ref, onSort, onMultiSort]);
 
   return (
     <goa-table
@@ -64,6 +75,7 @@ export function GoabxTable({ onSort, version = "2", ...props }: GoabxTableProps)
       // TODO: Enable this later if needed
       // stickyheader={props.stickyHeader ? "true" : undefined}
       variant={props.variant}
+      sort-mode={sortMode}
       striped={props.striped ? "true" : undefined}
       testid={props.testId}
       mt={props.mt}

--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -1,18 +1,24 @@
-<svelte:options customElement={{
-  tag: "goa-table",
-  props: {
-    variant: { reflect: true },
-    version: { reflect: true },
-    striped: { reflect: true }
-  }
-}} />
+<svelte:options
+  customElement={{
+    tag: "goa-table",
+    props: {
+      variant: { reflect: true },
+      version: { reflect: true },
+      striped: { reflect: true },
+      sortMode: { attribute: "sort-mode", reflect: true },
+    },
+  }}
+/>
 
 <script lang="ts">
-  import { onMount, tick } from "svelte";
+  import { onMount } from "svelte";
   import { calculateMargin } from "../../common/styling";
-  import { typeValidator, toBoolean } from "../../common/utils";
-  import type { GoATableSortDirection } from "./TableSortHeader.svelte";
+  import { typeValidator, toBoolean, dispatch } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
+
+  // Types
+  type SortDirection = "asc" | "desc";
+  type SortEntry = { column: string; direction: SortDirection };
 
   // Validators
   const [Variants, validateVariant] = typeValidator(
@@ -24,6 +30,13 @@
 
   const [Version, validateVersion] = typeValidator("Version", ["1", "2"]);
   type VersionType = (typeof Version)[number];
+
+  const [SortModes, validateSortMode] = typeValidator(
+    "Sort mode",
+    ["single", "multi"],
+    { required: true },
+  );
+  type SortMode = (typeof SortModes)[number];
 
   // Public
 
@@ -39,6 +52,8 @@
   export let version: VersionType = "1";
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
+  /** Sort mode: "single" allows one column, "multi" allows up to 2 columns. */
+  export let sortMode: SortMode = "single";
 
   /** Top margin. */
   export let mt: Spacing = null;
@@ -53,6 +68,9 @@
 
   let _rootEl: HTMLElement;
   let _isTableRoot: boolean = false;
+  let _sorts: SortEntry[] = [];
+  let _headings: NodeListOf<Element> | undefined;
+  const MAX_SORTS = 2;
 
   // Reactive
 
@@ -64,9 +82,7 @@
   onMount(() => {
     validateVariant(variant);
     validateVersion(version);
-
-    // without setTimeout it won't properly sort in Safari
-    setTimeout(attachSortEventHandling, 0);
+    validateSortMode(sortMode);
 
     // exit here if when running tests (tests don't have assignedElements)
     const slot = _rootEl.querySelector("slot") as HTMLSlotElement;
@@ -76,65 +92,173 @@
 
     // React has everything nested in a table to prevent invalid DOM errors
     _isTableRoot = slot.assignedElements()[0].tagName === "TABLE";
+
+    // without setTimeout it won't properly find headers in Safari
+    setTimeout(initializeSortHeaders, 0);
   });
 
   // Functions
 
-  async function attachSortEventHandling() {
-    await tick();
-    const contentSlot = _rootEl?.querySelector("slot") as HTMLSlotElement;
-    const headings = contentSlot
+  function findSortHeaders(): NodeListOf<Element> | undefined {
+    const slot = _rootEl?.querySelector("slot") as HTMLSlotElement;
+    return slot
       ?.assignedElements()
       .find((el) => el.tagName === "THEAD" || el.tagName === "TABLE")
       ?.querySelectorAll("goa-table-sort-header");
+  }
 
-    headings?.forEach((heading) => {
+  function initializeSortHeaders() {
+    _headings = findSortHeaders();
+    if (!_headings || _headings.length === 0) return;
+
+    attachClickHandlers();
+    buildInitialSortState();
+    updateHeaderAttributes();
+    if (_sorts.length > 0) {
+      dispatchSortEvent();
+    }
+  }
+
+  function attachClickHandlers() {
+    _headings?.forEach((heading) => {
       heading.addEventListener("click", () => {
-        const sortBy = heading.getAttribute("name");
-        let sortDir: number = 0;
-
-        // relay state to all children
-        headings.forEach((child) => {
-          if (child.getAttribute("name") === sortBy) {
-            const direction = child["direction"] as GoATableSortDirection;
-            // starting direction is asc
-            const newDirection = direction === "asc" ? "desc" : "asc";
-
-            sortDir = newDirection === "asc" ? 1 : -1;
-            child.setAttribute("direction", newDirection);
-          } else {
-            child.setAttribute("direction", "none");
-          }
-        });
-
-        if (sortBy && sortDir !== 0) {
-          dispatch(heading, { sortBy, sortDir });
+        const name = heading.getAttribute("name");
+        if (name) {
+          handleSortClick(name);
         }
       });
+    });
+  }
 
-      // dispatch the default sort params if initially set
-      const initialSortBy = heading.getAttribute("name");
-      const initialDirection = heading["direction"] as GoATableSortDirection;
-      if (initialSortBy && initialDirection && initialDirection !== "none") {
-        setTimeout(() => {
-          dispatch(heading, {
-            sortBy: initialSortBy,
-            sortDir: initialDirection === "asc" ? 1 : -1,
-          });
-        }, 10);
+  function buildInitialSortState() {
+    const entries: {
+      column: string;
+      direction: SortDirection;
+      order: number;
+    }[] = [];
+
+    _headings?.forEach((heading) => {
+      const name = heading.getAttribute("name");
+      const direction = heading.getAttribute("direction") as SortDirection | "none" | null;
+      const sortOrder = Number(heading.getAttribute("sort-order")) || 0;
+      if (name && direction && direction !== "none") {
+        entries.push({ column: name, direction, order: sortOrder });
+      }
+    });
+
+    // When multiple headers have initial direction in multi mode, sortOrder
+    // determines priority. Without it the table falls back to DOM order,
+    // which may not match the author's intent.
+    if (sortMode === "multi" && entries.length > 1) {
+      const withoutSortOrder = entries.filter((e) => e.order === 0);
+      if (withoutSortOrder.length > 0) {
+        console.warn(
+          `[goa-table] Multiple headers have initial sort direction but no sort-order set ` +
+          `[${withoutSortOrder.map((e) => e.column).join(", ")}]. ` +
+          `Falling back to DOM order. Add sort-order="1", sort-order="2" to set explicit priority.`,
+        );
+      }
+    }
+
+    // Sort by sortOrder (headers with explicit order first, then by DOM order)
+    entries.sort((a, b) => {
+      if (a.order && b.order) return a.order - b.order;
+      if (a.order) return -1;
+      if (b.order) return 1;
+      return 0;
+    });
+
+    if (sortMode === "single") {
+      _sorts =
+        entries.length > 0
+          ? [{ column: entries[0].column, direction: entries[0].direction }]
+          : [];
+    } else {
+      _sorts = entries
+        .slice(0, MAX_SORTS)
+        .map(({ column, direction }) => ({ column, direction }));
+    }
+  }
+
+  function handleSortClick(column: string) {
+    if (sortMode === "single") {
+      handleSingleSort(column);
+    } else {
+      handleMultiSort(column);
+    }
+    updateHeaderAttributes();
+    dispatchSortEvent();
+  }
+
+  function handleSingleSort(column: string) {
+    const current = _sorts.find((s) => s.column === column);
+    const direction = current?.direction === "asc" ? "desc" : "asc";
+    _sorts = [{ column, direction }];
+  }
+
+  function handleMultiSort(column: string) {
+    const columnIndex = _sorts.findIndex((s) => s.column === column);
+
+    if (columnIndex >= 0) {
+      if (_sorts[columnIndex].direction === "asc") {
+        _sorts[columnIndex] = { column, direction: "desc" };
+        _sorts = [..._sorts];
+      } else {
+        // column has been sorted descending, click again to un-sort
+        _sorts = _sorts.filter((_, i) => i !== columnIndex);
+      }
+      return;
+    }
+
+    // Add new column, or replace the last sort if at max
+    if (_sorts.length < MAX_SORTS) {
+      _sorts = [..._sorts, { column, direction: "asc" }];
+    } else {
+      _sorts = [_sorts[0], { column, direction: "asc" }];
+    }
+  }
+
+  function updateHeaderAttributes() {
+    if (!_headings || _headings.length === 0) return;
+
+    _headings.forEach((heading) => {
+      const name = heading.getAttribute("name");
+      const sortIndex = _sorts.findIndex((s) => s.column === name);
+
+      if (sortIndex >= 0) {
+        heading.setAttribute("direction", _sorts[sortIndex].direction);
+        if (sortMode === "multi" && _sorts.length > 1) {
+          heading.setAttribute("sort-order", String(sortIndex + 1));
+        } else {
+          heading.setAttribute("sort-order", "0");
+        }
+      } else {
+        heading.setAttribute("direction", "none");
+        heading.setAttribute("sort-order", "0");
       }
     });
   }
 
-  function dispatch(el: Element, params: { sortBy: string; sortDir: number }) {
-    el.dispatchEvent(
-      new CustomEvent("_sort", {
-        composed: true,
-        bubbles: true,
-        cancelable: false,
-        detail: params,
-      }),
-    );
+  function dispatchSortEvent() {
+    if (sortMode === "multi") {
+      dispatch(
+        _rootEl,
+        "_multisort",
+        { sorts: _sorts },
+        { bubbles: true },
+      );
+    } else {
+      const firstSort = _sorts[0];
+      dispatch(
+        _rootEl,
+        "_sort",
+        {
+          sortBy: firstSort?.column ?? "",
+          sortDir: firstSort ? (firstSort.direction === "asc" ? 1 : -1) : 0,
+        },
+        { bubbles: true },
+      );
+    }
   }
 </script>
 

--- a/libs/web-components/src/components/table/TableSortHeader.spec.ts
+++ b/libs/web-components/src/components/table/TableSortHeader.spec.ts
@@ -16,7 +16,7 @@ describe("GoATableSortHeader", () => {
     const icon = container.querySelector("goa-icon");
 
     expect(button.classList.contains("asc"));
-    expect(icon.getAttribute("type")).toBe("caret-up")
+    expect(icon.getAttribute("type")).toBe("arrow-up")
   })
 
   it('binds desc direction param', async () => {
@@ -26,6 +26,6 @@ describe("GoATableSortHeader", () => {
     const icon = container.querySelector("goa-icon");
 
     expect(button.classList.contains("desc"));
-    expect(icon.getAttribute("type")).toBe("caret-down")
+    expect(icon.getAttribute("type")).toBe("arrow-down")
   })
 })

--- a/libs/web-components/src/components/table/TableSortHeader.svelte
+++ b/libs/web-components/src/components/table/TableSortHeader.svelte
@@ -1,22 +1,41 @@
-<svelte:options customElement="goa-table-sort-header" />
+<svelte:options
+  customElement={{
+    tag: "goa-table-sort-header",
+    props: {
+      name: { reflect: true },
+      direction: { reflect: true },
+      sortOrder: { attribute: "sort-order", reflect: true, type: "Number" },
+    },
+  }}
+/>
 
 <script context="module" lang="ts">
   export type GoATableSortDirection = "asc" | "desc" | "none";
+  export type GoATableSortOrder = 0 | 1 | 2;
 </script>
 
 <script lang="ts">
   import { onMount } from "svelte";
+
+  /** Column name identifier for sorting. */
+  export let name: string = "";
   /** Sets the sort direction indicator. */
   export let direction: GoATableSortDirection = "none";
+  /** @internal Design system version for styling. */
+  export let version: "1" | "2" = "1";
+  /** Sort order number for multi-column sort display ("1", "2", etc). */
+  export let sortOrder: GoATableSortOrder = 0;
 
   // Private
   let _rootEl: HTMLElement;
   onMount(() => {
     if (_rootEl) {
-      // Add styling if an ancestor has a class to style number columns,
-      const hostEl = _rootEl.getRootNode().host;
+      const host = (_rootEl.getRootNode() as ShadowRoot).host as HTMLElement;
 
-      const ancestor = hostEl?.closest("th.goa-table-number-header, th.goa-table-cell--numeric");
+      // Add styling if an ancestor has a class to style number columns
+      const ancestor = host?.closest(
+        "th.goa-table-number-header, th.goa-table-cell--numeric",
+      );
       if (ancestor) {
         _rootEl.style.setProperty("--header-text-align", "flex-end");
         _rootEl.style.setProperty("--header-align", "right");
@@ -25,24 +44,29 @@
   });
 </script>
 
-<button bind:this={_rootEl}>
+<button
+  bind:this={_rootEl}
+  class:sorted={direction !== "none"}
+  class:v2={version === "2"}
+>
   <slot />
-  {#if direction === "desc"}
-    <goa-icon type="caret-down" size="small" />
-  {:else if direction === "asc"}
-    <goa-icon type="caret-up" size="small" />
-  {:else}
-    <div class="direction--none">
-      <goa-icon type="caret-up" size="small" />
-      <goa-icon type="caret-down" size="small" />
-    </div>
-  {/if}
+  <span class="icon-wrapper">
+    <span class="sort-order" class:hidden={!sortOrder || direction === "none"}>{sortOrder}</span>
+    {#if direction === "desc"}
+      <goa-icon type="arrow-down" size="3" />
+    {:else if direction === "asc"}
+      <goa-icon type="arrow-up" size="3" />
+    {:else}
+      <goa-icon type="chevron-expand" size="3" />
+    {/if}
+  </span>
 </button>
 
 <style>
   :host {
     display: flex;
     align-items: flex-end;
+    cursor: pointer;
   }
 
   button {
@@ -53,56 +77,95 @@
     font-size: inherit;
     font-weight: inherit;
     color: inherit;
-		line-height: inherit;
-		height: inherit;
+    line-height: inherit;
+    height: inherit;
     width: 100%;
-    padding: var(--goa-table-padding-heading, var(--goa-space-s) var(--goa-space-m) var(--goa-space-xs));
+    padding: var(
+      --goa-table-padding-heading,
+      var(--goa-space-s) var(--goa-space-m) var(--goa-space-xs)
+    );
     justify-content: var(--header-text-align, flex-start);
     gap: var(--goa-table-sort-header-gap, var(--goa-space-2xs));
     align-items: flex-end;
     text-align: var(--header-align, left);
   }
 
-  /* User set classes */
+  /* Hover state - no background change, only text color */
   button:hover {
-    background-color: var(--goa-table-color-bg-heading-hover, var(--goa-color-greyscale-100));
-    cursor: pointer;
-    color: var(--goa-table-color-heading-hover, var(--goa-color-interactive-hover));
+    color: var(
+      --goa-table-color-heading-hover,
+      var(--goa-color-interactive-hover)
+    );
   }
 
   button:focus {
     outline: none;
   }
 
+  /* V1: Focus ring on whole button */
   button:focus-visible {
     box-shadow: 0 0 0 var(--goa-border-width-l)
-    var(--goa-color-interactive-focus);
+      var(--goa-color-interactive-focus);
   }
 
-  button goa-icon {
+  /* V2: No focus ring on button, focus ring goes on icon instead */
+  button.v2:focus-visible {
+    box-shadow: none;
+  }
+
+  /* Icon wrapper - contains the sort icon */
+  .icon-wrapper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--goa-border-radius-m);
+  }
+
+  /* V2: Focus ring on icon when button is focused */
+  button.v2:focus-visible .icon-wrapper {
+    box-shadow: 0 0 0 var(--goa-icon-button-focus-border-width, 2px)
+      var(
+        --goa-icon-button-focus-border-color,
+        var(--goa-color-interactive-focus)
+      );
+  }
+
+  /* Active sort icon */
+  button.sorted goa-icon {
     color: var(--goa-color-interactive-default);
   }
-  button:hover goa-icon {
-    color: var(--goa-color-interactive-hover);
-  }
-  button .direction--none goa-icon {
-    color: var(--goa-color-greyscale-400);
-  }
-  button:hover .direction--none goa-icon {
+  button.sorted:hover goa-icon {
     color: var(--goa-color-interactive-hover);
   }
 
-  goa-icon {
-    scale: 0.8;
+  /* Unsorted state - icon always visible */
+  button:not(.sorted) goa-icon {
+    color: var(--goa-color-greyscale-500);
   }
 
-  .direction--none goa-icon {
-    height: 0.625rem;
+  button:not(.sorted):hover goa-icon {
+    color: var(--goa-color-interactive-hover);
   }
 
-  .direction--none {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
+  /* V2: Icon color on focus for unsorted state */
+  button.v2:not(.sorted):focus-visible goa-icon {
+    color: var(--goa-color-interactive-hover);
+  }
+
+  /* Sort order number badge */
+  .sort-order {
+    font-size: var(--goa-font-size-1);
+    font-weight: var(--goa-font-weight-bold);
+    color: var(--goa-color-interactive-default);
+    line-height: 1;
+    margin-left: var(--goa-space-2xs);
+  }
+
+  .sort-order.hidden {
+    visibility: hidden;
+  }
+
+  button:hover .sort-order {
+    color: var(--goa-color-interactive-hover);
   }
 </style>


### PR DESCRIPTION
## Summary

Adds built-in multi-column sorting to Table and TableSortHeader components.

- **sortMode** prop: `"single"` (default) or `"multi"` (up to 2 columns)
- **initialSort** prop: Pre-configure sort state
- **onSortChange** callback: Receives array of current sorts
- **sortOrder** prop on TableSortHeader: Shows "1", "2" priority badges
- Table manages sort state internally, headers update automatically
- New icons: `chevron-expand` (unsorted), `arrow-up`/`arrow-down` (sorted)
- V2 focus ring on icon only

### Multi sort
<img width="2222" height="796" alt="image" src="https://github.com/user-attachments/assets/23ace09b-25af-4140-87fe-be8a4e97c001" />

### Single sort
<img width="1111" height="354" alt="image" src="https://github.com/user-attachments/assets/c370ef0f-7838-4396-9975-d1e04f2c1203" />


## Test plan

- [x] Visit React playground at `/features/3344`
- [x] Test single-column sort (Test 1) - click headers, verify only one sorts at a time
- [x] Test multi-column sort (Test 2) - click multiple headers, verify "1" and "2" badges appear
- [x] Test initial sort (Test 3) - verify Department starts sorted
- [x] Test V2 experimental wrappers (Test 4) - verify focus ring on icon only
- [x] Visit Angular playground at `/features/3344` and repeat tests

Closes #3344