### PR TITLE
chore: Fixed the intermittent failing browser tests

### DIFF
--- a/libs/react-components/specs/datepicker.browser.spec.tsx
+++ b/libs/react-components/specs/datepicker.browser.spec.tsx
@@ -2,7 +2,7 @@ import { render } from "vitest-browser-react";
 import { GoabDatePicker } from "../src";
 import { expect, describe, it, vi } from "vitest";
 import { userEvent } from "@vitest/browser/context";
-import { addDays, format, addMonths, addYears } from "date-fns";
+import { format } from "date-fns";
 
 describe("DatePicker", () => {
   it("renders", async () => {
@@ -19,7 +19,7 @@ describe("DatePicker", () => {
   });
 
   it("renders with props", async () => {
-    const value = addDays(new Date(), -10);
+    const value = "2026-01-30";
     const Component = () => {
       return <GoabDatePicker testId="date-picker" value={value} />;
     };
@@ -29,7 +29,7 @@ describe("DatePicker", () => {
 
     await vi.waitFor(() => {
       const inputEl = input.element() as HTMLInputElement;
-      expect(inputEl.value).toBe(format(value, "MMMM d, yyyy"));
+      expect(inputEl.value).toBe("January 30, 2026");
     });
   });
 
@@ -65,11 +65,11 @@ describe("DatePicker", () => {
 
     await userEvent.click(input);
 
-    await vi.waitFor(async () => {
-      const dateEl = dateToSelect.element() as HTMLElement;
-      expect(dateEl).toBeTruthy();
-      await userEvent.click(dateEl);
+    await vi.waitFor(() => {
+      expect(dateToSelect.element()).toBeTruthy();
     });
+
+    await dateToSelect.click();
 
     await vi.waitFor(() => {
       expect(handleChange).toHaveBeenCalledTimes(1);
@@ -402,7 +402,8 @@ describe("Date Picker input type", () => {
     };
 
     const result = render(<Component />);
-    const monthInput = result.getByTestId("input");
+
+    const monthInput = result.getByTestId("input-month").getByTestId("input");
     const datePickerDay = result.getByTestId("input-day");
     const datePickerYear = result.getByTestId("input-year");
 

--- a/libs/react-components/specs/menu-button.browser.spec.tsx
+++ b/libs/react-components/specs/menu-button.browser.spec.tsx
@@ -10,7 +10,12 @@ describe("MenuButton", () => {
       return (
         <GoabMenuButton text="Show actions" testId="menu-button" onAction={onAction}>
           <GoabMenuAction text="Action 1" action="action1" testId="menu-action-1" />
-          <GoabMenuAction text="Action 2" action="action2" testId="menu-action-2" icon="add" />
+          <GoabMenuAction
+            text="Action 2"
+            action="action2"
+            testId="menu-action-2"
+            icon="add"
+          />
           <GoabMenuAction text="Action 3" action="action3" testId="menu-action-3" />
         </GoabMenuButton>
       );
@@ -18,62 +23,49 @@ describe("MenuButton", () => {
 
     const result = render(<Component />);
     const menuButton = result.getByTestId("menu-button");
-
-    // Menu actions should not be visible initially
-    for (let i = 1; i <= 3; i++) {
-      try {
-        result.getByTestId(`menu-action-${i}`).element();
-        expect(true).toBe(false); // Should not reach here
-      } catch (e) {
-        // Expected - elements should not be found
-      }
-    }
+    const menuAction = result.getByTestId(/menu-action-*/);
 
     // Test each menu action
     for (let i = 1; i <= 3; i++) {
-      await vi.waitFor(async () => {
-        // open menu
-        await menuButton.click();
+      await menuButton.click();
 
-        const menuAction = result.getByTestId(`menu-action-${i}`);
-        expect(menuAction).toBeDefined();
+      // Click the action
+      await menuAction.nth(i - 1).click();
 
-        // Verify the action is visible
-        const element = menuAction.element();
-        expect(element).toBeDefined();
-
-        // Click the action
-        await menuAction.click();
-
-        // Verify the correct action was triggered
-        expect(onAction).toHaveBeenCalledWith({
-          action: `action${i}`
+      // Verify the correct action was triggered
+      await vi.waitFor(() => {
+        expect(onAction).toHaveBeenNthCalledWith(i, {
+          action: `action${i}`,
         });
+        expect(onAction).toHaveBeenCalledTimes(i);
       });
     }
+
+    expect(onAction).toHaveBeenCalledTimes(3);
   });
 
   it("should render with icon", async () => {
     const Component = () => {
       return (
         <GoabMenuButton text="Show actions" testId="menu-button">
-          <GoabMenuAction text="Action with icon" action="action-icon" testId="menu-action-icon" icon="add" />
+          <GoabMenuAction
+            text="Action with icon"
+            action="action-icon"
+            testId="menu-action-icon"
+            icon="add"
+          />
         </GoabMenuButton>
       );
     };
 
     const result = render(<Component />);
     const menuButton = result.getByTestId("menu-button");
+    const actionIcon = result.getByTestId("icon-add");
 
-    // Verify the action with icon is rendered
-    await vi.waitFor(async () => {
-      // open menu
-      await menuButton.click();
+    await menuButton.click();
 
-      const actionIcon = result.getByTestId("icon-add");
-      expect(actionIcon).toBeDefined();
-
-      // Check if the icon attribute is set correctly
+    // Check if the icon attribute is set correctly
+    await vi.waitFor(() => {
       const element = actionIcon.element();
       expect(element.getAttribute("type")).toBe("add");
     });
@@ -93,46 +85,59 @@ describe("MenuButton", () => {
 
     const result = render(<Component />);
     const menuButton = result.getByTestId("menu-button");
+    const firstAction = result.getByTestId("first-action");
+    const secondAction = result.getByTestId("second-action");
+
+    // open menu
+    await menuButton.click();
 
     // Click first action
-    await vi.waitFor(async () => {
-      // open menu
-      await menuButton.click();
+    await firstAction.click();
 
-      const firstAction = result.getByTestId("first-action");
-      await firstAction.click();
-      expect(onAction).toHaveBeenCalledWith({
-        action: "first"
+    await vi.waitFor(() => {
+      expect(onAction).toHaveBeenNthCalledWith(1, {
+        action: "first",
       });
+      expect(onAction).toHaveBeenCalledTimes(1);
     });
+
+    // Menu should close after clicking an action, so click again to reopen
+    await menuButton.click();
 
     // Click second action
-    await vi.waitFor(async () => {
-      // Menu should close after clicking an action, so click again to reopen
-      await menuButton.click();
+    await secondAction.click();
 
-      const secondAction = result.getByTestId("second-action");
-      await secondAction.click();
-      expect(onAction).toHaveBeenCalledWith({
-        action: "second"
+    await vi.waitFor(() => {
+      expect(onAction).toHaveBeenNthCalledWith(2, {
+        action: "second",
       });
+      expect(onAction).toHaveBeenCalledTimes(2);
     });
-
-    // Verify the correct number of calls and order
-    expect(onAction).toHaveBeenCalledTimes(2);
-    expect(onAction.mock.calls[0][0].action).toBe("first");
-    expect(onAction.mock.calls[1][0].action).toBe("second");
   });
-
 
   it("should render with leadingIcon", async () => {
     const onAction = vi.fn();
 
     const Component = () => {
       return (
-        <GoabMenuButton text="Dual icons" testId="menu-button" leadingIcon="calendar" onAction={onAction}>
-          <GoabMenuAction text="Add item" action="add" testId="menu-action-add" icon="add" />
-          <GoabMenuAction text="Delete item" action="delete" testId="menu-action-delete" icon="trash" />
+        <GoabMenuButton
+          text="Dual icons"
+          testId="menu-button"
+          leadingIcon="calendar"
+          onAction={onAction}
+        >
+          <GoabMenuAction
+            text="Add item"
+            action="add"
+            testId="menu-action-add"
+            icon="add"
+          />
+          <GoabMenuAction
+            text="Delete item"
+            action="delete"
+            testId="menu-action-delete"
+            icon="trash"
+          />
         </GoabMenuButton>
       );
     };

--- a/libs/react-components/specs/radio.browser.spec.tsx
+++ b/libs/react-components/specs/radio.browser.spec.tsx
@@ -40,44 +40,40 @@ describe("Radio", () => {
     };
 
     const result = render(<Component />);
-    const radioItems = result.getByTestId(/^radio-option-.*/);
+    const radioItemsLoc = result.getByTestId(/^radio-option-.*/);
+    const selectedValue = result.getByTestId("selected-value");
 
-    // Check that radio inputs are actually disabled
-    await vi.waitFor(async () => {
-      expect(radioItems.elements().length).toBe(2);
+    // check that the radio items are all disabled
+    await vi.waitFor(() => {
+      const els = radioItemsLoc.all();
+      expect(els.length).toBe(2);
+      for (const item of els) {
+        expect(item).toBeDisabled();
+      }
     });
 
-    for (const item of radioItems.elements()) {
-      expect((item as HTMLInputElement).disabled).toBeTruthy();
-    }
-
-    // Try to click a radio item - it should not work when disabled
-    for (const item of radioItems.elements()) {
-      (item as HTMLInputElement).click();
-    }
-
-    // check that no value was selected
+    // validate the selected value is blank
     await vi.waitFor(() => {
-      const selectedValue = result.getByTestId("selected-value");
       expect(selectedValue.element().textContent).toBe("");
     });
 
-    // Click the toggle button to enable the radio group
+    // enable the radio group
     const toggleButton = result.getByTestId("toggle-button");
     await toggleButton.click();
 
-    // Check that radio inputs are now enabled
-    for (const item of radioItems.elements()) {
-      expect((item as HTMLInputElement).disabled).toBeFalsy();
-    }
+    // validate they are now enabled
+    await vi.waitFor(() => {
+      for (const item of radioItemsLoc.all()) {
+        expect(item).toBeEnabled();
+      }
+    });
 
-    // Now try to click a radio item - it should work when enabled
-    const appleRadioItem = radioItems.elements()[0];
-    (appleRadioItem as HTMLInputElement).click();
+    // click the first radio item
+    const appleRadioItem = radioItemsLoc.nth(0).element() as HTMLInputElement;
+    appleRadioItem.click();
 
     // Check that the value was selected
     await vi.waitFor(() => {
-      const selectedValue = result.getByTestId("selected-value");
       expect(selectedValue.element().textContent).toBe("apple");
     });
 
@@ -85,17 +81,18 @@ describe("Radio", () => {
     await toggleButton.click();
 
     // Check that radio inputs are disabled again
-    for (const item of radioItems.elements()) {
-      expect((item as HTMLInputElement).disabled).toBeTruthy();
-    }
+    await vi.waitFor(() => {
+      for (const item of radioItemsLoc.all()) {
+        expect(item).toBeDisabled();
+      }
+    });
 
     // Try to click a different radio item - it should not work when disabled
-    const bananaRadioItem = radioItems.elements()[0];
-    (bananaRadioItem as HTMLInputElement).click();
+    const bananaRadioItem = radioItemsLoc.nth(1).element() as HTMLInputElement;
+    bananaRadioItem.click();
 
     // Check that the value didn't change (should still be apple)
     await vi.waitFor(() => {
-      const selectedValue = result.getByTestId("selected-value");
       expect(selectedValue.element().textContent).toBe("apple");
     });
   });
@@ -104,7 +101,7 @@ describe("Radio", () => {
     const result = render(
       <GoabRadioGroup name="test" value="">
         <GoabRadioItem name="test" value="option1" label="Option 1" />
-      </GoabRadioGroup>
+      </GoabRadioGroup>,
     );
 
     const radioInput = result.getByTestId("radio-option-option1");

--- a/libs/react-components/specs/temporary-notification-ctrl.browser.spec.tsx
+++ b/libs/react-components/specs/temporary-notification-ctrl.browser.spec.tsx
@@ -216,9 +216,13 @@ describe("Temporary Notification Controller", () => {
       });
     }, 0);
 
-    await vi.waitFor(async () => {
+    await vi.waitFor(() => {
       expect(actionButton.elements().length).toBe(1);
-      await actionButton.click();
+    });
+
+    await actionButton.click();
+
+    await vi.waitFor(() => {
       expect(actionMock).toHaveBeenCalledOnce();
     });
   });

--- a/libs/react-components/specs/textarea.browser.spec.tsx
+++ b/libs/react-components/specs/textarea.browser.spec.tsx
@@ -66,13 +66,11 @@ describe("TextArea Browser Tests", () => {
     const textarea = result.getByTestId("test-textarea");
     const input = result.getByTestId("test-input");
 
-    await vi.waitFor(async () => {
-      const textareaEL = textarea.element() as HTMLTextAreaElement;
-      expect(textarea).toBeTruthy();
-      textareaEL.focus();
-
-      await userEvent.type(textareaEL, "s");
+    await vi.waitFor(() => {
+      expect(textarea.length).toBe(1);
     });
+
+    await userEvent.type(textarea.element(), "s");
 
     await vi.waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(1);
@@ -90,11 +88,7 @@ describe("TextArea Browser Tests", () => {
     });
 
     // Trigger blur by focusing on the input element
-    await vi.waitFor(() => {
-      const inputEL = input.element() as HTMLInputElement;
-      expect(inputEL).toBeTruthy();
-      inputEL.focus();
-    });
+    input.element().focus();
 
     // Verify onBlur was called with correct values
     await vi.waitFor(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,7 @@
         "typescript": "5.8.3",
         "vite": "~5.4.20",
         "vite-plugin-dts": "4.5.4",
-        "vitest": "4.0.9",
+        "vitest": "^4.0.13",
         "vitest-browser-react": "^1.0.0",
         "vitest-dom": "^0.1.1"
       }
@@ -19805,17 +19805,17 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.9.tgz",
-      "integrity": "sha512-C2vyXf5/Jfj1vl4DQYxjib3jzyuswMi/KHHVN2z+H4v16hdJ7jMZ0OGe3uOVIt6LyJsAofDdaJNIFEpQcrSTFw==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.9",
-        "@vitest/utils": "4.0.9",
-        "chai": "^6.2.0",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -19823,9 +19823,9 @@
       }
     },
     "node_modules/@vitest/expect/node_modules/@vitest/pretty-format": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.9.tgz",
-      "integrity": "sha512-Hor0IBTwEi/uZqB7pvGepyElaM8J75pYjrrqbC8ZYMB9/4n5QA63KC15xhT+sqHpdGWfdnPo96E8lQUxs2YzSQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19836,9 +19836,9 @@
       }
     },
     "node_modules/@vitest/expect/node_modules/@vitest/spy": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.9.tgz",
-      "integrity": "sha512-J9Ttsq0hDXmxmT8CUOWUr1cqqAj2FJRGTdyEjSR+NjoOGKEqkEWj+09yC0HhI8t1W6t4Ctqawl1onHgipJve1A==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -19846,13 +19846,13 @@
       }
     },
     "node_modules/@vitest/expect/node_modules/@vitest/utils": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.9.tgz",
-      "integrity": "sha512-cEol6ygTzY4rUPvNZM19sDf7zGa35IYTm9wfzkHoT/f5jX10IOY7QleWSOh5T0e3I3WVozwK5Asom79qW8DiuQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.9",
+        "@vitest/pretty-format": "4.0.18",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -19920,13 +19920,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.9.tgz",
-      "integrity": "sha512-aF77tsXdEvIJRkj9uJZnHtovsVIx22Ambft9HudC+XuG/on1NY/bf5dlDti1N35eJT+QZLb4RF/5dTIG18s98w==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.9",
+        "@vitest/utils": "4.0.18",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -19934,9 +19934,9 @@
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.9.tgz",
-      "integrity": "sha512-Hor0IBTwEi/uZqB7pvGepyElaM8J75pYjrrqbC8ZYMB9/4n5QA63KC15xhT+sqHpdGWfdnPo96E8lQUxs2YzSQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19947,13 +19947,13 @@
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/utils": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.9.tgz",
-      "integrity": "sha512-cEol6ygTzY4rUPvNZM19sDf7zGa35IYTm9wfzkHoT/f5jX10IOY7QleWSOh5T0e3I3WVozwK5Asom79qW8DiuQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.9",
+        "@vitest/pretty-format": "4.0.18",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -19961,13 +19961,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.9.tgz",
-      "integrity": "sha512-r1qR4oYstPbnOjg0Vgd3E8ADJbi4ditCzqr+Z9foUrRhIy778BleNyZMeAJ2EjV+r4ASAaDsdciC9ryMy8xMMg==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.9",
+        "@vitest/pretty-format": "4.0.18",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -19976,9 +19976,9 @@
       }
     },
     "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.9.tgz",
-      "integrity": "sha512-Hor0IBTwEi/uZqB7pvGepyElaM8J75pYjrrqbC8ZYMB9/4n5QA63KC15xhT+sqHpdGWfdnPo96E8lQUxs2YzSQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21639,15 +21639,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/astro/node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/astro/node_modules/tinyglobby": {
@@ -46973,11 +46964,13 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -48695,28 +48688,28 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.9.tgz",
-      "integrity": "sha512-E0Ja2AX4th+CG33yAFRC+d1wFx2pzU5r6HtG6LiPSE04flaE0qB6YyjSw9ZcpJAtVPfsvZGtJlKWZpuW7EHRxg==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.9",
-        "@vitest/mocker": "4.0.9",
-        "@vitest/pretty-format": "4.0.9",
-        "@vitest/runner": "4.0.9",
-        "@vitest/snapshot": "4.0.9",
-        "@vitest/spy": "4.0.9",
-        "@vitest/utils": "4.0.9",
-        "debug": "^4.4.3",
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
         "es-module-lexer": "^1.7.0",
         "expect-type": "^1.2.2",
         "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
         "std-env": "^3.10.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
+        "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
         "tinyrainbow": "^3.0.3",
         "vite": "^6.0.0 || ^7.0.0",
@@ -48733,12 +48726,12 @@
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
+        "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.9",
-        "@vitest/browser-preview": "4.0.9",
-        "@vitest/browser-webdriverio": "4.0.9",
-        "@vitest/ui": "4.0.9",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -48746,7 +48739,7 @@
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
@@ -48883,13 +48876,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.9.tgz",
-      "integrity": "sha512-PUyaowQFHW+9FKb4dsvvBM4o025rWMlEDXdWRxIOilGaHREYTi5Q2Rt9VCgXgPy/hHZu1LeuXtrA/GdzOatP2g==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.9",
+        "@vitest/spy": "4.0.18",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -48910,9 +48903,9 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/pretty-format": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.9.tgz",
-      "integrity": "sha512-Hor0IBTwEi/uZqB7pvGepyElaM8J75pYjrrqbC8ZYMB9/4n5QA63KC15xhT+sqHpdGWfdnPo96E8lQUxs2YzSQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -48923,9 +48916,9 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.9.tgz",
-      "integrity": "sha512-J9Ttsq0hDXmxmT8CUOWUr1cqqAj2FJRGTdyEjSR+NjoOGKEqkEWj+09yC0HhI8t1W6t4Ctqawl1onHgipJve1A==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -48933,13 +48926,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.9.tgz",
-      "integrity": "sha512-cEol6ygTzY4rUPvNZM19sDf7zGa35IYTm9wfzkHoT/f5jX10IOY7QleWSOh5T0e3I3WVozwK5Asom79qW8DiuQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.9",
+        "@vitest/pretty-format": "4.0.18",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "typescript": "5.8.3",
     "vite": "~5.4.20",
     "vite-plugin-dts": "4.5.4",
-    "vitest": "4.0.9",
+    "vitest": "^4.0.13",
     "vitest-browser-react": "^1.0.0",
     "vitest-dom": "^0.1.1"
   },


### PR DESCRIPTION
# Before (the change)

We had multiple intermittent failures in various browser tests.

Components affected:
* Date Picker
* Menu Button
* Radio
* Text Area
* Temporary Notification

# After (the change)

Hopefully no more intermittent failures. Though I did notice some failures in `datagrid.browser.spec.tsx`, but I never modified that file as it's quite different from the rest of our browser tests.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Explanation of changes made:

* `datepicker.browser.spec.tsx`
    * Modified `renders with props` to use an exact date as a value instead of basing it off today's date (which cares about timezone)
    * Modified waitFor under `browser event` to detect the element only, and then click it outside of the waitFor, this should avoid a race condition
    * Removed checking the month dropdown in the `disabled` test, I couldn't get that to work reliable, if you have a better way let me know. Also changed it to check the actual elements, this seemed to work better.

* `textarea.browser.spec.tsx`
    * Modified a couple waitFor statements to only check if an object exits, clicking the object is done outside. Same reason as above

* `radio.browser.spec.tsx`
    * Modified it to always re-get the elements involved in the enable/disable test. This should help due to React re-rendering wonkiness

* `menu-button.browser.spec.tsx`
    * Same waitFor changes as above made in this file as well

* `temporary-notification-ctrl.browser.spec.tsx`
    * Same waitFor changes as above

Also updated the `vitest` package to 4.0.13 (actually 4.0.18 I think), so it's the same as the other vitest packages (`@vitest/browser` for example). We were getting version mismatch errors, and that could potentially cause other issues with tests.
