### PR TITLE
bug(#2655): popover open positioning inside modals

### DIFF
--- a/apps/prs/angular/src/routes/bugs/2655/bug2655.component.ts
+++ b/apps/prs/angular/src/routes/bugs/2655/bug2655.component.ts
@@ -31,10 +31,11 @@ import {
       <goab-modal
         [open]="isModalOpen"
         heading="Test Modal"
-        [closable]="true"
         (onClose)="closeModal()"
+        [closable]="true"
       >
-        <div>
+        <div [style.margin-bottom]="'2em'">
+          <h4>At the top these open downwards</h4>
           <div [style.margin-bottom]="'20px'">
             <goab-form-item>
               <goab-date-picker
@@ -43,44 +44,7 @@ import {
               ></goab-date-picker>
             </goab-form-item>
           </div>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae
-            ultricies leo. Cras sodales lacinia sagittis. Aliquam viverra, risus quis
-            imperdiet euismod, libero lacus blandit tortor, vel tristique est sapien sed
-            urna. Phasellus convallis auctor leo sed volutpat. Sed vel arcu suscipit,
-            porta augue et, vehicula felis. Pellentesque at pulvinar velit. Phasellus
-            lacus metus, dictum vel ultricies eu, rutrum eu nibh. Curabitur at dapibus
-            ligula. Nam nulla massa, egestas vitae urna a, maximus aliquam leo.
-            Suspendisse condimentum condimentum nunc, eu pulvinar tellus convallis sed.
-            Praesent non mauris quis diam feugiat gravida nec porta ipsum. Proin elementum
-            nibh eu tellus porta, sed rhoncus felis dictum. Nullam mattis purus at urna
-            convallis vulputate. Sed aliquet maximus varius. Sed aliquet mi eget arcu
-            ullamcorper tempor. Etiam condimentum fermentum lacus, sed ultricies velit
-            scelerisque id.
-          </p>
-          <div [style.margin-bottom]="'20px'" style="position: relative;">
-            <goab-form-item>
-              <goab-date-picker
-                name="date2"
-                (onChange)="onDate2Change($event)"
-              ></goab-date-picker>
-            </goab-form-item>
-          </div>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae
-            ultricies leo. Cras sodales lacinia sagittis. Aliquam viverra, risus quis
-            imperdiet euismod, libero lacus blandit tortor, vel tristique est sapien sed
-            urna. Phasellus convallis auctor leo sed volutpat. Sed vel arcu suscipit,
-            porta augue et, vehicula felis. Pellentesque at pulvinar velit. Phasellus
-            lacus metus, dictum vel ultricies eu, rutrum eu nibh. Curabitur at dapibus
-            ligula. Nam nulla massa, egestas vitae urna a, maximus aliquam leo.
-            Suspendisse condimentum condimentum nunc, eu pulvinar tellus convallis sed.
-            Praesent non mauris quis diam feugiat gravida nec porta ipsum. Proin elementum
-            nibh eu tellus porta, sed rhoncus felis dictum. Nullam mattis purus at urna
-            convallis vulputate. Sed aliquet maximus varius. Sed aliquet mi eget arcu
-            ullamcorper tempor. Etiam condimentum fermentum lacus, sed ultricies velit
-            scelerisque id.
-          </p>
+
           <div [style.margin-bottom]="'20px'">
             <goab-form-item>
               <goab-dropdown name="dropdown1" (onChange)="onDropdown1Change($event)">
@@ -91,7 +55,21 @@ import {
             </goab-form-item>
           </div>
 
-          <div [style.margin-bottom]="'20px'" style="position: relative;">
+          <div
+            [style.margin-bottom]="'20px'"
+            [style.margin-top]="'200px'"
+            style="position: relative;"
+          >
+            <h4>At the bottom these open upwards</h4>
+            <goab-form-item>
+              <goab-date-picker
+                name="date2"
+                (onChange)="onDate2Change($event)"
+              ></goab-date-picker>
+            </goab-form-item>
+          </div>
+
+          <div [style.margin-bottom]="'20px'">
             <goab-form-item>
               <goab-dropdown name="dropdown2" (onChange)="onDropdown2Change($event)">
                 <goab-dropdown-item value="red" label="Red"></goab-dropdown-item>
@@ -102,12 +80,50 @@ import {
           </div>
         </div>
       </goab-modal>
+
+      <goab-button (onClick)="openSmallModal()" ml="4"> Open Small Modal </goab-button>
+
+      <goab-modal
+        [open]="isSmallModalOpen"
+        heading="Small Height Test Modal"
+        (onClose)="closeSmallModal()"
+        [closable]="true"
+      >
+        <div [style.margin-bottom]="'2em'" [style.height]="'200px'">
+          <h4>
+            It should expand downwards within a space too small for the popover content
+          </h4>
+          <div [style.margin-bottom]="'20px'">
+            <goab-form-item>
+              <goab-date-picker
+                name="date3"
+                (onChange)="onDate3Change($event)"
+              ></goab-date-picker>
+            </goab-form-item>
+          </div>
+        </div>
+      </goab-modal>
+      <div [style.margin-top]="'20px'" style="position: relative;">
+        <p>
+          A good testing cheat to test if the dropdown opens above or below the target is
+          to anchor the developer tools window to the bottom and slide it up and down to
+          reduce window size.
+        </p>
+        <goab-form-item>
+          <goab-dropdown name="dropdown3" (onChange)="onDropdown3Change($event)">
+            <goab-dropdown-item value="red" label="Red"></goab-dropdown-item>
+            <goab-dropdown-item value="green" label="Green"></goab-dropdown-item>
+            <goab-dropdown-item value="blue" label="Blue"></goab-dropdown-item>
+          </goab-dropdown>
+        </goab-form-item>
+      </div>
     </div>
   `,
   styles: [],
 })
 export class Bug2655Component {
   isModalOpen = false;
+  isSmallModalOpen = false;
 
   openModal() {
     this.isModalOpen = true;
@@ -115,6 +131,14 @@ export class Bug2655Component {
 
   closeModal() {
     this.isModalOpen = false;
+  }
+
+  openSmallModal() {
+    this.isSmallModalOpen = true;
+  }
+
+  closeSmallModal() {
+    this.isSmallModalOpen = false;
   }
 
   onDate1Change(event: any) {
@@ -125,11 +149,19 @@ export class Bug2655Component {
     console.log("Date 2 changed:", event);
   }
 
+  onDate3Change(event: any) {
+    console.log("Date 3 changed:", event);
+  }
+
   onDropdown1Change(event: any) {
     console.log("Dropdown 1 changed:", event);
   }
 
   onDropdown2Change(event: any) {
     console.log("Dropdown 2 changed:", event);
+  }
+
+  onDropdown3Change(event: any) {
+    console.log("Dropdown 3 changed:", event);
   }
 }

--- a/apps/prs/react/src/routes/bugs/bug2655.tsx
+++ b/apps/prs/react/src/routes/bugs/bug2655.tsx
@@ -10,6 +10,7 @@ import {
 
 export function Bug2655Route() {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isSmallModalOpen, setIsSmallModalOpen] = useState(false);
 
   const openModal = () => {
     setIsModalOpen(true);
@@ -17,6 +18,14 @@ export function Bug2655Route() {
 
   const closeModal = () => {
     setIsModalOpen(false);
+  };
+
+  const openSmallModal = () => {
+    setIsSmallModalOpen(true);
+  };
+
+  const closeSmallModal = () => {
+    setIsSmallModalOpen(false);
   };
 
   const onDate1Change = (event: any) => {
@@ -27,12 +36,20 @@ export function Bug2655Route() {
     console.log("Date 2 changed:", event);
   };
 
+  const onDate3Change = (event: any) => {
+    console.log("Date 3 changed:", event);
+  };
+
   const onDropdown1Change = (event: any) => {
     console.log("Dropdown 1 changed:", event);
   };
 
   const onDropdown2Change = (event: any) => {
     console.log("Dropdown 2 changed:", event);
+  };
+
+  const onDropdown3Change = (event: any) => {
+    console.log("Dropdown 3 changed:", event);
   };
 
   return (
@@ -43,16 +60,11 @@ export function Bug2655Route() {
       <GoabButton onClick={openModal}>Open Modal</GoabButton>
 
       <GoabModal open={isModalOpen} heading="Test Modal" onClose={closeModal}>
-        <div>
+        <div style={{ marginBottom: "2em" }}>
+          <h4>At the top these open downwards</h4>
           <div style={{ marginBottom: "20px" }}>
             <GoabFormItem>
               <GoabDatePicker name="date1" onChange={onDate1Change} />
-            </GoabFormItem>
-          </div>
-
-          <div style={{ marginBottom: "20px", position: "relative" }}>
-            <GoabFormItem>
-              <GoabDatePicker name="date2" onChange={onDate2Change} />
             </GoabFormItem>
           </div>
 
@@ -66,7 +78,14 @@ export function Bug2655Route() {
             </GoabFormItem>
           </div>
 
-          <div style={{ marginBottom: "20px", position: "relative" }}>
+          <div style={{ marginBottom: "20px", marginTop: "200px", position: "relative" }}>
+            <h4>At the bottom these open upwards</h4>
+            <GoabFormItem>
+              <GoabDatePicker name="date2" onChange={onDate2Change} />
+            </GoabFormItem>
+          </div>
+
+          <div style={{ marginBottom: "20px" }}>
             <GoabFormItem>
               <GoabDropdown name="dropdown2" onChange={onDropdown2Change}>
                 <GoabDropdownItem value="red" label="Red" />
@@ -77,6 +96,41 @@ export function Bug2655Route() {
           </div>
         </div>
       </GoabModal>
+
+      <GoabButton onClick={openSmallModal} ml="4">
+        Open Small Modal
+      </GoabButton>
+
+      <GoabModal
+        open={isSmallModalOpen}
+        heading="Small Height Test Modal"
+        onClose={closeSmallModal}
+      >
+        <div style={{ marginBottom: "2em", height: "200px" }}>
+          <h4>
+            It should expand downwards within a space too small for the popover content
+          </h4>
+          <div style={{ marginBottom: "20px" }}>
+            <GoabFormItem>
+              <GoabDatePicker name="date3" onChange={onDate3Change} />
+            </GoabFormItem>
+          </div>
+        </div>
+      </GoabModal>
+      <div style={{ marginTop: "20px", position: "relative" }}>
+        <p>
+          A good testing cheat to test if the dropdown opens above or below the target is
+          to anchor the developer tools window to the bottom and slide it up and down to
+          reduce window size.
+        </p>
+        <GoabFormItem>
+          <GoabDropdown name="dropdown3" onChange={onDropdown3Change}>
+            <GoabDropdownItem value="red" label="Red" />
+            <GoabDropdownItem value="green" label="Green" />
+            <GoabDropdownItem value="blue" label="Blue" />
+          </GoabDropdown>
+        </GoabFormItem>
+      </div>
     </div>
   );
 }

--- a/libs/react-components/specs/popover.browser.spec.tsx
+++ b/libs/react-components/specs/popover.browser.spec.tsx
@@ -1,6 +1,5 @@
 import { render } from "vitest-browser-react";
-
-import { GoabPopover, GoabButton } from "../src";
+import { GoabPopover, GoabButton, GoabModal } from "../src";
 import { expect, describe, it, vi } from "vitest";
 
 describe("Popover", () => {
@@ -23,16 +22,15 @@ describe("Popover", () => {
     // Actions
 
     await target.click();
-    expect(closeButton.element()).toBeTruthy()
+    expect(closeButton.element()).toBeTruthy();
     await closeButton.click();
 
     // Result
 
     await vi.waitFor(() => {
       expect(closeButton.element().checkVisibility()).toBeFalsy();
-    })
+    });
   });
-
 
   it("should close popover when clicking on the document body", async () => {
     const Component = () => {
@@ -65,4 +63,144 @@ describe("Popover", () => {
       expect(closeButton.element().checkVisibility()).toBeFalsy();
     });
   });
-})
+
+  describe("Popover within a modal", () => {
+    it("should open the popover downwards within a modal if content exceeds available space", async () => {
+      const Component = () => {
+        const longContent = Array.from({ length: 50 }, (_, i) => (
+          <p key={i}>This is line {i + 1} of the popover content.</p>
+        ));
+
+        return (
+          <GoabModal
+            heading="Scrollable Modal"
+            open={true}
+            onClose={() => {
+              console.log("Does nothing in this test");
+            }}
+            testId="test-modal"
+          >
+            <GoabPopover
+              testId="popover"
+              target={<GoabButton testId={"target"}>Open popover</GoabButton>}
+            >
+              <div style={{ minHeight: "300px" }}>{longContent}</div>
+              <GoabButton testId={"open-popover-button"} action={"close"}>
+                Close
+              </GoabButton>
+            </GoabPopover>
+          </GoabModal>
+        );
+      };
+
+      const result = render(<Component />);
+      const target = result.getByTestId("target");
+      await target.click();
+
+      await vi.waitFor(() => {
+        const popoverContentEl = result.getByTestId("popover-content");
+        expect(popoverContentEl.element()).toBeTruthy();
+        expect(popoverContentEl.element().style.bottom).toBe("auto");
+      });
+    });
+
+    it("should open the popover upwards within a modal if there is more space above than below", async () => {
+      const Component = () => {
+        return (
+          <GoabModal
+            heading="Scrollable Modal"
+            open={true}
+            onClose={() => {
+              console.log("Does nothing in this test");
+            }}
+            testId="test-modal"
+          >
+            <div style={{ height: "400px" }}>
+              <p>Space above</p>
+              <p>Space above</p>
+              <p>Space above</p>
+              <p>Space above</p>
+              <p>Space above</p>
+              <p>Space above</p>
+              <p>Space above</p>
+              <p>Space above</p>
+              <GoabPopover
+                testId="popover"
+                position="auto"
+                target={<GoabButton testId={"target"}>Open popover</GoabButton>}
+              >
+                <div style={{ minHeight: "200px" }}>
+                  <p>Popover Content</p>
+                </div>
+                <GoabButton testId={"open-popover-button"} action={"close"}>
+                  Close
+                </GoabButton>
+              </GoabPopover>
+              <p>Space Below</p>
+            </div>
+          </GoabModal>
+        );
+      };
+
+      const result = render(<Component />);
+      const target = result.getByTestId("target");
+      await target.click();
+
+      await vi.waitFor(() => {
+        const popoverContentEl = result.getByTestId("popover-content");
+        expect(popoverContentEl.element()).toBeTruthy();
+        // It should be a number ending with px when opening upwards
+        expect(popoverContentEl.element().style.bottom).toMatch(/-?\d+px/);
+      });
+    });
+
+    it("should open the popover downwards within a modal if there is enough space below", async () => {
+      const Component = () => {
+        return (
+          <GoabModal
+            heading="Scrollable Modal"
+            open={true}
+            onClose={() => {
+              console.log("Does nothing in this test");
+            }}
+            testId="test-modal"
+          >
+            <div style={{ height: "400px" }}>
+              <p>Space above</p>
+              <p>Space above</p>
+              <GoabPopover
+                testId="popover"
+                position="auto"
+                target={<GoabButton testId={"target"}>Open popover</GoabButton>}
+              >
+                <div style={{ minHeight: "200px" }}>
+                  <p>Popover Content</p>
+                </div>
+                <GoabButton testId={"open-popover-button"} action={"close"}>
+                  Close
+                </GoabButton>
+              </GoabPopover>
+              <p>Space Below</p>
+              <p>Space Below</p>
+              <p>Space Below</p>
+              <p>Space Below</p>
+              <p>Space Below</p>
+              <p>Space Below</p>
+            </div>
+          </GoabModal>
+        );
+      };
+
+      const result = render(<Component />);
+      const target = result.getByTestId("target");
+      await target.click();
+
+      await vi.waitFor(() => {
+        const popoverContentEl = result.getByTestId("popover-content");
+        expect(popoverContentEl.element()).toBeTruthy();
+        // bottom should be set to 'auto' when opening downwards
+        expect(popoverContentEl.element().style.bottom).toBe("auto");
+      });
+    });
+  });
+});

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -101,6 +101,9 @@
   let _targetEl: HTMLElement;
   let _popoverEl: HTMLElement;
   let _focusTrapEl: HTMLElement;
+  // the closest parent parent Container element (i.e. <goa-modal>), if one
+  // doesn't exist it is null. Used to determine popover position.
+  let _parentContainerEl: HTMLElement | null = null;
   let _sectionHeight: number;
   let _contentFitsWidth: boolean = false;
 
@@ -142,9 +145,30 @@
 
     showDeprecationWarnings();
     addGlobalCloseListener();
+
+    _parentContainerEl = findContainingParentElement(_rootEl);
   });
 
   // Functions
+
+  function findContainingParentElement(
+    rootEl: HTMLElement,
+  ): HTMLElement | null {
+    const containingParentNodeNames = ["GOA-MODAL"];
+
+    let parentNode: HTMLElement = rootEl;
+    while (parentNode) {
+      if (containingParentNodeNames.includes(parentNode.nodeName)) {
+        return parentNode;
+      }
+      parentNode = parentNode.parentNode as HTMLElement;
+      if (parentNode && (parentNode as unknown as { host: HTMLElement }).host) {
+        parentNode = (parentNode as unknown as { host: HTMLElement }).host;
+      }
+    }
+
+    return null;
+  }
 
   // Since the focused element is being changed when the popover is open, the scoped keybinding for the escape key may
   // no longer work, so the binding must be done on the document.body
@@ -341,26 +365,70 @@
     };
   }
 
+  function getParentContentElement() {
+    if (!_parentContainerEl) return null;
+
+    let contentEl: HTMLElement | null = null;
+
+    switch (_parentContainerEl.nodeName) {
+      case "GOA-MODAL":
+        // Assuming parent is <goa-modal>, the content element is the div with class
+        // "modal-pane" within the modal's shadow DOM
+        contentEl =
+          _parentContainerEl.shadowRoot?.querySelector("div.modal-pane") ||
+          null;
+        break;
+      default:
+        console.error(
+          "Unhandled parent container type: ",
+          _parentContainerEl.nodeName,
+        );
+    }
+
+    if (!contentEl) {
+      // If a CSS or structural DOM change was made to the parent container, the
+      // query selector in the switch above must also be updated. (i.e. if the
+      // "modal-pane" class was removed or changed)
+      console.error(
+        "Could not find content element within parent container. Popover positioning may be incorrect.",
+      );
+    }
+
+    return contentEl;
+  }
+
   async function setPopoverPosition() {
     await tick();
 
     // Get target and content rectangles
+    const isWithinModal = !!_parentContainerEl;
     const targetRect = getBoundingClientRectWithMargins(_targetEl);
+    const parentContainerContentEl = getParentContentElement();
+    const parentContainerRect = !!parentContainerContentEl
+      ? getBoundingClientRectWithMargins(parentContainerContentEl)
+      : null;
+
     const popoverRect = getBoundingClientRectWithMargins(_popoverEl);
 
     // exit if the popover hasn't yet been filled
     if (popoverRect.height < 20) return;
 
     // Calculate available space above and below the target element
-    const spaceAbove = targetRect.top;
-    const spaceBelow = window.innerHeight - targetRect.bottom;
+    const spaceAbove =
+      isWithinModal && parentContainerRect
+        ? targetRect.top - parentContainerRect.top
+        : targetRect.top;
+    const spaceBelow =
+      isWithinModal && parentContainerRect
+        ? parentContainerRect.bottom - targetRect.bottom
+        : window.innerHeight - targetRect.bottom;
 
     // Determine if there's more space above or below the target element
     const displayOnTop =
       position === "auto"
-        ? spaceBelow < popoverRect.height &&
-          spaceAbove > popoverRect.height &&
-          spaceAbove > spaceBelow
+        ? spaceBelow < popoverRect.height && // Not enough room below the target
+          spaceAbove > popoverRect.height && // Enough room above the target
+          spaceAbove > spaceBelow // More space above than below
         : position === "above";
 
     if (displayOnTop) {
@@ -428,11 +496,21 @@
         // attribute is set, the content width is set to fit-content instead of inheriting the target width.
         style("width", _contentFitsWidth ? "fit-content" : width),
         style("min-width", minwidth),
-        style("max-width", _contentFitsWidth ? maxwidth : width ? `max(${width}, ${maxwidth})` : maxwidth),
+        style(
+          "max-width",
+          _contentFitsWidth
+            ? maxwidth
+            : width
+              ? `max(${width}, ${maxwidth})`
+              : maxwidth,
+        ),
         style("padding", _padded ? "var(--goa-space-m)" : "0"),
       )}
     >
-      <goa-focus-trap open="true" prevent-scroll-into-view={preventScrollIntoView || undefined}>
+      <goa-focus-trap
+        open="true"
+        prevent-scroll-into-view={preventScrollIntoView || undefined}
+      >
         <div bind:this={_focusTrapEl}>
           <slot />
         </div>


### PR DESCRIPTION
# Before (the change)

See [#2655 Expanding dropdown or date picker inside modal](https://github.com/GovAlta/ui-components/issues/2655) - this is copied from that description.

There are two problems with expanding dropdown or date picker inside modal.

Problem 1: When inside a modal and expanding a dropdown or date picker, if the modal did not have a vertical scrollbar until popover expands downwards then, a horizontal line does not does not appear at the bottom of modal to signal to the user that they can scroll down.

Problem 2: When inside a modal and expanding a dropdown or date picker, sometimes the popover will expand downwards when it would be more ideal to expand upwards.

# After (the change)

Problem 1: I believe this was fixed before I started this PR. In the PR test file you can check using the "Open Small Modal". It should appear like this:

<img width="582" height="373" alt="image" src="https://github.com/user-attachments/assets/b39786a1-9592-46ad-b010-c9e59fe5dbe4" />

The shadows that are shown in the issue screenshots are not there.

Problem 2: The popover will try to expand correctly using the following rules:
1. If there is enough room below the target, expand downwards
2. If there is not enough room above but there is enough room above, expand upwards
3. If there is not enough room upwards _or_ downwards then expand downwards and the modal scrollbars appear and you can scroll to the dropped-down content.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests (I created browser tests in this case)
- [x] I have tested the funtctionality in both React and Angular.

## Steps needed to test

The changes were made to the `goa-popover` component.
All existing controls using `goa-popover` **must** still work the same as before.
The PRs pages have good examples:
- "Open Modal" button opens a Test Modal where Calendar and Dropdowns can be tested within a modal and will open upwards or downwards as appropriate
- "Open Small Modal" tests the 3rd situation where there is not enough room above or below, so the calendar will open downwards
- A dropdown is on the page that will usually open downwards, however if you shrink the browser window to a height below the dropdown it will open upwards
- the drop shadows from `goa-scrollable` appear as appropriate