### PR TITLE
fix(#3273): keep Side Menu Group open

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -52,6 +52,7 @@
           <a href="/bugs/3201">3201</a>
           <a href="/bugs/3215">3215</a>
           <a href="/bugs/3248">3248</a>
+          <a href="/bugs/3273">3273</a>
           <a href="/bugs/3275">3275 Can't unset month</a>
           <a href="/bugs/3281">3281</a>
           <a href="/bugs/3337">3337 - Autocomplete styling</a>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -38,6 +38,8 @@ import { Bug3156Component } from "../routes/bugs/3156/bug3156.component";
 import { Bug3201Component } from "../routes/bugs/3201/bug3201.component";
 import { Bug3215Component } from "../routes/bugs/3215/bug3215.component";
 import { Bug3248Component } from "../routes/bugs/3248/bug3248.component";
+import { Bug3273Component } from "../routes/bugs/3273/bug3273.component";
+import { Bug32732Component } from "../routes/bugs/3273/bug3273-2.component";
 import { Bug3275Component } from "../routes/bugs/3275/bug3275.component";
 import { Bug3281Component } from "../routes/bugs/3281/bug3281.component";
 import { Bug3337Component } from "../routes/bugs/3337/bug3337.component";
@@ -114,6 +116,8 @@ export const appRoutes: Route[] = [
   { path: "bugs/3201", component: Bug3201Component },
   { path: "bugs/3215", component: Bug3215Component },
   { path: "bugs/3248", component: Bug3248Component },
+  { path: "bugs/3273", component: Bug3273Component },
+  { path: "bugs/3273-2", component: Bug32732Component },
   { path: "bugs/3275", component: Bug3275Component },
   { path: "bugs/3281", component: Bug3281Component },
   { path: "bugs/3337", component: Bug3337Component },

--- a/apps/prs/angular/src/routes/bugs/3273/bug3273-2.component.html
+++ b/apps/prs/angular/src/routes/bugs/3273/bug3273-2.component.html
@@ -1,0 +1,25 @@
+<div>
+  <h2>Bug 3273: Keep side menu group open</h2>
+  <p>This page tests a nested side menu group.</p>
+
+  <h4>Scenario two</h4>
+  <p>
+    When you select the Parent Item,
+    <br />
+    Then the Child Group will be closed,
+    <br />
+    And the Parent Group will be open.
+  </p>
+
+  <div style="max-width: 300px; margin-top: 24px">
+    <goab-side-menu>
+      <goab-side-menu-group heading="Parent Group">
+        <a href="/bugs/3273">Parent Item</a>
+
+        <goab-side-menu-group heading="Child Group">
+          <a href="/bugs/3273-2">Child Item</a>
+        </goab-side-menu-group>
+      </goab-side-menu-group>
+    </goab-side-menu>
+  </div>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3273/bug3273-2.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3273/bug3273-2.component.ts
@@ -1,0 +1,11 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { GoabSideMenu, GoabSideMenuGroup } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3273-2",
+  templateUrl: "./bug3273-2.component.html",
+  imports: [CommonModule, GoabSideMenu, GoabSideMenuGroup],
+})
+export class Bug32732Component {}

--- a/apps/prs/angular/src/routes/bugs/3273/bug3273.component.html
+++ b/apps/prs/angular/src/routes/bugs/3273/bug3273.component.html
@@ -1,0 +1,27 @@
+<div>
+  <h2>Bug 3273: Keep side menu group open</h2>
+  <p>This page tests a nested side menu group.</p>
+
+  <h4>Scenario one</h4>
+  <p>
+    When you open the Child Group,
+    <br />
+    And you select the Child Item,
+    <br />
+    Then the Child Group will be open,
+    <br />
+    And the Parent Group will be open.
+  </p>
+
+  <div style="max-width: 300px; margin-top: 24px">
+    <goab-side-menu>
+      <goab-side-menu-group heading="Parent Group">
+        <a href="/bugs/3273">Parent Item</a>
+
+        <goab-side-menu-group heading="Child Group">
+          <a href="/bugs/3273-2">Child Item</a>
+        </goab-side-menu-group>
+      </goab-side-menu-group>
+    </goab-side-menu>
+  </div>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3273/bug3273.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3273/bug3273.component.ts
@@ -1,0 +1,11 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { GoabSideMenu, GoabSideMenuGroup } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3273",
+  templateUrl: "./bug3273.component.html",
+  imports: [CommonModule, GoabSideMenu, GoabSideMenuGroup],
+})
+export class Bug3273Component {}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -61,6 +61,7 @@ export function App() {
               <Link to="/bugs/3215">3215 Drawer Initial Height</Link>
               <Link to="/bugs/3232">3232 GoabText Tag Size</Link>
               <Link to="/bugs/3248">3248 Dropdown Dynamic Children Sync</Link>
+              <Link to="/bugs/3273">3273 Nested Side Menu Groups</Link>
               <Link to="/bugs/3275">3275 Can't unset month</Link>
               <Link to="/bugs/3322">3322 App Header Menu Hover</Link>
               <Link to="/bugs/3281">3281 GoabText p tag margin issues</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -40,6 +40,8 @@ import { Bug3215Route } from "./routes/bugs/bug3215";
 import { Bug3232Route } from "./routes/bugs/bug3232";
 import { Bug3279Route } from "./routes/bugs/bug3279";
 import { Bug3248Route } from "./routes/bugs/bug3248";
+import { Bug3273Route } from "./routes/bugs/bug3273";
+import { Bug3273Page2Route } from "./routes/bugs/bug3273-2";
 import { Bug3275Route } from "./routes/bugs/bug3275";
 import { Bug3322Route } from "./routes/bugs/bug3322";
 import { Bug3281Route } from "./routes/bugs/bug3281";
@@ -125,6 +127,8 @@ root.render(
           <Route path="bugs/3215" element={<Bug3215Route />} />
           <Route path="bugs/3232" element={<Bug3232Route />} />
           <Route path="bugs/3248" element={<Bug3248Route />} />
+          <Route path="bugs/3273" element={<Bug3273Route />} key={"bugs/3273"} />
+          <Route path="bugs/3273-2" element={<Bug3273Page2Route key={"bugs/3273-2"} />} />
           <Route path="bugs/3275" element={<Bug3275Route />} />
           <Route path="bugs/3322" element={<Bug3322Route />} />
           <Route path="bugs/3281" element={<Bug3281Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3273-2.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3273-2.tsx
@@ -1,0 +1,32 @@
+import { GoabSideMenu, GoabSideMenuGroup } from "@abgov/react-components";
+import { Link } from "react-router-dom";
+
+export function Bug3273Page2Route() {
+  return (
+    <div>
+      <h2>Bug 3273: Keep side menu group open</h2>
+      <p>This page tests a nested side menu group.</p>
+
+      <h4>Scenario two</h4>
+      <p>
+        When you select the Parent Item,
+        <br />
+        Then the Child Group will be closed,
+        <br />
+        And the Parent Group will be open.
+      </p>
+
+      <div style={{ maxWidth: "300px", marginTop: "24px" }}>
+        <GoabSideMenu>
+          <GoabSideMenuGroup heading="Parent Group">
+            <Link to="/bugs/3273">Parent Item</Link>
+
+            <GoabSideMenuGroup heading="Child Group">
+              <Link to="/bugs/3273-2">Child Item</Link>
+            </GoabSideMenuGroup>
+          </GoabSideMenuGroup>
+        </GoabSideMenu>
+      </div>
+    </div>
+  );
+}

--- a/apps/prs/react/src/routes/bugs/bug3273.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3273.tsx
@@ -1,0 +1,34 @@
+import { GoabSideMenu, GoabSideMenuGroup } from "@abgov/react-components";
+import { Link } from "react-router-dom";
+
+export function Bug3273Route() {
+  return (
+    <div>
+      <h2>Bug 3273: Keep side menu group open</h2>
+      <p>This page tests a nested side menu group.</p>
+
+      <h4>Scenario one</h4>
+      <p>
+        When you open the Child Group,
+        <br />
+        And you select the Child Item,
+        <br />
+        Then the Child Group will be open,
+        <br />
+        And the Parent Group will be open.
+      </p>
+
+      <div style={{ maxWidth: "300px", marginTop: "24px" }}>
+        <GoabSideMenu>
+          <GoabSideMenuGroup heading="Parent Group">
+            <Link to="/bugs/3273">Parent Item</Link>
+
+            <GoabSideMenuGroup heading="Child Group">
+              <Link to="/bugs/3273-2">Child Item</Link>
+            </GoabSideMenuGroup>
+          </GoabSideMenuGroup>
+        </GoabSideMenu>
+      </div>
+    </div>
+  );
+}

--- a/libs/react-components/specs/side-menu.browser.spec.tsx
+++ b/libs/react-components/specs/side-menu.browser.spec.tsx
@@ -1,0 +1,115 @@
+import { render } from "vitest-browser-react";
+import { GoabSideMenu, GoabSideMenuGroup } from "../src";
+import { describe, it, expect, vi } from "vitest";
+
+describe("SideMenu", () => {
+  const Component = () => {
+    return (
+      <GoabSideMenu testId="side-menu">
+        <GoabSideMenuGroup heading="Parent Group" testId="parent-group">
+          <a href="/parent-item">Parent Item</a>
+
+          <GoabSideMenuGroup heading="Child Group" testId="child-group">
+            <a href="/child-item" data-testid="child-item-link">
+              Child Item
+            </a>
+          </GoabSideMenuGroup>
+        </GoabSideMenuGroup>
+      </GoabSideMenu>
+    );
+  };
+
+  const isGroupOpen = (groupHost: HTMLElement | null) => {
+    if (!groupHost) return;
+    const container = groupHost.shadowRoot?.querySelector('[data-testid="group"]');
+    return !!container && !container.classList.contains("hidden");
+  };
+
+  const updateURL = async (url: string) => {
+    window.history.pushState({}, "", url);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  };
+
+  beforeEach(() => {
+    window.history.pushState({}, "", "/");
+  });
+
+  it("closes parent and child groups when no items are current", async () => {
+    const handler = vi.fn();
+
+    const result = render(<Component />);
+
+    const menu = result.baseElement.querySelector("goa-side-menu");
+    menu?.addEventListener("_open", handler);
+
+    const parentGroup = result.baseElement.querySelector(
+      "goa-side-menu-group",
+    ) as HTMLElement;
+    const childGroup = parentGroup?.querySelector("goa-side-menu-group") as HTMLElement;
+
+    expect(parentGroup).toBeTruthy();
+    expect(childGroup).toBeTruthy();
+
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalled();
+      expect(isGroupOpen(parentGroup)).toBe(false);
+      expect(isGroupOpen(childGroup)).toBe(false);
+    });
+  });
+
+  it("opens parent and child group when the child item is current", async () => {
+    const handler = vi.fn();
+
+    const result = render(<Component />);
+
+    const menu = result.baseElement.querySelector("goa-side-menu");
+    menu?.addEventListener("_open", handler);
+
+    const parentGroup = result.baseElement.querySelector(
+      "goa-side-menu-group",
+    ) as HTMLElement;
+    const childGroup = parentGroup?.querySelector("goa-side-menu-group") as HTMLElement;
+
+    expect(parentGroup).toBeTruthy();
+    expect(childGroup).toBeTruthy();
+
+    expect(isGroupOpen(parentGroup)).toBe(false);
+    expect(isGroupOpen(childGroup)).toBe(false);
+
+    await updateURL("/child-item");
+
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalled();
+      expect(isGroupOpen(parentGroup)).toBe(true);
+      expect(isGroupOpen(childGroup)).toBe(true);
+    });
+  });
+
+  it("opens parent and closes child group when the parent item is current", async () => {
+    const handler = vi.fn();
+
+    const result = render(<Component />);
+
+    const menu = result.baseElement.querySelector("goa-side-menu");
+    menu?.addEventListener("_open", handler);
+
+    const parentGroup = result.baseElement.querySelector(
+      "goa-side-menu-group",
+    ) as HTMLElement;
+    const childGroup = parentGroup?.querySelector("goa-side-menu-group") as HTMLElement;
+
+    expect(parentGroup).toBeTruthy();
+    expect(childGroup).toBeTruthy();
+
+    expect(isGroupOpen(parentGroup)).toBe(false);
+    expect(isGroupOpen(childGroup)).toBe(false);
+
+    updateURL("/parent-item");
+
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalled();
+      expect(isGroupOpen(childGroup)).toBe(false);
+      expect(isGroupOpen(parentGroup)).toBe(true);
+    });
+  });
+});

--- a/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
+++ b/libs/web-components/src/components/side-menu-group/SideMenuGroup.svelte
@@ -34,6 +34,7 @@
   let _open = false;
   let _current = false;
   let _rootEl: HTMLElement;
+  let _senderEl: HTMLElement;
 
   $: _slug = toSlug(heading);
 
@@ -56,7 +57,7 @@
       });
 
     setTimeout(() => {
-      _rootEl.dispatchEvent(
+      _senderEl.dispatchEvent(
         new CustomEvent<SideMenuGroupProps>("sidemenugroup:mounted", {
           detail: {
             el: _rootEl,
@@ -78,7 +79,7 @@
 
     // listen to events by children (if child is open the parent also has to be open)
     _rootEl.addEventListener("_open", (e: Event) => {
-      _open = _current = (e as CustomEvent).detail.current;
+      _open = _current = true;
     });
   }
 
@@ -109,7 +110,7 @@
       (matchedChild as Element).classList.add("current");
     }
     _current = _open = !!matchedChild;
-    notifyParent(_open);
+    if (_open) dispatchGroupOpen();
   }
 
   function handleClick(e: Event) {
@@ -117,17 +118,17 @@
     e.preventDefault();
   }
 
-  function notifyParent(current: boolean) {
-    _rootEl.dispatchEvent(
+  function dispatchGroupOpen() {
+    _senderEl.dispatchEvent(
       new CustomEvent("_open", {
         bubbles: true,
-        composed: true,
-        detail: { current },
+        composed: true
       }),
     );
   }
 </script>
 
+<div bind:this={_senderEl}></div>
 <div bind:this={_rootEl}
      class="side-menu-group"
      class:v2={version === "2"}


### PR DESCRIPTION
# Before 

When a parent Side Menu Group is current and open,
But a child Group is not current or open,
The parent group will be closed.

![menu-group-broken](https://github.com/user-attachments/assets/4259c93a-c9dd-4f3a-bfe3-8bcdc8003cad)


# After 

When a parent Side Menu Group is current and open,
But a child Side Menu Group is not current or open,
The parent Group is still current and open.

![menu-group-fixed](https://github.com/user-attachments/assets/54afb767-3436-47df-96d0-5ce8bba332be)
