### PR TITLE
fix(#3455,#3450): Updated top and bottom positioning for Popover

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -1,13 +1,37 @@
 <div style="min-height: 100vh; display: flex; flex-direction: column">
-  <section slot="header" class="width" role="header" style="flex: 0 0 auto">
+  <section slot="header" id="top" class="width" role="header" style="flex: 0 0 auto">
     <goab-microsite-header type="alpha" version="UAT" />
     <goab-app-header>
       <a href="/">Home</a>
       <goab-app-header-menu heading="Insights">
-        <a class="interactive" href="/bugs/bug2720">2878</a>
-        <a href="/">Regional Insights</a>
-        <a href="/">Occupational Insights</a>
+        <a href="/bugs/bug2720"> bug2720 </a>
+        <a href="/bugs/3450"> Dropdown expanding </a>
+        <a href="/bugs/3450"> ...inside Container </a>
+        <a href="/bugs/3450">
+          Interactive super long menu item to test overflow handling lorem ipsum dolor sit
+          amet
+        </a>
+        <a href="/bugs/3450">
+          Noninteractive super long menu item to test overflow handling lorem ipsum dolor
+          sit amet
+        </a>
       </goab-app-header-menu>
+      <goab-app-header-menu heading="Popover">
+        <a href="/bugs/3450"> Bug 3450 </a>
+        <a href="/bugs/3450">Bug 3450</a>
+        <a href="/bugs/3450">
+          Super long menu item to test overflow handling lorem ipsum dolor sit amet
+        </a>
+      </goab-app-header-menu>
+      <goa-app-header-menu heading="John Smith" leadingIcon="person-circle">
+        <a href="#top">Manage account</a>
+        <a href="#top">Request new staff account for a long</a>
+        <a href="#top">System admin</a>
+        <a href="#top" class="interactive">Sign out</a
+        ><a href="/bugs/3450">
+          Super long menu item to test overflow handling lorem ipsum dolor sit amet
+        </a>
+      </goa-app-header-menu>
     </goab-app-header>
   </section>
 
@@ -57,6 +81,7 @@
           <a href="/bugs/3337">3337 - Autocomplete styling</a>
           <a href="/bugs/3279">3279</a>
           <a href="/bugs/3384">3384 Table v2 sample</a>
+          <a href="/bugs/3450">3450 Dropdown expanding inside Container</a>
         </goab-side-menu-group>
         <goab-side-menu-group heading="Features">
           <a href="/features/1328">1328</a>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -43,6 +43,7 @@ import { Bug3281Component } from "../routes/bugs/3281/bug3281.component";
 import { Bug3337Component } from "../routes/bugs/3337/bug3337.component";
 import { Bug3279Component } from "../routes/bugs/3279/bug3279.component";
 import { Bug3384Component } from "../routes/bugs/3384/bug3384.component";
+import { Bug3450Component } from "../routes/bugs/3450/bug3450.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -119,6 +120,8 @@ export const appRoutes: Route[] = [
   { path: "bugs/3337", component: Bug3337Component },
   { path: "bugs/3279", component: Bug3279Component },
   { path: "bugs/3384", component: Bug3384Component },
+  { path: "bugs/3450", component: Bug3450Component },
+
   // Feature routes
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1383", component: Feat1383Component },

--- a/apps/prs/angular/src/routes/bugs/3450/bug3450.component.html
+++ b/apps/prs/angular/src/routes/bugs/3450/bug3450.component.html
@@ -1,0 +1,49 @@
+<div>
+  <h1>Bug 3450 - Dropdown expanding inside Container</h1>
+
+  <goab-block gap="m" direction="row">
+    <goab-container>
+      <p>The GoabDropdown below should expand outside of the container.</p>
+
+      <goab-form-item label="Basic GoabDropdown">
+        <goab-dropdown placeholder="-- Watch me Expand --">
+          <goab-dropdown-item value="1" label="Option 1"></goab-dropdown-item>
+          <goab-dropdown-item value="2" label="Option 2"></goab-dropdown-item>
+          <goab-dropdown-item value="3" label="Option 3"></goab-dropdown-item>
+        </goab-dropdown>
+      </goab-form-item>
+    </goab-container>
+    <goab-container>
+      <p>The GoabDatePicker below should expand outside of the container.</p>
+
+      <goab-form-item label="Basic GoabDatePicker">
+        <goab-date-picker></goab-date-picker>
+      </goab-form-item>
+    </goab-container>
+    <goab-container>
+      <p>Menu Button should open properly also.</p>
+      <goab-menu-button text="Download" (onAction)="onMenuAction($event)">
+        <goab-menu-action text="CSV (Filtered)" action="csv-filtered" />
+        <goab-menu-action text="CSV (All)" action="csv-all" />
+        <goab-menu-action text="JSON (Filtered)" action="json-filtered" />
+        <goab-menu-action text="JSON (All)" action="json-all" />
+      </goab-menu-button>
+    </goab-container>
+  </goab-block>
+
+  <h2>Testing Directions</h2>
+  <p>This is a test of GoabPopover not GoabDropdown or GoabDatePicker.</p>
+  <ul>
+    <li>
+      Open the GoabDropdown and GoabDatePicker and verify that they expand outside of the
+      container.
+    </li>
+    <li>
+      Verify that the GoabDropdown and GoabDatePicker are not cut off by the container.
+    </li>
+    <li>
+      Shrink and expand the window to cause the GoabDropdown and GoabDatePicker to expand
+      upwards instead.
+    </li>
+  </ul>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3450/bug3450.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3450/bug3450.component.ts
@@ -1,0 +1,35 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabBlock,
+  GoabContainer,
+  GoabDatePicker,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFormItem,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabMenuButtonOnActionDetail,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3450",
+  templateUrl: "./bug3450.component.html",
+  imports: [
+    CommonModule,
+    GoabBlock,
+    GoabContainer,
+    GoabDatePicker,
+    GoabDropdown,
+    GoabDropdownItem,
+    GoabFormItem,
+    GoabMenuAction,
+    GoabMenuButton,
+  ],
+})
+export class Bug3450Component {
+  onMenuAction(detail: GoabMenuButtonOnActionDetail) {
+    console.log("Menu action:", detail.action);
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -2,6 +2,7 @@ import { Link, Outlet } from "react-router-dom";
 import {
   GoabAppFooter,
   GoabAppHeader,
+  GoabAppHeaderMenu,
   GoabMicrositeHeader,
   GoabOneColumnLayout,
   GoabSideMenu,
@@ -12,9 +13,37 @@ import "@abgov/style";
 export function App() {
   return (
     <GoabOneColumnLayout>
-      <section slot="header">
+      <section slot="header" id="top">
         <GoabMicrositeHeader type="alpha" version="UAT" />
-        <GoabAppHeader heading="Testing Playground" url="/"></GoabAppHeader>
+        <GoabAppHeader heading="Testing Playground" url="/">
+          <a href="/">Home</a>
+          <GoabAppHeaderMenu heading="Insights">
+            <a href="/bugs/bug2720">bug2720</a>
+            <a href="/bugs/3450">Dropdown expanding</a>
+            <a href="/bugs/3450">...inside Container</a>
+            <a href="/bugs/3450">
+              Super long menu item to test overflow handling lorem ipsum dolor sit amet
+            </a>
+          </GoabAppHeaderMenu>
+          <GoabAppHeaderMenu heading="Popover">
+            <a href="/bugs/3450">Bug 3450</a>
+            <a href="/bugs/3450">Bug 3450</a>
+            <a href="/bugs/3450">
+              Super long menu item to test overflow handling lorem ipsum dolor sit amet
+            </a>
+          </GoabAppHeaderMenu>
+          <GoabAppHeaderMenu heading="John Smith" leadingIcon="person-circle">
+            <a href="#top">Manage account</a>
+            <a href="#top">Request new staff account</a>
+            <a href="#top">System admin</a>
+            <a href="#top" className="interactive">
+              Sign out
+            </a>
+            <a href="/bugs/3450">
+              Super long menu item to test overflow handling lorem ipsum dolor sit amet
+            </a>
+          </GoabAppHeaderMenu>
+        </GoabAppHeader>
       </section>
       <div style={{ display: "flex", minHeight: "100vh" }}>
         <section
@@ -67,6 +96,7 @@ export function App() {
               <Link to="/bugs/3337">3337 Input autocomplete styling</Link>
               <Link to="/bugs/3279">3279 Work Side Menu Key Nav</Link>
               <Link to="/bugs/3384">3384 v2 Table Border</Link>
+              <Link to="/bugs/3450">3450 Dropdown expanding inside Container</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Features">
               <Link to="/features/1383">1383 Button Filled Icons</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -45,6 +45,7 @@ import { Bug3322Route } from "./routes/bugs/bug3322";
 import { Bug3281Route } from "./routes/bugs/bug3281";
 import { Bug3337Route } from "./routes/bugs/bug3337";
 import { Bug3384Route } from "./routes/bugs/bug3384";
+import { Bug3450Route } from "./routes/bugs/bug3450";
 
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
@@ -130,6 +131,7 @@ root.render(
           <Route path="bugs/3281" element={<Bug3281Route />} />
           <Route path="bugs/3337" element={<Bug3337Route />} />
           <Route path="bugs/3384" element={<Bug3384Route />} />
+          <Route path="bugs/3450" element={<Bug3450Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3450.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3450.tsx
@@ -1,0 +1,71 @@
+import {
+  GoabBlock,
+  GoabContainer,
+  GoabDatePicker,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFormItem,
+  GoabMenuAction,
+  GoabMenuButton,
+} from "@abgov/react-components";
+import { GoabMenuButtonOnActionDetail } from "@abgov/ui-components-common";
+
+export function Bug3450Route() {
+  function onMenuAction(detail: GoabMenuButtonOnActionDetail) {
+    console.log("Menu action:", detail.action);
+  }
+
+  return (
+    <div>
+      <h1>Bug 3450 - Dropdown expanding inside Container</h1>
+
+      <GoabBlock gap="m" direction="row">
+        <GoabContainer>
+          <p>The GoabDropdown below should expand outside of the container.</p>
+
+          <GoabFormItem label="Basic GoabDropdown">
+            <GoabDropdown placeholder="-- Watch me Expand --">
+              <GoabDropdownItem value="1" label="Option 1" />
+              <GoabDropdownItem value="2" label="Option 2" />
+              <GoabDropdownItem value="3" label="Option 3" />
+            </GoabDropdown>
+          </GoabFormItem>
+        </GoabContainer>
+        <GoabContainer>
+          <p>The GoabDatePicker below should expand outside of the container.</p>
+
+          <GoabFormItem label="Basic GoabDatePicker">
+            <GoabDatePicker></GoabDatePicker>
+          </GoabFormItem>
+        </GoabContainer>
+        <GoabContainer>
+          <p>Menu Button should open properly also.</p>
+
+          <GoabMenuButton text="Download" onAction={onMenuAction}>
+            <GoabMenuAction text="CSV (Filtered)" action="csv-filtered" />
+            <GoabMenuAction text="CSV (All)" action="csv-all" />
+            <GoabMenuAction text="JSON (Filtered)" action="json-filtered" />
+            <GoabMenuAction text="JSON (All)" action="json-all" />
+          </GoabMenuButton>
+        </GoabContainer>
+      </GoabBlock>
+
+      <h2>Testing Directions</h2>
+      <p>This is a test of GoabPopover not GoabDropdown or GoabDatePicker.</p>
+      <ul>
+        <li>
+          Open the GoabDropdown and GoabDatePicker and verify that they expand outside of
+          the container.
+        </li>
+        <li>
+          Verify that the GoabDropdown and GoabDatePicker are not cut off by the
+          container.
+        </li>
+        <li>
+          Shrink and expand the window to cause the GoabDropdown and GoabDatePicker to
+          expand upwards instead.
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/libs/react-components/specs/popover.browser.spec.tsx
+++ b/libs/react-components/specs/popover.browser.spec.tsx
@@ -100,7 +100,7 @@ describe("Popover", () => {
       await vi.waitFor(() => {
         const popoverContentEl = result.getByTestId("popover-content");
         expect(popoverContentEl.element()).toBeTruthy();
-        expect(popoverContentEl.element().style.bottom).toBe("auto");
+        expect(popoverContentEl.element().style.bottom).toBe("");
       });
     });
 
@@ -150,7 +150,7 @@ describe("Popover", () => {
         const popoverContentEl = result.getByTestId("popover-content");
         expect(popoverContentEl.element()).toBeTruthy();
         // It should be a number ending with px when opening upwards
-        expect(popoverContentEl.element().style.bottom).toMatch(/-?\d+px/);
+        expect(popoverContentEl.element().style.top).toMatch(/-?\d+px/);
       });
     });
 
@@ -199,7 +199,7 @@ describe("Popover", () => {
         const popoverContentEl = result.getByTestId("popover-content");
         expect(popoverContentEl.element()).toBeTruthy();
         // bottom should be set to 'auto' when opening downwards
-        expect(popoverContentEl.element().style.bottom).toBe("auto");
+        expect(popoverContentEl.element().style.bottom).toBe("");
       });
     });
   });

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -409,6 +409,8 @@
       : null;
 
     const popoverRect = getBoundingClientRectWithMargins(_popoverEl);
+    const offsetParent = _popoverEl.offsetParent as HTMLElement | null;
+    const offsetParentTop = offsetParent?.getBoundingClientRect().top || 0;
 
     // exit if the popover hasn't yet been filled
     if (popoverRect.height < 20) return;
@@ -432,9 +434,12 @@
         : position === "above";
 
     if (displayOnTop) {
-      _popoverEl.style.bottom = `${targetRect.height}px`;
+      const topPos = targetRect.top - popoverRect.height - offsetParentTop;
+      _popoverEl.style.top = `${topPos}px`;
     } else {
-      _popoverEl.style.bottom = "auto"; // In case this is triggered by _sectionHeight is changed
+      // Clear top/bottom to keep default below-target static positioning.
+      _popoverEl.style.top = "";
+      _popoverEl.style.bottom = "";
     }
 
     // Move the popover to the left if it is too far to the right and only if there is space to the left
@@ -480,12 +485,7 @@
     <slot name="target" />
   </button>
 
-  <div
-    style={styles(
-      style("display", _open ? "block" : "none"),
-      style("position", "relative"),
-    )}
-  >
+  <div style={styles(style("display", _open ? "block" : "none"))}>
     <section
       bind:clientHeight={_sectionHeight}
       bind:this={_popoverEl}


### PR DESCRIPTION
# Before (the change)

The two issues were Dropdown not expanding outside a Container, and AppHeaderMenu not expanding to max width when necessary.

# After (the change)

Both the above issues should be resolved.

Check samples in
- http://localhost:4201/bugs/2655
- http://localhost:4201/bugs/3450

It works for dropdowns in Containers:

<img width="579" height="330" alt="image" src="https://github.com/user-attachments/assets/2b274e2e-3b47-4bf7-acd4-055ce3dfb4ea" />

It also works for inside a modal:

<img width="617" height="614" alt="image" src="https://github.com/user-attachments/assets/34953693-a758-4420-b575-a4b7b8f85155" />

Also the main navbar was updated. Other than the border, the navbar items push right up to the side of the screen but don't go past:

<img width="577" height="384" alt="image" src="https://github.com/user-attachments/assets/1f903b44-983c-4edd-ba3b-88ac8d4bc51b" />

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
