### PR TITLE
feat: Rewrote Popover using Popover and Anchor Position API

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -118,6 +118,7 @@
           <a href="/features/3407-skip-on-focus-tab">3407 Skip Focus on Tab</a>
           <a href="/features/3407-stack-on-mobile">3407 Tabs Orientation</a>
           <a href="/features/v2-checkbox">3399 V2 Checkbox Spacing</a>
+          <a href="/features/3478">3478 Popover API Rewrite</a>
         </goab-side-menu-group>
       </goab-side-menu>
     </section>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -80,6 +80,7 @@ import { Feat3398Component } from "../routes/features/feat3398/feat3398.componen
 import { FeatV2IconsComponent } from "../routes/features/featV2Icons/feat-v2-icons.component";
 import { Feat3396Component } from "../routes/features/feat3396/feat3396.component";
 import { FeatV2CheckboxComponent } from "../routes/features/featV2Checkbox/featV2Checkbox.component";
+import { Feat3478Component } from "../routes/features/feat3478/feat3478.component";
 
 export const appRoutes: Route[] = [
   { path: "everything", component: EverythingComponent },
@@ -164,4 +165,5 @@ export const appRoutes: Route[] = [
   { path: "features/3407-stack-on-mobile", component: Feat3407StackOnMobileComponent },
   { path: "features/v2-checkbox", component: FeatV2CheckboxComponent },
   { path: "features/3398", component: Feat3398Component },
+  { path: "features/3478", component: Feat3478Component },
 ];

--- a/apps/prs/angular/src/routes/features/feat3478/feat3478.component.html
+++ b/apps/prs/angular/src/routes/features/feat3478/feat3478.component.html
@@ -1,0 +1,370 @@
+<div>
+  <goab-text tag="h1" mt="m">Feature #3478: Popover API Rewrite</goab-text>
+  <goab-text tag="h2">Test Cases</goab-text>
+
+  <!-- Calendar -->
+  <goab-text tag="h2" mt="l">Calendar</goab-text>
+  <goab-form-item
+    label="Date Picker with width to test vs popover"
+    helpText="Verify when Calendar opens, the year and month dropdown 'open' stage are independent from Popover. We are using popover 'auto' attribute so it should handle correctly. This test is to verify we are safe to remove 'disableGlobalClosePopover' from Popover.svelte. Verify when we select a date, the date picker will auto-close."
+  >
+    <goab-date-picker
+      width="500px"
+      (onChange)="onDateChange($event)"
+      name="item"
+      [value]="'2026-03-03'"
+    ></goab-date-picker>
+  </goab-form-item>
+
+  <!-- Popover -->
+  <goab-text tag="h2" mt="l">Popover</goab-text>
+
+  <goab-text tag="h3">Popover with Close Button (Focus Trap test)</goab-text>
+  <goab-text tag="p">
+    Open the popover and verify Tab key cycles focus within the popover content (focus
+    trap). Click the Close button inside to close.
+  </goab-text>
+  <goab-popover [target]="closeBtnTarget" minWidth="250px">
+    <ng-template #closeBtnTarget>
+      <goab-button>Open Popover</goab-button>
+    </ng-template>
+    <p>This popover has buttons inside. Tab between them to test focus trap.</p>
+    <goab-block gap="s" mt="m">
+      <goab-button type="primary" size="compact" (onClick)="onMenuAction($any($event))">
+        Action
+      </goab-button>
+      <goab-button type="secondary" size="compact" action="close">
+        Close Popover
+      </goab-button>
+    </goab-block>
+  </goab-popover>
+
+  <goab-text tag="h3">Popover Playground</goab-text>
+  <goab-text tag="p">
+    Modify popover properties dynamically to verify positioning, sizing, and padding work
+    correctly after the rewrite.
+  </goab-text>
+
+  <div
+    style="
+      border: 1px solid var(--goa-color-greyscale-200);
+      padding: 2rem;
+      display: flex;
+      justify-content: center;
+      margin-bottom: 1rem;
+    "
+  >
+    <goab-popover
+      [target]="playgroundTarget"
+      [maxWidth]="popoverMaxWidth"
+      [minWidth]="popoverMinWidth"
+      [position]="popoverPosition"
+      [padded]="popoverPadded"
+    >
+      <ng-template #playgroundTarget>
+        <goab-button>Click me</goab-button>
+      </ng-template>
+      <goab-text tag="p">Popover content with dynamic properties.</goab-text>
+      <goab-text tag="p">
+        Max Width: {{ popoverMaxWidth || "(default)" }} | Min Width:
+        {{ popoverMinWidth || "(none)" }} | Position: {{ popoverPosition }} | Padded:
+        {{ popoverPadded ? "Yes" : "No" }}
+      </goab-text>
+    </goab-popover>
+  </div>
+
+  <goab-details heading="Playground controls" [open]="true">
+    <goab-block gap="l" direction="column" mt="m">
+      <goab-block gap="l">
+        <goab-form-item label="Max Width">
+          <goab-input
+            name="maxWidth"
+            [value]="popoverMaxWidth"
+            (onChange)="onMaxWidthChange($event)"
+          ></goab-input>
+        </goab-form-item>
+        <goab-form-item label="Min Width">
+          <goab-input
+            name="minWidth"
+            [value]="popoverMinWidth"
+            (onChange)="onMinWidthChange($event)"
+          ></goab-input>
+        </goab-form-item>
+      </goab-block>
+      <goab-block gap="l">
+        <goab-form-item label="Position">
+          <goab-dropdown
+            name="position"
+            [value]="popoverPosition"
+            (onChange)="onPositionChange($event)"
+          >
+            <goab-dropdown-item value="auto" label="Auto"></goab-dropdown-item>
+            <goab-dropdown-item value="above" label="Above"></goab-dropdown-item>
+            <goab-dropdown-item value="below" label="Below"></goab-dropdown-item>
+          </goab-dropdown>
+        </goab-form-item>
+        <goab-form-item label="Padding">
+          <goab-checkbox
+            name="padded"
+            [checked]="popoverPadded"
+            text="Yes"
+            (onChange)="onPaddedChange($event)"
+          ></goab-checkbox>
+        </goab-form-item>
+      </goab-block>
+    </goab-block>
+  </goab-details>
+
+  <!-- Menu Button -->
+  <hr style="margin: 2rem 0" />
+  <goab-text tag="h2" mt="l">Menu Button</goab-text>
+  <goab-text tag="p">
+    Test Menu Button: Press Enter and arrow up and down see whether Menu Button works as
+    expected.
+  </goab-text>
+  <goab-block gap="l" direction="column">
+    <div>
+      <goab-text tag="p" mb="s"><strong>Short actions:</strong></goab-text>
+      <goab-menu-button text="Quick Actions" (onAction)="onMenuAction($event)">
+        <goab-menu-action key="1" text="Edit" action="edit"></goab-menu-action>
+        <goab-menu-action key="2" text="Delete" action="delete"></goab-menu-action>
+      </goab-menu-button>
+    </div>
+    <div>
+      <goab-text tag="p" mb="s"><strong>Many actions with long text:</strong></goab-text>
+      <goab-menu-button text="More Actions" (onAction)="onMenuAction($event)">
+        <goab-menu-action key="1" text="Edit this item" action="edit"></goab-menu-action>
+        <goab-menu-action
+          key="2"
+          text="Delete permanently"
+          action="delete"
+        ></goab-menu-action>
+        <goab-menu-action
+          key="3"
+          text="Archive for later review"
+          action="archive"
+        ></goab-menu-action>
+        <goab-menu-action
+          key="4"
+          text="Duplicate and create a new copy"
+          action="duplicate"
+        ></goab-menu-action>
+        <goab-menu-action
+          key="5"
+          text="Share with team members"
+          action="share"
+        ></goab-menu-action>
+      </goab-menu-button>
+    </div>
+  </goab-block>
+
+  <!-- Dropdown -->
+  <hr style="margin: 2rem 0" />
+  <goab-text tag="h2" mt="l">Dropdown</goab-text>
+
+  <goab-text tag="h3">Standard Dropdown</goab-text>
+  <goab-text tag="p">
+    Dropdown controls its popover by setting open="true"/"false". Click it to verify the
+    option list appears. If the open prop is missing, the Dropdown will not show its
+    options.
+  </goab-text>
+  <goab-dropdown
+    name="open-prop-test"
+    [value]="modalDropdownValue"
+    (onChange)="onModalDropdownChange($event)"
+  >
+    <goab-dropdown-item value="alpha" label="Alpha"></goab-dropdown-item>
+    <goab-dropdown-item value="beta" label="Beta"></goab-dropdown-item>
+    <goab-dropdown-item value="gamma" label="Gamma"></goab-dropdown-item>
+  </goab-dropdown>
+  <goab-text tag="p">Selected: {{ modalDropdownValue || "(none)" }}</goab-text>
+
+  <goab-text tag="h3" mt="l">Filterable Dropdown</goab-text>
+  <goab-text tag="p">
+    Focus the input and press Space — it should type a space, not toggle the popover.
+  </goab-text>
+  <goab-dropdown
+    name="filterable-test"
+    [filterable]="true"
+    value=""
+    (onChange)="onFilterableChange($event)"
+  >
+    <goab-dropdown-item value="new york" label="New York"></goab-dropdown-item>
+    <goab-dropdown-item value="los angeles" label="Los Angeles"></goab-dropdown-item>
+    <goab-dropdown-item value="san francisco" label="San Francisco"></goab-dropdown-item>
+    <goab-dropdown-item value="las vegas" label="Las Vegas"></goab-dropdown-item>
+  </goab-dropdown>
+
+  <!-- Edge Cases -->
+  <hr style="margin: 2rem 0" />
+  <goab-text tag="h2" mt="l">Edge Cases</goab-text>
+
+  <!-- Test 1: Popover in Modal -->
+  <goab-text tag="h3">Test 1: Popover in Modal (z-index fix)</goab-text>
+  <goab-text tag="p">
+    Previously, position: absolute and z-index: 99 on the popover content caused dropdowns
+    and date pickers inside modals to render behind or outside the modal. The native
+    Popover API renders in the top layer, fixing this. Click the button below to open a
+    modal with a Dropdown and DatePicker inside.
+  </goab-text>
+  <goab-button (onClick)="modalOpen = true"
+    >Open Modal with Popover Components</goab-button
+  >
+  <goab-modal
+    heading="Popover in Modal Test"
+    [open]="modalOpen"
+    (onClose)="modalOpen = false"
+    [closable]="true"
+  >
+    <goab-text tag="p" maxWidth="40ch">
+      The Dropdown and DatePicker below should render their popovers correctly above the
+      modal — not clipped or hidden behind it.
+    </goab-text>
+    <goab-block direction="column" gap="l" mt="m">
+      <goab-form-item label="Dropdown (top of modal)">
+        <goab-dropdown
+          name="modal-dropdown"
+          [value]="modalDropdownValue"
+          (onChange)="onModalDropdownChange($event)"
+        >
+          <goab-dropdown-item value="option1" label="Option 1"></goab-dropdown-item>
+          <goab-dropdown-item value="option2" label="Option 2"></goab-dropdown-item>
+          <goab-dropdown-item value="option3" label="Option 3"></goab-dropdown-item>
+        </goab-dropdown>
+      </goab-form-item>
+
+      <div style="padding: 1rem 0">
+        <goab-text tag="p" maxWidth="40ch">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+          incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+          nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </goab-text>
+        <goab-text tag="p" mt="m" maxWidth="40ch">
+          Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+          deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus
+          error sit voluptatem accusantium doloremque laudantium.
+        </goab-text>
+      </div>
+
+      <goab-form-item label="Date Picker (bottom of modal — scroll down)">
+        <goab-date-picker
+          name="modal-datepicker"
+          [value]="modalDateValue"
+          (onChange)="onModalDateChange($event)"
+        ></goab-date-picker>
+      </goab-form-item>
+    </goab-block>
+  </goab-modal>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- Test 2: AppHeaderMenu closes on navigation -->
+  <goab-text tag="h3">Test 2: AppHeaderMenu closes on navigation</goab-text>
+  <goab-text tag="p">
+    The "Services" and "Account" menus <strong>in the header above</strong> use
+    goab-app-header-menu, which uses goa-popover internally. Open a menu, then click a
+    link inside it. The page content will change but the header stays — verify the menu
+    popover closed. This is to test handleUrlChange inside the Popover.svelte
+  </goab-text>
+
+  <!-- Test 3: Multiple Popovers -->
+  <goab-text tag="h3">Test 3: Multiple Popovers</goab-text>
+  <goab-text tag="p">
+    Opening one popover should close others (popover="auto" behavior).
+  </goab-text>
+  <goab-block gap="l">
+    <goab-popover [target]="popoverATarget">
+      <ng-template #popoverATarget><goab-button>Popover A</goab-button></ng-template>
+      <goab-text tag="p">Content A</goab-text>
+    </goab-popover>
+    <goab-popover [target]="popoverBTarget">
+      <ng-template #popoverBTarget><goab-button>Popover B</goab-button></ng-template>
+      <goab-text tag="p">Content B</goab-text>
+    </goab-popover>
+    <goab-popover [target]="popoverCTarget">
+      <ng-template #popoverCTarget><goab-button>Popover C</goab-button></ng-template>
+      <goab-text tag="p">Content C</goab-text>
+    </goab-popover>
+  </goab-block>
+
+  <!-- Test 4: #3499 Dismissing Notification breaks AppHeaderMenu -->
+  <goab-text tag="h3"
+    >Test 4: #3499 Dismissing Notification breaks AppHeaderMenu</goab-text
+  >
+  <goab-text tag="p">
+    When a Notification banner is dismissed (removed from the DOM), it should not break
+    the AppHeaderMenu popover. Steps to reproduce: dismiss the notification below, then
+    try opening the AppHeaderMenu in the header. It should still work.
+  </goab-text>
+  <goab-app-header-menu heading="Test Menu">
+    <a href="#">Menu Item 1</a>
+    <a href="#">Menu Item 2</a>
+    <a href="#">Menu Item 3</a>
+  </goab-app-header-menu>
+  @if (showBanner) {
+    <goab-notification type="information" (onDismiss)="dismissNotification()">
+      Dismiss this notification, then verify AppHeaderMenu still works.
+    </goab-notification>
+  }
+  @if (!showBanner) {
+    <goab-text tag="p" mt="m">
+      Notification dismissed. Now open the AppHeaderMenu above — it should still function
+      correctly.
+    </goab-text>
+    <goab-button mt="m" type="tertiary" (onClick)="resetNotification()">
+      Reset notification
+    </goab-button>
+  }
+
+  <!-- Test 5: #3067 Focus issues with Popover -->
+  <goab-text tag="h3">Test 5: #3067 Focus issues with Popover</goab-text>
+  <goab-text tag="p">
+    After closing a popover with Escape, focus should return to the trigger element.
+    Steps: 1) Focus the button below, 2) Press Enter to open the popover, 3) Press Escape
+    to close, 4) The button should still be focused (yellow border visible), 5) Press Tab
+    — the next interactive element should be selected, not the popover.
+  </goab-text>
+  <goab-block gap="l">
+    <goab-popover [target]="focusTestTarget">
+      <ng-template #focusTestTarget
+        ><goab-button>Focus Test Button</goab-button></ng-template
+      >
+      <goab-text tag="p"
+        >Press Escape to close. Focus should return to the button.</goab-text
+      >
+    </goab-popover>
+    <goab-button type="secondary">Next Focusable Element</goab-button>
+  </goab-block>
+
+  <!-- Test 6: #3062 Popover maxWidth not respected above a button -->
+  <goab-text tag="h3"
+    >Test 6: #3062 Popover maxWidth not respected above a button</goab-text
+  >
+  <goab-text tag="p">
+    When a Popover is placed directly above a goab-button or goab-input in the DOM, it
+    should still respect the maxWidth property. Both popovers below should have the same
+    width (default 320px). Previously the one above the button would ignore maxWidth.
+  </goab-text>
+  <goab-block direction="column" gap="l">
+    <goab-popover [target]="maxWidthTarget1">
+      <ng-template #maxWidthTarget1>
+        <goab-button type="secondary">Show Popover</goab-button>
+      </ng-template>
+      <goab-text tag="p"
+        >This popover is above the button. It should respect maxWidth (320px).</goab-text
+      >
+    </goab-popover>
+
+    <goab-button type="primary">Submit Form</goab-button>
+
+    <goab-popover [target]="maxWidthTarget2">
+      <ng-template #maxWidthTarget2>
+        <goab-button type="secondary" size="compact">Popover Test</goab-button>
+      </ng-template>
+      <goab-text tag="p"
+        >This popover is below the button. It should also respect maxWidth
+        (320px).</goab-text
+      >
+    </goab-popover>
+  </goab-block>
+</div>

--- a/apps/prs/angular/src/routes/features/feat3478/feat3478.component.ts
+++ b/apps/prs/angular/src/routes/features/feat3478/feat3478.component.ts
@@ -1,0 +1,108 @@
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import {
+  GoabBlock,
+  GoabButton,
+  GoabCheckbox,
+  GoabDatePicker,
+  GoabDetails,
+  GoabDivider,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFormItem,
+  GoabInput,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabModal,
+  GoabNotification,
+  GoabPopover,
+  GoabText,
+  GoabAppHeaderMenu,
+} from "@abgov/angular-components";
+import {
+  GoabCheckboxOnChangeDetail,
+  GoabDatePickerOnChangeDetail,
+  GoabDropdownOnChangeDetail,
+  GoabInputOnChangeDetail,
+  GoabMenuButtonOnActionDetail,
+} from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat3478",
+  templateUrl: "./feat3478.component.html",
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [
+    GoabBlock,
+    GoabButton,
+    GoabCheckbox,
+    GoabDatePicker,
+    GoabDetails,
+    GoabDivider,
+    GoabDropdown,
+    GoabDropdownItem,
+    GoabFormItem,
+    GoabInput,
+    GoabMenuAction,
+    GoabMenuButton,
+    GoabModal,
+    GoabNotification,
+    GoabPopover,
+    GoabText,
+    GoabAppHeaderMenu,
+  ],
+})
+export class Feat3478Component {
+  modalOpen = false;
+  modalDropdownValue = "";
+  modalDateValue: string | Date = "";
+
+  popoverMaxWidth = "320px";
+  popoverMinWidth = "";
+  popoverPosition: "above" | "below" | "auto" = "auto";
+  popoverPadded = true;
+  showBanner = true;
+
+  onDateChange(detail: GoabDatePickerOnChangeDetail) {
+    console.log("DatePicker changed:", detail);
+  }
+
+  onModalDropdownChange(detail: GoabDropdownOnChangeDetail) {
+    this.modalDropdownValue = detail.value ?? "";
+  }
+
+  onModalDateChange(detail: GoabDatePickerOnChangeDetail) {
+    this.modalDateValue = detail.valueStr;
+  }
+
+  onMenuAction(detail: GoabMenuButtonOnActionDetail) {
+    console.log("Action:", detail);
+  }
+
+  onFilterableChange(detail: GoabDropdownOnChangeDetail) {
+    console.log("Filterable selected:", detail.value);
+  }
+
+  onMaxWidthChange(detail: GoabInputOnChangeDetail) {
+    this.popoverMaxWidth = detail.value;
+  }
+
+  onMinWidthChange(detail: GoabInputOnChangeDetail) {
+    this.popoverMinWidth = detail.value;
+  }
+
+  onPositionChange(detail: GoabDropdownOnChangeDetail) {
+    this.popoverPosition = detail.value as "above" | "below" | "auto";
+  }
+
+  onPaddedChange(detail: GoabCheckboxOnChangeDetail) {
+    this.popoverPadded = detail.checked;
+  }
+
+  dismissNotification() {
+    this.showBanner = false;
+  }
+
+  resetNotification() {
+    this.showBanner = true;
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -16,9 +16,10 @@ export function App() {
       <section slot="header" id="top">
         <GoabMicrositeHeader type="alpha" version="UAT" />
         <GoabAppHeader heading="Testing Playground" url="/">
-          <a href="/">Home</a>
-          <GoabAppHeaderMenu heading="Insights">
+          {/* Verify AppHeaderMenu still works after Popover API refactor (PR #3478) */}
+          <GoabAppHeaderMenu heading="Services" leadingIcon="apps">
             <a href="/bugs/bug2720">bug2720</a>
+            <a href="/features/3478">Popover Test</a>
             <a href="/bugs/3450">Dropdown expanding</a>
             <a href="/bugs/3450">...inside Container</a>
             <a href="/bugs/3450">
@@ -132,6 +133,7 @@ export function App() {
               <Link to="/features/3407-skip-on-focus-tab">3407 Skip Focus on Tab</Link>
               <Link to="/features/3407-stack-on-mobile">3407 Tabs Orientation</Link>
               <Link to="/features/3398">3398 Group open prop</Link>
+              <Link to="/features/3478">3478 Popover API Rewrite</Link>
             </GoabSideMenuGroup>
             <GoabSideMenuGroup heading="Everything">
               <Link to="/everything">A</Link>

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -84,6 +84,7 @@ import { Feat3396Route } from "./routes/features/feat3396";
 import { Feat3229Route } from "./routes/features/feat3229";
 import { FeatV2CheckboxRoute } from "./routes/features/featV2Checkbox";
 import { Feat3398Route } from "./routes/features/feat3398";
+import { Feat3478Route } from "./routes/features/feat3478";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 
@@ -171,10 +172,17 @@ root.render(
           <Route path="features/3306" element={<Feat3306Route />} />
           <Route path="features/3370" element={<Feat3370Route />} />
           <Route path="features/3396" element={<Feat3396Route />} />
-          <Route path="features/3407-skip-on-focus-tab" element={<Feat3407SkipOnFocusTabRoute />} />
-          <Route path="features/3407-stack-on-mobile" element={<Feat3407StackOnMobileRoute />} />
+          <Route
+            path="features/3407-skip-on-focus-tab"
+            element={<Feat3407SkipOnFocusTabRoute />}
+          />
+          <Route
+            path="features/3407-stack-on-mobile"
+            element={<Feat3407StackOnMobileRoute />}
+          />
           <Route path="features/v2-checkbox" element={<FeatV2CheckboxRoute />} />
           <Route path="features/3398" element={<Feat3398Route />} />
+          <Route path="features/3478" element={<Feat3478Route />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/apps/prs/react/src/routes/features/feat3478.tsx
+++ b/apps/prs/react/src/routes/features/feat3478.tsx
@@ -1,0 +1,486 @@
+/**
+ * PR #3478: Popover API Rewrite
+ *
+ * Rewrote goa-popover to use the native HTML Popover API + CSS Anchor Positioning API.
+ * This test page verifies popover behavior across various scenarios.
+ */
+
+import { useState } from "react";
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabDetails,
+  GoabButton,
+  GoabModal,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabDatePicker,
+  GoabFormItem,
+  GoabInput,
+  GoabCheckbox,
+  GoabPopover,
+  GoabMenuButton,
+  GoabMenuAction,
+  GoabNotification,
+  GoabAppHeaderMenu,
+} from "@abgov/react-components";
+
+export function Feat3478Route() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalDropdownValue, setModalDropdownValue] = useState("");
+  const [modalDateValue, setModalDateValue] = useState("");
+
+  // Popover playground controls
+  const [popoverMaxWidth, setPopoverMaxWidth] = useState("320px");
+  const [popoverMinWidth, setPopoverMinWidth] = useState("");
+  const [popoverPosition, setPopoverPosition] = useState<"above" | "below" | "auto">(
+    "auto",
+  );
+  const [popoverPadded, setPopoverPadded] = useState(true);
+  const [showBanner, setShowBanner] = useState(true);
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Feature #3478: Popover API Rewrite
+      </GoabText>
+      <GoabText tag="h2">Test Cases</GoabText>
+      <GoabText tag="h2" mt="l">
+        Calendar
+      </GoabText>
+      <GoabFormItem
+        label="Date Picker with width to test vs popover"
+        helpText="Verify when Calendar opens, the year and moth dropdown `open` stage are independent from Popover.
+        We are using popover `auto` attribute so it should handle correctly.
+        This test is to verify we are safe to remove `disableGlobalClosePopover` from Popover.svelte. Verify when we select a date, the date picker will auto-close."
+      >
+        <GoabDatePicker
+          width="500px"
+          onChange={(detail) => console.log("DatePicker changed:", detail)}
+          name="item"
+          value={new Date(2026, 2, 3)}
+        />
+      </GoabFormItem>
+
+      <GoabText tag="h2" mt="l">
+        Popover
+      </GoabText>
+
+      <GoabText tag="h3">Popover with Close Button (Focus Trap test)</GoabText>
+      <GoabText tag="p">
+        Open the popover and verify Tab key cycles focus within the popover content (focus
+        trap). Click the Close button inside to close.
+      </GoabText>
+      <GoabPopover target={<GoabButton>Open Popover</GoabButton>} minWidth="250px">
+        <p>This popover has buttons inside. Tab between them to test focus trap.</p>
+        <GoabBlock gap="s" mt="m">
+          <GoabButton
+            type="primary"
+            size="compact"
+            onClick={() => console.log("Action clicked")}
+          >
+            Action
+          </GoabButton>
+          <GoabButton type="secondary" size="compact" action="close">
+            Close Popover
+          </GoabButton>
+        </GoabBlock>
+      </GoabPopover>
+
+      <GoabText tag="h3">Popover Playground</GoabText>
+      <GoabText tag="p">
+        Modify popover properties dynamically to verify positioning, sizing, and padding
+        work correctly after the rewrite.
+      </GoabText>
+
+      <div
+        style={{
+          border: "1px solid var(--goa-color-greyscale-200)",
+          padding: "2rem",
+          display: "flex",
+          justifyContent: "center",
+          marginBottom: "1rem",
+        }}
+      >
+        <GoabPopover
+          target={<GoabButton>Click me</GoabButton>}
+          maxWidth={popoverMaxWidth || undefined}
+          minWidth={popoverMinWidth || undefined}
+          position={popoverPosition}
+          padded={popoverPadded}
+        >
+          <GoabText tag="p">Popover content with dynamic properties.</GoabText>
+          <GoabText tag="p">
+            Max Width: {popoverMaxWidth || "(default)"} | Min Width:{" "}
+            {popoverMinWidth || "(none)"} | Position: {popoverPosition} | Padded:{" "}
+            {popoverPadded ? "Yes" : "No"}
+          </GoabText>
+        </GoabPopover>
+      </div>
+
+      <GoabDetails heading="Playground controls" open>
+        <GoabBlock gap="l" direction="column" mt="m">
+          <GoabBlock gap="l">
+            <GoabFormItem label="Max Width">
+              <GoabInput
+                name="maxWidth"
+                value={popoverMaxWidth}
+                onChange={(detail) => setPopoverMaxWidth(detail.value)}
+              />
+            </GoabFormItem>
+            <GoabFormItem label="Min Width">
+              <GoabInput
+                name="minWidth"
+                value={popoverMinWidth}
+                onChange={(detail) => setPopoverMinWidth(detail.value)}
+              />
+            </GoabFormItem>
+          </GoabBlock>
+          <GoabBlock gap="l">
+            <GoabFormItem label="Position">
+              <GoabDropdown
+                name="position"
+                value={popoverPosition}
+                onChange={(detail) =>
+                  setPopoverPosition(detail.value as "above" | "below" | "auto")
+                }
+              >
+                <GoabDropdownItem value="auto" label="Auto" />
+                <GoabDropdownItem value="above" label="Above" />
+                <GoabDropdownItem value="below" label="Below" />
+              </GoabDropdown>
+            </GoabFormItem>
+            <GoabFormItem label="Padding">
+              <GoabCheckbox
+                name="padded"
+                checked={popoverPadded}
+                text="Yes"
+                onChange={(detail) => setPopoverPadded(detail.checked)}
+              />
+            </GoabFormItem>
+          </GoabBlock>
+        </GoabBlock>
+      </GoabDetails>
+
+      <GoabText tag="h2" mt="l">
+        Menu Button
+      </GoabText>
+      <GoabText tag="p">
+        Test Menu Button: Press Enter and arrow up and down see whether Menu Button works
+        as expected.
+      </GoabText>
+      <GoabBlock gap="l" direction="column">
+        <div>
+          <GoabText tag="p" mb="s">
+            <strong>Short actions:</strong>
+          </GoabText>
+          <GoabMenuButton
+            text="Quick Actions"
+            onAction={(detail) => console.log("Action:", detail)}
+          >
+            <GoabMenuAction key="1" text="Edit" action="edit" />
+            <GoabMenuAction key="2" text="Delete" action="delete" />
+          </GoabMenuButton>
+        </div>
+        <div>
+          <GoabText tag="p" mb="s">
+            <strong>Many actions with long text:</strong>
+          </GoabText>
+          <GoabMenuButton
+            text="More Actions"
+            onAction={(detail) => console.log("Action:", detail)}
+          >
+            <GoabMenuAction key="1" text="Edit this item" action="edit" />
+            <GoabMenuAction key="2" text="Delete permanently" action="delete" />
+            <GoabMenuAction key="3" text="Archive for later review" action="archive" />
+            <GoabMenuAction
+              key="4"
+              text="Duplicate and create a new copy"
+              action="duplicate"
+            />
+            <GoabMenuAction key="5" text="Share with team members" action="share" />
+            <GoabMenuAction key="6" text="Export as PDF document" action="export-pdf" />
+            <GoabMenuAction
+              key="7"
+              text="Export as CSV spreadsheet"
+              action="export-csv"
+            />
+            <GoabMenuAction key="8" text="Print preview and settings" action="print" />
+            <GoabMenuAction
+              key="9"
+              text="View full activity history and audit log"
+              action="history"
+            />
+            <GoabMenuAction
+              key="10"
+              text="Transfer ownership to another user"
+              action="transfer"
+            />
+          </GoabMenuButton>
+        </div>
+        <div>
+          <GoabText tag="p" mb="s">
+            <strong>Menu button at the bottom of the page (scroll down):</strong>
+          </GoabText>
+          <GoabText tag="p">
+            This one is placed lower on the page. Open it and check whether the page
+            scrolls when the focus trap kicks in.
+          </GoabText>
+        </div>
+      </GoabBlock>
+
+      <GoabText tag="h2" mt="l">
+        Dropdown
+      </GoabText>
+
+      <GoabText tag="h3">Standard Dropdown</GoabText>
+      <GoabText tag="p">
+        Dropdown controls its popover by setting open=&quot;true&quot;/&quot;false&quot;.
+        Click it to verify the option list appears. If the open prop is missing, the
+        Dropdown will not show its options.
+        <br />
+        Test to make sure when we click an option (or Enter to select an option), Dropdown
+        will close (test open dynamically set by Dropdown works in Popover)
+      </GoabText>
+      <GoabDropdown
+        name="open-prop-test"
+        value={modalDropdownValue}
+        onChange={(detail) => setModalDropdownValue(detail.value ?? "")}
+      >
+        <GoabDropdownItem value="alpha" label="Alpha" />
+        <GoabDropdownItem value="beta" label="Beta" />
+        <GoabDropdownItem value="gamma" label="Gamma" />
+      </GoabDropdown>
+      <GoabText tag="p">Selected: {modalDropdownValue || "(none)"}</GoabText>
+
+      <GoabText tag="h3" mt="l">
+        Filterable Dropdown
+      </GoabText>
+      <GoabText tag="p">
+        Focus the input and press Space — it should type a space, not toggle the popover.
+      </GoabText>
+      <GoabDropdown
+        name="filterable-test"
+        filterable
+        value=""
+        onChange={(detail) => console.log("Filterable selected:", detail.value)}
+      >
+        <GoabDropdownItem value="new york" label="New York" />
+        <GoabDropdownItem value="los angeles" label="Los Angeles" />
+        <GoabDropdownItem value="san francisco" label="San Francisco" />
+        <GoabDropdownItem value="las vegas" label="Las Vegas" />
+      </GoabDropdown>
+
+      <hr style={{ margin: "2rem 0" }} />
+
+      <GoabText tag="h2" mt="l">
+        Edge Cases
+      </GoabText>
+
+      {/* Test 1: Popover in Modal (Benji's review comment) */}
+      <GoabText tag="h3">Test 1: Popover in Modal (z-index fix)</GoabText>
+      <GoabText tag="p">
+        Previously, position: absolute and z-index: 99 on the popover content caused
+        dropdowns and date pickers inside modals to render behind or outside the modal.
+        The native Popover API renders in the top layer, fixing this. Click the button
+        below to open a modal with a Dropdown and DatePicker inside.
+      </GoabText>
+      <GoabButton onClick={() => setModalOpen(true)}>
+        Open Modal with Popover Components
+      </GoabButton>
+      <GoabModal
+        heading="Popover in Modal Test"
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+      >
+        <GoabText tag="p" maxWidth="40ch">
+          The Dropdown and DatePicker below should render their popovers correctly above
+          the modal — not clipped or hidden behind it.
+        </GoabText>
+        <GoabBlock direction="column" gap="l" mt="m">
+          <GoabFormItem label="Dropdown (top of modal)">
+            <GoabDropdown
+              name="modal-dropdown"
+              value={modalDropdownValue}
+              onChange={(detail) => setModalDropdownValue(detail.value ?? "")}
+            >
+              <GoabDropdownItem value="option1" label="Option 1" />
+              <GoabDropdownItem value="option2" label="Option 2" />
+              <GoabDropdownItem value="option3" label="Option 3" />
+            </GoabDropdown>
+          </GoabFormItem>
+
+          <div style={{ padding: "1rem 0" }}>
+            <GoabText tag="p" maxWidth="40ch">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+              tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+              quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+              consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+              cillum dolore eu fugiat nulla pariatur.
+            </GoabText>
+            <GoabText tag="p" mt="m" maxWidth="40ch">
+              Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+              deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste
+              natus error sit voluptatem accusantium doloremque laudantium, totam rem
+              aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto
+              beatae vitae dicta sunt explicabo.
+            </GoabText>
+            <GoabText tag="p" mt="m" maxWidth="40ch">
+              Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit,
+              sed quia consequuntur magni dolores eos qui ratione voluptatem sequi
+              nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet,
+              consectetur, adipisci velit.
+            </GoabText>
+            <GoabText tag="p" mt="m" maxWidth="40ch">
+              At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis
+              praesentium voluptatum deleniti atque corrupti quos dolores et quas
+              molestias excepturi sint occaecati cupiditate non provident, similique sunt
+              in culpa qui officia deserunt mollitia animi, id est laborum et dolorum
+              fuga.
+            </GoabText>
+            <GoabText tag="p" mt="m" maxWidth="40ch">
+              Et harum quidem rerum facilis est et expedita distinctio. Nam libero
+              tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus
+              id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis
+              dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut
+              rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et
+              molestiae non recusandae.
+            </GoabText>
+            <GoabText tag="p" mt="m" maxWidth="40ch">
+              Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis
+              voluptatibus maiores alias consequatur aut perferendis doloribus asperiores
+              repellat. Quis autem vel eum iure reprehenderit qui in ea voluptate velit
+              esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo
+              voluptas nulla pariatur.
+            </GoabText>
+          </div>
+
+          <GoabFormItem label="Date Picker (bottom of modal — scroll down)">
+            <GoabDatePicker
+              testId="modal-datepicker"
+              name="modal-datepicker"
+              value={modalDateValue}
+              onChange={(detail) => setModalDateValue(detail.valueStr)}
+            />
+          </GoabFormItem>
+        </GoabBlock>
+      </GoabModal>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Test 2: AppHeaderMenu closes on navigation (popstate) */}
+      <GoabText tag="h3">Test 2: AppHeaderMenu closes on navigation</GoabText>
+      <GoabText tag="p">
+        The &quot;Services&quot; and &quot;Account&quot; menus{" "}
+        <strong> in the header above </strong> use GoabAppHeaderMenu, which uses
+        goa-popover internally. Open a menu, then click a link inside it. The page content
+        will change but the header stays — verify the menu popover closed. This is to test
+        handleUrlChange inside the Popover.svelte
+      </GoabText>
+
+      {/* Test 3: Multiple Popovers */}
+      <GoabText tag="h3">Test 3: Multiple Popovers</GoabText>
+      <GoabText tag="p">
+        Opening one popover should close others (popover=&quot;auto&quot; behavior).
+      </GoabText>
+      <GoabBlock gap="l">
+        <GoabPopover target={<GoabButton>Popover A</GoabButton>}>
+          <GoabText tag="p">Content A</GoabText>
+        </GoabPopover>
+        <GoabPopover target={<GoabButton>Popover B</GoabButton>}>
+          <GoabText tag="p">Content B</GoabText>
+        </GoabPopover>
+        <GoabPopover target={<GoabButton>Popover C</GoabButton>}>
+          <GoabText tag="p">Content C</GoabText>
+        </GoabPopover>
+      </GoabBlock>
+
+      {/* Test 4: #3499 Dismissing Notification breaks AppHeaderMenu */}
+      <GoabText tag="h3">
+        Test 4: #3499 Dismissing Notification breaks AppHeaderMenu
+      </GoabText>
+      <GoabText tag="p">
+        When a Notification banner is dismissed (removed from the DOM), it should not
+        break the AppHeaderMenu popover. Steps to reproduce: dismiss the notification
+        below, then try opening the AppHeaderMenu in the header. It should still work.
+      </GoabText>
+      <GoabAppHeaderMenu heading="Test Menu" testId="test-menu">
+        <a href="#">Menu Item 1</a>
+        <a href="#">Menu Item 2</a>
+        <a href="#">Menu Item 3</a>
+      </GoabAppHeaderMenu>
+      {showBanner && (
+        <GoabNotification
+          type="information"
+          testId="test-banner"
+          onDismiss={() => setShowBanner(false)}
+        >
+          Dismiss this notification, then verify AppHeaderMenu still works.
+        </GoabNotification>
+      )}
+      {!showBanner && (
+        <>
+          <GoabText tag="p" mt="m">
+            Notification dismissed. Now open the AppHeaderMenu above — it should still
+            function correctly.
+          </GoabText>
+          <GoabButton mt="m" type="tertiary" onClick={() => setShowBanner(true)}>
+            Reset notification
+          </GoabButton>
+        </>
+      )}
+
+      {/* Test 5: #3067 Focus issues with Popover */}
+      <GoabText tag="h3">Test 5: #3067 Focus issues with Popover</GoabText>
+      <GoabText tag="p">
+        After closing a popover with Escape, focus should return to the trigger element.
+        Steps: 1) Focus the button below, 2) Press Enter to open the popover, 3) Press
+        Escape to close, 4) The button should still be focused (yellow border visible), 5)
+        Press Tab — the next interactive element should be selected, not the popover.
+      </GoabText>
+      <GoabBlock gap="l">
+        <GoabPopover target={<GoabButton>Focus Test Button</GoabButton>}>
+          <GoabText tag="p">
+            Press Escape to close. Focus should return to the button.
+          </GoabText>
+        </GoabPopover>
+        <GoabButton type="secondary">Next Focusable Element</GoabButton>
+      </GoabBlock>
+
+      {/* Test 6: #3062 Popover maxWidth not respected above a button */}
+      <GoabText tag="h3">
+        Test 6: #3062 Popover maxWidth not respected above a button
+      </GoabText>
+      <GoabText tag="p">
+        When a Popover is placed directly above a GoabButton or GoabInput in the DOM, it
+        should still respect the maxWidth property. Both popovers below should have the
+        same width (default 320px). Previously the one above the button would ignore
+        maxWidth.
+      </GoabText>
+      <GoabBlock direction="column" gap="l">
+        <GoabPopover target={<GoabButton type="secondary">Show Popover</GoabButton>}>
+          <GoabText tag="p">
+            This popover is above the button. It should respect maxWidth (320px).
+          </GoabText>
+        </GoabPopover>
+
+        <GoabButton type="primary">Submit Form</GoabButton>
+
+        <GoabPopover
+          target={
+            <GoabButton type="secondary" size="compact">
+              Popover Test
+            </GoabButton>
+          }
+        >
+          <GoabText tag="p">
+            This popover is below the button. It should also respect maxWidth (320px).
+          </GoabText>
+        </GoabPopover>
+      </GoabBlock>
+    </div>
+  );
+}
+
+export default Feat3478Route;

--- a/libs/react-components/specs/app-header-menu.browser.spec.tsx
+++ b/libs/react-components/specs/app-header-menu.browser.spec.tsx
@@ -1,0 +1,74 @@
+import { render } from "vitest-browser-react";
+import { GoabAppHeaderMenu, GoabNotification } from "../src";
+import { expect, describe, it, vi, beforeAll } from "vitest";
+import { useState } from "react";
+import { page, userEvent } from "@vitest/browser/context";
+
+describe("AppHeaderMenu", () => {
+  // AppHeaderMenu uses goa-popover only in desktop mode (>= 1024px)
+  beforeAll(async () => {
+    await page.viewport(1280, 800);
+  });
+
+  it("should work before and after dismissing a notification banner - issue 3499", async () => {
+    const Component = () => {
+      const [showBanner, setShowBanner] = useState(true);
+
+      return (
+        <>
+          <GoabAppHeaderMenu heading="Test Menu" testId="test-menu">
+            <a href="#" data-testid="menu-item-1">
+              Menu Item 1
+            </a>
+            <a href="#" data-testid="menu-item-2">
+              Menu Item 2
+            </a>
+            <a href="#" data-testid="menu-item-3">
+              Menu Item 3
+            </a>
+          </GoabAppHeaderMenu>
+          {showBanner && (
+            <GoabNotification
+              type="information"
+              testId="test-banner"
+              onDismiss={() => setShowBanner(false)}
+            >
+              Dismiss this notification, then verify AppHeaderMenu still works.
+            </GoabNotification>
+          )}
+        </>
+      );
+    };
+
+    const result = render(<Component />);
+    const menuTrigger = result.getByText("Test Menu");
+
+    // 1. Open menu while banner is visible
+    await menuTrigger.click();
+    await vi.waitFor(() => {
+      const popoverContent = result.getByTestId("popover-content");
+      expect(popoverContent.element().checkVisibility()).toBeTruthy();
+    });
+    expect(result.getByTestId("menu-item-1").element().checkVisibility()).toBeTruthy();
+
+    // Close menu with Escape
+    await userEvent.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      const popoverContent = result.getByTestId("popover-content");
+      expect(popoverContent.element().checkVisibility()).toBeFalsy();
+    });
+
+    // 2. Dismiss the notification banner
+    const banner = result.getByTestId("test-banner");
+    const dismissButton = banner.getByRole("button");
+    await dismissButton.click();
+
+    // 3. Open menu again — should still work after banner is removed from DOM
+    await menuTrigger.click();
+    await vi.waitFor(() => {
+      const popoverContent = result.getByTestId("popover-content");
+      expect(popoverContent.element().checkVisibility()).toBeTruthy();
+    });
+    expect(result.getByTestId("menu-item-1").element().checkVisibility()).toBeTruthy();
+  });
+});

--- a/libs/react-components/specs/modal.browser.spec.tsx
+++ b/libs/react-components/specs/modal.browser.spec.tsx
@@ -1,6 +1,15 @@
 import { render } from "vitest-browser-react";
-import { GoabModal, GoabButton, GoabIcon } from "../src";
+import {
+  GoabModal,
+  GoabButton,
+  GoabIcon,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabDatePicker,
+  GoabFormItem,
+} from "../src";
 import { expect, describe, it, vi } from "vitest";
+import { userEvent } from "@vitest/browser/context";
 import { useState } from "react";
 
 describe("Modal", () => {
@@ -124,5 +133,80 @@ describe("Modal", () => {
     
     expect(testLink1.element()).toBeTruthy();
     expect(testLink2.element()).toBeTruthy();
+  });
+
+  it("should allow dropdown selection within a modal", async () => {
+    const onChange = vi.fn();
+    const Component = () => {
+      return (
+        <GoabModal
+          heading="Modal with Dropdown"
+          open={true}
+          onClose={vi.fn()}
+          testId="test-modal"
+        >
+          <GoabFormItem label="Dropdown">
+            <GoabDropdown
+              name="modal-dropdown"
+              value=""
+              testId="modal-dropdown"
+              onChange={onChange}
+            >
+              <GoabDropdownItem value="option1" label="Option 1" />
+              <GoabDropdownItem value="option2" label="Option 2" />
+              <GoabDropdownItem value="option3" label="Option 3" />
+            </GoabDropdown>
+          </GoabFormItem>
+        </GoabModal>
+      );
+    };
+
+    const result = render(<Component />);
+
+    // Click the dropdown to open it
+    const dropdown = result.getByTestId("modal-dropdown");
+    await dropdown.click();
+
+    // The dropdown popover should be visible (rendered in top layer)
+    await vi.waitFor(() => {
+      const popoverContent = result.getByTestId("popover-content");
+      expect(popoverContent.element()).toBeTruthy();
+      expect(popoverContent.element().checkVisibility()).toBeTruthy();
+    });
+  });
+
+  it("should open date picker calendar within a modal", async () => {
+    const Component = () => {
+      return (
+        <GoabModal
+          heading="Modal with DatePicker"
+          open={true}
+          onClose={vi.fn()}
+          testId="test-modal"
+        >
+          <GoabFormItem label="Date Picker">
+            <GoabDatePicker
+              name="modal-datepicker"
+              value="2026-03-19"
+              testId="modal-datepicker"
+              onChange={vi.fn()}
+            />
+          </GoabFormItem>
+        </GoabModal>
+      );
+    };
+
+    const result = render(<Component />);
+
+    // Click the calendar input to open the date picker
+    const calendarInput = result.getByTestId("calendar-input");
+    await userEvent.click(calendarInput);
+
+    // The calendar popover should be visible (rendered in top layer)
+    await vi.waitFor(() => {
+      const popoverContent = result.getByTestId("calendar-popover");
+      expect(popoverContent.element()).toBeTruthy();
+      expect(popoverContent.element().checkVisibility()).toBeTruthy();
+    });
   });
 });

--- a/libs/react-components/specs/popover.browser.spec.tsx
+++ b/libs/react-components/specs/popover.browser.spec.tsx
@@ -1,6 +1,7 @@
 import { render } from "vitest-browser-react";
 import { GoabPopover, GoabButton, GoabModal } from "../src";
 import { expect, describe, it, vi } from "vitest";
+import { userEvent } from "@vitest/browser/context";
 
 describe("Popover", () => {
   it("should allow popover to be closed via a button with a close action", async () => {
@@ -19,20 +20,16 @@ describe("Popover", () => {
     const target = result.getByTestId("target");
     const closeButton = result.getByTestId("close-button");
 
-    // Actions
-
     await target.click();
-    expect(closeButton.element()).toBeTruthy();
+    expect(closeButton).toBeVisible();
     await closeButton.click();
 
-    // Result
-
     await vi.waitFor(() => {
-      expect(closeButton.element().checkVisibility()).toBeFalsy();
+      expect(closeButton).not.toBeVisible();
     });
   });
 
-  it("should close popover when clicking on the document body", async () => {
+  it("should close popover when pressing Escape", async () => {
     const Component = () => {
       return (
         <GoabPopover target={<GoabButton testId={"target"}>Open popover</GoabButton>}>
@@ -46,26 +43,167 @@ describe("Popover", () => {
 
     const result = render(<Component />);
     const target = result.getByTestId("target");
+    const closeButton = result.getByTestId("close-button");
 
-    // Actions
+    // Open popover
     await target.click();
 
     await vi.waitFor(() => {
-      const closeButton = result.getByTestId("close-button");
-      expect(closeButton.element().checkVisibility()).toBeTruthy();
+      expect(closeButton).toBeVisible();
     });
 
-    document.body.click(); // Simulate click on document body
+    // Press Escape to close (native popover light dismiss)
+    await userEvent.keyboard("{Escape}");
 
-    // Result
     await vi.waitFor(() => {
-      const closeButton = result.getByTestId("close-button");
-      expect(closeButton.element().checkVisibility()).toBeFalsy();
+      expect(closeButton).not.toBeVisible();
     });
   });
 
+  it("should return focus to trigger after closing with Escape - issue3067", async () => {
+    const Component = () => {
+      return (
+        <GoabPopover
+          target={<GoabButton testId={"focus-target"}>Focus Test Button</GoabButton>}
+        >
+          <p>Popover content</p>
+        </GoabPopover>
+      );
+    };
+
+    const result = render(<Component />);
+    const target = result.getByTestId("focus-target");
+    const popoverContent = result.getByTestId("popover-content");
+    const popoverTarget = result.getByTestId("popover-target");
+
+    // Open popover
+    await target.click();
+    await vi.waitFor(() => {
+      expect(popoverContent).toBeVisible();
+    });
+
+    // Close with Escape
+    await userEvent.keyboard("{Escape}");
+    await vi.waitFor(() => {
+      expect(popoverContent).not.toBeVisible();
+    });
+
+    // Focus should be on the popover target button
+    await vi.waitFor(() => {
+      expect(popoverTarget.element().matches(":focus-within")).toBeTruthy();
+    });
+  });
+
+  it("should close Popover A when Popover B is opened (popover='auto' behavior)", async () => {
+    const Component = () => {
+      return (
+        <>
+          <GoabPopover
+            testId="popover-a"
+            target={<GoabButton testId={"target-a"}>Popover A</GoabButton>}
+          >
+            <p data-testid="content-a">Content A</p>
+          </GoabPopover>
+          <GoabPopover
+            testId="popover-b"
+            target={<GoabButton testId={"target-b"}>Popover B</GoabButton>}
+          >
+            <p data-testid="content-b">Content B</p>
+          </GoabPopover>
+        </>
+      );
+    };
+
+    const result = render(<Component />);
+    const targetA = result.getByTestId("target-a");
+    const targetB = result.getByTestId("target-b");
+    const contentA = result.getByTestId("content-a");
+    const contentB = result.getByTestId("content-b");
+
+    // Open Popover A
+    await targetA.click();
+    await vi.waitFor(() => {
+      expect(contentA).toBeVisible();
+    });
+
+    // Open Popover B — should auto-close Popover A
+    await targetB.click();
+    await vi.waitFor(() => {
+      expect(contentB).toBeVisible();
+      expect(contentA).not.toBeVisible();
+    });
+  });
+
+  it("should respect maxWidth when popover is placed above a button - issue3062", async () => {
+    const Component = () => {
+      return (
+        <>
+          <GoabPopover
+            testId="popover-above"
+            maxWidth="320px"
+            target={
+              <GoabButton testId={"target-above"} type="secondary">
+                Show Popover
+              </GoabButton>
+            }
+          >
+            <p>This popover is above the button. It should respect maxWidth (320px).</p>
+          </GoabPopover>
+
+          <GoabButton type="primary">Submit Form</GoabButton>
+
+          <GoabPopover
+            testId="popover-below"
+            maxWidth="320px"
+            target={
+              <GoabButton testId={"target-below"} type="secondary" size="compact">
+                Popover Test
+              </GoabButton>
+            }
+          >
+            <p>
+              This popover is below the button. It should also respect maxWidth (320px).
+            </p>
+          </GoabPopover>
+        </>
+      );
+    };
+
+    const result = render(<Component />);
+    const targetAbove = result.getByTestId("target-above");
+    const targetBelow = result.getByTestId("target-below");
+    const popoverAbove = result.getByTestId("popover-above");
+    const popoverBelow = result.getByTestId("popover-below");
+
+    // Open popover above the button
+    await targetAbove.click();
+
+    let aboveWidth: number;
+    const contentAbove = popoverAbove.getByTestId("popover-content");
+    await vi.waitFor(() => {
+      expect(contentAbove).toBeVisible();
+      aboveWidth = contentAbove.element().getBoundingClientRect().width;
+    });
+
+    // Close it
+    await userEvent.keyboard("{Escape}");
+
+    // Open popover below the button
+    await targetBelow.click();
+
+    let belowWidth: number;
+    const contentBelow = popoverBelow.getByTestId("popover-content");
+    await vi.waitFor(() => {
+      expect(contentBelow).toBeVisible();
+      belowWidth = contentBelow.element().getBoundingClientRect().width;
+    });
+
+    // Both popovers should have the same width (maxWidth respected equally)
+    expect(aboveWidth!).toBe(belowWidth!);
+  });
+
   describe("Popover within a modal", () => {
-    it("should open the popover downwards within a modal if content exceeds available space", async () => {
+    it("should open the popover within a modal even with long content", async () => {
       const Component = () => {
         const longContent = Array.from({ length: 50 }, (_, i) => (
           <p key={i}>This is line {i + 1} of the popover content.</p>
@@ -75,9 +213,7 @@ describe("Popover", () => {
           <GoabModal
             heading="Scrollable Modal"
             open={true}
-            onClose={() => {
-              console.log("Does nothing in this test");
-            }}
+            onClose={vi.fn()}
             testId="test-modal"
           >
             <GoabPopover
@@ -85,9 +221,7 @@ describe("Popover", () => {
               target={<GoabButton testId={"target"}>Open popover</GoabButton>}
             >
               <div style={{ minHeight: "300px" }}>{longContent}</div>
-              <GoabButton testId={"open-popover-button"} action={"close"}>
-                Close
-              </GoabButton>
+              <GoabButton action={"close"}>Close</GoabButton>
             </GoabPopover>
           </GoabModal>
         );
@@ -95,12 +229,12 @@ describe("Popover", () => {
 
       const result = render(<Component />);
       const target = result.getByTestId("target");
+      const popoverContent = result.getByTestId("popover-content");
+
       await target.click();
 
       await vi.waitFor(() => {
-        const popoverContentEl = result.getByTestId("popover-content");
-        expect(popoverContentEl.element()).toBeTruthy();
-        expect(popoverContentEl.element().style.bottom).toBe("");
+        expect(popoverContent).toBeVisible();
       });
     });
 
@@ -110,9 +244,7 @@ describe("Popover", () => {
           <GoabModal
             heading="Scrollable Modal"
             open={true}
-            onClose={() => {
-              console.log("Does nothing in this test");
-            }}
+            onClose={vi.fn()}
             testId="test-modal"
           >
             <div style={{ height: "400px" }}>
@@ -132,9 +264,7 @@ describe("Popover", () => {
                 <div style={{ minHeight: "200px" }}>
                   <p>Popover Content</p>
                 </div>
-                <GoabButton testId={"open-popover-button"} action={"close"}>
-                  Close
-                </GoabButton>
+                <GoabButton action={"close"}>Close</GoabButton>
               </GoabPopover>
               <p>Space Below</p>
             </div>
@@ -144,13 +274,12 @@ describe("Popover", () => {
 
       const result = render(<Component />);
       const target = result.getByTestId("target");
+      const popoverContent = result.getByTestId("popover-content");
+
       await target.click();
 
       await vi.waitFor(() => {
-        const popoverContentEl = result.getByTestId("popover-content");
-        expect(popoverContentEl.element()).toBeTruthy();
-        // It should be a number ending with px when opening upwards
-        expect(popoverContentEl.element().style.top).toMatch(/-?\d+px/);
+        expect(popoverContent).toBeVisible();
       });
     });
 
@@ -160,9 +289,7 @@ describe("Popover", () => {
           <GoabModal
             heading="Scrollable Modal"
             open={true}
-            onClose={() => {
-              console.log("Does nothing in this test");
-            }}
+            onClose={vi.fn()}
             testId="test-modal"
           >
             <div style={{ height: "400px" }}>
@@ -176,9 +303,7 @@ describe("Popover", () => {
                 <div style={{ minHeight: "200px" }}>
                   <p>Popover Content</p>
                 </div>
-                <GoabButton testId={"open-popover-button"} action={"close"}>
-                  Close
-                </GoabButton>
+                <GoabButton action={"close"}>Close</GoabButton>
               </GoabPopover>
               <p>Space Below</p>
               <p>Space Below</p>
@@ -193,13 +318,12 @@ describe("Popover", () => {
 
       const result = render(<Component />);
       const target = result.getByTestId("target");
+      const popoverContent = result.getByTestId("popover-content");
+
       await target.click();
 
       await vi.waitFor(() => {
-        const popoverContentEl = result.getByTestId("popover-content");
-        expect(popoverContentEl.element()).toBeTruthy();
-        // bottom should be set to 'auto' when opening downwards
-        expect(popoverContentEl.element().style.bottom).toBe("");
+        expect(popoverContent).toBeVisible();
       });
     });
   });

--- a/libs/web-components/src/components/calendar/Calendar.svelte
+++ b/libs/web-components/src/components/calendar/Calendar.svelte
@@ -337,7 +337,6 @@
     >
       <goa-dropdown
         name="month"
-        disable-global-close-popover="yes"
         arialabel={`${name} month`}
         data-testid="months"
         width="160px"
@@ -361,7 +360,6 @@
     >
       <goa-dropdown
         name="year"
-        disable-global-close-popover="yes"
         arialabel={`${name} year`}
         data-testid="years"
         width="104px"

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -1,13 +1,7 @@
 <svelte:options
   customElement={{
     tag: "goa-dropdown",
-    props: {
-      disableGlobalClosePopover: {
-        type: "Boolean",
-        reflect: true,
-        attribute: "disable-global-close-popover",
-      },
-    },
+    props: {},
   }}
 />
 
@@ -99,12 +93,6 @@
   export let autocomplete: string = "";
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
-
-  // Exposed Privates
-
-  /** Prevents the popover from closing when clicking outside. Used for nested dropdowns or complex interactions. */
-  export let disableGlobalClosePopover: boolean = false;
-
   //
   // Private
 
@@ -176,9 +164,6 @@
     sendMountedMessage();
     setupPopoverListeners();
 
-    if (disableGlobalClosePopover) {
-      _popoverEl.setAttribute("disable-global-close-popover", "yes");
-    }
     _eventHandler = _filterable
       ? new ComboboxKeyUpHandler(_inputEl)
       : new DropdownKeyUpHandler(_inputEl);
@@ -824,7 +809,7 @@
           <goa-icon
             class="dropdown-input--leading-icon"
             data-testid="leading-icon"
-              size={size === "compact" ? "small" : "medium"}
+            size={size === "compact" ? "small" : "medium"}
             type={leadingicon}
           />
         {/if}
@@ -1048,7 +1033,10 @@
 
   /** menu **/
   ul[role="listbox"] {
-    border-radius: var(--goa-dropdown-menu-border-radius, var(--goa-dropdown-border-radius));
+    border-radius: var(
+      --goa-dropdown-menu-border-radius,
+      var(--goa-dropdown-border-radius)
+    );
     padding: 0;
     margin: var(--goa-dropdown-menu-margin, 0);
   }
@@ -1066,7 +1054,6 @@
     overflow-wrap: break-word; /* Alternative for word wrapping */
     border-radius: var(--goa-dropdown-item-border-radius, 0);
   }
-
 
   .dropdown-item:hover,
   .dropdown-item--highlighted {

--- a/libs/web-components/src/components/menu-button/MenuButton.svelte
+++ b/libs/web-components/src/components/menu-button/MenuButton.svelte
@@ -157,7 +157,6 @@
   padded="false"
   tabindex="-1"
   maxwidth={maxWidth || "none"}
-  prevent-scroll-into-view={true}
 >
   {#if text}
     <goa-button

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -3,30 +3,19 @@
     tag: "goa-popover",
     props: {
       open: { reflect: true, type: "String" },
-      disableGlobalClosePopover: {
-        reflect: true,
-        type: "Boolean",
-        attribute: "disable-global-close-popover",
-      },
-      preventScrollIntoView: {
-        attribute: "prevent-scroll-into-view",
-        type: "Boolean",
-      },
     },
   }}
 />
 
-<!-- Script -->
 <script lang="ts">
-  import { onMount, tick } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { calculateMargin } from "../../common/styling";
   import {
+    dispatch,
+    generateRandomId,
     style,
-    getSlottedChildren,
     styles,
     toBoolean,
-    dispatch,
-    isPointInRectangle,
   } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
 
@@ -44,19 +33,12 @@
   export let width: string = "";
   /** Controls the height behavior. 'full' stretches to parent height, 'wrap-content' fits content. */
   export let height: "full" | "wrap-content" = "wrap-content";
-
-  /** Prevents scrolling into view when focus trap is activated. Passed to FocusTrap. */
-  export let preventScrollIntoView: boolean = false;
-
   /** Sets if the popover has padding. Use false when content needs to be flush with boundaries. */
   export let padded: string = "true";
-
   /** Sets the tabindex. Use -1 to skip tabbing when a parent handles keyboard events. */
   export let tabindex: number = 0;
-
   /** @deprecated This property has no effect and will be removed in a future version. */
   export let relative: string = "";
-
   /** Top margin. */
   export let mt: Spacing = null;
   /** Right margin. */
@@ -67,76 +49,67 @@
   export let ml: Spacing = null;
 
   // Exposed privates - used internally by other components
-
-  /** @internal Prevents the popover from closing when other popovers open. */
-  export let disableGlobalClosePopover: boolean = false;
-
-  /** Controls whether the popover is open or closed. Used by parent components like AppHeaderMenu. */
+  /** Controls the open state of the popover programmatically. Used by Dropdown, AppHeaderMenu. */
   export let open: string = "false";
-
   /** Disables the popover interaction. Used by parent components like Dropdown. */
   export let disabled: string = "false";
-
   /** Additional vertical offset added to the popover's position. */
   export let voffset = "";
-
   /** Additional horizontal offset added to the popover's position. */
   export let hoffset = "";
-
   /** Width of the focus outline border. */
   export let focusborderwidth = "var(--goa-border-width-l)";
-
   /** Border radius of the popover window. */
   export let borderradius = "var(--goa-border-radius-m)";
-
-  /** @internal When true, clicking inside the popover will close it. */
-  export let closeOnClickWithinBounds = false;
-
   /** Indicates the popover is used within a filterable context like a combobox. */
   export let filterablecontext: string = "false";
 
   // Private
-
   let _rootEl: HTMLElement;
-  let _targetEl: HTMLElement;
   let _popoverEl: HTMLElement;
-  let _focusTrapEl: HTMLElement;
-  // the closest parent parent Container element (i.e. <goa-modal>), if one
-  // doesn't exist it is null. Used to determine popover position.
-  let _parentContainerEl: HTMLElement | null = null;
-  let _sectionHeight: number;
-  let _contentFitsWidth: boolean = false;
 
   // Reactive
+  let _targetEl: HTMLElement;
+  let _isOpen = false;
+  let _autoPosition: "above" | "below" = "below";
+  const _popoverId = `goa-popover-${generateRandomId()}`;
 
-  $: _padded = toBoolean(padded);
-  $: _open = toBoolean(open);
   $: _disabled = toBoolean(disabled);
+  $: _padded = toBoolean(padded);
   $: _filterableContext = toBoolean(filterablecontext);
 
-  $: (async () => _open && (await setPopoverPosition()))();
-  $: (async () => _sectionHeight && (await setPopoverPosition()))();
+  $: syncPopoverOpenState(_popoverEl, open);
+
+  function syncPopoverOpenState(
+    popoverEl: HTMLElement | undefined,
+    openProp: string,
+  ) {
+    if (!popoverEl) return;
+
+    const shouldBeOpen = toBoolean(openProp);
+    const actuallyOpen = isPopoverOpen();
+
+    if (shouldBeOpen && !actuallyOpen) {
+      popoverEl.showPopover();
+    } else if (!shouldBeOpen && actuallyOpen) {
+      popoverEl.hidePopover();
+    }
+  }
+
+  // Close the popover on URL changes (e.g. clicking a link inside the popover)
   $: {
-    if (_open) {
+    if (_isOpen) {
       window.addEventListener("popstate", handleUrlChange, true);
     } else {
       window.removeEventListener("popstate", handleUrlChange, true);
     }
   }
 
-  // Hooks
-
-  onMount(async () => {
-    await tick();
-
-    // to make the popover content fit its contents instead of the target width
-    const hostElement = _rootEl?.getRootNode() as ShadowRoot;
-    _contentFitsWidth =
-      hostElement?.host?.getAttribute("data-content-fits-width") === "true";
+  onMount(() => {
+    _popoverEl?.addEventListener("toggle", handleNativeToggle);
 
     // add keybinding to open the popover
-    _targetEl.addEventListener("keydown", onTargetEvent);
-
+    _targetEl?.addEventListener("keydown", onTargetEvent);
     // listener for `close` events emitted from child components
     _rootEl.addEventListener("close", (e) => {
       closePopover();
@@ -145,55 +118,30 @@
 
     showDeprecationWarnings();
     addGlobalCloseListener();
+    window.addEventListener("resize", updateAutoPosition);
+  });
 
-    _parentContainerEl = findContainingParentElement(_rootEl);
+  onDestroy(() => {
+    window.removeEventListener("resize", updateAutoPosition);
+    // true was passed when the listener was added, so it's necesary to be passed here as well
+    window.removeEventListener("popstate", handleUrlChange, true);
   });
 
   // Functions
 
-  function findContainingParentElement(
-    rootEl: HTMLElement,
-  ): HTMLElement | null {
-    const containingParentNodeNames = ["GOA-MODAL"];
-
-    let parentNode: HTMLElement = rootEl;
-    while (parentNode) {
-      if (containingParentNodeNames.includes(parentNode.nodeName)) {
-        return parentNode;
-      }
-      parentNode = parentNode.parentNode as HTMLElement;
-      if (parentNode && (parentNode as unknown as { host: HTMLElement }).host) {
-        parentNode = (parentNode as unknown as { host: HTMLElement }).host;
-      }
+  function isPopoverOpen(): boolean {
+    try {
+      return _popoverEl.matches(":popover-open");
+    } catch {
+      return _popoverEl.getAttribute("data-popover-open") === "true";
     }
-
-    return null;
-  }
-
-  // Since the focused element is being changed when the popover is open, the scoped keybinding for the escape key may
-  // no longer work, so the binding must be done on the document.body
-  function addGlobalEscapeKeybinding() {
-    document.body.addEventListener("keydown", handleGlobalEscapeKeybinding);
-  }
-
-  function handleGlobalEscapeKeybinding(e: KeyboardEvent) {
-    if (e.key === "Escape") {
-      if (_open) {
-        closePopover();
-      }
-      e.stopPropagation();
-    }
-  }
-
-  function removeGlobalEscapeKeybinding() {
-    document.body.removeEventListener("keydown", handleGlobalEscapeKeybinding);
   }
 
   // When one popover is opened it dispatches a `goa:closePopover` to the document.body element, so adding a listener
   // here will allow any other popover that is currently open to be closed
   function addGlobalCloseListener() {
     document.body.addEventListener("goa:closePopover", (e: Event) => {
-      if (!_open) {
+      if (!_isOpen) {
         return;
       }
 
@@ -208,7 +156,7 @@
   }
 
   function showDeprecationWarnings() {
-    if (relative != "") {
+    if (relative !== "") {
       console.warn(
         "Popover `relative` property is deprecated. It should be removed from your code because it is no longer needed to help with positioning.",
       );
@@ -218,243 +166,89 @@
   // Called on window popstate changes. This allows for clicking links within
   // the popover to close the popover
   function handleUrlChange(_e: Event) {
-    closePopover();
+    if (_popoverEl && isPopoverOpen()) {
+      _popoverEl.hidePopover();
+    }
   }
 
-  // Handles events when the targetEl has focus
   function onTargetEvent(e: KeyboardEvent) {
     switch (e.key) {
       case " ":
         if (_filterableContext) {
           break;
         }
-        // case "Enter":
-        openPopover();
+        // Prevent the button's native click from firing on Space keyup,
+        // which would immediately toggle the popover closed again.
+        e.preventDefault();
+        if (!_isOpen) {
+          _popoverEl?.showPopover();
+        }
         e.stopPropagation();
         break;
     }
   }
 
-  // Opens the popover and adds the required binding to the new slot element
-  function openPopover() {
-    if (_disabled) return;
-
-    // close any other open popovers
-    if (!disableGlobalClosePopover) {
-      dispatch(document.body, "goa:closePopover", { target: _targetEl });
-    }
-
-    // open this popover
-    _open = true;
-
-    addGlobalEscapeKeybinding();
-    // keep current tab within the bounds of the wrapping focustrap component
-    // _focusTrapEl.addEventListener("keydown", onFocusTrapEvent, true);
-
-    // notify parent components of the status change
-    dispatch(_rootEl, "_open");
-
-    // find the element that will have initial focus when the popover is shown
-    setTimeout(() => {
-      const firstFocusableEl = getFirstFocusableEl(_focusTrapEl);
-      firstFocusableEl?.focus();
-    }, 0);
-
-    document.body.addEventListener("click", handleClick);
-  }
-
-  /**
-   * Recursively retrieves the first focusable element within a given HTML element.
-   * A focusable element is determined by having a non-negative tabIndex.
-   *
-   * @param {HTMLElement} el - The root HTML element to search within for focusable elements.
-   * @return {HTMLElement | null} - Returns the first focusable HTML element found within the given element,
-   * or null if no focusable element is found.
-   */
-  function getFirstFocusableEl(el: HTMLElement): HTMLElement | null {
-    if (el.tabIndex >= 0) {
-      return el;
-    }
-    const children = [
-      ...el.children,
-      ...getSlottedChildren(el),
-      el.shadowRoot,
-    ].filter(Boolean) as HTMLElement[];
-    for (const child of children) {
-      const firstFocusable = getFirstFocusableEl(child);
-      if (firstFocusable) {
-        return firstFocusable;
-      }
-    }
-    return null;
-  }
-
-  function handleClick(e: MouseEvent) {
-    e.stopPropagation();
-
-    if (!_popoverEl) return;
-
-    const rect = _popoverEl.getBoundingClientRect();
-    const clickedInPopover = isPointInRectangle(
-      e.clientX,
-      e.clientY,
-      rect.x,
-      rect.y,
-      rect.width,
-      rect.height,
-    );
-    const onlyCloseWhenClickedOutside = !closeOnClickWithinBounds;
-
-    // keep open on click
-    if (onlyCloseWhenClickedOutside && clickedInPopover) {
-      return;
-    }
-
-    if (_open) {
-      closePopover();
-    }
-  }
-
-  // Ensures that upon closing of the popover that the element that triggered
-  // the popover to be shown re-attains focus and that any window event binding
-  // is removed (it may not have been added if target was clicked)
-  function closePopover() {
-    if (!_open) {
-      return;
-    }
-
-    if (!_rootEl || !_targetEl || !_popoverEl) {
-      return;
-    }
-
-    _open = false;
-
-    removeGlobalEscapeKeybinding();
-
-    window.removeEventListener("popstate", handleUrlChange, true);
-    dispatch(_rootEl, "_close");
-    _targetEl.focus();
-
-    document.body.removeEventListener("click", handleClick);
-  }
-
-  function togglePopover(e: Event) {
-    _open ? closePopover() : openPopover();
-    e.stopPropagation();
-  }
-
-  function getBoundingClientRectWithMargins(
-    el: Element,
-  ): Omit<DOMRect, "toJSON"> {
-    const rect = el.getBoundingClientRect();
-    const style = window.getComputedStyle(el);
-    const mTop = parseInt(style.marginTop, 10) || 0;
-    const mRight = parseInt(style.marginRight, 10) || 0;
-    const mBottom = parseInt(style.marginBottom, 10) || 0;
-    const mLeft = parseInt(style.marginLeft, 10) || 0;
-
-    return {
-      top: rect.top - mTop,
-      right: rect.right + mRight,
-      bottom: rect.bottom + mBottom,
-      left: rect.left - mLeft,
-      width: rect.width + mLeft + mRight,
-      height: rect.height + mTop + mBottom,
-      x: rect.x - mLeft,
-      y: rect.y - mTop,
-    };
-  }
-
-  function getParentContentElement() {
-    if (!_parentContainerEl) return null;
-
-    let contentEl: HTMLElement | null = null;
-
-    switch (_parentContainerEl.nodeName) {
-      case "GOA-MODAL":
-        // Assuming parent is <goa-modal>, the content element is the div with class
-        // "modal-pane" within the modal's shadow DOM
-        contentEl =
-          _parentContainerEl.shadowRoot?.querySelector("div.modal-pane") ||
-          null;
-        break;
-      default:
-        console.error(
-          "Unhandled parent container type: ",
-          _parentContainerEl.nodeName,
-        );
-    }
-
-    if (!contentEl) {
-      // If a CSS or structural DOM change was made to the parent container, the
-      // query selector in the switch above must also be updated. (i.e. if the
-      // "modal-pane" class was removed or changed)
-      console.error(
-        "Could not find content element within parent container. Popover positioning may be incorrect.",
-      );
-    }
-
-    return contentEl;
-  }
-
-  async function setPopoverPosition() {
-    await tick();
-
-    // Get target and content rectangles
-    const isWithinModal = !!_parentContainerEl;
-    const targetRect = getBoundingClientRectWithMargins(_targetEl);
-    const parentContainerContentEl = getParentContentElement();
-    const parentContainerRect = !!parentContainerContentEl
-      ? getBoundingClientRectWithMargins(parentContainerContentEl)
-      : null;
-
-    const popoverRect = getBoundingClientRectWithMargins(_popoverEl);
-    const offsetParent = _popoverEl.offsetParent as HTMLElement | null;
-    const offsetParentTop = offsetParent?.getBoundingClientRect().top || 0;
-
-    // exit if the popover hasn't yet been filled
-    if (popoverRect.height < 20) return;
-
-    // Calculate available space above and below the target element
-    const spaceAbove =
-      isWithinModal && parentContainerRect
-        ? targetRect.top - parentContainerRect.top
-        : targetRect.top;
-    const spaceBelow =
-      isWithinModal && parentContainerRect
-        ? parentContainerRect.bottom - targetRect.bottom
-        : window.innerHeight - targetRect.bottom;
-
-    // Determine if there's more space above or below the target element
-    const displayOnTop =
-      position === "auto"
-        ? spaceBelow < popoverRect.height && // Not enough room below the target
-          spaceAbove > popoverRect.height && // Enough room above the target
-          spaceAbove > spaceBelow // More space above than below
-        : position === "above";
-
-    if (displayOnTop) {
-      const topPos = targetRect.top - popoverRect.height - offsetParentTop;
-      _popoverEl.style.top = `${topPos}px`;
+  function handleNativeToggle(e: Event) {
+    const toggleEvent = e as Event & { newState?: "open" | "closed" };
+    if (toggleEvent.newState === "open") {
+      _isOpen = true;
+    } else if (toggleEvent.newState === "closed") {
+      _isOpen = false;
     } else {
-      // Clear top/bottom to keep default below-target static positioning.
-      _popoverEl.style.top = "";
-      _popoverEl.style.bottom = "";
+      _isOpen = isPopoverOpen();
     }
 
-    // Move the popover to the left if it is too far to the right and only if there is space to the left
-    const rightAligned =
-      document.body.clientWidth - targetRect.left < popoverRect.width &&
-      targetRect.left > popoverRect.width;
+    open = _isOpen ? "true" : "false";
 
-    if (rightAligned) {
-      _popoverEl.style.right = "0";
-      _popoverEl.style.left = "";
+    // Dispatch _open/_close events for consumer components
+    // (MenuButton, AppHeader, AppHeaderMenu, Dropdown)
+    if (_isOpen) {
+      dispatch(_rootEl, "_open");
+      requestAnimationFrame(updateAutoPosition); // same vs await tick(), make sure popover element is fully rendered before we measure its dimension
+    } else {
+      _targetEl.focus();
+      dispatch(_rootEl, "_close");
     }
+  }
+
+  function closePopover() {
+    if (_isOpen) {
+      _popoverEl?.hidePopover(); // browser will fire and trigger handleNativeToggle
+    }
+  }
+
+  function togglePopover(e: MouseEvent) {
+    e.stopPropagation();
+    if (_disabled || !_popoverEl) {
+      return;
+    }
+
+    if (_isOpen) {
+      _popoverEl.hidePopover();
+      _isOpen = false;
+    } else {
+      _popoverEl.showPopover();
+      _isOpen = true;
+      requestAnimationFrame(updateAutoPosition);
+    }
+  }
+
+  function updateAutoPosition() {
+    if (position !== "auto" || !_isOpen || !_targetEl || !_popoverEl) {
+      return;
+    }
+
+    const targetRect = _targetEl.getBoundingClientRect();
+    const popoverRect = _popoverEl.getBoundingClientRect();
+    const spaceAbove = targetRect.top;
+    const spaceBelow = window.innerHeight - targetRect.bottom;
+
+    _autoPosition =
+      spaceBelow < popoverRect.height && spaceAbove > spaceBelow
+        ? "above"
+        : "below";
   }
 </script>
-
-<!-- HTML -->
 
 <div
   bind:this={_rootEl}
@@ -475,7 +269,10 @@
   <button
     class="popover-target"
     bind:this={_targetEl}
+    aria-haspopup="dialog"
+    aria-controls={_popoverId}
     {tabindex}
+    disabled={_disabled}
     on:click={togglePopover}
     on:keyup={(e) => {
       e.preventDefault();
@@ -485,38 +282,28 @@
     <slot name="target" />
   </button>
 
-  <div style={styles(style("display", _open ? "block" : "none"))}>
-    <section
-      bind:clientHeight={_sectionHeight}
-      bind:this={_popoverEl}
-      data-testid="popover-content"
-      class="popover-content"
-      style={styles(
-        // For certain contexts (e.g., DatePicker) when the internal data-content-fits-width
-        // attribute is set, the content width is set to fit-content instead of inheriting the target width.
-        style("width", _contentFitsWidth ? "fit-content" : width),
-        style("min-width", minwidth),
-        style(
-          "max-width",
-          _contentFitsWidth
-            ? maxwidth
-            : width
-              ? `max(${width}, ${maxwidth})`
-              : maxwidth,
-        ),
-        style("padding", _padded ? "var(--goa-space-m)" : "0"),
-      )}
-    >
-      <goa-focus-trap
-        open="true"
-        prevent-scroll-into-view={preventScrollIntoView || undefined}
-      >
-        <div bind:this={_focusTrapEl}>
-          <slot />
-        </div>
-      </goa-focus-trap>
-    </section>
-  </div>
+  <section
+    id={_popoverId}
+    popover="auto"
+    bind:this={_popoverEl}
+    data-testid="popover-content"
+    class="popover-content"
+    class:is-open={_isOpen}
+    class:position-above={position === "above" ||
+      (position === "auto" && _autoPosition === "above")}
+    class:position-below={position === "below" ||
+      (position === "auto" && _autoPosition === "below")}
+    style={styles(
+      style("width", width),
+      style("min-width", minwidth),
+      style("max-width", width ? `max(${width}, ${maxwidth})` : maxwidth),
+      style("padding", _padded ? "var(--goa-space-m)" : "0"),
+    )}
+  >
+    <goa-focus-trap open={_isOpen}>
+      <slot />
+    </goa-focus-trap>
+  </section>
 </div>
 
 <!-- Style -->
@@ -540,29 +327,46 @@
     padding: 0;
     background-color: transparent;
     width: inherit;
+    anchor-name: --goa-popover-target;
   }
 
   .popover-target:has(:focus-visible) {
-    outline: var(--goa-popover-border-focus);
+    outline: var(
+      --goa-popover-border-focus,
+      var(--focus-border-width) solid var(--goa-color-interactive-default)
+    );
   }
 
   .popover-content {
     color: var(--goa-color-text-default);
-    position: absolute;
-    z-index: 99;
     width: fit-content;
     list-style-type: none;
     background: var(--goa-popover-color-bg);
-    border-radius: var(--goa-popover-border-radius);
+    border-radius: var(--border-radius, var(--goa-popover-border-radius));
     outline: none;
     overflow: visible;
     box-shadow: var(--goa-popover-box-shadow, none);
     filter: var(--goa-popover-shadow, none);
     border: var(--goa-popover-border, none);
-    margin-top: var(--offset-top, 3px);
-    margin-bottom: var(--offset-bottom, 3px);
-    margin-left: var(--offset-left, 0);
-    margin-right: var(--offset-right, 0);
+    margin: 0;
+
+    position-anchor: --goa-popover-target;
+    inset-block-start: anchor(bottom);
+    inset-inline-start: anchor(left);
+    --popover-translate-x: var(--offset-left, 0);
+    --popover-translate-y: var(--offset-top, 3px);
+    translate: var(--popover-translate-x) var(--popover-translate-y);
+  }
+
+  .popover-content.position-above {
+    inset-block-start: anchor(top);
+    --popover-translate-y: calc(-100% - var(--offset-bottom, 3px));
+    position-try-fallbacks: none;
+  }
+
+  .popover-content.position-below {
+    inset-block-start: anchor(bottom);
+    --popover-translate-y: var(--offset-top, 3px);
   }
 
   :global(::slotted(ul)) {

--- a/libs/web-components/src/components/popover/popover.spec.ts
+++ b/libs/web-components/src/components/popover/popover.spec.ts
@@ -17,7 +17,7 @@ describe("Popover", () => {
     const slotContent = result.queryByTestId("popover-content");
     const slotTarget = result.queryByTestId("popover-target");
 
-    expect(slotContent?.parentElement?.style.display).toBe("none");
+    expect(slotContent?.classList.contains("is-open")).toBe(false);
     expect(slotTarget).toBeTruthy();
   });
 
@@ -28,12 +28,83 @@ describe("Popover", () => {
 
     target && (await user.click(target));
     const popOverContent = result.queryByTestId("popover-content");
-    expect(popOverContent?.parentElement?.style.display).not.toBe("none");
+    expect(popOverContent?.classList.contains("is-open")).toBe(true);
 
     const style = popOverContent?.getAttribute("style");
     expect(style).toContain("min-width: 8rem");
     expect(style).toContain("max-width: 16rem");
     expect(style).toContain("padding: var(--goa-space-m)");
+  });
+
+  it("should close content when target is clicked again", async () => {
+    const result = render(Popover);
+    const target = result.queryByTestId("popover-target");
+
+    // open
+    target && (await user.click(target));
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(true);
+
+    // close
+    target && (await user.click(target));
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(false);
+  });
+
+  it("should open when open prop is set to true", async () => {
+    const result = render(Popover, { open: "true" });
+    const popoverContent = result.queryByTestId("popover-content");
+
+    expect(popoverContent?.classList.contains("is-open")).toBe(true);
+  });
+
+  it("should close when open prop changes from true to false", async () => {
+    const result = render(Popover, { open: "true" });
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(true);
+
+    await result.rerender({ open: "false" });
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(false);
+  });
+
+  it("should dispatch _open event when popover opens", async () => {
+    const result = render(Popover);
+    const rootEl = result.queryByTestId("popover");
+    const target = result.queryByTestId("popover-target");
+
+    const openHandler = vi.fn();
+    rootEl?.addEventListener("_open", openHandler);
+
+    target && (await user.click(target));
+    expect(openHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("should dispatch _close event when popover closes", async () => {
+    const result = render(Popover);
+    const rootEl = result.queryByTestId("popover");
+    const target = result.queryByTestId("popover-target");
+
+    const closeHandler = vi.fn();
+    rootEl?.addEventListener("_close", closeHandler);
+
+    // open then close
+    target && (await user.click(target));
+    target && (await user.click(target));
+    expect(closeHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not open on space key when disabled", async () => {
+    const result = render(Popover, { disabled: "true" });
+    const target = result.queryByTestId("popover-target");
+
+    target?.focus();
+    await user.keyboard(" ");
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(false);
+  });
+
+  it("should apply explicit placement classes", async () => {
+    const result = render(Popover, { position: "above" });
+    const popoverContent = result.queryByTestId("popover-content") as HTMLElement;
+
+    expect(popoverContent.classList.contains("position-above")).toBe(true);
+    expect(popoverContent.classList.contains("position-auto")).toBe(false);
   });
 
   it("should not close content when clicked focusable target then click focusable content inside the content container", async () => {
@@ -45,16 +116,16 @@ describe("Popover", () => {
 
     const target = result.queryByTestId("clickable-target");
     expect(target).toBeTruthy();
-    expect(result.queryByTestId("popover-content")?.parentElement?.style.display).toBe("none");
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(false);
 
     // click on focusable element within popover target
     target && (await user.click(target));
-    expect(result.queryByTestId("popover-content")?.parentElement?.style.display).not.toBe("none");
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(true);
 
     // click on focusable content inside popover content
     const button = result.queryByTestId("clickable-content");
     button && (await user.click(button));
-    expect(result.queryByTestId("popover-content")?.parentElement?.style.display).not.toBe("none");
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(true);
   });
 
   it("should not close content when clicked non-focusable target then click non-focusable content inside the content container", async () => {
@@ -66,17 +137,17 @@ describe("Popover", () => {
 
     const target = result.queryByTestId("non-focusable-target");
     expect(target).toBeTruthy();
-    expect(result.queryByTestId("popover-content")?.parentElement?.style.display).toBe("none");
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(false);
 
     // click on non-focusable element within popover target
     target && (await user.click(target));
-    expect(result.queryByTestId("popover-content")?.parentElement?.style.display).not.toBe("none");
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(true);
 
     // click on non-focusable content within popover content
     const contentNonfocusableEl = result.queryByTestId("non-focusable-content");
     expect(contentNonfocusableEl?.tabIndex).toBe(-1);
 
     contentNonfocusableEl && (await user.click(contentNonfocusableEl));
-    expect(result.queryByTestId("popover-content")?.parentElement?.style.display).not.toBe("none");
+    expect(result.queryByTestId("popover-content")?.classList.contains("is-open")).toBe(true);
   });
 })

--- a/vitest.web-component.setup.ts
+++ b/vitest.web-component.setup.ts
@@ -14,3 +14,30 @@ console.error = (...params) => {
     originalConsoleError(...params);
   }
 };
+
+// jsdom does not implement the HTML Popover API yet.
+if (!HTMLElement.prototype.showPopover) {
+  Object.defineProperty(HTMLElement.prototype, "showPopover", {
+    configurable: true,
+    writable: true,
+    value() {
+      this.setAttribute("data-popover-open", "true");
+      this.dispatchEvent(
+        Object.assign(new Event("toggle"), { newState: "open", oldState: "closed" }),
+      );
+    },
+  });
+}
+
+if (!HTMLElement.prototype.hidePopover) {
+  Object.defineProperty(HTMLElement.prototype, "hidePopover", {
+    configurable: true,
+    writable: true,
+    value() {
+      this.removeAttribute("data-popover-open");
+      this.dispatchEvent(
+        Object.assign(new Event("toggle"), { newState: "closed", oldState: "open" }),
+      );
+    },
+  });
+}


### PR DESCRIPTION
# Before (the change)

Before we had a very extensive Popover component that was used in so many places. It had to be jury rigged to fit into so many situations, and often when fixing a problem with one component, two more were created elsewhere. This created a component that was essentially impossible to maintain and keep up.

# After (the change)

The component has been completely re-written using the HTML Popover API paired with the CSS Anchor Positioning API.

[CSS Anchor Positioning browser support](https://caniuse.com/?search=Anchor+Positioning)
[HTML Popover browser support](https://caniuse.com/?search=Popover)

This sees a reduction in lines of about 250 lines of code. This obviously removes a lot of functionality, further testing will need to happen to determine what may or may not need to be added back. But one thing this gives us is, we no longer need to calculate anything in regards to positioning.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Extra work needed to happen to support this feature in our tests, because jsdom doesn't have support for the Popover API just yet. No idea when it's going to be added, there is a [feature request](https://github.com/jsdom/jsdom/issues/3721) for it though.

This has not been adequately tested, nor has proper test PR's been written for this yet. This is merely an idea, it is not meant to be used just yet. If we want to go forward with this, then I can write actual test PR's for this.
