### PR TITLE
fix(#3493): show tooltip on hover for Work Side Menu Group

### DIFF
--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuGroup.spec.ts
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuGroup.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import GoAWorkSideMenuGroup from "./WorkSideMenuGroup.svelte";
+
+describe("WorkSideMenuGroup", () => {
+  it("dispatches an event on hover", async () => {
+    const { container } = render(GoAWorkSideMenuGroup, {
+      heading: "Test Group",
+      icon: "star",
+      testid: "test-group",
+    });
+
+    const fn = vi.fn();
+    container.addEventListener("_hoverItem", fn);
+
+    const details = container.querySelector("details");
+    expect(details).toBeTruthy();
+
+    await fireEvent.mouseEnter(details!);
+    expect(fn).toHaveBeenCalled();
+
+    const event = fn.mock.calls[0][0];
+    expect(event.detail.label).toBe("Test Group");
+    expect(event.detail.el).toBeTruthy();
+  });
+});

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuGroup.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuGroup.svelte
@@ -2,20 +2,26 @@
 
 <script lang="ts">
   import type { GoAIconType } from "../icon/Icon.svelte";
-  import { toBoolean } from "../../common/utils";
+  import { toBoolean, dispatch } from "../../common/utils";
 
   export let heading: string;
   export let icon: GoAIconType;
   export let testid: string = "";
 
   let _open = false;
+  let _rootEl: HTMLElement;
+
+  function handleMouseEnter() {
+    dispatch(_rootEl, "_hoverItem", { el: _rootEl, label: heading }, { bubbles: true });
+  }
 </script>
 
-<div class="root" data-testid={testid}>
+<div class="root" data-testid={testid} bind:this={_rootEl}>
   <details
     open={_open}
     aria-label={_open ? "Close group" : "Open group"}
     on:toggle={({ target }) => (_open = toBoolean(`${target?.open}`))}
+    on:mouseenter={handleMouseEnter}
   >
     <summary aria-expanded={_open}>
       <goa-icon type={icon} size="small" theme={_open ? "filled" : "outline"} />


### PR DESCRIPTION
# Before (the change)

I cannot see a tooltip when I hover a Work Side Menu Group in a closed menu.

https://github.com/user-attachments/assets/3c2cea1a-70a4-4ff4-9f1c-6a4bb128238c

# After (the change)

https://github.com/user-attachments/assets/872abfc4-b2e0-40c0-ac6a-d60180df3d3a

I can see a tooltip when I hover a Work Side Menu Group in a closed menu.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
1. Close the Work Side Menu
2. Hover the icon of a Work Side Menu Group
