### PR TITLE
fix(#3397): use existing design tokens in Astro docs

### DIFF
--- a/docs/src/components/CodeSnippet.tsx
+++ b/docs/src/components/CodeSnippet.tsx
@@ -540,7 +540,7 @@ function CodeSnippetStyles() {
         border-radius: var(--goa-border-radius-m, 4px);
         overflow: hidden;
         background: var(--goa-color-greyscale-100, #f1f1f1);
-        font-size: 0.875rem;
+        font-size: var(--goa-font-size-2);
       }
 
       .framework-switcher .code-snippet {
@@ -568,19 +568,19 @@ function CodeSnippetStyles() {
 
       .code-block-title {
         font-size: 0.75rem;
-        font-weight: 600;
+        font-weight: var(--goa-font-weight-semi-bold);
         color: var(--goa-color-text-secondary, #666);
         text-transform: uppercase;
         letter-spacing: 0.5px;
       }
 
       .copy-button {
-        background: white;
+        background: var(--goa-color-greyscale-white);
         border: 1px solid var(--goa-color-greyscale-200, #dcdcdc);
         color: var(--goa-color-interactive-default, #0070c4);
         width: 28px;
         height: 28px;
-        border-radius: 4px;
+        border-radius: var(--goa-border-radius-xs);
         cursor: pointer;
         display: flex;
         align-items: center;
@@ -596,7 +596,7 @@ function CodeSnippetStyles() {
       .copy-button.copied {
         background: var(--goa-color-status-success, #2e7d32);
         border-color: var(--goa-color-status-success, #2e7d32);
-        color: white;
+        color: var(--goa-color-greyscale-white);
       }
 
       .copy-icon {

--- a/docs/src/components/ComponentSandbox.tsx
+++ b/docs/src/components/ComponentSandbox.tsx
@@ -175,16 +175,16 @@ export function ComponentSandbox({
 
       <style>{`
         .component-sandbox {
-          border: 1px solid var(--goa-color-border, #ddd);
-          border-radius: var(--goa-radius-m, 8px);
+          border: 1px solid var(--goa-color-greyscale-200);
+          border-radius: var(--goa-border-radius-m);
           overflow: hidden;
-          background: white;
+          background: var(--goa-color-greyscale-white);
         }
 
         .sandbox-preview {
           padding: var(--goa-space-xl, 2rem);
           background: #fafafa;
-          border-bottom: 1px solid var(--goa-color-border, #ddd);
+          border-bottom: 1px solid var(--goa-color-greyscale-200);
           display: flex;
           align-items: center;
           justify-content: center;
@@ -197,16 +197,16 @@ export function ComponentSandbox({
 
         .sandbox-controls {
           padding: var(--goa-space-m, 1rem);
-          border-bottom: 1px solid var(--goa-color-border, #ddd);
-          background: white;
+          border-bottom: 1px solid var(--goa-color-greyscale-200);
+          background: var(--goa-color-greyscale-white);
         }
 
         .controls-header {
           display: flex;
           align-items: center;
           gap: var(--goa-space-xs, 0.25rem);
-          font-weight: 600;
-          font-size: 0.875rem;
+          font-weight: var(--goa-font-weight-semi-bold);
+          font-size: var(--goa-font-size-2);
           margin-bottom: var(--goa-space-m, 1rem);
           color: var(--goa-color-text-secondary, #666);
         }
@@ -232,9 +232,9 @@ export function ComponentSandbox({
 
         .control-item input[type="text"] {
           padding: 0.5rem;
-          border: 1px solid var(--goa-color-border, #ddd);
-          border-radius: 4px;
-          font-size: 0.875rem;
+          border: 1px solid var(--goa-color-greyscale-200);
+          border-radius: var(--goa-border-radius-xs);
+          font-size: var(--goa-font-size-2);
         }
 
         .toggle-label {
@@ -252,7 +252,7 @@ export function ComponentSandbox({
           display: flex;
           align-items: center;
           background: #f5f5f5;
-          border-bottom: 1px solid var(--goa-color-border, #ddd);
+          border-bottom: 1px solid var(--goa-color-greyscale-200);
         }
 
         .code-tab {
@@ -261,18 +261,18 @@ export function ComponentSandbox({
           border: none;
           border-bottom: 2px solid transparent;
           cursor: pointer;
-          font-size: 0.875rem;
+          font-size: var(--goa-font-size-2);
           color: var(--goa-color-text-secondary, #666);
           transition: color 0.15s, border-color 0.15s;
         }
 
         .code-tab:hover {
-          color: var(--goa-color-brand, #0070c4);
+          color: var(--goa-color-brand-default);
         }
 
         .code-tab.active {
-          color: var(--goa-color-brand, #0070c4);
-          border-bottom-color: var(--goa-color-brand, #0070c4);
+          color: var(--goa-color-brand-default);
+          border-bottom-color: var(--goa-color-brand-default);
           font-weight: 500;
         }
 
@@ -293,7 +293,7 @@ export function ComponentSandbox({
         }
 
         .action-link:hover {
-          color: var(--goa-color-brand, #0070c4);
+          color: var(--goa-color-brand-default);
         }
 
         .code-panel {

--- a/docs/src/components/ComponentsGrid.tsx
+++ b/docs/src/components/ComponentsGrid.tsx
@@ -947,7 +947,7 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
           position: sticky;
           top: 0;
           z-index: 1;
-          background: white;
+          background: var(--goa-color-greyscale-white);
           display: flex;
           flex-direction: row;
           align-items: flex-start;
@@ -970,7 +970,7 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
           bottom: 0;
           left: -9999px;
           right: -9999px;
-          background: white;
+          background: var(--goa-color-greyscale-white);
           box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.15);
           z-index: -1;
         }

--- a/docs/src/components/ConfigurationPreview.tsx
+++ b/docs/src/components/ConfigurationPreview.tsx
@@ -221,7 +221,7 @@ export function ConfigurationPreview({
         }
 
         .github-link {
-          font-size: 0.875rem;
+          font-size: var(--goa-font-size-2);
         }
 
         .issue-count {

--- a/docs/src/components/DoDont.astro
+++ b/docs/src/components/DoDont.astro
@@ -237,12 +237,12 @@ const config = typeConfig[type];
   .do-indicator {
     height: 1.25rem;
     background-color: var(--goa-color-success-default);
-    border-radius: 0 0 8px 8px;
+    border-radius: var(--goa-border-radius-none) var(--goa-border-radius-none)  var(--goa-border-radius-m) var(--goa-border-radius-m);
   }
 
   /* When container is visible, indicator doesn't need top radius */
   .do-container:not([style*="display: none"]) + .do-indicator {
-    border-radius: 0 0 8px 8px;
+    border-radius: var(--goa-border-radius-none) var(--goa-border-radius-none)  var(--goa-border-radius-m) var(--goa-border-radius-m);
   }
 
   /* When container is hidden, indicator needs full radius */
@@ -276,7 +276,7 @@ const config = typeConfig[type];
   }
 
   .content-label {
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
     margin-top: 1px;
   }
 
@@ -329,7 +329,7 @@ const config = typeConfig[type];
   .details-content :global(code) {
     background: rgba(0, 0, 0, 0.06);
     padding: 0.1em 0.3em;
-    border-radius: 3px;
+    border-radius: var(--goa-border-radius-xs);
     font-size: 0.85em;
   }
 </style>

--- a/docs/src/components/ExampleCard.astro
+++ b/docs/src/components/ExampleCard.astro
@@ -98,9 +98,9 @@ const scaleStyle = scaleColors[data.scale] || { bg: '#f5f5f5', color: '#666' };
 
 <style>
   .example-card {
-    background: white;
-    border: 1px solid var(--goa-color-border);
-    border-radius: var(--goa-radius-m);
+    background: var(--goa-color-greyscale-white);
+    border: 1px solid var(--goa-color-greyscale-200);
+    border-radius: var(--goa-border-radius-m);
     overflow: hidden;
     transition: box-shadow 0.15s;
   }
@@ -111,8 +111,8 @@ const scaleStyle = scaleColors[data.scale] || { bg: '#f5f5f5', color: '#666' };
 
   .example-header {
     padding: var(--goa-space-m);
-    border-bottom: 1px solid var(--goa-color-border);
-    background: var(--goa-color-background-light);
+    border-bottom: 1px solid var(--goa-color-greyscale-200);
+    background: var(--goa-color-greyscale-100);
   }
 
   .example-badges {
@@ -126,11 +126,11 @@ const scaleStyle = scaleColors[data.scale] || { bg: '#f5f5f5', color: '#666' };
   .category-badge,
   .user-type-badge {
     font-size: 0.65rem;
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
     text-transform: uppercase;
     letter-spacing: 0.03em;
     padding: 0.2em 0.5em;
-    border-radius: var(--goa-radius-s);
+    border-radius: var(--goa-border-radius-s);
   }
 
   .category-badge {
@@ -150,13 +150,13 @@ const scaleStyle = scaleColors[data.scale] || { bg: '#f5f5f5', color: '#666' };
 
   .example-title {
     font-size: 1.1rem;
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
     margin: 0;
-    color: var(--goa-color-text);
+    color: var(--goa-color-text-default);
   }
 
   .example-preview {
-    border-bottom: 1px solid var(--goa-color-border);
+    border-bottom: 1px solid var(--goa-color-greyscale-200);
     background: #fafafa;
     min-height: 150px;
     display: flex;
@@ -171,7 +171,7 @@ const scaleStyle = scaleColors[data.scale] || { bg: '#f5f5f5', color: '#666' };
 
   .preview-placeholder {
     color: var(--goa-color-text-secondary);
-    font-size: 0.875rem;
+    font-size: var(--goa-font-size-2);
   }
 
   .example-content {
@@ -191,8 +191,8 @@ const scaleStyle = scaleColors[data.scale] || { bg: '#f5f5f5', color: '#666' };
 
   .example-footer {
     padding: var(--goa-space-m);
-    background: var(--goa-color-background-light);
-    border-top: 1px solid var(--goa-color-border);
+    background: var(--goa-color-greyscale-100);
+    border-top: 1px solid var(--goa-color-greyscale-200);
     font-size: 0.85rem;
   }
 
@@ -202,7 +202,7 @@ const scaleStyle = scaleColors[data.scale] || { bg: '#f5f5f5', color: '#666' };
   }
 
   .component-link {
-    color: var(--goa-color-brand);
+    color: var(--goa-color-brand-default);
     text-decoration: none;
   }
 
@@ -213,15 +213,15 @@ const scaleStyle = scaleColors[data.scale] || { bg: '#f5f5f5', color: '#666' };
   .a11y-notes {
     margin: var(--goa-space-s) 0;
     padding: var(--goa-space-s);
-    background: white;
-    border-radius: var(--goa-radius-s);
+    background: var(--goa-color-greyscale-white);
+    border-radius: var(--goa-border-radius-s);
     border: 1px solid #e0e0e0;
   }
 
   .a11y-notes summary {
     cursor: pointer;
     font-weight: 500;
-    color: var(--goa-color-text);
+    color: var(--goa-color-text-default);
     display: flex;
     align-items: center;
     gap: var(--goa-space-xs);
@@ -245,6 +245,6 @@ const scaleStyle = scaleColors[data.scale] || { bg: '#f5f5f5', color: '#666' };
   }
 
   .related-examples a {
-    color: var(--goa-color-brand);
+    color: var(--goa-color-brand-default);
   }
 </style>

--- a/docs/src/components/ExampleDisplay.astro
+++ b/docs/src/components/ExampleDisplay.astro
@@ -61,7 +61,7 @@ const code = await getExampleCode(example.slug);
 
   .example-meta p {
     margin: 0;
-    color: var(--goa-color-text-secondary, #666);
+    color: var(--goa-color-text-secondary);
     line-height: 1.5;
   }
 </style>

--- a/docs/src/components/ExampleListingCard.astro
+++ b/docs/src/components/ExampleListingCard.astro
@@ -113,7 +113,7 @@ const userGoal = getUserGoal(data.title);
   .card-image-link {
     display: block;
     text-decoration: none;
-    border-radius: 12px;
+    border-radius: var(--goa-border-radius-xl);
     margin-bottom: var(--goa-space-l, 24px);
   }
 
@@ -126,7 +126,7 @@ const userGoal = getUserGoal(data.title);
   .card-image {
     aspect-ratio: 4/3;
     background: var(--goa-color-greyscale-200, #e5e5e5);
-    border-radius: 12px;
+    border-radius: var(--goa-border-radius-xl);
     overflow: hidden;
   }
 

--- a/docs/src/components/ExamplesGrid.tsx
+++ b/docs/src/components/ExamplesGrid.tsx
@@ -1027,7 +1027,7 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
           position: sticky;
           top: 0;
           z-index: 1;
-          background: white;
+          background: var(--goa-color-greyscale-white);
           display: flex;
           flex-direction: row;
           align-items: flex-start;
@@ -1050,7 +1050,7 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
           bottom: 0;
           left: -9999px;
           right: -9999px;
-          background: white;
+          background: var(--goa-color-greyscale-white);
           box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.15);
           z-index: -1;
         }

--- a/docs/src/components/GuidanceGrid.astro
+++ b/docs/src/components/GuidanceGrid.astro
@@ -122,8 +122,8 @@ const mdxComponents = { Preview, InfoCard };
     font-style: italic;
     padding: var(--goa-space-l);
     text-align: center;
-    background: var(--goa-color-background-light);
-    border-radius: var(--goa-radius-m);
+    background: var(--goa-color-greyscale-100);
+    border-radius: var(--goa-border-radius-m);
   }
 
   .guidance-content {
@@ -141,7 +141,7 @@ const mdxComponents = { Preview, InfoCard };
   .guidance-content :global(code) {
     background: rgba(0, 0, 0, 0.06);
     padding: 0.1em 0.3em;
-    border-radius: 3px;
+    border-radius: var(--goa-border-radius-xs);
     font-size: 0.85em;
   }
 </style>

--- a/docs/src/components/GuidanceSection.astro
+++ b/docs/src/components/GuidanceSection.astro
@@ -83,7 +83,7 @@ const typeConfig: Record<string, { containerType: string; icon: string; label: s
   .guidance-content :global(code) {
     background: var(--goa-color-greyscale-100);
     padding: 0.1em 0.3em;
-    border-radius: 3px;
+    border-radius: var(--goa-border-radius-xs);
     font-size: 0.85em;
   }
 </style>

--- a/docs/src/components/TokensGrid.tsx
+++ b/docs/src/components/TokensGrid.tsx
@@ -1009,7 +1009,7 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
           position: sticky;
           top: 0;
           z-index: 1;
-          background: white;
+          background: var(--goa-color-greyscale-white);
           display: flex;
           flex-direction: row;
           align-items: flex-start;
@@ -1032,7 +1032,7 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
           bottom: 0;
           left: -9999px;
           right: -9999px;
-          background: white;
+          background: var(--goa-color-greyscale-white);
           box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.15);
           z-index: -1;
         }

--- a/docs/src/components/nav/menu-secondary.css
+++ b/docs/src/components/nav/menu-secondary.css
@@ -37,6 +37,6 @@
   font-size: var(--goa-font-size-2);
   background-color: var(--goa-color-greyscale-100);
   border: 1px solid var(--goa-color-greyscale-200);
-  border-radius: 6px;
+  border-radius: var(--goa-border-radius-s);
   padding: 0 6px;
 }

--- a/docs/src/components/search/search.css
+++ b/docs/src/components/search/search.css
@@ -41,7 +41,7 @@
 }
 
 .search-modal {
-  background: white;
+  background: var(--goa-color-greyscale-white);
   border-radius: var(--goa-space-m);
   box-shadow:
     0 4px 6px -1px rgba(0, 0, 0, 0.1),
@@ -134,7 +134,7 @@
   color: var(--goa-color-greyscale-600, #555);
   background: var(--goa-color-greyscale-100, #f5f5f5);
   border: 1px solid var(--goa-color-greyscale-200, #e0e0e0);
-  border-radius: 4px;
+  border-radius: var(--goa-border-radius-xs);
 }
 
 .search-input-close {
@@ -143,7 +143,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--goa-border-radius-xs);
   color: var(--goa-color-greyscale-500, #666);
   display: flex;
   align-items: center;
@@ -201,7 +201,7 @@
   display: block;
   color: var(--goa-color-status-emergency, #d32f2f);
   font: var(--goa-typography-body-m);
-  font-weight: 600;
+  font-weight: var(--goa-font-weight-semi-bold);
   margin-bottom: var(--goa-space-xs);
 }
 
@@ -298,7 +298,7 @@
 
 .search-result-title {
   font: var(--goa-typography-body-m);
-  font-weight: 600;
+  font-weight: var(--goa-font-weight-semi-bold);
   color: var(--goa-color-interactive-default, #0070c4);
   margin-bottom: var(--goa-space-3xs);
 }
@@ -322,7 +322,7 @@
   font: var(--goa-typography-body-xs);
   font-size: 11px;
   text-transform: uppercase;
-  border-radius: 4px;
+  border-radius: var(--goa-border-radius-xs);
   vertical-align: middle;
 }
 
@@ -362,7 +362,7 @@
   color: var(--goa-color-interactive-default, #0070c4);
   background: none;
   border: 1px solid var(--goa-color-greyscale-200, #e0e0e0);
-  border-radius: 4px;
+  border-radius: var(--goa-border-radius-xs);
   cursor: pointer;
   transition: background-color 100ms ease;
 }
@@ -386,11 +386,11 @@
   gap: var(--goa-space-2xs);
   padding: var(--goa-space-3xs) var(--goa-space-xs);
   background: var(--goa-color-interactive-default, #0070c4);
-  color: white;
+  color: var(--goa-color-greyscale-white);
   font: var(--goa-typography-body-xs);
   font-size: 12px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--goa-border-radius-xs);
   cursor: pointer;
   flex-shrink: 0;
   transition: background-color 100ms ease;
@@ -472,7 +472,7 @@
 
 .search-filter-hints-command {
   font: var(--goa-typography-body-m);
-  font-weight: 600;
+  font-weight: var(--goa-font-weight-semi-bold);
   color: var(--goa-color-interactive-default, #0070c4);
 }
 
@@ -506,7 +506,7 @@
   font-size: 11px;
   background: var(--goa-color-greyscale-100, #f5f5f5);
   border: 1px solid var(--goa-color-greyscale-200, #e0e0e0);
-  border-radius: 3px;
+  border-radius: var(--goa-border-radius-xs);
 }
 
 /* ==========================================================================
@@ -548,7 +548,7 @@
   border: none;
   cursor: pointer;
   padding: var(--goa-space-3xs) var(--goa-space-xs);
-  border-radius: 4px;
+  border-radius: var(--goa-border-radius-xs);
 }
 
 .search-empty-clear:hover {
@@ -623,7 +623,7 @@
 }
 
 .search-no-results-query {
-  font-weight: 600;
+  font-weight: var(--goa-font-weight-semi-bold);
   color: var(--goa-color-text-default, #333);
 }
 
@@ -656,7 +656,7 @@
   color: var(--goa-color-interactive-default, #0070c4);
   background: var(--goa-color-greyscale-100, #f5f5f5);
   border: 1px solid var(--goa-color-greyscale-200, #e0e0e0);
-  border-radius: 4px;
+  border-radius: var(--goa-border-radius-xs);
   padding: var(--goa-space-2xs) var(--goa-space-s);
   cursor: pointer;
   transition:
@@ -688,7 +688,7 @@
   align-items: center;
   gap: var(--goa-space-s);
   padding: var(--goa-space-s) var(--goa-space-m);
-  background: white;
+  background: var(--goa-color-greyscale-white);
   border: 1px solid var(--goa-color-greyscale-300, #ccc);
   border-radius: var(--goa-border-radius-m);
   transition:
@@ -716,7 +716,7 @@
 
 .search-page-results {
   margin-top: var(--goa-space-m);
-  background: white;
+  background: var(--goa-color-greyscale-white);
   border: 1px solid var(--goa-color-greyscale-200, #e0e0e0);
   border-radius: var(--goa-space-m);
   min-height: 300px;

--- a/docs/src/content/guidance/notification-above-fixed.mdx
+++ b/docs/src/content/guidance/notification-above-fixed.mdx
@@ -21,7 +21,7 @@ status: published
         Your profile information has been updated.
       </goa-notification>
     </div>
-    <div style="position: absolute; bottom: 8px; left: 16px; background: var(--goa-color-interactive-default); color: white; padding: 8px 16px; border-radius: 4px; font-size: 14px;">
+    <div style="position: absolute; bottom: 8px; left: 16px; background: var(--goa-color-interactive-default); color: var(--goa-color-greyscale-white); padding: 8px 16px; border-radius: var(--goa-border-radius-xs); font-size: 14px;">
       Click to chat
     </div>
   </div>

--- a/docs/src/content/guidance/tooltip-force-scroll.mdx
+++ b/docs/src/content/guidance/tooltip-force-scroll.mdx
@@ -20,7 +20,7 @@ status: published
         <goa-input name="email" value="user@example.com" />
       </goa-form-item>
     </div>
-    <div style="position: absolute; bottom: -40px; left: 100px; background: var(--goa-color-greyscale-700); color: white; padding: 8px 16px; border-radius: 4px; font-size: 14px;">
+    <div style="position: absolute; bottom: -40px; left: 100px; background: var(--goa-color-greyscale-700); color: var(--goa-color-greyscale-white); padding: 8px 16px; border-radius: var(--goa-border-radius-xs); font-size: 14px;">
       We will send important updates to this email address.
     </div>
   </div>

--- a/docs/src/content/guidance/tooltip-too-far.mdx
+++ b/docs/src/content/guidance/tooltip-too-far.mdx
@@ -16,7 +16,7 @@ status: published
 <Preview>
   <div style="position: relative; height: 100px;">
     <goa-icon-button icon="help" />
-    <div style="position: absolute; top: 60px; left: 80px; background: var(--goa-color-greyscale-700); color: white; padding: 8px 16px; border-radius: 4px; font-size: 14px;">
+    <div style="position: absolute; top: 60px; left: 80px; background: var(--goa-color-greyscale-700); color: var(--goa-color-greyscale-white); padding: 8px 16px; border-radius: var(--goa-border-radius-xs); font-size: 14px;">
       Tooltip
     </div>
   </div>

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -53,184 +53,171 @@ const { title, description, page } = Astro.props;
     import '../scripts/mobile-bridge.ts';
   </script>
 
-  <style is:global>
-    /* GoA Design System CSS Custom Properties */
-    :root {
-      --goa-color-brand: #0070c4;
-      --goa-color-brand-dark: #004f8a;
-      --goa-color-text: #333;
-      --goa-color-text-secondary: #666;
-      --goa-color-border: #ddd;
-      --goa-color-background-light: #f5f5f5;
-      --goa-color-success: #2e7d32;
-      --goa-color-error: #d32f2f;
-      --goa-color-warning: #ed6c02;
-      --goa-color-info: #0288d1;
+    <style is:global>
+      * {
+        box-sizing: border-box;
+      }
 
-      /* Spacing tokens */
-      --goa-space-3xs: 0.125rem;
-      --goa-space-2xs: 0.25rem;
-      --goa-space-xs: 0.5rem;
-      --goa-space-s: 0.75rem;
-      --goa-space-m: 1rem;
-      --goa-space-l: 1.5rem;
-      --goa-space-xl: 2rem;
-      --goa-space-2xl: 3rem;
-      --goa-space-3xl: 4rem;
+      /* Reset margin but NOT padding - padding resets break component internals and slots */
+      *:where(:not([slot])) {
+        margin: 0;
+      }
 
-      /* Border radius */
-      --goa-radius-s: 4px;
-      --goa-radius-m: 8px;
-      --goa-radius-l: 12px;
+      html {
+        color-scheme: light;
+      }
 
-      /* Typography */
-      --goa-font-family: 'acumin-pro-semi-condensed', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      --goa-font-family-mono: 'SF Mono', Monaco, 'Courier New', monospace;
-    }
+      body {
+        font: var(--goa-typography-body-m);
+        color: var(--goa-color-text-default);
+        background: var(--goa-color-greyscale-white);
+      }
 
-    * {
-      box-sizing: border-box;
-    }
+      h1 {
+        font: var(--goa-typography-heading-xl);
+      }
 
-    /* Reset margin but NOT padding - padding resets break component internals and slots */
-    *:where(:not([slot])) {
-      margin: 0;
-    }
+      h2 {
+        font: var(--goa-typography-heading-l);
+      }
 
-    html {
-      color-scheme: light;
-    }
+      h3 {
+        font: var(--goa-typography-heading-m);
+      }
 
-    body {
-      font-family: var(--goa-font-family);
-      line-height: 1.6;
-      color: var(--goa-color-text);
-      background: #fff;
-    }
+      h4 {
+        font: var(--goa-typography-heading-s);
+      }
 
-    h1, h2, h3, h4, h5, h6 {
-      line-height: 1.3;
-      font-weight: 600;
-    }
+      h5 {
+        font: var(--goa-typography-heading-xs);
+      }
 
-    code {
-      background: var(--goa-color-background-light);
-      padding: 0.2em 0.4em;
-      border-radius: var(--goa-radius-s);
-      font-family: var(--goa-font-family-mono);
-      font-size: 0.9em;
-    }
+      h6 {
+        font: var(--goa-typography-heading-2xs);
+      }
 
-    pre code {
-      display: block;
-      padding: var(--goa-space-m);
-      overflow-x: auto;
-    }
+      code {
+        background: var(--goa-color-greyscale-white);
+        padding: var(--goa-space-2xs) var(--goa-space-xs);
+        border-radius: var(--goa-border-radius-s);
+        font-family: var(--goa-font-family-number);
+        font-size: var(--goa-font-size-2);
+      }
 
-    a {
-      color: var(--goa-color-brand);
-    }
+      pre code {
+        display: block;
+        padding: var(--goa-space-m);
+        overflow-x: auto;
+      }
 
-    a:hover {
-      color: var(--goa-color-brand-dark);
-    }
+      a {
+        color: var(--goa-color-interactive-default);
+      }
 
-    /* Focus styles for accessibility */
-    :focus-visible {
-      outline: 2px solid var(--goa-color-brand);
-      outline-offset: 2px;
-    }
+      a:hover {
+        color: var(--goa-color-interactive-hover);
+      }
 
-    /* ==========================================================================
+      /* Focus styles for accessibility */
+      :focus-visible {
+        outline: var(--goa-border-width-l) solid var(--goa-color-interactive-focus);
+        outline-offset: var(--goa-space-3xs);
+      }
+
+      /* ==========================================================================
        Mobile Bridge: Base styles for responsive behavior
        Uses body attributes set by mobile-bridge.ts script
        ========================================================================== */
 
-    /* Mobile header - hidden by default, shown on mobile */
-    .mobile-header-container {
-      display: none;
-    }
+      /* Mobile header - hidden by default, shown on mobile */
+      .mobile-header-container {
+        display: none;
+      }
 
-    /* Mobile viewport (< 624px) - matches GoA component breakpoint */
-    body[data-mobile="true"] .mobile-header-container {
-      display: block;
-      position: sticky;
-      top: 0;
-      background: white;
-      z-index: 50;
-      padding: var(--goa-space-m) var(--goa-space-m); /* 16px vertical, 16px horizontal */
-      border-bottom: 1px solid var(--goa-color-greyscale-150, #e0e0e0);
-      /* Smooth transitions for hide/show and background */
-      transform: translateY(0);
-      transition: transform 0.25s ease-out, background 0.2s ease, border-bottom 0.2s ease;
-    }
+      /* Mobile viewport (< 624px) - matches GoA component breakpoint */
+      body[data-mobile="true"] .mobile-header-container {
+        display: block;
+        position: sticky;
+        top: 0;
+        background: var(--goa-color-greyscale-white);
+        z-index: 50;
+        padding: var(--goa-space-m) var(--goa-space-m); /* 16px vertical, 16px horizontal */
+        border-bottom: 1px solid var(--goa-color-greyscale-150, #e0e0e0);
+        /* Smooth transitions for hide/show and background */
+        transform: translateY(0);
+        transition:
+          transform 0.25s ease-out,
+          background 0.2s ease,
+          border-bottom 0.2s ease;
+      }
 
-    /* Header hidden on scroll down */
-    body[data-mobile="true"][data-header-hidden="true"] .mobile-header-container {
-      transform: translateY(-100%);
-    }
+      /* Header hidden on scroll down */
+      body[data-mobile="true"][data-header-hidden="true"] .mobile-header-container {
+        transform: translateY(-100%);
+      }
 
-    /* Homepage: transparent header at top blends with hero */
-    body[data-page="home"][data-mobile="true"][data-scrolled="false"] .mobile-header-container {
-      background: transparent;
-      border-bottom: none;
-    }
+      /* Homepage: transparent header at top blends with hero */
+      body[data-page="home"][data-mobile="true"][data-scrolled="false"]
+        .mobile-header-container {
+        background: transparent;
+        border-bottom: none;
+      }
 
-    /* Homepage: restore white header when scrolled */
-    body[data-page="home"][data-mobile="true"][data-scrolled="true"] .mobile-header-container {
-      background: white;
-      border-bottom: 1px solid var(--goa-color-greyscale-150, #e0e0e0);
-    }
+      /* Homepage: restore white header when scrolled */
+      body[data-page="home"][data-mobile="true"][data-scrolled="true"]
+        .mobile-header-container {
+        background: var(--goa-color-greyscale-white);
+        border-bottom: 1px solid var(--goa-color-greyscale-150, #e0e0e0);
+      }
 
-    /* Mobile header content layout */
-    .mobile-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
+      /* Mobile header content layout */
+      .mobile-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
 
-    .mobile-header__left {
-      display: flex;
-      align-items: center;
-      gap: var(--goa-space-2xs);
-    }
+      .mobile-header__left {
+        display: flex;
+        align-items: center;
+        gap: var(--goa-space-2xs);
+      }
 
-    .mobile-header__right {
-      display: flex;
-      align-items: center;
-    }
+      .mobile-header__right {
+        display: flex;
+        align-items: center;
+      }
 
-    /* Pull icons slightly toward edges for better visual alignment */
-    .mobile-header__left > goa-icon-button:first-child {
-      margin-left: -8px;
-    }
+      /* Pull icons slightly toward edges for better visual alignment */
+      .mobile-header__left > goa-icon-button:first-child {
+        margin-left: -8px;
+      }
 
-    .mobile-header__right > goa-icon-button:last-child {
-      margin-right: -8px;
-    }
+      .mobile-header__right > goa-icon-button:last-child {
+        margin-right: -8px;
+      }
 
-    /* Brand link with logo and title */
-    .mobile-header__brand {
-      display: flex;
-      align-items: center;
-      gap: var(--goa-space-xs);
-      text-decoration: none;
-    }
+      /* Brand link with logo and title */
+      .mobile-header__brand {
+        display: flex;
+        align-items: center;
+        gap: var(--goa-space-xs);
+        text-decoration: none;
+      }
 
-    .mobile-header__brand:hover {
-      text-decoration: none;
-    }
+      .mobile-header__brand:hover {
+        text-decoration: none;
+      }
 
-    .mobile-header__logo {
-      flex-shrink: 0;
-    }
+      .mobile-header__logo {
+        flex-shrink: 0;
+      }
 
-    .mobile-header__title {
-      font-size: 18px;
-      font-weight: 400;
-      line-height: 1.2;
-      color: var(--goa-color-text-default, #333);
-    }
+      .mobile-header__title {
+        font: var(--goa-typography-mobile-heading-xs);
+        color: var(--goa-color-text-default);
+      }
 
     /* Menu overlay backdrop when sidebar is open on mobile */
     body[data-mobile="true"][data-menu-open="true"]::before {

--- a/docs/src/layouts/ComponentPageLayout.astro
+++ b/docs/src/layouts/ComponentPageLayout.astro
@@ -86,8 +86,8 @@ const { title, description, currentSlug, category } = Astro.props;
   }
 
   .content-card {
-    background: white;
-    border-radius: 24px;
+    background: var(--goa-color-greyscale-white);
+    border-radius: var(--goa-border-radius-3xl);
     border: 1px solid var(--goa-color-greyscale-150);
     padding: var(--goa-space-xl) var(--goa-space-2xl);
     min-height: calc(100vh - var(--goa-space-l) * 2);
@@ -104,7 +104,7 @@ const { title, description, currentSlug, category } = Astro.props;
   /* Mobile: 624px breakpoint matches GoA components */
   @media (max-width: 623px) {
     .layout-wrapper {
-      background: white;
+      background: var(--goa-color-greyscale-white);
     }
 
     .layout-container {
@@ -125,7 +125,7 @@ const { title, description, currentSlug, category } = Astro.props;
     }
 
     .content-card {
-      border-radius: 0;
+      border-radius: var(--goa-border-radius-none);
       border: none;
       padding: var(--goa-space-m);
       min-height: auto;

--- a/docs/src/layouts/DocumentationPageLayout.astro
+++ b/docs/src/layouts/DocumentationPageLayout.astro
@@ -110,8 +110,8 @@ const {
   }
 
   .content-card {
-    background: white;
-    border-radius: 24px;
+    background: var(--goa-color-greyscale-white);
+    border-radius: var(--goa-border-radius-3xl);
     border: 1px solid var(--goa-color-greyscale-150);
     padding: var(--goa-space-xl) var(--goa-space-2xl);
     min-height: calc(100vh - var(--goa-space-l) * 2);
@@ -138,7 +138,7 @@ const {
 
   /* Page title */
   .prose-content :global(h1) {
-    font-size: 2.5rem;
+    font-size: var(--goa-font-size-9);
     font-weight: 700;
     margin: 0 0 var(--goa-space-m);
     color: var(--goa-color-text-default, #333);
@@ -149,7 +149,7 @@ const {
   .prose-content :global(.lead),
   .prose-content :global(h1 + p) {
     font: var(--goa-typography-body-l);
-    color: var(--goa-color-text-secondary, #666);
+    color: var(--goa-color-text-secondary);
     margin: 0 0 var(--goa-space-2xl);
     max-width: 65ch;
   }
@@ -157,7 +157,7 @@ const {
   /* Section headings */
   .prose-content :global(h2) {
     font-size: 1.5rem;
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
     margin: var(--goa-space-2xl) 0 var(--goa-space-m);
     color: var(--goa-color-text-default, #333);
     line-height: 1.3;
@@ -169,7 +169,7 @@ const {
 
   .prose-content :global(h3) {
     font-size: 1.25rem;
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
     margin: var(--goa-space-xl) 0 var(--goa-space-m);
     color: var(--goa-color-text-default, #333);
     line-height: 1.3;
@@ -177,7 +177,7 @@ const {
 
   .prose-content :global(h4) {
     font-size: 1.125rem;
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
     margin: var(--goa-space-l) 0 var(--goa-space-s);
     color: var(--goa-color-text-default, #333);
   }
@@ -207,7 +207,7 @@ const {
   }
 
   .prose-content :global(li strong) {
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
   }
 
   /* Nested lists */
@@ -230,10 +230,10 @@ const {
   /* Inline code */
   .prose-content :global(code) {
     font-family: 'Roboto Mono', monospace;
-    font-size: 0.875em;
+    font-size: var(--goa-font-size-2);
     background: var(--goa-color-greyscale-100, #f5f5f5);
     padding: 0.125em 0.375em;
-    border-radius: 4px;
+    border-radius: var(--goa-border-radius-xs);
     color: var(--goa-color-text-default, #333);
   }
 
@@ -241,7 +241,7 @@ const {
   .prose-content :global(pre) {
     background: var(--goa-color-greyscale-100, #f5f5f5);
     padding: var(--goa-space-m);
-    border-radius: 8px;
+    border-radius: var(--goa-border-radius-m);
     overflow-x: auto;
     margin: 0 0 var(--goa-space-l);
   }
@@ -249,7 +249,7 @@ const {
   .prose-content :global(pre code) {
     background: none;
     padding: 0;
-    font-size: 0.875rem;
+    font-size: var(--goa-font-size-2);
   }
 
   /* GoA Divider spacing */
@@ -297,7 +297,7 @@ const {
   /* Mobile: 624px breakpoint */
   @media (max-width: 623px) {
     .layout-wrapper {
-      background: white;
+      background: var(--goa-color-greyscale-white);
     }
 
     .layout-container {
@@ -316,7 +316,7 @@ const {
     }
 
     .content-card {
-      border-radius: 0;
+      border-radius: var(--goa-border-radius-none);
       border: none;
       padding: var(--goa-space-m);
       min-height: auto;

--- a/docs/src/layouts/ExamplesPageLayout.astro
+++ b/docs/src/layouts/ExamplesPageLayout.astro
@@ -81,8 +81,8 @@ const { title, description, currentSlug } = Astro.props;
   }
 
   .content-card {
-    background: white;
-    border-radius: 24px;
+    background: var(--goa-color-greyscale-white);
+    border-radius: var(--goa-border-radius-3xl);
     border: 1px solid var(--goa-color-greyscale-150);
     padding: var(--goa-space-xl) var(--goa-space-2xl);
     min-height: calc(100vh - var(--goa-space-l) * 2);
@@ -99,7 +99,7 @@ const { title, description, currentSlug } = Astro.props;
   /* Mobile: 624px breakpoint matches GoA components */
   @media (max-width: 623px) {
     .layout-wrapper {
-      background: white;
+      background: var(--goa-color-greyscale-white);
     }
 
     .layout-container {
@@ -120,7 +120,7 @@ const { title, description, currentSlug } = Astro.props;
     }
 
     .content-card {
-      border-radius: 0;
+      border-radius: var(--goa-border-radius-none);
       border: none;
       padding: var(--goa-space-m);
       min-height: auto;

--- a/docs/src/layouts/HomeLayout.astro
+++ b/docs/src/layouts/HomeLayout.astro
@@ -83,7 +83,7 @@ const { title, description } = Astro.props;
   }
 
   .content-area {
-    background: white;
+    background: var(--goa-color-greyscale-white);
     border-radius: 24px;
     border: 1px solid var(--goa-color-greyscale-150);
     min-height: calc(100vh - var(--goa-space-l) * 2);
@@ -94,7 +94,7 @@ const { title, description } = Astro.props;
   /* Mobile: 624px breakpoint matches GoA components */
   @media (max-width: 623px) {
     .layout-wrapper {
-      background: white;
+      background: var(--goa-color-greyscale-white);
     }
 
     .layout-container {
@@ -115,7 +115,7 @@ const { title, description } = Astro.props;
     }
 
     .content-area {
-      border-radius: 0;
+      border-radius: var(--goa-border-radius-none);
       border: none;
       min-height: auto;
       /* Pull content up behind transparent header (header is ~73px) */

--- a/docs/src/layouts/TokensLayout.astro
+++ b/docs/src/layouts/TokensLayout.astro
@@ -79,8 +79,8 @@ const { title, description } = Astro.props;
   }
 
   .content-card {
-    background: white;
-    border-radius: 24px;
+    background: var(--goa-color-greyscale-white);
+    border-radius: var(--goa-border-radius-3xl);
     border: 1px solid var(--goa-color-greyscale-150);
     padding: var(--goa-space-xl) var(--goa-space-2xl);
     min-height: calc(100vh - var(--goa-space-l) * 2);
@@ -97,7 +97,7 @@ const { title, description } = Astro.props;
   /* Mobile: 624px breakpoint matches GoA components */
   @media (max-width: 623px) {
     .layout-wrapper {
-      background: white;
+      background: var(--goa-color-greyscale-white);
     }
 
     .layout-container {
@@ -118,7 +118,7 @@ const { title, description } = Astro.props;
     }
 
     .content-card {
-      border-radius: 0;
+      border-radius: var(--goa-border-radius-none);
       border: none;
       padding: var(--goa-space-m);
       min-height: auto;

--- a/docs/src/pages/components/[slug].astro
+++ b/docs/src/pages/components/[slug].astro
@@ -167,7 +167,7 @@ const githubIssuesUrl = `https://github.com/GovAlta/ui-components/issues?q=is%3A
   }
 
   .component-title {
-    font-size: 2.5rem;
+    font-size: var(--goa-font-size-9);
     font-weight: 700;
     margin: var(--goa-space-xs) 0 var(--goa-space-s);
     color: var(--goa-color-text-default, #333);
@@ -189,14 +189,14 @@ const githubIssuesUrl = `https://github.com/GovAlta/ui-components/issues?q=is%3A
   /* Tab content headings */
   :global(.tab-main-content) h2 {
     font-size: 1.5rem;
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
     margin-bottom: var(--goa-space-l);
     color: var(--goa-color-text-default, #333);
   }
 
   :global(.tab-main-content) h3 {
     font-size: 1.25rem;
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
     margin: var(--goa-space-l) 0 var(--goa-space-m);
     color: var(--goa-color-text-default, #333);
   }

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -160,7 +160,7 @@ function formatComponentName(component: string): string {
 
   .example-content :global(h2) {
     font-size: 1.25rem;
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
     margin: var(--goa-space-xl, 2rem) 0 var(--goa-space-m, 1rem);
     color: var(--goa-color-text-default, #333);
   }
@@ -194,7 +194,7 @@ function formatComponentName(component: string): string {
 
   .related-examples h2 {
     font-size: 1.25rem;
-    font-weight: 600;
+    font-weight: var(--goa-font-weight-semi-bold);
     margin: 0 0 var(--goa-space-m, 1rem);
     color: var(--goa-color-text-default, #333);
   }
@@ -226,7 +226,7 @@ function formatComponentName(component: string): string {
   }
 
   .related-category {
-    font-size: 0.875rem;
+    font-size: var(--goa-font-size-2);
     color: var(--goa-color-text-secondary, #666);
   }
 </style>

--- a/docs/src/pages/examples/all.astro
+++ b/docs/src/pages/examples/all.astro
@@ -88,7 +88,7 @@ const sortedExamples = allExamples.sort((a, b) =>
 
   .component-pages {
     margin-top: var(--goa-space-xs);
-    font-size: 0.875rem;
+    font-size: var(--goa-font-size-2);
     border-top: none;
   }
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -223,13 +223,13 @@ import CardLite from '../components/CardLite.astro';
     padding: var(--goa-space-2xs) var(--goa-space-xs);
     background: var(--goa-color-greyscale-100);
     border: 1px solid var(--goa-color-greyscale-200);
-    border-radius: 6px;
+    border-radius: var(--goa-border-radius-s);
     color: var(--goa-color-greyscale-800);
   }
 
   /* Main Content - White background */
   .ds-main-content {
-    background: white;
+    background: var(--goa-color-greyscale-white);
     padding: var(--goa-space-4xl) var(--goa-space-m);
   }
 
@@ -375,7 +375,7 @@ import CardLite from '../components/CardLite.astro';
       min-height: 515px;
       display: flex;
       flex-direction: column;
-      border-radius: 0;
+      border-radius: var(--goa-border-radius-none);
       padding: 0 var(--goa-space-xs);
       /* Extra top padding to account for header overlay (~73px) */
       padding-top: 73px;

--- a/docs/src/pages/search.astro
+++ b/docs/src/pages/search.astro
@@ -80,8 +80,8 @@ const initialQuery = url.searchParams.get('q') || '';
   }
 
   .content-card {
-    background: white;
-    border-radius: 24px;
+    background: var(--goa-color-greyscale-white);
+    border-radius: var(--goa-border-radius-3xl);
     border: 1px solid var(--goa-color-greyscale-150);
     padding: var(--goa-space-xl) var(--goa-space-2xl);
     min-height: calc(100vh - var(--goa-space-l) * 2);
@@ -95,7 +95,7 @@ const initialQuery = url.searchParams.get('q') || '';
   }
 
   .search-page-header h1 {
-    font-size: 2.5rem;
+    font-size: var(--goa-font-size-9);
     font-weight: 700;
     margin: 0 0 var(--goa-space-s);
     color: var(--goa-color-text-default, #333);
@@ -118,7 +118,7 @@ const initialQuery = url.searchParams.get('q') || '';
   /* Mobile: 624px breakpoint */
   @media (max-width: 623px) {
     .layout-wrapper {
-      background: white;
+      background: var(--goa-color-greyscale-white);
     }
 
     .layout-container {
@@ -137,7 +137,7 @@ const initialQuery = url.searchParams.get('q') || '';
     }
 
     .content-card {
-      border-radius: 0;
+      border-radius: var(--goa-border-radius-none);
       border: none;
       padding: var(--goa-space-m);
       min-height: auto;


### PR DESCRIPTION
# Before (the change)

The Astro layouts and components for our v2 Docs used custom design tokens that overwrote some existing ones.

# After (the change)

The Astro layouts and components for our v2 Docs uses existing design tokens.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
