### PR TITLE
docs: add push drawer documentation page

### DIFF
--- a/docs/generated/component-apis/push-drawer.json
+++ b/docs/generated/component-apis/push-drawer.json
@@ -1,0 +1,46 @@
+{
+  "componentSlug": "push-drawer",
+  "extractedFrom": "libs/web-components/src/components/push-drawer/PushDrawer.svelte",
+  "extractedAt": "2026-03-03T18:47:38.073Z",
+  "props": [
+    {
+      "name": "testId",
+      "type": "\"string\"",
+      "required": false,
+      "default": null,
+      "description": ""
+    },
+    {
+      "name": "open",
+      "type": "boolean",
+      "required": false,
+      "default": "false",
+      "description": ""
+    },
+    {
+      "name": "heading",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": ""
+    },
+    {
+      "name": "width",
+      "type": "string",
+      "required": false,
+      "default": "492px",
+      "description": ""
+    }
+  ],
+  "events": [],
+  "slots": [
+    {
+      "name": "default",
+      "description": ""
+    },
+    {
+      "name": "actions",
+      "description": ""
+    }
+  ]
+}

--- a/docs/src/components/DoDont.astro
+++ b/docs/src/components/DoDont.astro
@@ -91,6 +91,9 @@ const config = typeConfig[type];
 ) : (
   <!-- Info type: raw content, no wrapper -->
   <div class="info-content">
+    {description && (
+      <div class="description">{description}</div>
+    )}
     <slot />
   </div>
 )}
@@ -196,6 +199,7 @@ const config = typeConfig[type];
   .info-content {
     color: var(--goa-color-info-text);
     margin-bottom: var(--goa-space-l);
+    max-width: 70ch;
   }
 
   .info-content :global(p) {

--- a/docs/src/content/components/push-drawer.mdx
+++ b/docs/src/content/components/push-drawer.mdx
@@ -1,0 +1,18 @@
+---
+name: Push Drawer
+description: A panel that pushes the main page content aside on desktop, falling back to an overlay drawer on smaller screens.
+status: stable
+category: content-layout
+tags:
+  - sections
+  - structure and navigation
+  - drawer
+  - sidebar
+  - panel
+relatedComponents:
+  - drawer
+githubUrl: https://github.com/GovAlta/ui-components/labels/Push%20Drawer
+webComponentTag: goa-push-drawer
+reactClassName: GoabPushDrawer
+angularSelector: goab-push-drawer
+---

--- a/docs/src/content/examples/filter-a-list-using-a-push-drawer/index.mdx
+++ b/docs/src/content/examples/filter-a-list-using-a-push-drawer/index.mdx
@@ -1,0 +1,39 @@
+---
+id: filter-a-list-using-a-push-drawer
+title: Filter a list using a push drawer
+categories:
+  - content-layout
+scale: task
+userType: worker
+tags:
+  - push-drawer
+  - filters
+  - list
+  - search
+components:
+  - push-drawer
+  - button
+  - table
+  - badge
+  - checkbox
+  - checkbox-list
+  - dropdown
+  - form-item
+status: published
+---
+
+Use a push drawer to house filters alongside a list of records. The push drawer keeps the filter controls accessible while users can still see and interact with the filtered results.
+
+## When to use
+
+Use this pattern when:
+
+- Users need to filter a list or table and see results update alongside the filters
+- The filter panel should be dismissible to reclaim screen space
+- Users go back and forth between adjusting filters and reviewing results
+
+## Considerations
+
+- On smaller screens, the push drawer falls back to an overlay drawer automatically
+- Consider whether filters should apply immediately or require a Save action
+- Consider hiding the trigger button while the drawer is open to reduce visual clutter

--- a/docs/src/content/examples/filter-a-list-using-a-push-drawer/react.tsx
+++ b/docs/src/content/examples/filter-a-list-using-a-push-drawer/react.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import {
+  GoabxButton,
+  GoabxCheckbox,
+  GoabxCheckboxList,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxFormItem,
+  GoabxTable,
+  GoabxBadge,
+} from "@abgov/react-components/experimental";
+import { GoabPushDrawer } from "@abgov/react-components";
+
+export function FilterAListUsingAPushDrawer() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ display: "flex", minHeight: "480px" }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "1rem",
+            marginBottom: "1rem",
+          }}
+        >
+          <h3 style={{ flex: 1, margin: 0 }}>All cases</h3>
+          {!open && (
+            <GoabxButton
+              type="secondary"
+              size="compact"
+              leadingIcon="filter"
+              onClick={() => setOpen(true)}
+            >
+              Filters
+            </GoabxButton>
+          )}
+        </div>
+
+        <GoabxTable width="100%">
+          <table width="100%">
+            <thead>
+              <tr>
+                <th>Status</th>
+                <th>Name</th>
+                <th>File number</th>
+                <th>Act</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <GoabxBadge type="success" content="Completed" />
+                </td>
+                <td>Gilbert Barton</td>
+                <td>24567-9876</td>
+                <td>Traffic safety act</td>
+              </tr>
+              <tr>
+                <td>
+                  <GoabxBadge type="information" content="New" />
+                </td>
+                <td>Brynn Hurley</td>
+                <td>98765-3456</td>
+                <td>Trespass to premises act</td>
+              </tr>
+              <tr>
+                <td>
+                  <GoabxBadge type="midtone" content="In review" />
+                </td>
+                <td>Marco Silva</td>
+                <td>34521-7890</td>
+                <td>Gaming, liquor, and cannabis act</td>
+              </tr>
+              <tr>
+                <td>
+                  <GoabxBadge type="success" content="Completed" />
+                </td>
+                <td>Dana Chen</td>
+                <td>55123-4567</td>
+                <td>Traffic safety act</td>
+              </tr>
+              <tr>
+                <td>
+                  <GoabxBadge type="information" content="New" />
+                </td>
+                <td>Amira Hassan</td>
+                <td>67890-1234</td>
+                <td>Trespass to premises act</td>
+              </tr>
+            </tbody>
+          </table>
+        </GoabxTable>
+      </div>
+
+      <GoabPushDrawer
+        heading="Filters"
+        width="260px"
+        open={open}
+        onClose={() => setOpen(false)}
+      >
+        <GoabxFormItem label="Act">
+          <GoabxCheckboxList name="act" onChange={() => {}}>
+            <GoabxCheckbox name="traffic" text="Traffic safety act" size="compact" />
+            <GoabxCheckbox
+              name="gaming"
+              text="Gaming, liquor, and cannabis act"
+              size="compact"
+            />
+            <GoabxCheckbox
+              name="trespass"
+              text="Trespass to premises act"
+              size="compact"
+            />
+          </GoabxCheckboxList>
+        </GoabxFormItem>
+        <GoabxFormItem label="Status" mt="l">
+          <GoabxDropdown name="status" onChange={() => {}} value="" size="compact">
+            <GoabxDropdownItem value="" label="All statuses" />
+            <GoabxDropdownItem value="new" label="New" />
+            <GoabxDropdownItem value="in-review" label="In review" />
+            <GoabxDropdownItem value="completed" label="Completed" />
+          </GoabxDropdown>
+        </GoabxFormItem>
+      </GoabPushDrawer>
+    </div>
+  );
+}

--- a/docs/src/content/examples/filter-a-list-using-a-push-drawer/web-components.html
+++ b/docs/src/content/examples/filter-a-list-using-a-push-drawer/web-components.html
@@ -1,0 +1,114 @@
+<div style="display: flex; min-height: 480px">
+  <div style="flex: 1; min-width: 0">
+    <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem">
+      <h3 style="flex: 1; margin: 0">All cases</h3>
+      <goa-button
+        version="2"
+        id="open-filters-btn"
+        type="secondary"
+        size="compact"
+        leadingicon="filter"
+        >Filters</goa-button
+      >
+    </div>
+
+    <goa-table version="2" width="100%">
+      <table width="100%">
+        <thead>
+          <tr>
+            <th>Status</th>
+            <th>Name</th>
+            <th>File number</th>
+            <th>Act</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <goa-badge version="2" type="success" content="Completed"></goa-badge>
+            </td>
+            <td>Gilbert Barton</td>
+            <td>24567-9876</td>
+            <td>Traffic safety act</td>
+          </tr>
+          <tr>
+            <td><goa-badge version="2" type="information" content="New"></goa-badge></td>
+            <td>Brynn Hurley</td>
+            <td>98765-3456</td>
+            <td>Trespass to premises act</td>
+          </tr>
+          <tr>
+            <td>
+              <goa-badge version="2" type="midtone" content="In review"></goa-badge>
+            </td>
+            <td>Marco Silva</td>
+            <td>34521-7890</td>
+            <td>Gaming, liquor, and cannabis act</td>
+          </tr>
+          <tr>
+            <td>
+              <goa-badge version="2" type="success" content="Completed"></goa-badge>
+            </td>
+            <td>Dana Chen</td>
+            <td>55123-4567</td>
+            <td>Traffic safety act</td>
+          </tr>
+          <tr>
+            <td><goa-badge version="2" type="information" content="New"></goa-badge></td>
+            <td>Amira Hassan</td>
+            <td>67890-1234</td>
+            <td>Trespass to premises act</td>
+          </tr>
+        </tbody>
+      </table>
+    </goa-table>
+  </div>
+
+  <goa-push-drawer id="filters-drawer" heading="Filters" width="260px">
+    <goa-form-item version="2" label="Act">
+      <goa-checkbox-list name="act">
+        <goa-checkbox
+          version="2"
+          name="traffic"
+          text="Traffic safety act"
+          size="compact"
+        ></goa-checkbox>
+        <goa-checkbox
+          version="2"
+          name="gaming"
+          text="Gaming, liquor, and cannabis act"
+          size="compact"
+        ></goa-checkbox>
+        <goa-checkbox
+          version="2"
+          name="trespass"
+          text="Trespass to premises act"
+          size="compact"
+        ></goa-checkbox>
+      </goa-checkbox-list>
+    </goa-form-item>
+    <goa-form-item version="2" label="Status" mt="l">
+      <goa-dropdown version="2" name="status" size="compact">
+        <goa-dropdown-item value="" label="All statuses"></goa-dropdown-item>
+        <goa-dropdown-item value="new" label="New"></goa-dropdown-item>
+        <goa-dropdown-item value="in-review" label="In review"></goa-dropdown-item>
+        <goa-dropdown-item value="completed" label="Completed"></goa-dropdown-item>
+      </goa-dropdown>
+    </goa-form-item>
+  </goa-push-drawer>
+</div>
+
+<script>
+  const filtersDrawer = document.getElementById("filters-drawer");
+  const openFiltersBtn = document.getElementById("open-filters-btn");
+
+  openFiltersBtn.addEventListener("_click", () => {
+    filtersDrawer.setAttribute("open", "true");
+    openFiltersBtn.style.display = "none";
+  });
+
+  filtersDrawer.addEventListener("_close", () => {
+    filtersDrawer.removeAttribute("open");
+    openFiltersBtn.style.display = "";
+  });
+</script>

--- a/docs/src/content/guidance/push-drawer-actions-optional.mdx
+++ b/docs/src/content/guidance/push-drawer-actions-optional.mdx
@@ -1,0 +1,14 @@
+---
+id: push-drawer-actions-optional
+type: tip
+description: The actions slot is optional. Include Save or Cancel buttons when the drawer content requires explicit confirmation. Omit them when changes apply immediately, like live filtering.
+topic: other
+tags:
+  - push-drawer
+  - actions
+  - forms
+appliesTo:
+  components:
+    - push-drawer
+status: published
+---

--- a/docs/src/content/guidance/push-drawer-dont-use-for-focused-tasks.mdx
+++ b/docs/src/content/guidance/push-drawer-dont-use-for-focused-tasks.mdx
@@ -1,0 +1,15 @@
+---
+id: push-drawer-dont-use-for-focused-tasks
+type: dont
+description: Don't use a push drawer for tasks that require the user's full attention. Use a regular drawer instead — it blocks interaction with the background and focuses the user on the task.
+topic: other
+tags:
+  - push-drawer
+  - drawer
+  - modal
+appliesTo:
+  components:
+    - push-drawer
+    - drawer
+status: published
+---

--- a/docs/src/content/guidance/push-drawer-mobile-fallback.mdx
+++ b/docs/src/content/guidance/push-drawer-mobile-fallback.mdx
@@ -1,0 +1,14 @@
+---
+id: push-drawer-mobile-fallback
+type: tip
+description: On screens narrower than 1024px, the push drawer automatically falls back to an overlay drawer. Design content that works well in both layouts.
+topic: other
+tags:
+  - push-drawer
+  - responsive
+  - mobile
+appliesTo:
+  components:
+    - push-drawer
+status: published
+---

--- a/docs/src/content/guidance/push-drawer-use-for-reference-tasks.mdx
+++ b/docs/src/content/guidance/push-drawer-use-for-reference-tasks.mdx
@@ -1,0 +1,14 @@
+---
+id: push-drawer-use-for-reference-tasks
+type: do
+description: Use a push drawer when users need to reference or interact with page content while the panel is open, such as filtering a list, viewing record details, or adjusting settings.
+topic: other
+tags:
+  - push-drawer
+  - drawer
+  - layout
+appliesTo:
+  components:
+    - push-drawer
+status: published
+---

--- a/docs/src/data/configurations/index.ts
+++ b/docs/src/data/configurations/index.ts
@@ -5,162 +5,164 @@
  * Add new component configurations here as they're created.
  */
 
-export * from './types';
+export * from "./types";
 
 // Form components
-export { buttonConfigurations } from './button';
-export { inputConfigurations } from './input';
-export { dropdownConfigurations } from './dropdown';
-export { checkboxConfigurations } from './checkbox';
-export { checkboxListConfigurations } from './checkbox-list';
-export { radioGroupConfigurations } from './radio-group';
-export { radioItemConfigurations } from './radio-item';
-export { textAreaConfigurations } from './text-area';
-export { formItemConfigurations } from './form-item';
-export { formConfigurations } from './form';
-export { formStepperConfigurations } from './form-stepper';
-export { formStepConfigurations } from './form-step';
-export { datePickerConfigurations } from './date-picker';
-export { calendarConfigurations } from './calendar';
-export { fileUploadInputConfigurations } from './file-upload-input';
-export { fileUploadCardConfigurations } from './file-upload-card';
+export { buttonConfigurations } from "./button";
+export { inputConfigurations } from "./input";
+export { dropdownConfigurations } from "./dropdown";
+export { checkboxConfigurations } from "./checkbox";
+export { checkboxListConfigurations } from "./checkbox-list";
+export { radioGroupConfigurations } from "./radio-group";
+export { radioItemConfigurations } from "./radio-item";
+export { textAreaConfigurations } from "./text-area";
+export { formItemConfigurations } from "./form-item";
+export { formConfigurations } from "./form";
+export { formStepperConfigurations } from "./form-stepper";
+export { formStepConfigurations } from "./form-step";
+export { datePickerConfigurations } from "./date-picker";
+export { calendarConfigurations } from "./calendar";
+export { fileUploadInputConfigurations } from "./file-upload-input";
+export { fileUploadCardConfigurations } from "./file-upload-card";
 
 // Feedback components
-export { calloutConfigurations } from './callout';
-export { notificationConfigurations } from './notification';
-export { temporaryNotificationConfigurations } from './temporary-notification';
-export { badgeConfigurations } from './badge';
-export { chipConfigurations } from './chip';
-export { filterChipConfigurations } from './filter-chip';
-export { tooltipConfigurations } from './tooltip';
-export { spinnerConfigurations } from './spinner';
-export { circularProgressConfigurations } from './circular-progress';
-export { linearProgressConfigurations } from './linear-progress';
-export { skeletonConfigurations } from './skeleton';
+export { calloutConfigurations } from "./callout";
+export { notificationConfigurations } from "./notification";
+export { temporaryNotificationConfigurations } from "./temporary-notification";
+export { badgeConfigurations } from "./badge";
+export { chipConfigurations } from "./chip";
+export { filterChipConfigurations } from "./filter-chip";
+export { tooltipConfigurations } from "./tooltip";
+export { spinnerConfigurations } from "./spinner";
+export { circularProgressConfigurations } from "./circular-progress";
+export { linearProgressConfigurations } from "./linear-progress";
+export { skeletonConfigurations } from "./skeleton";
 
 // Layout components
-export { containerConfigurations } from './container';
-export { blockConfigurations } from './block';
-export { gridConfigurations } from './grid';
-export { pageBlockConfigurations } from './page-block';
-export { pagesConfigurations } from './pages';
-export { dividerConfigurations } from './divider';
-export { spacerConfigurations } from './spacer';
-export { scrollableConfigurations } from './scrollable';
-export { heroBannerConfigurations } from './hero-banner';
+export { containerConfigurations } from "./container";
+export { blockConfigurations } from "./block";
+export { gridConfigurations } from "./grid";
+export { pageBlockConfigurations } from "./page-block";
+export { pagesConfigurations } from "./pages";
+export { dividerConfigurations } from "./divider";
+export { spacerConfigurations } from "./spacer";
+export { scrollableConfigurations } from "./scrollable";
+export { heroBannerConfigurations } from "./hero-banner";
 
 // Navigation components
-export { tabsConfigurations } from './tabs';
-export { tabConfigurations } from './tab';
-export { paginationConfigurations } from './pagination';
-export { sideMenuConfigurations } from './side-menu';
-export { sideMenuGroupConfigurations } from './side-menu-group';
-export { sideMenuHeadingConfigurations } from './side-menu-heading';
-export { workSideMenuConfigurations } from './work-side-menu';
-export { menuButtonConfigurations } from './menu-button';
-export { appHeaderConfigurations } from './app-header';
-export { appHeaderMenuConfigurations } from './app-header-menu';
-export { micrositeHeaderConfigurations } from './microsite-header';
-export { footerConfigurations } from './footer';
-export { footerNavSectionConfigurations } from './footer-nav-section';
-export { footerMetaSectionConfigurations } from './footer-meta-section';
-export { linkButtonConfigurations } from './link-button';
+export { tabsConfigurations } from "./tabs";
+export { tabConfigurations } from "./tab";
+export { paginationConfigurations } from "./pagination";
+export { sideMenuConfigurations } from "./side-menu";
+export { sideMenuGroupConfigurations } from "./side-menu-group";
+export { sideMenuHeadingConfigurations } from "./side-menu-heading";
+export { workSideMenuConfigurations } from "./work-side-menu";
+export { menuButtonConfigurations } from "./menu-button";
+export { appHeaderConfigurations } from "./app-header";
+export { appHeaderMenuConfigurations } from "./app-header-menu";
+export { micrositeHeaderConfigurations } from "./microsite-header";
+export { footerConfigurations } from "./footer";
+export { footerNavSectionConfigurations } from "./footer-nav-section";
+export { footerMetaSectionConfigurations } from "./footer-meta-section";
+export { linkButtonConfigurations } from "./link-button";
 
 // Display components
-export { cardConfigurations } from './card';
-export { cardGroupConfigurations } from './card-group';
-export { cardContentConfigurations } from './card-content';
-export { cardImageConfigurations } from './card-image';
-export { cardActionsConfigurations } from './card-actions';
-export { tableConfigurations } from './table';
-export { tableSortHeaderConfigurations } from './table-sort-header';
-export { dataGridConfigurations } from './data-grid';
-export { modalConfigurations } from './modal';
-export { drawerConfigurations } from './drawer';
-export { popoverConfigurations } from './popover';
-export { accordionConfigurations } from './accordion';
-export { detailsConfigurations } from './details';
+export { cardConfigurations } from "./card";
+export { cardGroupConfigurations } from "./card-group";
+export { cardContentConfigurations } from "./card-content";
+export { cardImageConfigurations } from "./card-image";
+export { cardActionsConfigurations } from "./card-actions";
+export { tableConfigurations } from "./table";
+export { tableSortHeaderConfigurations } from "./table-sort-header";
+export { dataGridConfigurations } from "./data-grid";
+export { modalConfigurations } from "./modal";
+export { drawerConfigurations } from "./drawer";
+export { pushDrawerConfigurations } from "./push-drawer";
+export { popoverConfigurations } from "./popover";
+export { accordionConfigurations } from "./accordion";
+export { detailsConfigurations } from "./details";
 
 // Utility components
-export { iconConfigurations } from './icon';
-export { iconButtonConfigurations } from './icon-button';
-export { buttonGroupConfigurations } from './button-group';
-export { linkConfigurations } from './link';
-export { textConfigurations } from './text';
-export { focusTrapConfigurations } from './focus-trap';
+export { iconConfigurations } from "./icon";
+export { iconButtonConfigurations } from "./icon-button";
+export { buttonGroupConfigurations } from "./button-group";
+export { linkConfigurations } from "./link";
+export { textConfigurations } from "./text";
+export { focusTrapConfigurations } from "./focus-trap";
 
 // Import all configurations for registry
-import type { ComponentConfigurations, ConfigurationRegistry } from './types';
-import { buttonConfigurations } from './button';
-import { inputConfigurations } from './input';
-import { dropdownConfigurations } from './dropdown';
-import { checkboxConfigurations } from './checkbox';
-import { checkboxListConfigurations } from './checkbox-list';
-import { radioGroupConfigurations } from './radio-group';
-import { radioItemConfigurations } from './radio-item';
-import { textAreaConfigurations } from './text-area';
-import { formItemConfigurations } from './form-item';
-import { formConfigurations } from './form';
-import { formStepperConfigurations } from './form-stepper';
-import { formStepConfigurations } from './form-step';
-import { datePickerConfigurations } from './date-picker';
-import { calendarConfigurations } from './calendar';
-import { fileUploadInputConfigurations } from './file-upload-input';
-import { fileUploadCardConfigurations } from './file-upload-card';
-import { calloutConfigurations } from './callout';
-import { notificationConfigurations } from './notification';
-import { temporaryNotificationConfigurations } from './temporary-notification';
-import { badgeConfigurations } from './badge';
-import { chipConfigurations } from './chip';
-import { filterChipConfigurations } from './filter-chip';
-import { tooltipConfigurations } from './tooltip';
-import { spinnerConfigurations } from './spinner';
-import { circularProgressConfigurations } from './circular-progress';
-import { linearProgressConfigurations } from './linear-progress';
-import { skeletonConfigurations } from './skeleton';
-import { containerConfigurations } from './container';
-import { blockConfigurations } from './block';
-import { gridConfigurations } from './grid';
-import { pageBlockConfigurations } from './page-block';
-import { pagesConfigurations } from './pages';
-import { dividerConfigurations } from './divider';
-import { spacerConfigurations } from './spacer';
-import { scrollableConfigurations } from './scrollable';
-import { heroBannerConfigurations } from './hero-banner';
-import { tabsConfigurations } from './tabs';
-import { tabConfigurations } from './tab';
-import { paginationConfigurations } from './pagination';
-import { sideMenuConfigurations } from './side-menu';
-import { sideMenuGroupConfigurations } from './side-menu-group';
-import { sideMenuHeadingConfigurations } from './side-menu-heading';
-import { workSideMenuConfigurations } from './work-side-menu';
-import { menuButtonConfigurations } from './menu-button';
-import { appHeaderConfigurations } from './app-header';
-import { appHeaderMenuConfigurations } from './app-header-menu';
-import { micrositeHeaderConfigurations } from './microsite-header';
-import { footerConfigurations } from './footer';
-import { footerNavSectionConfigurations } from './footer-nav-section';
-import { footerMetaSectionConfigurations } from './footer-meta-section';
-import { linkButtonConfigurations } from './link-button';
-import { cardConfigurations } from './card';
-import { cardGroupConfigurations } from './card-group';
-import { cardContentConfigurations } from './card-content';
-import { cardImageConfigurations } from './card-image';
-import { cardActionsConfigurations } from './card-actions';
-import { tableConfigurations } from './table';
-import { tableSortHeaderConfigurations } from './table-sort-header';
-import { dataGridConfigurations } from './data-grid';
-import { modalConfigurations } from './modal';
-import { drawerConfigurations } from './drawer';
-import { popoverConfigurations } from './popover';
-import { accordionConfigurations } from './accordion';
-import { detailsConfigurations } from './details';
-import { iconConfigurations } from './icon';
-import { iconButtonConfigurations } from './icon-button';
-import { buttonGroupConfigurations } from './button-group';
-import { linkConfigurations } from './link';
-import { textConfigurations } from './text';
-import { focusTrapConfigurations } from './focus-trap';
+import type { ComponentConfigurations, ConfigurationRegistry } from "./types";
+import { buttonConfigurations } from "./button";
+import { inputConfigurations } from "./input";
+import { dropdownConfigurations } from "./dropdown";
+import { checkboxConfigurations } from "./checkbox";
+import { checkboxListConfigurations } from "./checkbox-list";
+import { radioGroupConfigurations } from "./radio-group";
+import { radioItemConfigurations } from "./radio-item";
+import { textAreaConfigurations } from "./text-area";
+import { formItemConfigurations } from "./form-item";
+import { formConfigurations } from "./form";
+import { formStepperConfigurations } from "./form-stepper";
+import { formStepConfigurations } from "./form-step";
+import { datePickerConfigurations } from "./date-picker";
+import { calendarConfigurations } from "./calendar";
+import { fileUploadInputConfigurations } from "./file-upload-input";
+import { fileUploadCardConfigurations } from "./file-upload-card";
+import { calloutConfigurations } from "./callout";
+import { notificationConfigurations } from "./notification";
+import { temporaryNotificationConfigurations } from "./temporary-notification";
+import { badgeConfigurations } from "./badge";
+import { chipConfigurations } from "./chip";
+import { filterChipConfigurations } from "./filter-chip";
+import { tooltipConfigurations } from "./tooltip";
+import { spinnerConfigurations } from "./spinner";
+import { circularProgressConfigurations } from "./circular-progress";
+import { linearProgressConfigurations } from "./linear-progress";
+import { skeletonConfigurations } from "./skeleton";
+import { containerConfigurations } from "./container";
+import { blockConfigurations } from "./block";
+import { gridConfigurations } from "./grid";
+import { pageBlockConfigurations } from "./page-block";
+import { pagesConfigurations } from "./pages";
+import { dividerConfigurations } from "./divider";
+import { spacerConfigurations } from "./spacer";
+import { scrollableConfigurations } from "./scrollable";
+import { heroBannerConfigurations } from "./hero-banner";
+import { tabsConfigurations } from "./tabs";
+import { tabConfigurations } from "./tab";
+import { paginationConfigurations } from "./pagination";
+import { sideMenuConfigurations } from "./side-menu";
+import { sideMenuGroupConfigurations } from "./side-menu-group";
+import { sideMenuHeadingConfigurations } from "./side-menu-heading";
+import { workSideMenuConfigurations } from "./work-side-menu";
+import { menuButtonConfigurations } from "./menu-button";
+import { appHeaderConfigurations } from "./app-header";
+import { appHeaderMenuConfigurations } from "./app-header-menu";
+import { micrositeHeaderConfigurations } from "./microsite-header";
+import { footerConfigurations } from "./footer";
+import { footerNavSectionConfigurations } from "./footer-nav-section";
+import { footerMetaSectionConfigurations } from "./footer-meta-section";
+import { linkButtonConfigurations } from "./link-button";
+import { cardConfigurations } from "./card";
+import { cardGroupConfigurations } from "./card-group";
+import { cardContentConfigurations } from "./card-content";
+import { cardImageConfigurations } from "./card-image";
+import { cardActionsConfigurations } from "./card-actions";
+import { tableConfigurations } from "./table";
+import { tableSortHeaderConfigurations } from "./table-sort-header";
+import { dataGridConfigurations } from "./data-grid";
+import { modalConfigurations } from "./modal";
+import { drawerConfigurations } from "./drawer";
+import { pushDrawerConfigurations } from "./push-drawer";
+import { popoverConfigurations } from "./popover";
+import { accordionConfigurations } from "./accordion";
+import { detailsConfigurations } from "./details";
+import { iconConfigurations } from "./icon";
+import { iconButtonConfigurations } from "./icon-button";
+import { buttonGroupConfigurations } from "./button-group";
+import { linkConfigurations } from "./link";
+import { textConfigurations } from "./text";
+import { focusTrapConfigurations } from "./focus-trap";
 
 /**
  * Registry of all component configurations.
@@ -172,82 +174,83 @@ export const configurationRegistry: ConfigurationRegistry = {
   input: inputConfigurations,
   dropdown: dropdownConfigurations,
   checkbox: checkboxConfigurations,
-  'checkbox-list': checkboxListConfigurations,
-  'radio-group': radioGroupConfigurations,
-  'radio-item': radioItemConfigurations,
-  'text-area': textAreaConfigurations,
-  'form-item': formItemConfigurations,
+  "checkbox-list": checkboxListConfigurations,
+  "radio-group": radioGroupConfigurations,
+  "radio-item": radioItemConfigurations,
+  "text-area": textAreaConfigurations,
+  "form-item": formItemConfigurations,
   form: formConfigurations,
-  'form-stepper': formStepperConfigurations,
-  'form-step': formStepConfigurations,
-  'date-picker': datePickerConfigurations,
+  "form-stepper": formStepperConfigurations,
+  "form-step": formStepConfigurations,
+  "date-picker": datePickerConfigurations,
   calendar: calendarConfigurations,
-  'file-upload-input': fileUploadInputConfigurations,
-  'file-upload-card': fileUploadCardConfigurations,
+  "file-upload-input": fileUploadInputConfigurations,
+  "file-upload-card": fileUploadCardConfigurations,
 
   // Feedback components
   callout: calloutConfigurations,
   notification: notificationConfigurations,
-  'temporary-notification': temporaryNotificationConfigurations,
+  "temporary-notification": temporaryNotificationConfigurations,
   badge: badgeConfigurations,
   chip: chipConfigurations,
-  'filter-chip': filterChipConfigurations,
+  "filter-chip": filterChipConfigurations,
   tooltip: tooltipConfigurations,
   spinner: spinnerConfigurations,
-  'circular-progress': circularProgressConfigurations,
-  'linear-progress': linearProgressConfigurations,
+  "circular-progress": circularProgressConfigurations,
+  "linear-progress": linearProgressConfigurations,
   skeleton: skeletonConfigurations,
 
   // Layout components
   container: containerConfigurations,
   block: blockConfigurations,
   grid: gridConfigurations,
-  'page-block': pageBlockConfigurations,
+  "page-block": pageBlockConfigurations,
   pages: pagesConfigurations,
   divider: dividerConfigurations,
   spacer: spacerConfigurations,
   scrollable: scrollableConfigurations,
-  'hero-banner': heroBannerConfigurations,
+  "hero-banner": heroBannerConfigurations,
 
   // Navigation components
   tabs: tabsConfigurations,
   tab: tabConfigurations,
   pagination: paginationConfigurations,
-  'side-menu': sideMenuConfigurations,
-  'side-menu-group': sideMenuGroupConfigurations,
-  'side-menu-heading': sideMenuHeadingConfigurations,
-  'work-side-menu': workSideMenuConfigurations,
-  'menu-button': menuButtonConfigurations,
-  'app-header': appHeaderConfigurations,
-  'app-header-menu': appHeaderMenuConfigurations,
-  'microsite-header': micrositeHeaderConfigurations,
+  "side-menu": sideMenuConfigurations,
+  "side-menu-group": sideMenuGroupConfigurations,
+  "side-menu-heading": sideMenuHeadingConfigurations,
+  "work-side-menu": workSideMenuConfigurations,
+  "menu-button": menuButtonConfigurations,
+  "app-header": appHeaderConfigurations,
+  "app-header-menu": appHeaderMenuConfigurations,
+  "microsite-header": micrositeHeaderConfigurations,
   footer: footerConfigurations,
-  'footer-nav-section': footerNavSectionConfigurations,
-  'footer-meta-section': footerMetaSectionConfigurations,
-  'link-button': linkButtonConfigurations,
+  "footer-nav-section": footerNavSectionConfigurations,
+  "footer-meta-section": footerMetaSectionConfigurations,
+  "link-button": linkButtonConfigurations,
 
   // Display components
   card: cardConfigurations,
-  'card-group': cardGroupConfigurations,
-  'card-content': cardContentConfigurations,
-  'card-image': cardImageConfigurations,
-  'card-actions': cardActionsConfigurations,
+  "card-group": cardGroupConfigurations,
+  "card-content": cardContentConfigurations,
+  "card-image": cardImageConfigurations,
+  "card-actions": cardActionsConfigurations,
   table: tableConfigurations,
-  'table-sort-header': tableSortHeaderConfigurations,
-  'data-grid': dataGridConfigurations,
+  "table-sort-header": tableSortHeaderConfigurations,
+  "data-grid": dataGridConfigurations,
   modal: modalConfigurations,
   drawer: drawerConfigurations,
+  "push-drawer": pushDrawerConfigurations,
   popover: popoverConfigurations,
   accordion: accordionConfigurations,
   details: detailsConfigurations,
 
   // Utility components
   icon: iconConfigurations,
-  'icon-button': iconButtonConfigurations,
-  'button-group': buttonGroupConfigurations,
+  "icon-button": iconButtonConfigurations,
+  "button-group": buttonGroupConfigurations,
   link: linkConfigurations,
   text: textConfigurations,
-  'focus-trap': focusTrapConfigurations,
+  "focus-trap": focusTrapConfigurations,
 };
 
 /**
@@ -255,7 +258,7 @@ export const configurationRegistry: ConfigurationRegistry = {
  * Returns undefined if no configurations exist.
  */
 export function getComponentConfigurations(
-  slug: string
+  slug: string,
 ): ComponentConfigurations | undefined {
   return configurationRegistry[slug];
 }

--- a/docs/src/data/configurations/push-drawer.ts
+++ b/docs/src/data/configurations/push-drawer.ts
@@ -1,0 +1,174 @@
+/**
+ * Push Drawer Component Configurations
+ *
+ * Push drawers push the main page content aside on desktop,
+ * falling back to an overlay drawer on smaller screens.
+ */
+
+import type { ComponentConfigurations } from "./types";
+
+const pushDrawerScript = `
+document.getElementById('open-push-drawer').addEventListener('click', () => {
+  document.getElementById('demo-push-drawer').setAttribute('open', 'true');
+});
+document.getElementById('demo-push-drawer').addEventListener('_close', (e) => {
+  e.target.removeAttribute('open');
+});
+`;
+
+export const pushDrawerConfigurations: ComponentConfigurations = {
+  componentSlug: "push-drawer",
+  componentName: "Push Drawer",
+  defaultConfigurationId: "basic",
+
+  configurations: [
+    {
+      id: "basic",
+      name: "Basic push drawer",
+      description: "Opens from the right, pushing page content aside",
+      code: {
+        react: `<GoabPushDrawer heading="Application details" width="260px" open={isOpen} onClose={handleClose}>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="none">Applicant name</GoabText>
+  <GoabText size="body-m" mt="none">Jane Smith</GoabText>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="none">File number</GoabText>
+  <GoabText size="body-m" mt="none">24567-9876</GoabText>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="none">Status</GoabText>
+  <GoabxBadge type="success" content="Approved" />
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="m">Submitted</GoabText>
+  <GoabText size="body-m" mt="none">January 15, 2025</GoabText>
+</GoabPushDrawer>`,
+        angular: `<goab-push-drawer heading="Application details" width="260px" [open]="isOpen" (onClose)="handleClose()">
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="none">Applicant name</goab-text>
+  <goab-text size="body-m" mt="none">Jane Smith</goab-text>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="none">File number</goab-text>
+  <goab-text size="body-m" mt="none">24567-9876</goab-text>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="none">Status</goab-text>
+  <goab-badge version="2" type="success" content="Approved"></goab-badge>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="m">Submitted</goab-text>
+  <goab-text size="body-m" mt="none">January 15, 2025</goab-text>
+</goab-push-drawer>`,
+        webComponents: `<div style="display: flex; min-height: 320px;">
+  <div style="flex: 1; min-width: 0; display: flex; align-items: center; justify-content: center;">
+    <goa-button version="2" id="open-push-drawer">Open push drawer</goa-button>
+  </div>
+  <goa-push-drawer version="2" id="demo-push-drawer" heading="Application details" width="260px">
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="none">Applicant name</goa-text>
+    <goa-text size="body-m" mt="none">Jane Smith</goa-text>
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="none">File number</goa-text>
+    <goa-text size="body-m" mt="none">24567-9876</goa-text>
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="none">Status</goa-text>
+    <goa-badge version="2" type="success" content="Approved"></goa-badge>
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="m">Submitted</goa-text>
+    <goa-text size="body-m" mt="none">January 15, 2025</goa-text>
+  </goa-push-drawer>
+</div>
+<script>${pushDrawerScript}</script>`,
+      },
+    },
+    {
+      id: "custom-width",
+      name: "Custom width",
+      description: "Push drawer with a custom width",
+      code: {
+        react: `<GoabPushDrawer heading="Case notes" width="600px" open={isOpen} onClose={handleClose}>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="none">Officer</GoabText>
+  <GoabText size="body-m" mt="none">Const. M. Roberts, Badge #4412</GoabText>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="none">Date</GoabText>
+  <GoabText size="body-m" mt="none">February 3, 2025</GoabText>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="none">Notes</GoabText>
+  <GoabText size="body-m" mt="none">Applicant provided updated documentation. Reviewed supporting evidence and confirmed eligibility criteria are met. Forwarded to supervisor for final approval.</GoabText>
+</GoabPushDrawer>`,
+        angular: `<goab-push-drawer heading="Case notes" width="600px" [open]="isOpen" (onClose)="handleClose()">
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="none">Officer</goab-text>
+  <goab-text size="body-m" mt="none">Const. M. Roberts, Badge #4412</goab-text>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="none">Date</goab-text>
+  <goab-text size="body-m" mt="none">February 3, 2025</goab-text>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="none">Notes</goab-text>
+  <goab-text size="body-m" mt="none">Applicant provided updated documentation. Reviewed supporting evidence and confirmed eligibility criteria are met. Forwarded to supervisor for final approval.</goab-text>
+</goab-push-drawer>`,
+        webComponents: `<div style="display: flex; min-height: 320px;">
+  <div style="flex: 1; min-width: 0; display: flex; align-items: center; justify-content: center;">
+    <goa-button version="2" id="open-push-drawer">Open push drawer</goa-button>
+  </div>
+  <goa-push-drawer version="2" id="demo-push-drawer" heading="Case notes" width="600px">
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="none">Officer</goa-text>
+    <goa-text size="body-m" mt="none">Const. M. Roberts, Badge #4412</goa-text>
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="none">Date</goa-text>
+    <goa-text size="body-m" mt="none">February 3, 2025</goa-text>
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="none">Notes</goa-text>
+    <goa-text size="body-m" mt="none">Applicant provided updated documentation. Reviewed supporting evidence and confirmed eligibility criteria are met. Forwarded to supervisor for final approval.</goa-text>
+  </goa-push-drawer>
+</div>
+<script>${pushDrawerScript}</script>`,
+      },
+    },
+    {
+      id: "with-actions",
+      name: "With actions",
+      description: "Push drawer with footer actions",
+      code: {
+        react: `<GoabPushDrawer
+  heading="Edit notification preferences"
+  width="280px"
+  open={isOpen}
+  onClose={handleClose}
+  actions={
+    <GoabButtonGroup alignment="start">
+      <GoabxButton size="compact">Save</GoabxButton>
+      <GoabxButton type="secondary" size="compact">Cancel</GoabxButton>
+    </GoabButtonGroup>
+  }
+>
+  <GoabxFormItem label="Email notifications">
+    <GoabxCheckboxList name="email-notifications" value={["updates", "deadlines"]}>
+      <GoabxCheckbox name="updates" text="Case status updates" />
+      <GoabxCheckbox name="deadlines" text="Upcoming deadlines" />
+      <GoabxCheckbox name="assignments" text="New assignments" />
+    </GoabxCheckboxList>
+  </GoabxFormItem>
+</GoabPushDrawer>`,
+        angular: `<goab-push-drawer
+  heading="Edit notification preferences"
+  width="280px"
+  [open]="isOpen"
+  (onClose)="handleClose()"
+  [actions]="pushDrawerActions"
+>
+  <goabx-form-item label="Email notifications">
+    <goabx-checkbox-list name="email-notifications" [value]="checkboxListValues">
+      <goabx-checkbox name="updates" text="Case status updates"></goabx-checkbox>
+      <goabx-checkbox name="deadlines" text="Upcoming deadlines"></goabx-checkbox>
+      <goabx-checkbox name="assignments" text="New assignments"></goabx-checkbox>
+    </goabx-checkbox-list>
+  </goabx-form-item>
+</goab-push-drawer>
+
+<ng-template #pushDrawerActions>
+  <goab-button-group alignment="start">
+    <goabx-button size="compact">Save</goabx-button>
+    <goabx-button type="secondary" size="compact">Cancel</goabx-button>
+  </goab-button-group>
+</ng-template>`,
+        webComponents: `<div style="display: flex; min-height: 320px;">
+  <div style="flex: 1; min-width: 0; display: flex; align-items: center; justify-content: center;">
+    <goa-button version="2" id="open-push-drawer">Open push drawer</goa-button>
+  </div>
+  <goa-push-drawer version="2" id="demo-push-drawer" heading="Edit notification preferences" width="280px">
+    <goa-form-item version="2" label="Email notifications">
+      <goa-checkbox-list name="email-notifications" value="updates,deadlines">
+        <goa-checkbox version="2" name="updates" text="Case status updates"></goa-checkbox>
+        <goa-checkbox version="2" name="deadlines" text="Upcoming deadlines"></goa-checkbox>
+        <goa-checkbox version="2" name="assignments" text="New assignments"></goa-checkbox>
+      </goa-checkbox-list>
+    </goa-form-item>
+    <goa-button-group slot="actions" alignment="start">
+      <goa-button version="2" size="compact">Save</goa-button>
+      <goa-button version="2" type="secondary" size="compact">Cancel</goa-button>
+    </goa-button-group>
+  </goa-push-drawer>
+</div>
+<script>${pushDrawerScript}</script>`,
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- Adds the missing push drawer component documentation to the docs website
- MDX page with frontmatter (name, description, status, category, tags)
- 3 configuration previews: basic, custom width, with actions
- 4 guidance atoms (do/don't/info/tip)
- Example: "Filter a list using a push drawer" with table, badges, checkbox-list, and dropdown (React + web components)

## Dependencies

- **PR #3513** (API extraction + nav automation) — must merge first or rebase after. The `index.ts` config registry has a formatting conflict. Once #3513 lands, the temporary `docs/generated/component-apis/push-drawer.json` will be auto-generated and gitignored.
- **No other blockers** — this PR stands on its own for review.

## Notes

- Push drawer only has standard wrappers (`GoabPushDrawer` / `goab-push-drawer`), not experimental. Configs and examples use standard wrappers accordingly. Brief 84 tracks adding experimental wrappers.
- The config preview uses a flex wrapper to demonstrate the push effect within the sandbox — a centered button shifts left when the drawer slides in.
- The example renders a live table with the push drawer as a sibling, showing the actual push behavior.

## Test plan

- [ ] Verify page renders at [`/components/push-drawer`](https://deploy-preview-3521--goa-design-2.netlify.app/components/push-drawer/#react#properties)
- [ ] Configuration previews: open/close each, check push effect and content
- [ ] Example: open filters drawer, verify table pushes left, button hides
- [ ] Properties tab shows props and slots
- [ ] Usage guidelines tab shows 4 guidance atoms
- [ ] Responsive: check mobile fallback (overlay drawer below 1024px)