### PR TITLE
feat(#3569): fix the PushDrawer open prop so the docs site works

### DIFF
--- a/libs/react-components/src/lib/push-drawer/push-drawer.tsx
+++ b/libs/react-components/src/lib/push-drawer/push-drawer.tsx
@@ -53,7 +53,7 @@ export function GoabPushDrawer({
     <goa-push-drawer
       ref={el}
       testid={testid}
-      open={open ?? false}
+      open={open ? true : undefined}
       heading={typeof heading === "string" ? heading : undefined}
       width={width}
     >


### PR DESCRIPTION
This fixes how the `PushDrawer` open prop is propagated. This could be a bigger bug, but the main reason for this PR is that the Code Sandbox for the v1 docs will keep the `open` prop on the base control, which Svelte interprets as a "true".
This [copies what the `GoabDrawer` does.](https://github.com/GovAlta/ui-components/blob/183d34aa889fcd9586deb7812a601cad7c8eb88d/libs/react-components/src/lib/drawer/drawer.tsx#L41), and the PushDrawer's `heading` attribute.

# Before (the change)

The Push Drawer on the docs site is _always_ open.

# After (the change)

The Push Drawer on the docs site opens and closes with the controls and functions properly.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Most obviously, the http://localhost:4201/features/2469 tests still work.

To test the Docs site:

Build this branch
Run the following commands:
- `npm i`
- `npm run build:prod`
- `cd dist/libs/react-components`
- `npm pack`

Pull the `eric/2469-push-drawer-docs` branch: https://github.com/GovAlta/ui-components-docs/pull/471
- open `package.json`
- replace `"@abgov/react-components": "6.11.0",` with `"@abgov/react-components": "../ui-components/dist/libs/react-components/abgov-react-components-0.0.1.tgz",`
- `npm i`

Then go to `http://localhost:5173/components/push-drawer#code-playground`.
- [ ] the drawer will only open when the "Open Drawer" button is clicked
- [ ] the drawer will close when the "Close Drawer" and other "Close" buttons are clicked