### PR TITLE
fix: use Node 22 for Netlify deploys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,5 @@
   command = "npm ci && cd docs && npm ci && cd .. && npm run build:prod"
 
 [build.environment]
-  NODE_VERSION = "24"
+  NODE_VERSION = "22"
   NPM_FLAGS = "--legacy-peer-deps"


### PR DESCRIPTION
## Summary

- Netlify deploy previews are broken for branches based on the latest dev. The install step crashes before the build even starts with this error:

`npm error code ERR_INVALID_ARG_TYPE `
`npm error The "from" argument must be of type string. Received undefined`

- Branches based on older dev still deploy fine, which is why some PRs aren't affected.
- After troubleshooting with Claude, switching from Node 24 to Node 22 (the current stable version) fixes it. The deploy preview on this PR builds successfully.

## Test plan

- [ ] Netlify deploy preview builds successfully
- [ ] Verify the preview site loads and pages work