### PR TITLE
feat(#3402): dispatch _navigate on WorkSideMenuItem click for SPA navigation

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -36,92 +36,99 @@
   </section>
 
   <div style="display: flex; flex: 1 1 auto">
-    <section style="flex: 0 0 250px" role="nav">
-      <goab-side-menu>
-        <a href="/everything">All Components</a>
-        <goab-side-menu-group heading="Bugs">
-          <a href="/bugs/2152">2152</a>
-          <a href="/bugs/2331">2331</a>
-          <a href="/bugs/2393">2393</a>
-          <a href="/bugs/2404">2404</a>
-          <a href="/bugs/2408">2408</a>
-          <a href="/bugs/2459">2459</a>
-          <a href="/bugs/2473">2473</a>
-          <a href="/bugs/2502">2502</a>
-          <a href="/bugs/2529">2529</a>
-          <a href="/bugs/2547">2547</a>
-          <a href="/bugs/2655">2655</a>
-          <a href="/bugs/2720">2720</a>
-          <a href="/bugs/2721">2721</a>
-          <a href="/bugs/2750">2750</a>
-          <a href="/bugs/2768">2768</a>
-          <a href="/bugs/2782">2782</a>
-          <a href="/bugs/2789">2789</a>
-          <a href="/bugs/2821">2821</a>
-          <a href="/bugs/2837">2837</a>
-          <a href="/bugs/2839">2839</a>
-          <a href="/bugs/2849">2849</a>
-          <a href="/bugs/2852">2852</a>
-          <a href="/bugs/2873">2873</a>
-          <a href="/bugs/2878">2878</a>
-          <a href="/bugs/2892">2892</a>
-          <a href="/bugs/2922">2922</a>
-          <a href="/bugs/2943">2943</a>
-          <a href="/bugs/2948">2948</a>
-          <a href="/bugs/2977">2977</a>
-          <a href="/bugs/2991">2991</a>
-          <a href="/bugs/3072">3072</a>
-          <a href="/bugs/3118">3118</a>
-          <a href="/bugs/3156">3156</a>
-          <a href="/bugs/3201">3201</a>
-          <a href="/bugs/3215">3215</a>
-          <a href="/bugs/3248">3248</a>
-          <a href="/bugs/3273">3273</a>
-          <a href="/bugs/3275">3275 Can't unset month</a>
-          <a href="/bugs/3281">3281</a>
-          <a href="/bugs/3337">3337 - Autocomplete styling</a>
-          <a href="/bugs/3279">3279</a>
-          <a href="/bugs/3384">3384 Table v2 sample</a>
-          <a href="/bugs/3450">3450 Dropdown expanding inside Container</a>
-        </goab-side-menu-group>
-        <goab-side-menu-group heading="Features">
-          <a href="/features/1328">1328</a>
-          <a href="/features/1383">1383</a>
-          <a href="/features/1547">1547</a>
-          <a href="/features/1813">1813</a>
-          <a href="/features/1908">1908</a>
-          <a href="/features/2054">2054</a>
-          <a href="/features/2267">2267</a>
-          <a href="/features/2328">2328</a>
-          <a href="/features/2440">2440</a>
-          <a href="/features/2469">2469</a>
-          <a href="/features/2361">2361</a>
-          <a href="/features/2492">2492</a>
-          <a href="/features/2609">2609</a>
-          <a href="/features/2611">2611</a>
-          <a href="/features/2611-tabs-disabled">2611-tabs-disabled</a>
-          <a href="/features/2682">2682</a>
-          <a href="/features/2722">2722</a>
-          <a href="/features/2730">2730</a>
-          <a href="/features/2829">2829</a>
-          <a href="/features/3102">3102</a>
-          <a href="/features/3229">3229 MenuButton vs size and icon-only</a>
-          <a href="/features/3137">3137</a>
-          <a href="/features/3211">3211 Angular v21</a>
-          <a href="/features/3241">3241</a>
-          <a href="/features/3306">3306</a>
-          <a href="/features/3370">3370</a>
-          <a href="/features/3398">3398 Work side menu group open prop </a>
-          <a href="/features/v2-icons">v2 header icons</a>
-          <a href="/features/3344">3344 Table Multi-Sort</a>
-          <a href="/features/3396">3396 Text heading-2xs size</a>
-          <a href="/features/3407-skip-on-focus-tab">3407 Skip Focus on Tab</a>
-          <a href="/features/3407-stack-on-mobile">3407 Tabs Orientation</a>
-          <a href="/features/v2-checkbox">3399 V2 Checkbox Spacing</a>
-          <a href="/features/3478">3478 Popover API Rewrite</a>
-        </goab-side-menu-group>
-      </goab-side-menu>
-    </section>
+    <goabx-work-side-menu
+      heading="Testing Playground"
+      url="/"
+      [open]="true"
+      (onNavigate)="handleNavigate($event)"
+      [primaryContent]="primaryTemplate"
+    >
+    </goabx-work-side-menu>
+
+    <ng-template #primaryTemplate>
+      <goabx-work-side-menu-item label="All Components" url="/everything" icon="list"></goabx-work-side-menu-item>
+      <goabx-work-side-menu-group icon="alert-circle" heading="Bugs">
+        <goabx-work-side-menu-item label="2152" url="/bugs/2152"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2331" url="/bugs/2331"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2393" url="/bugs/2393"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2404" url="/bugs/2404"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2408" url="/bugs/2408"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2459" url="/bugs/2459"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2473" url="/bugs/2473"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2502" url="/bugs/2502"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2529" url="/bugs/2529"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2547" url="/bugs/2547"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2655" url="/bugs/2655"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2720" url="/bugs/2720"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2721" url="/bugs/2721"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2750" url="/bugs/2750"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2768" url="/bugs/2768"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2782" url="/bugs/2782"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2789" url="/bugs/2789"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2821" url="/bugs/2821"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2837" url="/bugs/2837"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2839" url="/bugs/2839"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2849" url="/bugs/2849"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2852" url="/bugs/2852"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2873" url="/bugs/2873"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2878" url="/bugs/2878"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2892" url="/bugs/2892"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2922" url="/bugs/2922"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2943" url="/bugs/2943"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2948" url="/bugs/2948"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2977" url="/bugs/2977"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2991" url="/bugs/2991"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3072" url="/bugs/3072"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3118" url="/bugs/3118"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3156" url="/bugs/3156"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3201" url="/bugs/3201"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3215" url="/bugs/3215"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3248" url="/bugs/3248"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3273" url="/bugs/3273"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3275 Can't unset month" url="/bugs/3275"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3281" url="/bugs/3281"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3337 Autocomplete styling" url="/bugs/3337"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3279" url="/bugs/3279"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3384 Table v2 sample" url="/bugs/3384"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3450 Dropdown expanding" url="/bugs/3450"></goabx-work-side-menu-item>
+      </goabx-work-side-menu-group>
+      <goabx-work-side-menu-group icon="star" heading="Features">
+        <goabx-work-side-menu-item label="1328" url="/features/1328"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="1383" url="/features/1383"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="1547" url="/features/1547"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="1813" url="/features/1813"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="1908" url="/features/1908"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2054" url="/features/2054"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2267" url="/features/2267"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2328" url="/features/2328"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2440" url="/features/2440"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2469" url="/features/2469"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2361" url="/features/2361"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2492" url="/features/2492"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2609" url="/features/2609"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2611" url="/features/2611"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2611 tabs disabled" url="/features/2611-tabs-disabled"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2682" url="/features/2682"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2722" url="/features/2722"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2730" url="/features/2730"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="2829" url="/features/2829"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3102" url="/features/3102"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3229 MenuButton" url="/features/3229"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3137" url="/features/3137"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3211 Angular v21" url="/features/3211"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3241" url="/features/3241"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3306" url="/features/3306"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3370" url="/features/3370"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3398 Group open prop" url="/features/3398"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="v2 header icons" url="/features/v2-icons"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3344 Table Multi-Sort" url="/features/3344"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3396 Text heading-2xs" url="/features/3396"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3407 Skip Focus on Tab" url="/features/3407-skip-on-focus-tab"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3407 Tabs Orientation" url="/features/3407-stack-on-mobile"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3399 V2 Checkbox" url="/features/v2-checkbox"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3478 Popover API Rewrite" url="/features/3478"></goabx-work-side-menu-item>
+      </goabx-work-side-menu-group>
+    </ng-template>
     <section style="padding: 30px; width: 100%" role="main">
       <router-outlet></router-outlet>
     </section>

--- a/apps/prs/angular/src/app/app.component.ts
+++ b/apps/prs/angular/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import { Router } from "@angular/router";
 
 @Component({
   selector: "abgov-root",
@@ -6,4 +7,10 @@ import { Component } from "@angular/core";
   styles: ``,
   standalone: false,
 })
-export class AppComponent {}
+export class AppComponent {
+  constructor(private router: Router) {}
+
+  handleNavigate(path: string): void {
+    this.router.navigateByUrl(path);
+  }
+}

--- a/apps/prs/angular/src/app/app.module.ts
+++ b/apps/prs/angular/src/app/app.module.ts
@@ -14,8 +14,9 @@ import {
   GoabAppFooter,
   GoabMicrositeHeader,
   GoabAppHeaderMenu,
-  GoabSideMenu,
-  GoabSideMenuGroup,
+  GoabxWorkSideMenu,
+  GoabxWorkSideMenuItem,
+  GoabxWorkSideMenuGroup,
 } from "@abgov/angular-components";
 
 @NgModule({
@@ -25,8 +26,9 @@ import {
     GoabAppFooter,
     GoabMicrositeHeader,
     GoabAppHeaderMenu,
-    GoabSideMenu,
-    GoabSideMenuGroup,
+    GoabxWorkSideMenu,
+    GoabxWorkSideMenuItem,
+    GoabxWorkSideMenuGroup,
     BrowserModule,
     RouterModule.forRoot(appRoutes),
     AngularComponentsModule,

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -1,16 +1,21 @@
-import { Link, Outlet } from "react-router-dom";
+import { Outlet, useNavigate } from "react-router-dom";
 import {
   GoabAppFooter,
   GoabAppHeader,
   GoabAppHeaderMenu,
   GoabMicrositeHeader,
   GoabOneColumnLayout,
-  GoabSideMenu,
-  GoabSideMenuGroup,
 } from "@abgov/react-components";
+import {
+  GoabxWorkSideMenu,
+  GoabxWorkSideMenuItem,
+  GoabxWorkSideMenuGroup,
+} from "@abgov/react-components/experimental";
 import "@abgov/style";
 
 export function App() {
+  const navigate = useNavigate();
+
   return (
     <GoabOneColumnLayout>
       <section slot="header" id="top">
@@ -47,99 +52,96 @@ export function App() {
         </GoabAppHeader>
       </section>
       <div style={{ display: "flex", minHeight: "100vh" }}>
-        <section
-          style={{
-            flex: "0 0 250px",
-            borderRight: "1px solid var(--goa-color-greyscale-200)",
-            minHeight: "100%",
-          }}
-          role="nav"
-        >
-          <GoabSideMenu>
-            <GoabSideMenuGroup heading="Bugs">
-              <Link to="/bugs/2152">2152 Icon Custom Alignment</Link>
-              <Link to="/bugs/2331">2331 Block and Tab Dynamic Data</Link>
-              <Link to="/bugs/2393">2393 Popover Not Appearing</Link>
-              <Link to="/bugs/2404">2404 Input Angular Icon Button</Link>
-              <Link to="/bugs/2408">2408 Form Stepper Incomplete Rendering</Link>
-              <Link to="/bugs/2459">2459 File Upload Card TestId</Link>
-              <Link to="/bugs/2473">2473 DatePicker Ordinal Suffixes</Link>
-              <Link to="/bugs/2502">2502 Native Dropdown Height</Link>
-              <Link to="/bugs/2529">2529 Input Width Generation</Link>
-              <Link to="/bugs/2547">2547 Popover Hidden Near Notification</Link>
-              <Link to="/bugs/2655">2655 Dropdown/DatePicker in Modal</Link>
-              <Link to="/bugs/2720">2720 Tabs Change via Link</Link>
-              <Link to="/bugs/2721">2721 Text Tag Margin</Link>
-              <Link to="/bugs/2750">2750 Year Select Sorting</Link>
-              <Link to="/bugs/2768">2768 Enable/Disable Components</Link>
-              <Link to="/bugs/2782">2782 Disabled Inputs Hidden</Link>
-              <Link to="/bugs/2789">2789 Width Rem Measurements</Link>
-              <Link to="/bugs/2821">2821 Table Header Sorting Toggle</Link>
-              <Link to="/bugs/2837">2837 InputNumber Leading/Trailing Content</Link>
-              <Link to="/bugs/2839">2839 Button State After Click</Link>
-              <Link to="/bugs/2849">2849 Filterable Dropdown Keyboard</Link>
-              <Link to="/bugs/2852">2852 Filterable Dropdown Space Key</Link>
-              <Link to="/bugs/2873">2873 Drawer Scrolling Focus</Link>
-              <Link to="/bugs/2878">2878 DatePicker Input onChange</Link>
-              <Link to="/bugs/2892">2892 Input Width Calculations</Link>
-              <Link to="/bugs/2922">2922 Form Stepper Vertical</Link>
-              <Link to="/bugs/2943">2943 Drawer Text Components</Link>
-              <Link to="/bugs/2948">2948 Modal Heading Spacing</Link>
-              <Link to="/bugs/2977">2977 OnChangeDetails Event Missing</Link>
-              <Link to="/bugs/3118">3118 Text Component ID</Link>
-              <Link to="/bugs/3201">3201 Input Component Events</Link>
-              <Link to="/bugs/3215">3215 Drawer Initial Height</Link>
-              <Link to="/bugs/3232">3232 GoabText Tag Size</Link>
-              <Link to="/bugs/3248">3248 Dropdown Dynamic Children Sync</Link>
-              <Link to="/bugs/3273">3273 Nested Side Menu Groups</Link>
-              <Link to="/bugs/3275">3275 Can't unset month</Link>
-              <Link to="/bugs/3322">3322 App Header Menu Hover</Link>
-              <Link to="/bugs/3281">3281 GoabText p tag margin issues</Link>
-              <Link to="/bugs/3337">3337 Input autocomplete styling</Link>
-              <Link to="/bugs/3279">3279 Work Side Menu Key Nav</Link>
-              <Link to="/bugs/3384">3384 v2 Table Border</Link>
-              <Link to="/bugs/3450">3450 Dropdown expanding inside Container</Link>
-            </GoabSideMenuGroup>
-            <GoabSideMenuGroup heading="Features">
-              <Link to="/features/1383">1383 Button Filled Icons</Link>
-              <Link to="/features/1547">1547 Tooltip Multiline</Link>
-              <Link to="/features/1813">1813 DatePicker Width Properties</Link>
-              <Link to="/features/1908">1908 Linear Progress</Link>
-              <Link to="/features/2054">2054 MaxWidth Support</Link>
-              <Link to="/features/2267">2267 Checkbox List</Link>
-              <Link to="/features/2328">2328 Container Height Property</Link>
-              <Link to="/features/2361">2361 Radio/Checkbox Clickable Area</Link>
-              <Link to="/features/2440">2440 MenuButton Icon</Link>
-              <Link to="/features/2469">2469 Push Drawer</Link>
-              <Link to="/features/2492">2492 TextArea onBlur</Link>
-              <Link to="/features/2609">2609 Data Table Base Component</Link>
-              <Link to="/features/2611">2611 Segmented Tab</Link>
-              <Link to="/features/2611-tabs-disabled">2611 Disabled Tab</Link>
-              <Link to="/features/2682">2682 DatePicker Issues</Link>
-              <Link to="/features/2722">2722 Input Text-Align</Link>
-              <Link to="/features/2730">2730 Temporary Notification Controller</Link>
-              <Link to="/features/2829">2829 Modal ARIA Live Region</Link>
-              <Link to="/features/2877">2877 Badge Types and Custom Icon</Link>
-              <Link to="/features/3102">3102 MenuButton Width</Link>
-              <Link to="/features/3137">3137 Work Side Menu Group</Link>
-              <Link to="/features/3241">3241 V2 Experimental Wrappers</Link>
-              <Link to="/features/v2-icons">v2 header icons</Link>
-              <Link to="/features/3229">3229 V2 Menu Button vs size and icon-only</Link>
-              <Link to="/features/3344">3344 Table Multi-Sort</Link>
-              <Link to="/features/3306">3306 Custom slug value for tabs</Link>
-              <Link to="/features/3370">3370 Clear calendar day selection</Link>
-              <Link to="/features/3396">3396 Text heading-2xs size</Link>
-              <Link to="/features/v2-checkbox">3399 V2 Checkbox Spacing</Link>
-              <Link to="/features/3407-skip-on-focus-tab">3407 Skip Focus on Tab</Link>
-              <Link to="/features/3407-stack-on-mobile">3407 Tabs Orientation</Link>
-              <Link to="/features/3398">3398 Group open prop</Link>
-              <Link to="/features/3478">3478 Popover API Rewrite</Link>
-            </GoabSideMenuGroup>
-            <GoabSideMenuGroup heading="Everything">
-              <Link to="/everything">A</Link>
-            </GoabSideMenuGroup>
-          </GoabSideMenu>
-        </section>
+        <GoabxWorkSideMenu
+          heading="Testing Playground"
+          url="/"
+          open={true}
+          onNavigate={(path: string) => navigate(path)}
+          primaryContent={
+            <>
+              <GoabxWorkSideMenuGroup icon="alert-circle" heading="Bugs">
+                <GoabxWorkSideMenuItem label="2152 Icon Custom Alignment" url="/bugs/2152" />
+                <GoabxWorkSideMenuItem label="2331 Block and Tab Dynamic Data" url="/bugs/2331" />
+                <GoabxWorkSideMenuItem label="2393 Popover Not Appearing" url="/bugs/2393" />
+                <GoabxWorkSideMenuItem label="2404 Input Angular Icon Button" url="/bugs/2404" />
+                <GoabxWorkSideMenuItem label="2408 Form Stepper Incomplete Rendering" url="/bugs/2408" />
+                <GoabxWorkSideMenuItem label="2459 File Upload Card TestId" url="/bugs/2459" />
+                <GoabxWorkSideMenuItem label="2473 DatePicker Ordinal Suffixes" url="/bugs/2473" />
+                <GoabxWorkSideMenuItem label="2502 Native Dropdown Height" url="/bugs/2502" />
+                <GoabxWorkSideMenuItem label="2529 Input Width Generation" url="/bugs/2529" />
+                <GoabxWorkSideMenuItem label="2547 Popover Hidden Near Notification" url="/bugs/2547" />
+                <GoabxWorkSideMenuItem label="2655 Dropdown/DatePicker in Modal" url="/bugs/2655" />
+                <GoabxWorkSideMenuItem label="2720 Tabs Change via Link" url="/bugs/2720" />
+                <GoabxWorkSideMenuItem label="2721 Text Tag Margin" url="/bugs/2721" />
+                <GoabxWorkSideMenuItem label="2750 Year Select Sorting" url="/bugs/2750" />
+                <GoabxWorkSideMenuItem label="2768 Enable/Disable Components" url="/bugs/2768" />
+                <GoabxWorkSideMenuItem label="2782 Disabled Inputs Hidden" url="/bugs/2782" />
+                <GoabxWorkSideMenuItem label="2789 Width Rem Measurements" url="/bugs/2789" />
+                <GoabxWorkSideMenuItem label="2821 Table Header Sorting Toggle" url="/bugs/2821" />
+                <GoabxWorkSideMenuItem label="2837 InputNumber Leading/Trailing Content" url="/bugs/2837" />
+                <GoabxWorkSideMenuItem label="2839 Button State After Click" url="/bugs/2839" />
+                <GoabxWorkSideMenuItem label="2849 Filterable Dropdown Keyboard" url="/bugs/2849" />
+                <GoabxWorkSideMenuItem label="2852 Filterable Dropdown Space Key" url="/bugs/2852" />
+                <GoabxWorkSideMenuItem label="2873 Drawer Scrolling Focus" url="/bugs/2873" />
+                <GoabxWorkSideMenuItem label="2878 DatePicker Input onChange" url="/bugs/2878" />
+                <GoabxWorkSideMenuItem label="2892 Input Width Calculations" url="/bugs/2892" />
+                <GoabxWorkSideMenuItem label="2922 Form Stepper Vertical" url="/bugs/2922" />
+                <GoabxWorkSideMenuItem label="2943 Drawer Text Components" url="/bugs/2943" />
+                <GoabxWorkSideMenuItem label="2948 Modal Heading Spacing" url="/bugs/2948" />
+                <GoabxWorkSideMenuItem label="2977 OnChangeDetails Event Missing" url="/bugs/2977" />
+                <GoabxWorkSideMenuItem label="3118 Text Component ID" url="/bugs/3118" />
+                <GoabxWorkSideMenuItem label="3201 Input Component Events" url="/bugs/3201" />
+                <GoabxWorkSideMenuItem label="3215 Drawer Initial Height" url="/bugs/3215" />
+                <GoabxWorkSideMenuItem label="3232 GoabText Tag Size" url="/bugs/3232" />
+                <GoabxWorkSideMenuItem label="3248 Dropdown Dynamic Children Sync" url="/bugs/3248" />
+                <GoabxWorkSideMenuItem label="3273 Nested Side Menu Groups" url="/bugs/3273" />
+                <GoabxWorkSideMenuItem label="3275 Can't unset month" url="/bugs/3275" />
+                <GoabxWorkSideMenuItem label="3322 App Header Menu Hover" url="/bugs/3322" />
+                <GoabxWorkSideMenuItem label="3281 GoabText p tag margin issues" url="/bugs/3281" />
+                <GoabxWorkSideMenuItem label="3337 Input autocomplete styling" url="/bugs/3337" />
+                <GoabxWorkSideMenuItem label="3279 Work Side Menu Key Nav" url="/bugs/3279" />
+                <GoabxWorkSideMenuItem label="3384 v2 Table Border" url="/bugs/3384" />
+                <GoabxWorkSideMenuItem label="3450 Dropdown expanding inside Container" url="/bugs/3450" />
+              </GoabxWorkSideMenuGroup>
+              <GoabxWorkSideMenuGroup icon="star" heading="Features">
+                <GoabxWorkSideMenuItem label="1383 Button Filled Icons" url="/features/1383" />
+                <GoabxWorkSideMenuItem label="1547 Tooltip Multiline" url="/features/1547" />
+                <GoabxWorkSideMenuItem label="1813 DatePicker Width Properties" url="/features/1813" />
+                <GoabxWorkSideMenuItem label="1908 Linear Progress" url="/features/1908" />
+                <GoabxWorkSideMenuItem label="2054 MaxWidth Support" url="/features/2054" />
+                <GoabxWorkSideMenuItem label="2267 Checkbox List" url="/features/2267" />
+                <GoabxWorkSideMenuItem label="2328 Container Height Property" url="/features/2328" />
+                <GoabxWorkSideMenuItem label="2361 Radio/Checkbox Clickable Area" url="/features/2361" />
+                <GoabxWorkSideMenuItem label="2440 MenuButton Icon" url="/features/2440" />
+                <GoabxWorkSideMenuItem label="2469 Push Drawer" url="/features/2469" />
+                <GoabxWorkSideMenuItem label="2492 TextArea onBlur" url="/features/2492" />
+                <GoabxWorkSideMenuItem label="2609 Data Table Base Component" url="/features/2609" />
+                <GoabxWorkSideMenuItem label="2611 Segmented Tab" url="/features/2611" />
+                <GoabxWorkSideMenuItem label="2611 Disabled Tab" url="/features/2611-tabs-disabled" />
+                <GoabxWorkSideMenuItem label="2682 DatePicker Issues" url="/features/2682" />
+                <GoabxWorkSideMenuItem label="2722 Input Text-Align" url="/features/2722" />
+                <GoabxWorkSideMenuItem label="2730 Temporary Notification Controller" url="/features/2730" />
+                <GoabxWorkSideMenuItem label="2829 Modal ARIA Live Region" url="/features/2829" />
+                <GoabxWorkSideMenuItem label="2877 Badge Types and Custom Icon" url="/features/2877" />
+                <GoabxWorkSideMenuItem label="3102 MenuButton Width" url="/features/3102" />
+                <GoabxWorkSideMenuItem label="3137 Work Side Menu Group" url="/features/3137" />
+                <GoabxWorkSideMenuItem label="3241 V2 Experimental Wrappers" url="/features/3241" />
+                <GoabxWorkSideMenuItem label="v2 header icons" url="/features/v2-icons" />
+                <GoabxWorkSideMenuItem label="3229 V2 Menu Button vs size and icon-only" url="/features/3229" />
+                <GoabxWorkSideMenuItem label="3344 Table Multi-Sort" url="/features/3344" />
+                <GoabxWorkSideMenuItem label="3306 Custom slug value for tabs" url="/features/3306" />
+                <GoabxWorkSideMenuItem label="3370 Clear calendar day selection" url="/features/3370" />
+                <GoabxWorkSideMenuItem label="3396 Text heading-2xs size" url="/features/3396" />
+                <GoabxWorkSideMenuItem label="3399 V2 Checkbox Spacing" url="/features/v2-checkbox" />
+                <GoabxWorkSideMenuItem label="3407 Skip Focus on Tab" url="/features/3407-skip-on-focus-tab" />
+                <GoabxWorkSideMenuItem label="3407 Tabs Orientation" url="/features/3407-stack-on-mobile" />
+                <GoabxWorkSideMenuItem label="3398 Group open prop" url="/features/3398" />
+                <GoabxWorkSideMenuItem label="3478 Popover API Rewrite" url="/features/3478" />
+              </GoabxWorkSideMenuGroup>
+              <GoabxWorkSideMenuItem icon="list" label="Everything" url="/everything" />
+            </>
+          }
+        />
         <section style={{ padding: "30px", width: "100%" }} role="main">
           <Outlet />
         </section>

--- a/docs/src/components/PropsTable.astro
+++ b/docs/src/components/PropsTable.astro
@@ -5,25 +5,27 @@
  * Uses goa-data-grid for keyboard navigation and GoabContainer for styling.
  * Matches the current ui-components-docs pattern.
  */
-import type { PropDefinition, EventDefinition, SlotDefinition } from '../lib/content-queries';
+import type { PropDefinition, EventDefinition, SlotDefinition } from "../lib/content-queries";
 
 interface Props {
   props?: PropDefinition[];
   events?: EventDefinition[];
   slots?: SlotDefinition[];
+  headingPrefix?: string;
 }
 
-const { props = [], events = [], slots = [] } = Astro.props;
+const { props = [], events = [], slots = [], headingPrefix = "" } = Astro.props;
+const prefix = headingPrefix ? `${headingPrefix} ` : "";
 
 // Filter slots: hide "default" slots with no description (adds noise, no value)
 // Keep named slots even without descriptions (the name itself is useful info)
 const meaningfulSlots = slots.filter(slot =>
-  slot.name !== 'default' || (slot.description && slot.description.trim() !== '')
+  slot.name !== "default" || (slot.description && slot.description.trim() !== "")
 );
 
 // Helper to detect and parse deprecated props
 function parseDeprecated(description: string | undefined): { isDeprecated: boolean; cleanDescription: string } {
-  if (!description) return { isDeprecated: false, cleanDescription: '' };
+  if (!description) return { isDeprecated: false, cleanDescription: "" };
 
   const deprecatedMatch = description.match(/^@deprecated\s*(.*)/i);
   if (deprecatedMatch) {
@@ -37,19 +39,19 @@ function parseDeprecated(description: string | undefined): { isDeprecated: boole
 }
 
 // Combine margin props (mt, mr, mb, ml) into a single row
-const marginPropNames = ['mt', 'mr', 'mb', 'ml'];
+const marginPropNames = ["mt", "mr", "mb", "ml"];
 const marginProps = props.filter(p => marginPropNames.includes(p.name));
 const hasAllMarginProps = marginPropNames.every(name => marginProps.some(p => p.name === name));
 
 // Standard spacing values used by margin props
-const spacingValues = ['none', '3xs', '2xs', 'xs', 's', 'm', 'l', 'xl', '2xl', '3xl', '4xl'];
+const spacingValues = ["none", "3xs", "2xs", "xs", "s", "m", "l", "xl", "2xl", "3xl", "4xl"];
 
 // Create combined margin prop if all four exist
 const combinedMarginProp = hasAllMarginProps ? {
-  name: 'mt, mr, mb, ml',
-  type: 'Spacing',
+  name: "mt, mr, mb, ml",
+  type: "Spacing",
   values: spacingValues,
-  description: 'Apply margin to the top, right, bottom, and/or left of the component.',
+  description: "Apply margin to the top, right, bottom, and/or left of the component.",
   required: false,
   default: null
 } : null;
@@ -67,7 +69,7 @@ const finalProps = combinedMarginProp
 
 {finalProps.length > 0 && (
   <div class="api-section">
-    <h3 id="props">Props</h3>
+    <h3 id={prefix ? `${headingPrefix.toLowerCase().replace(/\s+/g, "-")}-props` : "props"}>{prefix}Props</h3>
     <goa-container version="2" type="interactive">
       <goa-data-grid keyboard-nav="layout" keyboard-icon="false">
         {finalProps.map((prop, index) => {
@@ -84,7 +86,7 @@ const finalProps = combinedMarginProp
               {prop.type && (
                 <div class="prop-cell prop-cell-type" data-grid="cell">
                   <span class="prop-type">
-                    {prop.values ? prop.values.join(' | ') : prop.type}
+                    {prop.values ? prop.values.join(" | ") : prop.type}
                   </span>
                 </div>
               )}
@@ -95,7 +97,7 @@ const finalProps = combinedMarginProp
                 </div>
               )}
               {/* Cell 4: Default value (if exists) */}
-              {prop.default !== null && prop.default !== '' && (
+              {prop.default !== null && prop.default !== "" && (
                 <div class="prop-cell prop-cell-default" data-grid="cell">
                   Defaults to <code>{String(prop.default)}</code>.
                 </div>
@@ -110,11 +112,15 @@ const finalProps = combinedMarginProp
 
 {events.length > 0 && (
   <div class="api-section">
-    <h3 id="events">Events</h3>
+    <h3 id={prefix ? `${headingPrefix.toLowerCase().replace(/\s+/g, "-")}-events` : "events"}>{prefix}Events</h3>
     <goa-container version="2" type="interactive">
       <goa-data-grid keyboard-nav="layout" keyboard-icon="false">
         {events.map((event) => (
-          <div class="prop-row" data-grid="row">
+          <div
+            class="prop-row"
+            data-grid="row"
+            data-frameworks={event.frameworks?.join(",") || ""}
+          >
             <div class="prop-cell prop-cell-name" data-grid="cell">
               <span class="prop-name">{event.name}</span>
             </div>
@@ -135,16 +141,16 @@ const finalProps = combinedMarginProp
 
 {meaningfulSlots.length > 0 && (
   <div class="api-section">
-    <h3 id="slots">Slots</h3>
+    <h3 id={prefix ? `${headingPrefix.toLowerCase().replace(/\s+/g, "-")}-slots` : "slots"}>{prefix}Slots</h3>
     <goa-container version="2" type="interactive">
       <goa-data-grid keyboard-nav="layout" keyboard-icon="false">
         {meaningfulSlots.map((slot) => (
           <div class="prop-row" data-grid="row">
             <div class="prop-cell prop-cell-name" data-grid="cell">
-              <span class="prop-name">{slot.name === 'default' ? '(default)' : slot.name}</span>
+              <span class="prop-name">{slot.name === "default" ? "(default)" : slot.name}</span>
             </div>
             <div class="prop-cell prop-cell-description" data-grid="cell">
-              {slot.description || 'Named slot for content'}
+              {slot.description || "Named slot for content"}
             </div>
           </div>
         ))}
@@ -239,3 +245,32 @@ const finalProps = combinedMarginProp
     border-radius: var(--goa-border-radius-s);
   }
 </style>
+
+<script>
+  import { getFrameworkPreference, subscribeToFrameworkPreference } from "../lib/framework-preference";
+
+  // Map framework preference values to the frameworks field in event JSON
+  const frameworkMap: Record<string, string> = {
+    react: "react",
+    angular: "angular",
+    webComponents: "angular", // Web Components use the same event names as Angular (_prefix)
+  };
+
+  function filterEventsByFramework(framework: string) {
+    const mapped = frameworkMap[framework] || "react";
+    document.querySelectorAll("[data-frameworks]").forEach((row) => {
+      const el = row as HTMLElement;
+      const frameworks = el.dataset.frameworks;
+      if (!frameworks) return; // No framework filter, always show
+      el.style.display = frameworks.includes(mapped) ? "" : "none";
+    });
+  }
+
+  // Apply on load
+  filterEventsByFramework(getFrameworkPreference());
+
+  // React to changes
+  subscribeToFrameworkPreference((framework) => {
+    filterEventsByFramework(framework);
+  });
+</script>

--- a/docs/src/components/nav/ComponentsSubMenu.tsx
+++ b/docs/src/components/nav/ComponentsSubMenu.tsx
@@ -200,6 +200,7 @@ export function ComponentsSubMenu({
         url="/"
         open={isOpen}
         onToggle={onToggle}
+        onNavigate={(path: string) => { if (path && !path.startsWith("/__")) window.location.href = path; }}
         primaryContent={primaryContent}
         secondaryContent={<MenuSecondaryContent isOpen={isOpen} />}
       />

--- a/docs/src/components/nav/ParentMenu.tsx
+++ b/docs/src/components/nav/ParentMenu.tsx
@@ -145,6 +145,7 @@ export function ParentMenu({
         url="/"
         open={isOpen}
         onToggle={onToggle}
+        onNavigate={(path: string) => { if (path && !path.startsWith("/__")) window.location.href = path; }}
         primaryContent={primaryContent}
         secondaryContent={<MenuSecondaryContent isOpen={isOpen} />}
       />

--- a/docs/src/content/components/work-side-menu.mdx
+++ b/docs/src/content/components/work-side-menu.mdx
@@ -8,4 +8,7 @@ relatedComponents:
 webComponentTag: goa-work-side-menu
 reactClassName: GoabWorkSideMenu
 angularSelector: goab-work-side-menu
+childComponents:
+  - slug: work-side-menu-item
+    name: Work Side Menu Item
 ---

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -36,6 +36,12 @@ const components = defineCollection({
     reactClassName: z.string().optional(),
     angularSelector: z.string().optional(),
 
+    // Child components (shown on same page under separate headings)
+    childComponents: z.array(z.object({
+      slug: z.string(),
+      name: z.string(),
+    })).optional(),
+
     // Visibility
     hidden: z.boolean().optional(), // Hide from navigation and public views
   }),

--- a/docs/src/data/configurations/work-side-menu.ts
+++ b/docs/src/data/configurations/work-side-menu.ts
@@ -20,6 +20,7 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
         react: `<GoabxWorkSideMenu
   heading="My Application"
   url="/"
+  onNavigate={(path: string) => navigate(path)}
   primaryContent={
     <>
       <GoabxWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
@@ -29,7 +30,7 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
     </>
   }
 />`,
-        angular: `<goabx-work-side-menu heading="My Application" url="/">
+        angular: `<goabx-work-side-menu heading="My Application" url="/" (onNavigate)="handleNavigate($event)">
   <div slot="primary-content">
     <goabx-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goabx-work-side-menu-item>
     <goabx-work-side-menu-item icon="list" label="Cases" url="/cases"></goabx-work-side-menu-item>
@@ -37,12 +38,21 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
     <goabx-work-side-menu-item icon="settings" label="Admin" url="/admin"></goabx-work-side-menu-item>
   </div>
 </goabx-work-side-menu>`,
-        webComponents: `<goa-work-side-menu heading="My Application" url="/" open="true">
+        webComponents: `<!-- Listen for _navigate event to handle SPA navigation -->
+<goa-work-side-menu heading="My Application" url="/" open="true">
   <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
   <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
   <goa-work-side-menu-item slot="primary" icon="document" label="Reports" url="/reports"></goa-work-side-menu-item>
   <goa-work-side-menu-item slot="primary" icon="settings" label="Admin" url="/admin"></goa-work-side-menu-item>
-</goa-work-side-menu>`,
+</goa-work-side-menu>
+
+<script>
+  document.querySelector("goa-work-side-menu")
+    .addEventListener("_navigate", (e) => {
+      // Use your router's navigate function here
+      window.location.href = e.detail.url;
+    });
+</script>`,
       },
     },
     {
@@ -55,6 +65,7 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
   heading="My Application"
   url="/"
   open={true}
+  onNavigate={(path: string) => navigate(path)}
   primaryContent={
     <>
       <GoabxWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
@@ -74,6 +85,7 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
   url="/"
   [primaryContent]="primaryTemplate"
   [open]="true"
+  (onNavigate)="handleNavigate($event)"
 >
   <ng-template #primaryTemplate>
     <goabx-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard" />
@@ -87,6 +99,7 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
 </goabx-work-side-menu>
         `,
         webComponents: `
+<!-- Listen for _navigate event to handle SPA navigation -->
 <goa-work-side-menu heading="My Application" url="/" open="true">
   <div slot="primary">
     <goa-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
@@ -98,6 +111,14 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
     <goa-work-side-menu-item icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
   </div>
 </goa-work-side-menu>
+
+<script>
+  document.querySelector("goa-work-side-menu")
+    .addEventListener("_navigate", (e) => {
+      // Use your router's navigate function here
+      window.location.href = e.detail.url;
+    });
+</script>
         `,
       },
     },

--- a/docs/src/pages/components/[slug].astro
+++ b/docs/src/pages/components/[slug].astro
@@ -32,6 +32,15 @@ const { Content } = await render(component);
 // 2. Get the extracted API
 const api = await getComponentApi(slug);
 
+// 2b. Get child component APIs (if any)
+const childComponents = component.data.childComponents ?? [];
+const childApis = await Promise.all(
+  childComponents.map(async (child: { slug: string; name: string }) => ({
+    name: child.name,
+    api: await getComponentApi(child.slug),
+  }))
+);
+
 // 3. Query related guidance
 const allGuidance = await getGuidanceForComponent(slug);
 const { usage: usageGuidance, accessibility: accessibilityGuidance } =
@@ -101,6 +110,12 @@ const githubIssuesUrl = `https://github.com/GovAlta/ui-components/issues?q=is%3A
             API documentation is automatically extracted from the component source code.
           </goa-callout>
         )}
+        {childApis.map(({ name, api: childApi }) => childApi && (
+          <div class="child-component-api">
+            <h2>{name}</h2>
+            <PropsTable props={childApi.props} events={childApi.events} slots={childApi.slots} headingPrefix={name} />
+          </div>
+        ))}
       </TabContentWrapper>
     </goa-tab>
 
@@ -179,6 +194,20 @@ const githubIssuesUrl = `https://github.com/GovAlta/ui-components/issues?q=is%3A
     color: var(--goa-color-text-secondary, #666);
     margin: 0;
     max-width: 688px;
+  }
+
+  /* Child component API sections */
+  .child-component-api {
+    margin-top: var(--goa-space-2xl);
+    padding-top: var(--goa-space-xl);
+    border-top: 1px solid var(--goa-color-greyscale-200);
+  }
+
+  .child-component-api h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: var(--goa-space-l);
+    color: var(--goa-color-text-default, #333);
   }
 
   /* No configurations fallback */

--- a/libs/angular-components/src/experimental/work-side-menu-item/work-side-menu-item.spec.ts
+++ b/libs/angular-components/src/experimental/work-side-menu-item/work-side-menu-item.spec.ts
@@ -33,7 +33,6 @@ class TestWorkSideMenuItemComponent {
 
 describe("GoabxWorkSideMenuItem", () => {
   let fixture: ComponentFixture<TestWorkSideMenuItemComponent>;
-  let component: TestWorkSideMenuItemComponent;
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
@@ -41,7 +40,6 @@ describe("GoabxWorkSideMenuItem", () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestWorkSideMenuItemComponent);
-    component = fixture.componentInstance;
 
     fixture.detectChanges();
     tick(); // Wait for setTimeout in ngOnInit

--- a/libs/angular-components/src/experimental/work-side-menu/work-side-menu.spec.ts
+++ b/libs/angular-components/src/experimental/work-side-menu/work-side-menu.spec.ts
@@ -17,6 +17,7 @@ import { By } from "@angular/platform-browser";
       [primaryContent]="primaryTemplate"
       [secondaryContent]="secondaryTemplate"
       [accountContent]="accountTemplate"
+      (onNavigate)="handleNavigate($event)"
     >
     </goabx-work-side-menu>
     <ng-template #primaryTemplate>
@@ -37,6 +38,11 @@ class TestWorkSideMenuComponent {
   userName = "Test User";
   userSecondaryText = "test@example.com";
   testId = "test-id";
+  navigatedUrl = "";
+
+  handleNavigate(path: string) {
+    this.navigatedUrl = path;
+  }
 }
 describe("GoabxBWorkSideMenu", () => {
   let fixture: ComponentFixture<TestWorkSideMenuComponent>;
@@ -64,4 +70,17 @@ describe("GoabxBWorkSideMenu", () => {
     expect(menuElement.getAttribute("user-secondary-text")).toBe("test@example.com");
     expect(menuElement.getAttribute("testId")).toBe("test-id");
   });
+
+  it("should emit onNavigate when _navigate event is dispatched", fakeAsync(() => {
+    const menuElement = fixture.debugElement.query(
+      By.css("goa-work-side-menu"),
+    ).nativeElement;
+
+    menuElement.dispatchEvent(
+      new CustomEvent("_navigate", { detail: { url: "/dashboard" }, bubbles: true }),
+    );
+    fixture.detectChanges();
+
+    expect(component.navigatedUrl).toBe("/dashboard");
+  }));
 });

--- a/libs/angular-components/src/experimental/work-side-menu/work-side-menu.ts
+++ b/libs/angular-components/src/experimental/work-side-menu/work-side-menu.ts
@@ -24,6 +24,7 @@ import { NgTemplateOutlet } from "@angular/common";
         [attr.user-secondary-text]="userSecondaryText"
         [attr.testid]="testId"
         (_toggle)="_onToggle()"
+        (_navigate)="_onNavigate($event)"
       >
         <div slot="primary">
           <ng-container [ngTemplateOutlet]="primaryContent"></ng-container>
@@ -50,6 +51,7 @@ export class GoabxWorkSideMenu implements OnInit {
   @Input() secondaryContent!: TemplateRef<any>;
   @Input() accountContent!: TemplateRef<any>;
   @Output() onToggle = new EventEmitter();
+  @Output() onNavigate = new EventEmitter<string>();
 
   isReady = false;
 
@@ -66,5 +68,9 @@ export class GoabxWorkSideMenu implements OnInit {
 
   _onToggle() {
     this.onToggle.emit();
+  }
+
+  _onNavigate(e: Event) {
+    this.onNavigate.emit((e as CustomEvent).detail.url);
   }
 }

--- a/libs/react-components/specs/work-side-menu.browser.spec.tsx
+++ b/libs/react-components/specs/work-side-menu.browser.spec.tsx
@@ -109,34 +109,67 @@ describe("WorkSideMenu", () => {
       expect(menu.element().classList.contains("closed")).toBeFalsy();
     });
 
-    it("selecting a menu item navigates to a new location", async () => {
-      const handler = vi.fn();
-      window.addEventListener("_update", handler);
+    it("should call onNavigate and prevent default navigation when menu item is clicked", async () => {
+      await page.viewport(1024, 768);
+      const onNavigate = vi.fn();
 
       const Component = () => {
+        const [currentPage, setCurrentPage] = useState("/dashboard");
+
         return (
-          <GoabxWorkSideMenu
-            heading="Test Heading"
-            url="https://example.com/"
-            userName="John Doe"
-            userSecondaryText="test@example.com"
-            testId="work-side-menu"
-            primaryContent={
-              <GoabxWorkSideMenuItem url="#item1" label="Item 1" testId="menu-item-1" />
-            }
-            secondaryContent={<GoabxWorkSideMenuItem url="#item2" label="Item 2" />}
-            accountContent={<GoabxWorkSideMenuItem url="#item3" label="Item 3" />}
-            open={true}
-          />
+          <div>
+            <GoabxWorkSideMenu
+              heading="Test App"
+              url="/dashboard"
+              open={true}
+              testId="work-side-menu"
+              onNavigate={(path: string) => {
+                setCurrentPage(path);
+                onNavigate(path);
+              }}
+              primaryContent={
+                <>
+                  <GoabxWorkSideMenuItem
+                    icon="grid"
+                    label="Dashboard"
+                    url="/dashboard"
+                    testId="nav-dashboard"
+                  />
+                  <GoabxWorkSideMenuItem
+                    icon="search"
+                    label="Search"
+                    url="/search"
+                    testId="nav-search"
+                  />
+                </>
+              }
+            />
+            <div data-testid="current-page">{currentPage}</div>
+          </div>
         );
       };
-      const result = render(<Component />);
-      const item1 = result.getByTestId("menu-item-1");
 
-      await item1.click();
+      const result = render(<Component />);
+
       await vi.waitFor(() => {
-        expect(window.location.hash).toBe("#item1");
+        const searchItem = result.getByTestId("nav-search");
+        expect(searchItem).toBeTruthy();
       });
+
+      const searchItem = result.getByTestId("nav-search");
+      const link = searchItem.element().querySelector("a");
+      expect(link).toBeTruthy();
+
+      await searchItem.click();
+
+      await vi.waitFor(() => {
+        expect(onNavigate).toHaveBeenCalledWith("/search");
+        const currentPageEl = result.getByTestId("current-page");
+        expect(currentPageEl.element().textContent).toBe("/search");
+      });
+
+      // Verify no full page navigation occurred
+      expect(window.location.pathname).not.toBe("/search");
     });
   });
 

--- a/libs/react-components/src/experimental/work-side-menu/work-side-menu.spec.tsx
+++ b/libs/react-components/src/experimental/work-side-menu/work-side-menu.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/react";
+import { vi } from "vitest";
 
 import WorkSideMenu from "./work-side-menu";
 
@@ -20,5 +21,17 @@ describe("WorkSideMenu", () => {
     expect(menu?.getAttribute("user-name")).toBe("Test User");
     expect(menu?.getAttribute("user-secondary-text")).toBe("test.user@example.com");
     expect(menu?.getAttribute("testid")).toBe("bar");
+  });
+
+  it("should call onNavigate when _navigate event is dispatched", () => {
+    const onNavigate = vi.fn();
+    const { baseElement } = render(
+      <WorkSideMenu heading="foo" url="#" onNavigate={onNavigate} />,
+    );
+    const menu = baseElement.querySelector("goa-work-side-menu");
+    menu?.dispatchEvent(
+      new CustomEvent("_navigate", { detail: { url: "/dashboard" }, bubbles: true }),
+    );
+    expect(onNavigate).toHaveBeenCalledWith("/dashboard");
   });
 });

--- a/libs/react-components/src/experimental/work-side-menu/work-side-menu.tsx
+++ b/libs/react-components/src/experimental/work-side-menu/work-side-menu.tsx
@@ -33,6 +33,7 @@ export interface GoabWorkSideMenuProps {
   accountContent?: ReactNode;
   open?: boolean;
   onToggle?: () => void;
+  onNavigate?: (path: string) => void;
 }
 
 export function GoabxWorkSideMenu({
@@ -46,6 +47,7 @@ export function GoabxWorkSideMenu({
   accountContent,
   open,
   onToggle,
+  onNavigate,
 }: GoabWorkSideMenuProps): JSX.Element {
   const el = useRef<HTMLElement>(null);
 
@@ -58,6 +60,20 @@ export function GoabxWorkSideMenu({
       el.current?.removeEventListener("_toggle", onToggle);
     };
   }, [el, onToggle]);
+
+  useEffect(() => {
+    if (!el?.current || !onNavigate) {
+      return;
+    }
+    const handler = (e: Event) => {
+      onNavigate((e as CustomEvent).detail.url);
+    };
+    el.current?.addEventListener("_navigate", handler);
+    return () => {
+      el.current?.removeEventListener("_navigate", handler);
+    };
+  }, [el, onNavigate]);
+
   return (
     <goa-work-side-menu
       ref={el}

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.spec.ts
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.spec.ts
@@ -1,5 +1,5 @@
-import { it, expect } from "vitest";
-import { render } from "@testing-library/svelte";
+import { it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
 import GoAWorkSideMenuItem from "./WorkSideMenuItem.svelte";
 
 describe("WorkSideMenuItem", () => {
@@ -18,5 +18,36 @@ describe("WorkSideMenuItem", () => {
     expect(container).toBeTruthy();
     expect(link).toBeTruthy();
     expect(badge).toBeTruthy();
+  });
+
+  describe("click events", () => {
+    it("should dispatch _navigate event with url on click", async () => {
+      const onNavigate = vi.fn();
+      const { container } = render(GoAWorkSideMenuItem, {
+        label: "Dashboard",
+        url: "/dashboard",
+      });
+      const root = container.querySelector(".root") as HTMLElement;
+      const link = container.querySelector(".menu-item") as HTMLElement;
+
+      root.addEventListener("_navigate", onNavigate);
+      await fireEvent.click(link);
+
+      expect(onNavigate).toHaveBeenCalledTimes(1);
+      expect(onNavigate.mock.calls[0][0].detail).toEqual({ url: "/dashboard" });
+    });
+
+    it("should preventDefault on click", async () => {
+      const { container } = render(GoAWorkSideMenuItem, {
+        label: "Nav",
+        url: "/page",
+      });
+      const link = container.querySelector(".menu-item") as HTMLAnchorElement;
+
+      const clickEvent = new MouseEvent("click", { bubbles: true, cancelable: true });
+      const prevented = !link.dispatchEvent(clickEvent);
+
+      expect(prevented).toBe(true);
+    });
   });
 });

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte
@@ -61,8 +61,21 @@
   // Functions
   // *********
 
-  function handleClick() {
-    dispatch(_rootEl, "_update", {}, { bubbles: true });
+  // Intercepts anchor clicks to enable SPA navigation via the _navigate event.
+  // Modifier keys (Ctrl/Cmd/Shift/Alt) are allowed through so the browser can
+  // open links in new tabs as expected.
+  function handleClick(e: Event) {
+    const mouseEvent = e as MouseEvent;
+    if (
+      mouseEvent.ctrlKey ||
+      mouseEvent.metaKey ||
+      mouseEvent.shiftKey ||
+      mouseEvent.altKey
+    ) {
+      return;
+    }
+    e.preventDefault();
+    dispatch(_rootEl, "_navigate", { url }, { bubbles: true });
   }
 
   function handleUpdateItem(e: CustomEvent) {


### PR DESCRIPTION
# Before (the change)
When we click on the menu item, the whole page re-render (similar to we refresh the browser)
# After (the change)
Setting `action="navigate"` on a menu item prevents default link behaviour and emits a `_navigate` event that the parent `WorkSideMenu` catches via `onNavigate. 
## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test
<img width="1206" height="667" alt="image" src="https://github.com/user-attachments/assets/4cafcf11-23d9-45f7-b862-ab41312fac72" />

