### PR TITLE
fix(#3498): modified padding and border on radio group.

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -91,6 +91,7 @@
         <goabx-work-side-menu-item label="3279" url="/bugs/3279"></goabx-work-side-menu-item>
         <goabx-work-side-menu-item label="3384 Table v2 sample" url="/bugs/3384"></goabx-work-side-menu-item>
         <goabx-work-side-menu-item label="3450 Dropdown expanding" url="/bugs/3450"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item label="3498 Radio alignment" url="/bugs/3498"></goabx-work-side-menu-item>
       </goabx-work-side-menu-group>
       <goabx-work-side-menu-group icon="star" heading="Features">
         <goabx-work-side-menu-item label="1328" url="/features/1328"></goabx-work-side-menu-item>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -46,6 +46,7 @@ import { Bug3337Component } from "../routes/bugs/3337/bug3337.component";
 import { Bug3279Component } from "../routes/bugs/3279/bug3279.component";
 import { Bug3384Component } from "../routes/bugs/3384/bug3384.component";
 import { Bug3450Component } from "../routes/bugs/3450/bug3450.component";
+import { Bug3498Component } from "../routes/bugs/3498/bug3498.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -129,6 +130,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3279", component: Bug3279Component },
   { path: "bugs/3384", component: Bug3384Component },
   { path: "bugs/3450", component: Bug3450Component },
+  { path: "bugs/3498", component: Bug3498Component },
 
   // Feature routes
   { path: "features/1328", component: Feat1328Component },

--- a/apps/prs/angular/src/routes/bugs/3498/bug3498.component.html
+++ b/apps/prs/angular/src/routes/bugs/3498/bug3498.component.html
@@ -1,0 +1,82 @@
+<div>
+  <h1>3498 - Radio group alignment and border adjustment</h1>
+  <h2>Version 1</h2>
+  <goab-form-item label="How would you like to be contacted?" helpText="Select one option">
+    <goab-radio-group name="contactMethod" formControlName="contactMethod">
+      <goab-radio-item label="Email" description="Receive updates via email" value="email" [reveal]="emailReveal">
+        <ng-template #emailReveal>
+          <goab-form-item label="Email address">
+            <goab-input name="email" formControlName="emailAddress"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-radio-item>
+      <goab-radio-item value="phone" label="Phone" [reveal]="phoneReveal">
+        <ng-template #phoneReveal>
+          <goab-form-item label="Phone number">
+            <goab-input name="phone" formControlName="phoneNumber"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-radio-item>
+      <goab-radio-item value="text" label="Text message" [reveal]="textReveal">
+        <ng-template #textReveal>
+          <goab-form-item label="Mobile phone number">
+            <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-radio-item>
+    </goab-radio-group>
+  </goab-form-item>
+  <h2>Version 2 (Experimental)</h2>
+  <h3>Regular size</h3>
+  <goabx-form-item label="How would you like to be contacted?" helpText="Select one option">
+    <goabx-radio-group name="contactMethodTwo" formControlName="contactMethodTwo">
+      <goabx-radio-item label="Email" description="Receive updates via email" value="email" [reveal]="emailReveal">
+        <ng-template #emailReveal>
+          <goabx-form-item label="Email address">
+            <goabx-input name="email" formControlName="emailAddress"></goabx-input>
+          </goabx-form-item>
+        </ng-template>
+      </goabx-radio-item>
+      <goabx-radio-item value="phone" label="Phone" [reveal]="phoneReveal">
+        <ng-template #phoneReveal>
+          <goabx-form-item label="Phone number">
+            <goabx-input name="phone" formControlName="phoneNumber"></goabx-input>
+          </goabx-form-item>
+        </ng-template>
+      </goabx-radio-item>
+      <goabx-radio-item value="text" label="Text message" [reveal]="textReveal">
+        <ng-template #textReveal>
+          <goabx-form-item label="Mobile phone number">
+            <goabx-input name="mobile" formControlName="phoneNumber"></goabx-input>
+          </goabx-form-item>
+        </ng-template>
+      </goabx-radio-item>
+    </goabx-radio-group>
+  </goabx-form-item>
+  <h3>Compact size</h3>
+  <goabx-form-item label="How would you like to be contacted?" helpText="Select one option">
+    <goabx-radio-group name="contactMethodThree" size="compact" formControlName="contactMethodThree">
+      <goabx-radio-item label="Email" description="Receive updates via email" value="email" [reveal]="emailReveal">
+        <ng-template #emailReveal>
+          <goabx-form-item label="Email address">
+            <goabx-input name="email" formControlName="emailAddress"></goabx-input>
+          </goabx-form-item>
+        </ng-template>
+      </goabx-radio-item>
+      <goabx-radio-item value="phone" label="Phone" [reveal]="phoneReveal">
+        <ng-template #phoneReveal>
+          <goabx-form-item label="Phone number">
+            <goabx-input name="phone" formControlName="phoneNumber"></goabx-input>
+          </goabx-form-item>
+        </ng-template>
+      </goabx-radio-item>
+      <goabx-radio-item value="text" label="Text message" [reveal]="textReveal">
+        <ng-template #textReveal>
+          <goabx-form-item label="Mobile phone number">
+            <goabx-input name="mobile" formControlName="phoneNumber"></goabx-input>
+          </goabx-form-item>
+        </ng-template>
+      </goabx-radio-item>
+    </goabx-radio-group>
+  </goabx-form-item>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3498/bug3498.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3498/bug3498.component.ts
@@ -1,0 +1,30 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabFormItem,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/angular-components";
+
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3498",
+  templateUrl: "./bug3498.component.html",
+  imports: [CommonModule,
+  GoabFormItem,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+],
+})
+export class Bug3498Component {}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -14,6 +14,7 @@ import {
 import "@abgov/style";
 
 export function App() {
+
   const navigate = useNavigate();
 
   return (
@@ -102,6 +103,7 @@ export function App() {
                 <GoabxWorkSideMenuItem label="3279 Work Side Menu Key Nav" url="/bugs/3279" />
                 <GoabxWorkSideMenuItem label="3384 v2 Table Border" url="/bugs/3384" />
                 <GoabxWorkSideMenuItem label="3450 Dropdown expanding inside Container" url="/bugs/3450" />
+                <GoabxWorkSideMenuItem label="3498 Radio alignment" url="/bugs/3498" />
               </GoabxWorkSideMenuGroup>
               <GoabxWorkSideMenuGroup icon="star" heading="Features">
                 <GoabxWorkSideMenuItem label="1383 Button Filled Icons" url="/features/1383" />

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -48,6 +48,7 @@ import { Bug3281Route } from "./routes/bugs/bug3281";
 import { Bug3337Route } from "./routes/bugs/bug3337";
 import { Bug3384Route } from "./routes/bugs/bug3384";
 import { Bug3450Route } from "./routes/bugs/bug3450";
+import { Bug3498Route } from "./routes/bugs/bug3498";
 
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
@@ -139,6 +140,7 @@ root.render(
           <Route path="bugs/3337" element={<Bug3337Route />} />
           <Route path="bugs/3384" element={<Bug3384Route />} />
           <Route path="bugs/3450" element={<Bug3450Route />} />
+          <Route path="bugs/3498" element={<Bug3498Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3498.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3498.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import {
+  GoabFormItem,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+} from "@abgov/react-components";
+import {
+  GoabxFormItem,
+  GoabxInput,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
+
+export function Bug3498Route() {
+  const [contactMethod, setContactMethod] = useState("");
+  const [contactMethodTwo, setContactMethodTwo] = useState("");
+  const [contactMethodThree, setContactMethodThree] = useState("");
+
+  return (
+     <div>
+      <h1>3498 - Radio group alignment and border adjustment</h1>
+      <h2>Version 1</h2>
+      <GoabFormItem
+        label="How would you like to be contacted?"
+        helpText="Select one option"
+      >
+        <GoabRadioGroup
+          name="contactMethod"
+          value={contactMethod}
+          onChange={(e) => setContactMethod(e.value)}
+        >
+          <GoabRadioItem
+            value="email-1"
+            label="Email"
+            description="Receive updates via email"
+            reveal={
+              <GoabFormItem label="Email address">
+                <GoabInput name="email" value="" />
+              </GoabFormItem>
+            }
+          />
+          <GoabRadioItem
+            value="phone-1"
+            label="Phone"
+            reveal={
+              <GoabFormItem label="Phone number">
+                <GoabInput name="phoneNumber" value="" />
+              </GoabFormItem>
+            }
+          />
+          <GoabRadioItem
+            value="text-1"
+            label="Text message"
+            reveal={
+              <GoabFormItem label="Mobile phone number">
+                <GoabInput name="mobilePhoneNumber" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabRadioGroup>
+      </GoabFormItem>
+      <h2>Version 2 (Experimental)</h2>
+      <h3>Regular size</h3>
+      <GoabxFormItem
+        label="How would you like to be contacted?"
+        helpText="Select one option"
+      >
+        <GoabxRadioGroup
+          name="contactMethodTwo"
+          value={contactMethodTwo}
+          onChange={(e) => setContactMethodTwo(e.value)}
+        >
+          <GoabxRadioItem
+            value="email-2"
+            label="Email"
+            description="Receive updates via email"
+            reveal={
+              <GoabxFormItem label="Email address">
+                <GoabxInput name="email" value="" />
+              </GoabxFormItem>
+            }
+          />
+          <GoabxRadioItem
+            value="phone-2"
+            label="Phone"
+            reveal={
+              <GoabxFormItem label="Phone number">
+                <GoabxInput name="phoneNumber" value="" />
+              </GoabxFormItem>
+            }
+          />
+          <GoabxRadioItem
+            value="text-2"
+            label="Text message"
+            reveal={
+              <GoabxFormItem label="Mobile phone number">
+                <GoabxInput name="mobilePhoneNumber" value="" />
+              </GoabxFormItem>
+            }
+          />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
+      <h3>Compact size</h3>
+      <GoabxFormItem
+        label="How would you like to be contacted?"
+        helpText="Select one option"
+      >
+        <GoabxRadioGroup
+          size="compact"
+          name="contactMethodThree"
+          value={contactMethodThree}
+          onChange={(e) => setContactMethodThree(e.value)}
+        >
+          <GoabxRadioItem
+            value="email-3"
+            label="Email"
+            description="Receive updates via email"
+            reveal={
+              <GoabxFormItem label="Email address">
+                <GoabxInput name="email" value="" />
+              </GoabxFormItem>
+            }
+          />
+          <GoabxRadioItem
+            value="phone-3"
+            label="Phone"
+            reveal={
+              <GoabxFormItem label="Phone number">
+                <GoabxInput name="phoneNumber" value="" />
+              </GoabxFormItem>
+            }
+          />
+          <GoabxRadioItem
+            value="text-3"
+            label="Text message"
+            reveal={
+              <GoabxFormItem label="Mobile phone number">
+                <GoabxInput name="mobilePhoneNumber" value="" />
+              </GoabxFormItem>
+            }
+          />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
+    </div>
+
+  );
+}

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -53,6 +53,7 @@
     FormFieldMountRelayDetail,
   } from "../../types/relay-types";
 
+
   /** The value of this radio option. Will be emitted when selected. */
   export let value: string;
   /** The name of the radio group. Inherited from the parent RadioGroup if not set. */
@@ -310,12 +311,6 @@
   .radio {
     display: inline-flex;
     align-items: flex-start;
-    gap: var(--goa-radio-gap-label, var(--goa-space-xs));
-  }
-
-  /* V2 compact: Use smaller gap */
-  .radio.v2.compact {
-    gap: var(--goa-space-xs);
   }
 
   label.radio {
@@ -348,21 +343,26 @@
   .label {
     font: var(--goa-radio-label);
     margin-top: -3px; /* V1: Optical centering - move text up */
+    padding-left: var(--goa-radio-gap-label, var(--goa-space-s));
   }
-
   /* V2: Adjust for different line-height */
   .radio.v2 .label {
     margin-top: 1px; /* V2: Optical centering - slight downward adjustment */
   }
 
+  /* V2 compact: Use smaller gap */
+  .radio.v2.compact .label {
+    padding-left: var(--goa-radio-gap-label-compact);
+  }
+
   /* Compact mode - V2 only */
-  .radio.compact .label {
+  .radio.v2.compact .label {
     font: var(--goa-radio-label-compact);
   }
 
   .description {
     font: var(--goa-radio-description);
-    margin-left: var(--goa-space-xl);
+    margin-left: calc(var(--goa-radio-size) + var(--goa-space-s));
     margin-top: var(--goa-space-2xs);
     color: var(--goa-input-color-text-helper, var(--goa-color-text-default));
   }
@@ -370,6 +370,12 @@
   /* V2 default: Description aligns with label (icon width + gap) */
   .radio.v2:not(.compact) ~ .description {
     margin-left: calc(var(--goa-radio-size) + var(--goa-radio-gap-label));
+  }
+
+  /* V2 compact: Description aligns with label (icon width + gap) */
+  .radio.v2.compact ~ .description {
+    margin-left: calc(var(--goa-radio-size) + var(--goa-radio-gap-label-compact));
+    margin-top: var(--goa-space-3xs);
   }
 
   .reveal {
@@ -380,10 +386,20 @@
     height: fit-content;
     display: block;
   }
-  .reveal.visible.has-content {
-    padding: var(--goa-space-m);
-    margin: var(--goa-space-2xs) 0 0 calc(var(--goa-space-s) - 2px);
-    border-left: 4px solid var(--goa-color-greyscale-200);
+
+   .reveal.visible.has-content {
+    padding: var(--goa-radio-reveal-padding, var(--goa-space-m));
+    margin: var(--goa-radio-reveal-margin, var(--goa-space-2xs) 0 0 calc(var(--goa-space-s) - 2px));
+    border-left: var(--goa-radio-reveal-border, 4px solid var(--goa-color-greyscale-200));
+  }
+
+  .radio.v2 ~ .reveal.visible.has-content {
+    padding: var(--goa-radio-reveal-padding, var(--goa-space-l));
+    border-left: var(--goa-radio-reveal-border, 1px solid var(--goa-color-greyscale-200));
+  }
+
+  .radio.v2.compact ~ .reveal.visible.has-content {
+    padding: calc(var(--goa-space-m) + var(--goa-space-2xs));
   }
 
   .icon {
@@ -466,7 +482,7 @@
 
   /* Checked - Default */
   input[type="radio"]:checked ~ .icon {
-    border: var(--goa-radio-border-checked);
+    border: var(--goa-radio-border-checked, 4px solid var(--goa-color-greyscale-200));
   }
   /* V2 only: Inner dot */
   .radio.v2 input[type="radio"]:checked ~ .icon::after {


### PR DESCRIPTION
# Before (the change)
<img width="527" height="416" alt="image" src="https://github.com/user-attachments/assets/8092d3ac-2441-4efa-972d-25cc7243ff35" />

- Padding pushes radio buttons to the right, misaligning it with the border when expanded.
- Expanded border is too thick.

# After (the change)
<img width="457" height="331" alt="image" src="https://github.com/user-attachments/assets/698007c6-19ba-48af-bbc7-648b60702a97" />

- Padding is adjusted so label is aligned and radio button is centered with the border
- Border is the right thickness (1px).

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
