### PR TITLE
feat(#3511): add redirects from DS 1 docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,6 +12,19 @@ const workspaceRoot = path.resolve(__dirname, "..");
 export default defineConfig({
   root: ".",
   outDir: "../dist/docs",
+  redirects: {
+    "/components/circular-progress-indicator": "/components/circular-progress",
+    "/components/file-uploader": "/components/file-upload-input",
+    "/components/header": "/components/app-header",
+    "/components/icons": "/components/icon",
+    "/components/linear-progress-indicator": "/components/linear-progress",
+    "/components/notification-banner": "/components/notification",
+    "/components/radio": "/components/radio-group",
+    "/components/skeleton-loader": "/components/skeleton",
+    "/design-tokens": "/tokens",
+    "/get-started/support": "/support",
+    "/examples/show-multiple-actions-in-a-table": "/examples/show-multiple-actions-in-a-compact-table",
+  },
   build: {
     chunkSizeWarningLimit: 1000,
   },

--- a/docs/src/components/MobileHeader.tsx
+++ b/docs/src/components/MobileHeader.tsx
@@ -40,7 +40,7 @@ export function MobileHeader() {
             height="28"
             className="mobile-header__logo"
           />
-          <span className="mobile-header__title">Design system</span>
+          <span className="mobile-header__title">Design System</span>
         </a>
       </div>
       <div className="mobile-header__right">

--- a/docs/src/components/nav/ParentMenu.tsx
+++ b/docs/src/components/nav/ParentMenu.tsx
@@ -141,7 +141,7 @@ export function ParentMenu({
   return (
     <>
       <GoabxWorkSideMenu
-        heading="Design system"
+        heading="Design System"
         url="/"
         open={isOpen}
         onToggle={onToggle}

--- a/docs/src/pages/components/[slug].astro
+++ b/docs/src/pages/components/[slug].astro
@@ -45,6 +45,8 @@ const configurations = getComponentConfigurations(slug);
 
 // GitHub issues URL for this component
 const githubIssuesUrl = `https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22${encodeURIComponent(component.data.name)}%22`;
+
+const oldDocsUrl = `https://v1.design.alberta.ca/components/${slug}`;
 ---
 
 <ComponentPageLayout
@@ -101,6 +103,10 @@ const githubIssuesUrl = `https://github.com/GovAlta/ui-components/issues?q=is%3A
             API documentation is automatically extracted from the component source code.
           </goa-callout>
         )}
+        
+        <goa-link size="small" trailingicon="open">
+          <a href={oldDocsUrl} target="_blank" rel="noopener noreferrer">View old component docs</a>
+        </goa-link>
       </TabContentWrapper>
     </goa-tab>
 

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -63,6 +63,8 @@ function formatComponentName(component: string): string {
     .map((word, i) => i === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word)
     .join(' ');
 }
+
+const oldDocsUrl = `https://v1.design.alberta.ca/examples/${slug}`;
 ---
 
 <ExamplesPageLayout
@@ -112,6 +114,10 @@ function formatComponentName(component: string): string {
         </div>
       </section>
     )}
+
+    <goa-link size="small" trailingicon="open">
+      <a href={oldDocsUrl} target="_blank" rel="noopener noreferrer">View old example docs</a>
+    </goa-link>
   </article>
 </ExamplesPageLayout>
 
@@ -189,7 +195,7 @@ function formatComponentName(component: string): string {
   /* Related Examples */
   .related-examples {
     border-top: 1px solid var(--goa-color-greyscale-200, #dcdcdc);
-    padding-top: var(--goa-space-xl, 2rem);
+    padding: var(--goa-space-xl) 0;
   }
 
   .related-examples h2 {


### PR DESCRIPTION
This PR prepares our DS 2 docs for links from DS 1 docs with the following changes...

- Adds DS 1 docs links to the bottom of individual component and example pages
- Adds redirects from DS 1 docs URLs including...
  - Components with different paths (ex: `/components/circular-progress-indicator` ➡️ 	`/components/circular-progress`)
  - ~Paths with version segments (ex: `/components/v6.0.0+-react/button`)~ (I removed this b/c it caused a deploy issue)
- Changes the side menu heading to title case: "Design System"

<img width="456" height="232" alt="image" src="https://github.com/user-attachments/assets/55dd1f7d-15cd-4b0e-b8a1-bd07ec6c088d" />

<img width="369" height="232" alt="image" src="https://github.com/user-attachments/assets/4f079967-eaef-433b-b96b-5834a984b3c2" />

The related DS 1 docs changes: https://github.com/GovAlta/ui-components-docs/pull/484