### PR TITLE
docs(#3537): add getting started pages

### DIFF
--- a/docs/src/components/nav/ParentMenu.tsx
+++ b/docs/src/components/nav/ParentMenu.tsx
@@ -47,6 +47,8 @@ const GROUP_SECTIONS: Record<string, Array<{ label: string; url: string }>> = {
     { label: "Early Adopters", url: "/get-started" },
     { label: "Designers", url: "/get-started/designers" },
     { label: "Developers", url: "/get-started/developers" },
+    { label: "Migration guide", url: "/get-started/migration-guide" },
+    { label: "Roadmap", url: "/get-started/roadmap" },
   ],
 };
 

--- a/docs/src/pages/get-started/dev-setup.astro
+++ b/docs/src/pages/get-started/dev-setup.astro
@@ -1,0 +1,155 @@
+---
+/**
+ * Get Started - Developer Setup
+ *
+ * Setup instructions for Angular, React, and Web Components.
+ * Based on the current website content with DS 2.0 token updates.
+ */
+import DocumentationPageLayout from "../../layouts/DocumentationPageLayout.astro";
+---
+
+<DocumentationPageLayout
+  title="Developer setup"
+  description="Set up Angular, React, or Web Components to use the GoA Design System"
+  section="get-started"
+>
+  <goa-text version="2" size="heading-xl" mt="none" mb="m">Developer setup</goa-text>
+  <goa-text version="2" size="body-l" mt="none" mb="2xl">
+    Set up the Government of Alberta Design System in Angular, React, or directly with Web
+    Components.
+  </goa-text>
+
+  <h2 id="angular">Angular UI components</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Versions supported in latest:</strong> 18, 19, 20, 21
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    This is the web component library and utilizes Angular&apos;s web component
+    integration.
+  </goa-text>
+
+  <h3 id="angular-step-1">1. Add dependencies</h3>
+  <pre><code>npm i @abgov/web-components
+npm i @abgov/angular-components
+npm i @abgov/design-tokens</code></pre>
+
+  <h3 id="angular-step-2">2. Link ionicons in app/index.html</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Add the following in the <code>head</code> element:
+  </goa-text>
+  <pre><code>&lt;script type="module" src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.esm.js"&gt;&lt;/script&gt;
+&lt;script nomodule src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.js"&gt;&lt;/script&gt;</code></pre>
+
+  <h3 id="angular-step-3">3. Update src/app/app.module.ts</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Update <code>src/app/app.module.ts</code> as per the four steps below:
+  </goa-text>
+  <pre><code>// 1. Import the CUSTOM_ELEMENTS_SCHEMA
+import &#123; CUSTOM_ELEMENTS_SCHEMA &#125; from "@angular/core";
+
+// 2. Import the libs
+import "@abgov/web-components";
+import &#123; AngularComponentsModule &#125; from "@abgov/angular-components";
+
+@NgModule(&#123;
+	declarations: [AppComponent],
+	imports: [
+		// 3. Add the needed imports
+		BrowserModule,
+		AngularComponentsModule,
+	],
+	providers: [],
+	bootstrap: [AppComponent],
+	// 4. Add the CUSTOM_ELEMENTS_SCHEMA to the NgModule
+	schemas: [CUSTOM_ELEMENTS_SCHEMA],
+	&#125;)
+export class AppModule &#123;&#125;</code></pre>
+
+  <h3 id="angular-step-4">4. Add the styles link in src/styles.css</h3>
+  <pre><code>@import "@abgov/web-components/index.css";
+@import "@abgov/design-tokens/dist/tokens.css";</code></pre>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="react">React UI components</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Versions supported in latest:</strong> 17, 18, 19
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    This library contains React components which wrap the Government of Alberta Web
+    Components.
+  </goa-text>
+
+  <h3 id="react-step-1">1. Add dependencies</h3>
+  <pre><code>npm i @abgov/react-components
+npm i @abgov/web-components
+npm i @abgov/design-tokens</code></pre>
+
+  <h3 id="react-step-2">2. Link ionicons in app/index.html</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Add the following to the <code>head</code> element:
+  </goa-text>
+  <pre><code>&lt;script type="module" src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.esm.js"&gt;&lt;/script&gt;
+&lt;script nomodule src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.js"&gt;&lt;/script&gt;</code></pre>
+
+  <h3 id="react-step-3">3. Import the web components in src/main.tsx</h3>
+  <pre><code>import "@abgov/web-components";</code></pre>
+
+  <h3 id="react-step-4">4. Import the styles in src/index.css</h3>
+  <pre><code>@import "@abgov/web-components/index.css";
+@import "@abgov/design-tokens/dist/tokens.css";</code></pre>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="web-components">Web components</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    This library contains web components from the Government of Alberta.
+  </goa-text>
+
+  <h3 id="web-step-1">1. Add dependencies</h3>
+  <pre><code>npm i @abgov/web-components
+npm i @abgov/design-tokens</code></pre>
+
+  <h3 id="web-step-2">2. Link ionicons in index.html</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Add the following in the <code>head</code> element:
+  </goa-text>
+  <pre><code>&lt;script type="module" src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.esm.js"&gt;&lt;/script&gt;
+&lt;script nomodule src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.js"&gt;&lt;/script&gt;</code></pre>
+
+  <h3 id="web-step-3">3. Import the web components into src/main.js</h3>
+  <pre><code>import "@abgov/web-components";</code></pre>
+
+  <h3 id="web-step-4">4. Add the styles link in your main CSS file</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Add the following in <code>src/assets/main.css</code> or wherever your main CSS file is
+    located:
+  </goa-text>
+  <pre><code>@import "@abgov/web-components/index.css";
+@import "@abgov/design-tokens/dist/tokens.css";</code></pre>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <goa-callout
+    version="2"
+    type="information"
+    emphasis="low"
+    heading="Need help building a government service?"
+    mb="m"
+  >
+    Join design system drop-in hours to:
+    <ul>
+      <li>Get feedback on your service</li>
+      <li>Propose new components or patterns</li>
+      <li>Suggest updates to existing resources</li>
+      <li>Ask questions</li>
+      <li>Share feedback</li>
+    </ul>
+    Drop-in sessions are available to Government of Alberta product teams.
+    <br /><br />
+    <a
+      href="https://outlook.office365.com/book/BKGDesignsystemdropinhours@abgov.onmicrosoft.com/"
+      target="_blank">Book time in drop-in hours</a
+    >
+  </goa-callout>
+</DocumentationPageLayout>

--- a/docs/src/pages/get-started/migration-guide.astro
+++ b/docs/src/pages/get-started/migration-guide.astro
@@ -1,0 +1,228 @@
+---
+/**
+ * Get Started - Migration Guide
+ *
+ * Migration pathways and guidance for moving products from DS 1.x to DS 2.0.
+ * Content adapted from Confluence.
+ */
+import DocumentationPageLayout from "../../layouts/DocumentationPageLayout.astro";
+---
+
+<DocumentationPageLayout
+  title="Migration guide"
+  description="Choose the right Design System 2.0 migration pathway for your product"
+  section="get-started"
+>
+  <goa-text version="2" size="heading-xl" mt="none" mb="m">Migration guide</goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Design System 2.0 (DS 2.0) becomes the Government of Alberta standard in March 2026.
+    New products starting after launch should use DS 2.0. Existing active products should
+    plan their move to DS 2.0 during the recommended migration window, which runs from
+    March 2026 to September 2026.
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="migration-pathways">Migration pathways</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    The right migration path depends on your product&apos;s context, including team
+    funding and capacity, other delivery obligations, product lifecycle, and the effort
+    required to update. The three pathways are standard migration, late migration, and no
+    migration.
+  </goa-text>
+
+  <h3 id="starting-a-new-product">Starting a new product</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    If your product starts after March 2026, start with DS 2.0. Migration pathways apply
+    to existing products moving from DS 1.x to DS 2.0.
+  </goa-text>
+
+  <h3 id="compare-the-pathways">Compare the pathways</h3>
+  <div style="margin-bottom: var(--goa-space-xl);">
+    <goa-table version="2" width="100%">
+      <table width="100%" style="table-layout: fixed;">
+        <thead>
+          <tr>
+            <th style="width: 18%;">Pathway</th>
+            <th style="width: 58%;">Use it when</th>
+            <th style="width: 24%;">Recommendation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <goa-text version="2" size="body-s" mt="none" mb="none"
+                >Standard migration</goa-text
+              >
+            </td>
+            <td>
+              <goa-text version="2" size="body-s" mt="none" mb="none">
+                Your product has an active funded team and can migrate by September 2026
+              </goa-text>
+            </td>
+            <td>
+              <goa-text version="2" size="body-s" mt="none" mb="none"
+                >Recommended default</goa-text
+              >
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <goa-text version="2" size="body-s" mt="none" mb="none"
+                >Late migration</goa-text
+              >
+            </td>
+            <td>
+              <goa-text version="2" size="body-s" mt="none" mb="none">
+                Your team cannot meet the standard window because of delivery timelines,
+                dependencies, or capacity constraints
+              </goa-text>
+            </td>
+            <td>
+              <goa-text version="2" size="body-s" mt="none" mb="none"
+                >Only when necessary</goa-text
+              >
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <goa-text version="2" size="body-s" mt="none" mb="none"
+                >No migration</goa-text
+              >
+            </td>
+            <td>
+              <goa-text version="2" size="body-s" mt="none" mb="none">
+                Your product does not have an active funded team and/or is not in a
+                position to upgrade
+              </goa-text>
+            </td>
+            <td>
+              <goa-text version="2" size="body-s" mt="none" mb="none"
+                >Only in specific cases</goa-text
+              >
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </goa-table>
+  </div>
+
+  <h3 id="standard-migration">
+    Standard migration
+    <goa-badge
+      version="2"
+      type="success"
+      icon="false"
+      emphasis="subtle"
+      ml="m"
+      content="Recommended default"
+      style="vertical-align: middle;"></goa-badge>
+  </h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Standard migration is the <strong>default pathway for active products.</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Choose this path if your product has an active funded team and can schedule migration
+    work between March 2026 and September 2026. This is the recommended path for most
+    teams because it keeps your product aligned with the current standard and gives you
+    the best support.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">Use this pathway when:</goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li>your product is actively maintained</li>
+      <li>your team can reserve time to migrate by September 2026</li>
+      <li>you want access to the latest templates, components, tokens, and guidance</li>
+    </ul>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="xl">
+    Plan for work across the product team. Typical upgrade tasks include the library
+    updates, adjusting spacing and typography, and updating custom code to align with the
+    DS 2.0 visual design. This is a significant update and will usually involve design,
+    development, and testing.
+  </goa-text>
+
+  <h3 id="late-migration">Late migration</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Late migration is a last-resort pathway for active products.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Choose this path only when delivery deadlines, dependencies, or capacity constraints
+    make the standard migration window unrealistic. This path gives your team more time,
+    but it also increases risk and reduces your ongoing support.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">Use this pathway when:</goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <ul>
+      <li>a major delivery deadline blocks migration work</li>
+      <li>critical dependencies prevent the upgrade during the standard window</li>
+      <li>capacity or funding makes the standard window unrealistic</li>
+    </ul>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="xl">
+    Delaying migration means your product will wait longer to benefit from DS 2.0
+    improvements. Over time, compatibility gaps may increase, unresolved issues may
+    remain, and your product may be inconsistent with the new standard for longer.
+  </goa-text>
+
+  <h3 id="no-migration">No migration</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    No migration is an opt-out pathway for specific situations.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Choose this path only when your product does not have an active funded team and/or is
+    not in a position to upgrade. In these cases, the product may remain on DS 1.x.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="xl">
+    Teams on this path should understand that the product will not receive DS 2.0
+    improvements and will not align with the current standard. Support for DS 1.x is more
+    limited from March to September and ends after September 2026.
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="what-changes-after-launch">What changes after launch</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    After the DS 2.0 launch in March 2026:
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="xl">
+    <ul>
+      <li>New products should use DS 2.0</li>
+      <li>Active products should aim to migrate by September 2026</li>
+      <li>Web components 1.x receive limited fixes from March to September</li>
+      <li>Angular 4.x and React 6.x receive limited fixes or features after March</li>
+      <li>Support for DS 1.0 ends after September 2026</li>
+      <li>Web components will move to a new major version after September 2026</li>
+    </ul>
+  </goa-text>
+
+  <h2 id="how-to-choose">How to choose a pathway</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Use these questions to guide your decision:
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="xl">
+    <ul>
+      <li>Is this a new product starting after March 2026?</li>
+      <li>Does the product have an active funded team?</li>
+      <li>Can the team schedule migration work before September 2026?</li>
+      <li>
+        Are there delivery deadlines or dependencies that block the standard window?
+      </li>
+      <li>
+        Is the team prepared to accept reduced support and higher maintenance risk if
+        migration is delayed?
+      </li>
+    </ul>
+  </goa-text>
+
+  <h2 id="related-guidance">Related guidance</h2>
+  <goa-block version="2" gap="s" direction="column">
+    <goa-link version="2"
+      ><a href="/get-started/developers">Review the setup steps for developers</a
+      ></goa-link
+    >
+    <goa-text version="2" size="body-m" mt="none" mb="none">
+      Watch a real GoA service go through the migration when the recording is available.
+    </goa-text>
+  </goa-block>
+</DocumentationPageLayout>

--- a/docs/src/pages/get-started/roadmap.astro
+++ b/docs/src/pages/get-started/roadmap.astro
@@ -1,0 +1,276 @@
+---
+/**
+ * Get Started - Roadmap
+ *
+ * High-level roadmap for the design system team's 2026-27 fiscal year.
+ * Content adapted from Confluence.
+ */
+import DocumentationPageLayout from "../../layouts/DocumentationPageLayout.astro";
+---
+
+<DocumentationPageLayout
+  title="Roadmap"
+  description="High-level roadmap for the design system team's 2026-27 fiscal year"
+  section="get-started"
+>
+  <goa-text version="2" size="heading-xl" mt="none" mb="m">Roadmap</goa-text>
+  <goa-text version="2" size="body-l" mt="none" mb="2xl">
+    A high-level summary of the work the design system team plans to focus on in the
+    2026-27 Fiscal Year.
+  </goa-text>
+
+  <goa-callout version="2" type="information" emphasis="low" mb="m">
+    The roadmap is subject to change as we gather new information. We will communicate
+    updates to ensure product teams can align, prepare, and strategize their work
+    accordingly.
+  </goa-callout>
+
+  <goa-text version="2" size="body-m" mt="none" mb="xl">
+    For more details on our priorities and day-to-day activities, see our
+    <a href="https://github.com/orgs/GovAlta/projects/35/views/1" target="_blank">
+      design system backlog
+    </a>.
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="now">Now</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <strong>Focus:</strong> Drive DS 2.0 adoption momentum, protect post-launch stability, and
+    prove DS 2.0 helps teams move faster through prescriptive guidance and examples.
+  </goa-text>
+
+  <h3 id="adoption-measurement">DS 2.0 adoption and satisfaction measurement</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Objective:</strong> Establish reliable DS 2.0 adoption tracking and reporting, and
+    pair it with satisfaction signals from designers, developers, and end users to understand
+    whether DS 2.0 is improving service outcomes as teams upgrade.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Benefit:</strong> Enables accurate progress reporting and provides evidence that
+    DS 2.0 is improving usability, accessibility, and experience quality, not only adoption.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Examples:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <ul>
+      <li>Create a mechanism to reliably collect and report adoption rate</li>
+      <li>Track upgrade progress against the adoption schedule</li>
+      <li>
+        Capture qualitative signals from teams (developer and designer feedback themes)
+      </li>
+      <li>
+        Capture end-user feedback where available (citizen or worker satisfaction,
+        accessibility and usability feedback)
+      </li>
+    </ul>
+  </goa-text>
+
+  <h3 id="product-acceleration">Product acceleration enablement</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Objective:</strong> Provide prescriptive guidance and resources that help teams
+    get to screens, prototypes, and working experiences faster using DS 2.0.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Benefit:</strong> Reduces time to first screens and improves consistency by helping
+    teams start from proven patterns instead of building from scratch.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Examples:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <ul>
+      <li>
+        Create resources that show how to quickly prototype with DS 2.0 components and
+        examples
+      </li>
+      <li>
+        Provide contextual starting points for teams using Public form and Workspace
+        templates
+      </li>
+      <li>Pilot DS 2.0 with teams to generate strong examples to share</li>
+      <li>Create and publish migration success stories</li>
+    </ul>
+  </goa-text>
+
+  <h3 id="design-system-mcp">Design system MCP</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Objective:</strong> Stand up the design system Model Context Protocol (MCP) capability
+    so AI tools and platforms can reliably access design system guidance, components, patterns,
+    and standards.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Benefit:</strong> Helps teams and platforms generate more consistent, standards-aligned
+    front ends by making trusted design system context available directly in AI-assisted workflows.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Examples:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <ul>
+      <li>Define the initial MCP scope and supported design system resources</li>
+      <li>Stand up the MCP server and validate the hosting and maintenance approach</li>
+      <li>Test the MCP use in real product workflows and capture gaps to address</li>
+      <li>Document recommended workflows for teams</li>
+    </ul>
+  </goa-text>
+
+  <h3 id="vue-support-decision">Vue support decision</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Objective:</strong> Explore and define the minimum work required to confidently
+    state DS 2.0 officially supports Vue, including scope, constraints, and support model.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Benefit:</strong> Prevents unclear commitments and reduces strategic risk by enabling
+    an informed investment decision aligned to organizational needs.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Examples:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="xl">
+    <ul>
+      <li>Define what "official Vue support" means</li>
+      <li>Outline the minimum supportable scope</li>
+      <li>Identify implications for documentation, maintenance, testing, and support</li>
+    </ul>
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="next">Next</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <strong>Focus:</strong> Improve the core Public form and Workspace experience, mature reusable
+    patterns and examples, reduce adoption friction through better packaging, and execute on
+    the chosen Vue direction.
+  </goa-text>
+
+  <h3 id="capability-improvements">Public form and Workspace capability improvements</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Objective:</strong> Enhance key Public form and Workspace capabilities based on
+    adoption needs and workflow requirements.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Benefit:</strong> Improves feature sets and reduces the need for custom one-off
+    solutions by making common workflows easier to implement with DS 2.0.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Example:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <ul>
+      <li>Build the review, revise, resubmit feature</li>
+    </ul>
+  </goa-text>
+
+  <h3 id="pattern-maturity">Examples and pattern maturity</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Objective:</strong> Expand and refine examples and position them as adaptable reusable
+    patterns that teams can apply with confidence.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Benefit:</strong> Improves self-serve success and product consistency, reducing
+    implementation variance and support demand over time.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Examples:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <ul>
+      <li>Continue expanding and refining examples</li>
+      <li>Show how components and examples combine into larger contexts and workflows</li>
+    </ul>
+  </goa-text>
+
+  <h3 id="packaging-upgrades">Library packaging and tech stack upgrades</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Objective:</strong> Reduce friction in how design system assets are bundled and
+    adopted across libraries and update important tech stacks.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Benefit:</strong> Lowers setup and upgrade complexity, and keeps the design system
+    up to date with the latest supported versions.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Examples:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <ul>
+      <li>
+        Improve how code libraries are bundled together (React, web components, tokens)
+      </li>
+      <li>Update to Svelte 5</li>
+    </ul>
+  </goa-text>
+
+  <h3 id="vue-follow-through">Vue follow-through</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Objective:</strong> Based on Vue discovery, either implement formal Vue support
+    or clearly position Angular and React as the recommended approach for teams using AI-assisted
+    workflows.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Benefit:</strong> Provides clear direction to product teams and reduces uncertainty,
+    enabling progress on a supported path while keeping support sustainable for the design system
+    team.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Examples:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="xl">
+    <ul>
+      <li>Publish Vue support guidance and expectations</li>
+      <li>Implement agreed scope if approved</li>
+      <li>Publish recommended alternatives if Vue support is not pursued</li>
+    </ul>
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
+  <h2 id="later">Later</h2>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <strong>Focus:</strong> Support DS 2.0 version updates and improve documentation and communications
+    quality to support scaling and sustainability.
+  </goa-text>
+
+  <h3 id="docs-improvements">Documentation and communications improvements</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Objective:</strong> Improve how teams access and understand design system guidance,
+    and communicate design system value areas like accessibility more clearly.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Benefit:</strong> Increases trust, improves reuse, and supports self-serve adoption
+    by making guidance easier to consume and share.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Examples:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="l">
+    <ul>
+      <li>Add markdown file download to website documentation</li>
+      <li>
+        Articulate accessibility work more clearly (what is covered and how it supports
+        teams)
+      </li>
+    </ul>
+  </goa-text>
+
+  <h3 id="capacity-support">Targeted capacity support for DS 2.0 version updates</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Objective:</strong> Provide targeted design system team capacity to help remaining
+    DS 1.0 product teams complete the DS 2.0 version update.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Benefit:</strong> Accelerates adoption progress and unblocks teams facing more difficult
+    migrations, supporting adoption targets while keeping support sustainable through a focus
+    on teams most in need.
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    <strong>Example:</strong>
+  </goa-text>
+  <goa-text version="2" size="body-m" mt="none" mb="none">
+    <ul>
+      <li>Focus support on highest-impact teams or systemic blockers</li>
+    </ul>
+  </goa-text>
+</DocumentationPageLayout>


### PR DESCRIPTION
This PR adds the following pages to DS 2 docs:

- Migration Guide
- Developer Setup
- Roadmap