### PR TITLE
feat(#3579): add push drawer experimental wrappers

### DIFF
--- a/docs/src/content/examples/filter-a-list-using-a-push-drawer/react.tsx
+++ b/docs/src/content/examples/filter-a-list-using-a-push-drawer/react.tsx
@@ -9,7 +9,7 @@ import {
   GoabxTable,
   GoabxBadge,
 } from "@abgov/react-components/experimental";
-import { GoabPushDrawer } from "@abgov/react-components";
+import { GoabxPushDrawer } from "@abgov/react-components/experimental";
 
 export function FilterAListUsingAPushDrawer() {
   const [open, setOpen] = useState(false);
@@ -94,7 +94,7 @@ export function FilterAListUsingAPushDrawer() {
         </GoabxTable>
       </div>
 
-      <GoabPushDrawer
+      <GoabxPushDrawer
         heading="Filters"
         width="260px"
         open={open}
@@ -123,7 +123,7 @@ export function FilterAListUsingAPushDrawer() {
             <GoabxDropdownItem value="completed" label="Completed" />
           </GoabxDropdown>
         </GoabxFormItem>
-      </GoabPushDrawer>
+      </GoabxPushDrawer>
     </div>
   );
 }

--- a/docs/src/content/examples/filter-a-list-using-a-push-drawer/web-components.html
+++ b/docs/src/content/examples/filter-a-list-using-a-push-drawer/web-components.html
@@ -64,7 +64,7 @@
     </goa-table>
   </div>
 
-  <goa-push-drawer id="filters-drawer" heading="Filters" width="260px">
+  <goa-push-drawer version="2" id="filters-drawer" heading="Filters" width="260px">
     <goa-form-item version="2" label="Act">
       <goa-checkbox-list name="act">
         <goa-checkbox

--- a/docs/src/data/configurations/push-drawer.ts
+++ b/docs/src/data/configurations/push-drawer.ts
@@ -27,7 +27,7 @@ export const pushDrawerConfigurations: ComponentConfigurations = {
       name: "Basic push drawer",
       description: "Opens from the right, pushing page content aside",
       code: {
-        react: `<GoabPushDrawer heading="Application details" width="260px" open={isOpen} onClose={handleClose}>
+        react: `<GoabxPushDrawer heading="Application details" width="260px" open={isOpen} onClose={handleClose}>
   <GoabText tag="h4" size="heading-xs" mb="s" mt="none">Applicant name</GoabText>
   <GoabText size="body-m" mt="none">Jane Smith</GoabText>
   <GoabText tag="h4" size="heading-xs" mb="s" mt="none">File number</GoabText>
@@ -36,8 +36,8 @@ export const pushDrawerConfigurations: ComponentConfigurations = {
   <GoabxBadge type="success" content="Approved" />
   <GoabText tag="h4" size="heading-xs" mb="s" mt="m">Submitted</GoabText>
   <GoabText size="body-m" mt="none">January 15, 2025</GoabText>
-</GoabPushDrawer>`,
-        angular: `<goab-push-drawer heading="Application details" width="260px" [open]="isOpen" (onClose)="handleClose()">
+</GoabxPushDrawer>`,
+        angular: `<goabx-push-drawer heading="Application details" width="260px" [open]="isOpen" (onClose)="handleClose()">
   <goab-text tag="h4" size="heading-xs" mb="s" mt="none">Applicant name</goab-text>
   <goab-text size="body-m" mt="none">Jane Smith</goab-text>
   <goab-text tag="h4" size="heading-xs" mb="s" mt="none">File number</goab-text>
@@ -46,7 +46,7 @@ export const pushDrawerConfigurations: ComponentConfigurations = {
   <goab-badge version="2" type="success" content="Approved"></goab-badge>
   <goab-text tag="h4" size="heading-xs" mb="s" mt="m">Submitted</goab-text>
   <goab-text size="body-m" mt="none">January 15, 2025</goab-text>
-</goab-push-drawer>`,
+</goabx-push-drawer>`,
         webComponents: `<div style="display: flex; min-height: 320px;">
   <div style="flex: 1; min-width: 0; display: flex; align-items: center; justify-content: center;">
     <goa-button version="2" id="open-push-drawer">Open push drawer</goa-button>
@@ -70,22 +70,22 @@ export const pushDrawerConfigurations: ComponentConfigurations = {
       name: "Custom width",
       description: "Push drawer with a custom width",
       code: {
-        react: `<GoabPushDrawer heading="Case notes" width="600px" open={isOpen} onClose={handleClose}>
+        react: `<GoabxPushDrawer heading="Case notes" width="600px" open={isOpen} onClose={handleClose}>
   <GoabText tag="h4" size="heading-xs" mb="s" mt="none">Officer</GoabText>
   <GoabText size="body-m" mt="none">Const. M. Roberts, Badge #4412</GoabText>
   <GoabText tag="h4" size="heading-xs" mb="s" mt="none">Date</GoabText>
   <GoabText size="body-m" mt="none">February 3, 2025</GoabText>
   <GoabText tag="h4" size="heading-xs" mb="s" mt="none">Notes</GoabText>
   <GoabText size="body-m" mt="none">Applicant provided updated documentation. Reviewed supporting evidence and confirmed eligibility criteria are met. Forwarded to supervisor for final approval.</GoabText>
-</GoabPushDrawer>`,
-        angular: `<goab-push-drawer heading="Case notes" width="600px" [open]="isOpen" (onClose)="handleClose()">
+</GoabxPushDrawer>`,
+        angular: `<goabx-push-drawer heading="Case notes" width="600px" [open]="isOpen" (onClose)="handleClose()">
   <goab-text tag="h4" size="heading-xs" mb="s" mt="none">Officer</goab-text>
   <goab-text size="body-m" mt="none">Const. M. Roberts, Badge #4412</goab-text>
   <goab-text tag="h4" size="heading-xs" mb="s" mt="none">Date</goab-text>
   <goab-text size="body-m" mt="none">February 3, 2025</goab-text>
   <goab-text tag="h4" size="heading-xs" mb="s" mt="none">Notes</goab-text>
   <goab-text size="body-m" mt="none">Applicant provided updated documentation. Reviewed supporting evidence and confirmed eligibility criteria are met. Forwarded to supervisor for final approval.</goab-text>
-</goab-push-drawer>`,
+</goabx-push-drawer>`,
         webComponents: `<div style="display: flex; min-height: 320px;">
   <div style="flex: 1; min-width: 0; display: flex; align-items: center; justify-content: center;">
     <goa-button version="2" id="open-push-drawer">Open push drawer</goa-button>
@@ -107,7 +107,7 @@ export const pushDrawerConfigurations: ComponentConfigurations = {
       name: "With actions",
       description: "Push drawer with footer actions",
       code: {
-        react: `<GoabPushDrawer
+        react: `<GoabxPushDrawer
   heading="Edit notification preferences"
   width="280px"
   open={isOpen}
@@ -126,8 +126,8 @@ export const pushDrawerConfigurations: ComponentConfigurations = {
       <GoabxCheckbox name="assignments" text="New assignments" />
     </GoabxCheckboxList>
   </GoabxFormItem>
-</GoabPushDrawer>`,
-        angular: `<goab-push-drawer
+</GoabxPushDrawer>`,
+        angular: `<goabx-push-drawer
   heading="Edit notification preferences"
   width="280px"
   [open]="isOpen"
@@ -141,7 +141,7 @@ export const pushDrawerConfigurations: ComponentConfigurations = {
       <goabx-checkbox name="assignments" text="New assignments"></goabx-checkbox>
     </goabx-checkbox-list>
   </goabx-form-item>
-</goab-push-drawer>
+</goabx-push-drawer>
 
 <ng-template #pushDrawerActions>
   <goab-button-group alignment="start">
@@ -164,6 +164,90 @@ export const pushDrawerConfigurations: ComponentConfigurations = {
     <goa-button-group slot="actions" alignment="start">
       <goa-button version="2" size="compact">Save</goa-button>
       <goa-button version="2" type="secondary" size="compact">Cancel</goa-button>
+    </goa-button-group>
+  </goa-push-drawer>
+</div>
+<script>${pushDrawerScript}</script>`,
+      },
+    },
+    {
+      id: "long-content",
+      name: "Long content",
+      description:
+        "Content that exceeds the drawer height scrolls while the header and actions stay pinned",
+      code: {
+        react: `<GoabxPushDrawer
+  heading="Case history"
+  width="320px"
+  open={isOpen}
+  onClose={handleClose}
+  actions={
+    <GoabButtonGroup alignment="start">
+      <GoabxButton size="compact">Export</GoabxButton>
+      <GoabxButton type="secondary" size="compact">Close</GoabxButton>
+    </GoabButtonGroup>
+  }
+>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="none">Jan 15, 2025</GoabText>
+  <GoabText size="body-m" mt="none">Application received. Initial review completed by intake officer. All required documents present.</GoabText>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="l">Feb 3, 2025</GoabText>
+  <GoabText size="body-m" mt="none">Background check initiated. Applicant contacted for additional verification of employment history.</GoabText>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="l">Feb 18, 2025</GoabText>
+  <GoabText size="body-m" mt="none">Employment verification received. Forwarded to senior reviewer for assessment.</GoabText>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="l">Mar 1, 2025</GoabText>
+  <GoabText size="body-m" mt="none">Senior review complete. Recommendation for approval pending supervisor sign-off.</GoabText>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="l">Mar 10, 2025</GoabText>
+  <GoabText size="body-m" mt="none">Supervisor approved. Final documentation prepared for applicant notification.</GoabText>
+  <GoabText tag="h4" size="heading-xs" mb="s" mt="l">Mar 12, 2025</GoabText>
+  <GoabText size="body-m" mt="none">Approval letter sent to applicant via registered mail. Case marked as complete.</GoabText>
+</GoabxPushDrawer>`,
+        angular: `<goabx-push-drawer
+  heading="Case history"
+  width="320px"
+  [open]="isOpen"
+  (onClose)="handleClose()"
+  [actions]="pushDrawerActions"
+>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="none">Jan 15, 2025</goab-text>
+  <goab-text size="body-m" mt="none">Application received. Initial review completed by intake officer. All required documents present.</goab-text>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="l">Feb 3, 2025</goab-text>
+  <goab-text size="body-m" mt="none">Background check initiated. Applicant contacted for additional verification of employment history.</goab-text>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="l">Feb 18, 2025</goab-text>
+  <goab-text size="body-m" mt="none">Employment verification received. Forwarded to senior reviewer for assessment.</goab-text>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="l">Mar 1, 2025</goab-text>
+  <goab-text size="body-m" mt="none">Senior review complete. Recommendation for approval pending supervisor sign-off.</goab-text>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="l">Mar 10, 2025</goab-text>
+  <goab-text size="body-m" mt="none">Supervisor approved. Final documentation prepared for applicant notification.</goab-text>
+  <goab-text tag="h4" size="heading-xs" mb="s" mt="l">Mar 12, 2025</goab-text>
+  <goab-text size="body-m" mt="none">Approval letter sent to applicant via registered mail. Case marked as complete.</goab-text>
+</goabx-push-drawer>
+
+<ng-template #pushDrawerActions>
+  <goab-button-group alignment="start">
+    <goabx-button size="compact">Export</goabx-button>
+    <goabx-button type="secondary" size="compact">Close</goabx-button>
+  </goab-button-group>
+</ng-template>`,
+        webComponents: `<div style="display: flex; min-height: 320px;">
+  <div style="flex: 1; min-width: 0; display: flex; align-items: center; justify-content: center;">
+    <goa-button version="2" id="open-push-drawer">Open push drawer</goa-button>
+  </div>
+  <goa-push-drawer version="2" id="demo-push-drawer" heading="Case history" width="320px">
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="none">Jan 15, 2025</goa-text>
+    <goa-text size="body-m" mt="none">Application received. Initial review completed by intake officer. All required documents present.</goa-text>
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="l">Feb 3, 2025</goa-text>
+    <goa-text size="body-m" mt="none">Background check initiated. Applicant contacted for additional verification of employment history.</goa-text>
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="l">Feb 18, 2025</goa-text>
+    <goa-text size="body-m" mt="none">Employment verification received. Forwarded to senior reviewer for assessment.</goa-text>
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="l">Mar 1, 2025</goa-text>
+    <goa-text size="body-m" mt="none">Senior review complete. Recommendation for approval pending supervisor sign-off.</goa-text>
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="l">Mar 10, 2025</goa-text>
+    <goa-text size="body-m" mt="none">Supervisor approved. Final documentation prepared for applicant notification.</goa-text>
+    <goa-text tag="h4" size="heading-xs" mb="s" mt="l">Mar 12, 2025</goa-text>
+    <goa-text size="body-m" mt="none">Approval letter sent to applicant via registered mail. Case marked as complete.</goa-text>
+    <goa-button-group slot="actions" alignment="start">
+      <goa-button version="2" size="compact">Export</goa-button>
+      <goa-button version="2" type="secondary" size="compact">Close</goa-button>
     </goa-button-group>
   </goa-push-drawer>
 </div>

--- a/libs/angular-components/src/experimental/index.ts
+++ b/libs/angular-components/src/experimental/index.ts
@@ -8,6 +8,7 @@ export * from "./checkbox/checkbox";
 export * from "./checkbox-list/checkbox-list";
 export * from "./date-picker/date-picker";
 export * from "./drawer/drawer";
+export * from "./push-drawer/push-drawer";
 export * from "./dropdown/dropdown";
 export * from "./dropdown-item/dropdown-item";
 export * from "./file-upload-card/file-upload-card";

--- a/libs/angular-components/src/experimental/push-drawer/push-drawer.spec.ts
+++ b/libs/angular-components/src/experimental/push-drawer/push-drawer.spec.ts
@@ -1,0 +1,67 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { GoabxPushDrawer } from "./push-drawer";
+import { Component } from "@angular/core";
+
+@Component({
+  standalone: true,
+  imports: [GoabxPushDrawer],
+  template: `
+    <goabx-push-drawer
+      [open]="open"
+      [width]="width"
+      [testId]="testId"
+      (onClose)="onClose()"
+      [heading]="heading"
+      [actions]="actions"
+    >
+      {{ content }}
+      <ng-template #heading>
+        <h1>Heading</h1>
+      </ng-template>
+      <ng-template #actions>
+        <button>Close</button>
+      </ng-template>
+    </goabx-push-drawer>
+  `,
+})
+class TestPushDrawerComponent {
+  open = false;
+  width = "600px";
+  testId = "test-push-drawer";
+  content = "Test Content";
+
+  onClose() {
+    /* empty */
+  }
+}
+
+describe("GoabxPushDrawer", () => {
+  let component: TestPushDrawerComponent;
+  let fixture: ComponentFixture<TestPushDrawerComponent>;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestPushDrawerComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestPushDrawerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+  }));
+
+  it("renders with correct attributes", fakeAsync(() => {
+    const pushDrawerElement = fixture.nativeElement.querySelector("goa-push-drawer");
+    expect(pushDrawerElement).toBeTruthy();
+
+    expect(pushDrawerElement.getAttribute("width")).toBe("600px");
+    expect(pushDrawerElement.getAttribute("testid")).toBe("test-push-drawer");
+    expect(pushDrawerElement.getAttribute("version")).toBe("2");
+    const headingContent = pushDrawerElement.querySelector("[slot='heading']");
+    expect(headingContent?.textContent).toContain("Heading");
+    expect(pushDrawerElement.textContent).toContain("Test Content");
+    const actionsContent = pushDrawerElement.querySelector("[slot='actions']");
+    expect(actionsContent?.textContent).toContain("Close");
+  }));
+});

--- a/libs/angular-components/src/experimental/push-drawer/push-drawer.ts
+++ b/libs/angular-components/src/experimental/push-drawer/push-drawer.ts
@@ -1,0 +1,73 @@
+import { NgTemplateOutlet } from "@angular/common";
+import {
+  booleanAttribute,
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  EventEmitter,
+  Input,
+  Output,
+  TemplateRef,
+  OnInit,
+  ChangeDetectorRef,
+} from "@angular/core";
+
+@Component({
+  standalone: true,
+  selector: "goabx-push-drawer",
+  imports: [NgTemplateOutlet],
+  template: `@if (isReady) {
+    <goa-push-drawer
+      [open]="open"
+      [attr.heading]="getHeadingAsString()"
+      [attr.testid]="testId"
+      [attr.width]="width"
+      [attr.version]="version"
+      (_close)="_onClose()"
+    >
+      <ng-content></ng-content>
+      <div slot="heading">
+        <ng-container [ngTemplateOutlet]="getHeadingAsTemplate()"></ng-container>
+      </div>
+      @if (actions) {
+        <div slot="actions">
+          <ng-container [ngTemplateOutlet]="actions"></ng-container>
+        </div>
+      }
+    </goa-push-drawer>
+  } `,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class GoabxPushDrawer implements OnInit {
+  version = "2";
+
+  @Input({ transform: booleanAttribute }) open?: boolean;
+  @Input() heading!: string | TemplateRef<any>;
+  @Input() width?: string;
+  @Input() testId?: string;
+  @Input() actions!: TemplateRef<any>;
+  @Output() onClose = new EventEmitter();
+
+  isReady = false;
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.isReady = true;
+      this.cdr.detectChanges();
+    }, 0);
+  }
+
+  _onClose() {
+    this.onClose.emit();
+  }
+
+  getHeadingAsString(): string {
+    return this.heading instanceof TemplateRef ? "" : this.heading;
+  }
+
+  getHeadingAsTemplate(): TemplateRef<any> | null {
+    if (!this.heading) return null;
+    return this.heading instanceof TemplateRef ? this.heading : null;
+  }
+}

--- a/libs/react-components/src/experimental/index.ts
+++ b/libs/react-components/src/experimental/index.ts
@@ -8,6 +8,7 @@ export * from "./checkbox/checkbox";
 export * from "./checkbox-list/checkbox-list";
 export * from "./date-picker/date-picker";
 export * from "./drawer/drawer";
+export * from "./push-drawer/push-drawer";
 export * from "./dropdown/dropdown";
 export * from "./dropdown/dropdown-item";
 export * from "./file-upload-card/file-upload-card";

--- a/libs/react-components/src/experimental/push-drawer/push-drawer.spec.tsx
+++ b/libs/react-components/src/experimental/push-drawer/push-drawer.spec.tsx
@@ -1,0 +1,79 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, it } from "vitest";
+import GoabxPushDrawer from "./push-drawer";
+
+const noop = () => {
+  /* nothing */
+};
+
+describe("GoabxPushDrawer", () => {
+  it("should render", async () => {
+    const content = render(<GoabxPushDrawer onClose={noop}>The content</GoabxPushDrawer>);
+
+    const el = content.container.querySelector("goa-push-drawer");
+
+    expect(el?.getAttribute("open")).toBeNull();
+    expect(el?.getAttribute("version")).toBe("2");
+  });
+
+  it("should render with properties", async () => {
+    const content = render(
+      <GoabxPushDrawer
+        open
+        heading="The heading"
+        width="600px"
+        testId="the testid"
+        onClose={noop}
+      >
+        The content
+      </GoabxPushDrawer>,
+    );
+
+    const el = content.container.querySelector("goa-push-drawer");
+    expect(el).toBeTruthy();
+    await waitFor(() => {
+      expect(el?.getAttribute("open")).not.toBeNull();
+      expect(el?.getAttribute("heading")).toBe("The heading");
+      expect(el?.getAttribute("width")).toBe("600px");
+      expect(el?.getAttribute("testid")).toBe("the testid");
+      expect(el?.getAttribute("version")).toBe("2");
+    });
+  });
+
+  it("renders with React node heading", async () => {
+    const headingNode = <div>Custom Heading</div>;
+    const content = render(
+      <GoabxPushDrawer open heading={headingNode} onClose={noop}>
+        The content
+      </GoabxPushDrawer>,
+    );
+
+    const el = content.container.querySelector("goa-push-drawer");
+    expect(el).toBeTruthy();
+    await waitFor(() => {
+      expect(el?.getAttribute("heading")).toBeNull();
+      const headingSlot = el?.querySelector('[slot="heading"]');
+      expect(headingSlot).toBeTruthy();
+      expect(headingSlot?.textContent).toBe("Custom Heading");
+    });
+  });
+
+  it("renders with actions", async () => {
+    const actionsNode = <button>Action Button</button>;
+    const content = render(
+      <GoabxPushDrawer open heading="The heading" actions={actionsNode} onClose={noop}>
+        The content
+      </GoabxPushDrawer>,
+    );
+
+    const el = content.container.querySelector("goa-push-drawer");
+    expect(el).toBeTruthy();
+    await waitFor(() => {
+      const actionsSlot = el?.querySelector('[slot="actions"]');
+      expect(actionsSlot).toBeTruthy();
+      const actionButton = actionsSlot?.querySelector("button");
+      expect(actionButton).toBeTruthy();
+      expect(actionButton?.textContent).toBe("Action Button");
+    });
+  });
+});

--- a/libs/react-components/src/experimental/push-drawer/push-drawer.tsx
+++ b/libs/react-components/src/experimental/push-drawer/push-drawer.tsx
@@ -1,0 +1,70 @@
+import { ReactNode, useEffect, useRef, type JSX } from "react";
+
+interface WCProps {
+  open?: boolean;
+  heading?: string;
+  width?: string;
+  testid?: string;
+  version?: string;
+  ref: React.RefObject<HTMLElement | null>;
+}
+
+declare module "react" {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      "goa-push-drawer": WCProps & React.HTMLAttributes<HTMLElement>;
+    }
+  }
+}
+
+export interface GoabxPushDrawerProps {
+  open?: boolean;
+  heading?: string | ReactNode;
+  width?: string;
+  testId?: string;
+  actions?: ReactNode;
+  children: ReactNode;
+  onClose: () => void;
+  version?: string;
+}
+
+export function GoabxPushDrawer({
+  open,
+  heading,
+  width,
+  testId,
+  actions,
+  children,
+  onClose,
+  version = "2",
+}: GoabxPushDrawerProps): JSX.Element {
+  const el = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!el?.current || !onClose) {
+      return;
+    }
+    el.current?.addEventListener("_close", onClose);
+    return () => {
+      el.current?.removeEventListener("_close", onClose);
+    };
+  }, [el, onClose]);
+
+  return (
+    <goa-push-drawer
+      ref={el}
+      open={open ? true : undefined}
+      heading={typeof heading === "string" ? heading : undefined}
+      width={width}
+      testid={testId}
+      version={version}
+    >
+      {heading && typeof heading !== "string" && <div slot="heading">{heading}</div>}
+      {actions && <div slot="actions">{actions}</div>}
+      {children}
+    </goa-push-drawer>
+  );
+}
+
+export default GoabxPushDrawer;

--- a/libs/react-components/src/lib/push-drawer/push-drawer.tsx
+++ b/libs/react-components/src/lib/push-drawer/push-drawer.tsx
@@ -1,21 +1,5 @@
 import { ReactNode, useEffect, useRef } from "react";
 
-interface WCProps {
-  open?: boolean;
-  testid?: string;
-  heading?: string;
-  width?: string;
-  ref: React.RefObject<HTMLElement | null>;
-}
-declare module "react" {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {
-      "goa-push-drawer": WCProps & React.HTMLAttributes<HTMLElement>;
-    }
-  }
-}
-
 export interface GoabPushDrawerProps {
   testid?: string;
   open?: boolean;

--- a/libs/web-components/src/components/push-drawer/PushDrawer.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawer.svelte
@@ -6,6 +6,7 @@
       open: { type: "Boolean", reflect: true },
       heading: { type: "String", reflect: true },
       width: { type: "String", reflect: true },
+      version: { type: "String", reflect: true },
     },
   }}
 />
@@ -17,6 +18,7 @@
   export let open: boolean = false;
   export let heading: string = "";
   export let width: string = "492px";
+  export let version: string | undefined = undefined;
 
   // Minimum window width for desktop layout from vite.config.js
   const minimumDesktopWidth = 1023;
@@ -40,6 +42,7 @@
     position="right"
     maxsize={width}
     {heading}
+    {version}
   >
     <span slot="actions">
       <slot name="actions" />
@@ -53,6 +56,7 @@
     {open}
     {width}
     {heading}
+    {version}
   >
     <span slot="actions">
       <slot name="actions" />

--- a/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
@@ -6,6 +6,7 @@
       open: { type: "Boolean", reflect: true },
       heading: { type: "String", reflect: true },
       width: { type: "String", reflect: true },
+      version: { type: "String", attribute: "version", reflect: true },
     },
   }}
 />
@@ -19,6 +20,7 @@
   export let open: boolean = false;
   export let heading: string = "";
   export let width: string = "492px";
+  export let version: string | undefined = undefined;
   let _contentEl: HTMLElement | null = null;
   let drawerState: DrawerState = "initial";
   let closingTimeout: number | null = null;
@@ -63,21 +65,15 @@
   };
 
   // Scrolling ---
-  let _scrollEl: HTMLElement | null = null;
-  let _scrollPos: "top" | "middle" | "bottom" | null = null; // to add the box-shadow to the drawer content
+  let _scrollPos: "top" | "middle" | "bottom" | null = null;
   let _actionsSlotHasContent: boolean = false;
   async function checkActionsSlotContent() {
     await tick();
     _actionsSlotHasContent = !!$$slots.actions;
   }
 
-  // Add reactive statement for checking actions slot content (for class style and height calculations) and scroll position (for box-shadow)
   $: if (open) {
     checkActionsSlotContent();
-    if (_scrollEl) {
-      const hasScroll = _scrollEl.scrollHeight > _scrollEl.offsetHeight;
-      _scrollPos = hasScroll ? "top" : null;
-    }
   }
 
   function onScroll(e: Event) {


### PR DESCRIPTION
## Summary
- Add GoabxPushDrawer experimental wrappers for React and Angular with version="2" default
- Add version prop to PushDrawer.svelte and PushDrawerInternal.svelte (passthrough to goa-drawer on mobile, goa-push-drawer-internal on desktop)
- Add version to standard React wrapper's WCProps to avoid TS IntrinsicElements conflict
- React: 4 tests, Angular: 1 test

Closes #3579

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run test:pr` passes (1 pre-existing failure in TwoColumnLayout unrelated)
- [ ] React experimental wrapper renders with version="2" by default
- [ ] Angular experimental wrapper renders with version="2" by default
- [ ] Standard push drawer (V1) behavior unchanged