### PR TITLE
feat(#3580): push drawer V2 styling and dynamic edge behavior

### DIFF
--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -258,7 +258,7 @@ export function App() {
                   label="2440 MenuButton Icon"
                   url="/features/2440"
                 />
-                <GoabxWorkSideMenuItem label="2469 Push Drawer" url="/features/2469" />
+                <GoabxWorkSideMenuItem label="2469/3580 Push Drawer" url="/features/2469" />
                 <GoabxWorkSideMenuItem
                   label="2492 TextArea onBlur"
                   url="/features/2492"

--- a/apps/prs/react/src/routes/features/feat2469.tsx
+++ b/apps/prs/react/src/routes/features/feat2469.tsx
@@ -1,4 +1,4 @@
-import { JSX, useState } from "react";
+import { JSX, useState, useEffect } from "react";
 import {
   GoabButton,
   GoabFormItem,
@@ -7,7 +7,9 @@ import {
   GoabPushDrawer,
   GoabTable,
 } from "@abgov/react-components";
+import { GoabxPushDrawer, GoabxTable } from "@abgov/react-components/experimental";
 import { GoabInputOnChangeDetail } from "@abgov/ui-components-common";
+import v2TokensUrl from "@abgov/design-tokens-v2/dist/tokens.css?url";
 
 type DataTableFields = {
   firstName: string;
@@ -30,23 +32,84 @@ function generateFakeData(numRows: number): DataTableFields[] {
 }
 
 export function Feat2469Route(): JSX.Element {
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = v2TokensUrl;
+    document.head.appendChild(link);
+
+    const deletedRules: Array<{ sheet: CSSStyleSheet; index: number; cssText: string }> =
+      [];
+
+    link.onload = () => {
+      [...document.styleSheets].forEach((ss) => {
+        if (ss.ownerNode === link) return;
+        try {
+          for (let i = ss.cssRules.length - 1; i >= 0; i--) {
+            const rule = ss.cssRules[i];
+            if (rule instanceof CSSStyleRule && rule.selectorText === ":root") {
+              deletedRules.push({ sheet: ss, index: i, cssText: rule.cssText });
+              ss.deleteRule(i);
+            }
+          }
+        } catch (e) {
+          // skip cross-origin sheets
+        }
+      });
+    };
+
+    return () => {
+      link.remove();
+      deletedRules.forEach(({ sheet, index, cssText }) => {
+        try {
+          sheet.insertRule(cssText, Math.min(index, sheet.cssRules.length));
+        } catch (e) {
+          // skip if sheet is no longer available
+        }
+      });
+    };
+  }, []);
+
   const smallDrawerControlSet = (
     <div key={`key=${Date.now()}`}>
-      <h1>Drawer</h1>
+      <h1 style={{ marginTop: 0 }}>Drawer</h1>
       <p>This is a drawer</p>
     </div>
   );
 
-  const pageStyle: React.CSSProperties = {
+  // Simulates a full-screen app layout (like the workspace app).
+  // Fixed height container where content scrolls internally.
+  const appShellBase: React.CSSProperties = {
+    height: "80vh",
     display: "flex",
     flexDirection: "row",
-    minHeight: "80vh",
+    border: "2px solid #666",
+    borderRadius: "8px",
+    overflow: "hidden",
+    margin: "16px 0",
+    padding: 0,
   };
 
-  const pageContainerStyles: React.CSSProperties = {
+  const v2ShellStyle: React.CSSProperties = {
+    ...appShellBase,
+    background: "var(--goa-color-greyscale-50)",
+  };
+
+  const v2PageContainerStyles: React.CSSProperties = {
     flex: "1 1 0%",
-    overflow: "hidden",
-    border: "1px solid green",
+    overflowY: "auto",
+    padding: "var(--goa-space-l)",
+    margin:
+      "var(--goa-drawer-offset, 16px) 0 var(--goa-drawer-offset, 16px) var(--goa-drawer-offset, 16px)",
+    borderRadius: "var(--goa-push-drawer-border-radius)",
+    border: "var(--goa-border-width-s) solid var(--goa-color-greyscale-150)",
+    background: "var(--goa-color-greyscale-white)",
+  };
+
+  const v1PageContainerStyles: React.CSSProperties = {
+    flex: "1 1 0%",
+    overflowY: "auto",
+    padding: "16px",
   };
 
   const [pushDrawerOpen, setPushDrawerOpen] = useState(false);
@@ -88,38 +151,53 @@ export function Feat2469Route(): JSX.Element {
     setDrawerWidth(detail.value);
   };
 
-  const actions = (
-    <GoabButton type="secondary" onClick={() => togglePushDrawerOpen()}>
+  const [showActions, setShowActions] = useState(true);
+  const actions = showActions ? (
+    <GoabButton type="secondary" size="compact" onClick={() => togglePushDrawerOpen()}>
       Close
     </GoabButton>
-  );
+  ) : undefined;
+
+  // --- V1 state ---
+  const [v1Open, setV1Open] = useState(false);
+  const [v1Controls, setV1Controls] = useState<JSX.Element[]>([smallDrawerControlSet]);
+  const [v1ShowActions, setV1ShowActions] = useState(true);
+  const v1Actions = v1ShowActions ? (
+    <GoabButton type="secondary" onClick={() => setV1Open(false)}>
+      Close
+    </GoabButton>
+  ) : undefined;
 
   return (
     <GoabPageBlock width="100%">
-      <div style={pageStyle}>
-        <div style={pageContainerStyles} test-id="container">
-          <h1>Pushed In Content</h1>
-          <div style={{ display: "flex", gap: "10px", marginTop: "20px" }}>
-            <GoabButton onClick={togglePushDrawerOpen}>
-              {pushDrawerOpen ? "Close" : "Open"} Push Drawer
-            </GoabButton>
-          </div>
-          <GoabFormItem label="Width">
-            <GoabInput
-              name="width"
-              type="text"
-              value={drawerWidth}
-              width="20ch"
-              onChange={onWidthChange}
-            ></GoabInput>
-          </GoabFormItem>
-          <div style={{ display: "flex", gap: "10px", marginTop: "10px" }}>
-            <GoabButton onClick={clearTableData}>Clear Table Data</GoabButton>
-            <GoabButton onClick={addTableData}>Add Table Data</GoabButton>
-            <GoabButton onClick={clearDrawerContent}>Clear Drawer Content</GoabButton>
-            <GoabButton onClick={addDrawerContent}>Add Drawer Content</GoabButton>
-          </div>
-          <GoabTable width="100%">
+      <h2>V2 (Experimental)</h2>
+      <div
+        style={{ display: "flex", gap: "10px", flexWrap: "wrap", alignItems: "center" }}
+      >
+        <GoabButton onClick={togglePushDrawerOpen}>
+          {pushDrawerOpen ? "Close" : "Open"} Push Drawer
+        </GoabButton>
+        <GoabFormItem label="Width" mb="none">
+          <GoabInput
+            name="width"
+            type="text"
+            value={drawerWidth}
+            width="12ch"
+            onChange={onWidthChange}
+          ></GoabInput>
+        </GoabFormItem>
+        <GoabButton onClick={clearTableData}>Clear Table</GoabButton>
+        <GoabButton onClick={addTableData}>Add Row</GoabButton>
+        <GoabButton onClick={clearDrawerContent}>Clear Drawer</GoabButton>
+        <GoabButton onClick={addDrawerContent}>Add Drawer Content</GoabButton>
+        <GoabButton onClick={() => setShowActions(!showActions)}>
+          {showActions ? "Remove Actions" : "Add Actions"}
+        </GoabButton>
+      </div>
+      <div style={v2ShellStyle}>
+        <div style={v2PageContainerStyles}>
+          <h2 style={{ marginTop: 0 }}>Page Content</h2>
+          <GoabxTable width="100%">
             <thead>
               <tr>
                 <th>First</th>
@@ -136,10 +214,10 @@ export function Feat2469Route(): JSX.Element {
                 </tr>
               ))}
             </tbody>
-          </GoabTable>
+          </GoabxTable>
         </div>
-        <GoabPushDrawer
-          testid="drawer"
+        <GoabxPushDrawer
+          testId="drawer"
           open={pushDrawerOpen}
           heading="Push Drawer"
           width={drawerWidth}
@@ -147,7 +225,55 @@ export function Feat2469Route(): JSX.Element {
           actions={actions}
         >
           {pushDrawerControls}
-          <GoabButton onClick={closePushDrawer}>Close</GoabButton>
+        </GoabxPushDrawer>
+      </div>
+
+      <h2 style={{ marginTop: "48px" }}>V1 (Standard)</h2>
+      <div
+        style={{ display: "flex", gap: "10px", flexWrap: "wrap", alignItems: "center" }}
+      >
+        <GoabButton onClick={() => setV1Open(!v1Open)}>
+          {v1Open ? "Close" : "Open"} Push Drawer
+        </GoabButton>
+        <GoabButton
+          onClick={() =>
+            setV1Controls([
+              ...v1Controls,
+              <div key={Date.now()}>
+                <h2>Additional Content</h2>
+                <p>More drawer content</p>
+                <ul>
+                  <li>Item 1</li>
+                  <li>Item 2</li>
+                  <li>Item 3</li>
+                </ul>
+              </div>,
+            ])
+          }
+        >
+          Add Drawer Content
+        </GoabButton>
+        <GoabButton onClick={() => setV1Controls([smallDrawerControlSet])}>
+          Clear Drawer Content
+        </GoabButton>
+        <GoabButton onClick={() => setV1ShowActions(!v1ShowActions)}>
+          {v1ShowActions ? "Remove Actions" : "Add Actions"}
+        </GoabButton>
+      </div>
+      <div style={appShellBase}>
+        <div style={v1PageContainerStyles}>
+          <h2 style={{ marginTop: 0 }}>Page Content</h2>
+          <p>V1 push drawer for comparison.</p>
+        </div>
+        <GoabPushDrawer
+          testid="v1-drawer"
+          open={v1Open}
+          heading="Push Drawer (V1)"
+          width="500px"
+          onClose={() => setV1Open(false)}
+          actions={v1Actions}
+        >
+          {v1Controls}
         </GoabPushDrawer>
       </div>
     </GoabPageBlock>

--- a/libs/web-components/src/components/push-drawer/PushDrawer.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawer.svelte
@@ -44,9 +44,11 @@
     {heading}
     {version}
   >
-    <span slot="actions">
-      <slot name="actions" />
-    </span>
+    {#if $$slots.actions}
+      <span slot="actions">
+        <slot name="actions" />
+      </span>
+    {/if}
     <slot />
   </goa-drawer>
 {:else}
@@ -58,9 +60,11 @@
     {heading}
     {version}
   >
-    <span slot="actions">
-      <slot name="actions" />
-    </span>
+    {#if $$slots.actions}
+      <span slot="actions">
+        <slot name="actions" />
+      </span>
+    {/if}
     <slot />
   </goa-push-drawer-internal>
 {/if}

--- a/libs/web-components/src/components/push-drawer/PushDrawerInternal.spec.ts
+++ b/libs/web-components/src/components/push-drawer/PushDrawerInternal.spec.ts
@@ -133,4 +133,90 @@ describe("GoAPushDrawerInternal", () => {
 
     consoleErrorSpy.mockRestore();
   });
+
+  describe("V2", () => {
+    it("should apply v2 class when version is 2", async () => {
+      const result = render(PushDrawerInternalWrapper, {
+        props: {
+          testId: "test-drawer",
+          open: true,
+          version: "2",
+        },
+      });
+
+      const drawer = result.getByTestId("test-drawer");
+      await waitFor(() => {
+        expect(drawer).toHaveClass("v2");
+      });
+    });
+
+    it("should not apply v2 class when version is 1", async () => {
+      const result = render(PushDrawerInternalWrapper, {
+        props: {
+          testId: "test-drawer",
+          open: true,
+          version: "1",
+        },
+      });
+
+      const drawer = result.getByTestId("test-drawer");
+      await waitFor(() => {
+        expect(drawer).not.toHaveClass("v2");
+      });
+    });
+
+    it("should use heading-s for V2 heading", async () => {
+      const result = render(PushDrawerInternalWrapper, {
+        props: {
+          testId: "test-drawer",
+          open: true,
+          version: "2",
+          heading: "Test Heading",
+        },
+      });
+
+      const heading = result.container.querySelector("goa-text");
+      await waitFor(() => {
+        expect(heading?.getAttribute("size")).toBe("heading-s");
+      });
+    });
+
+    it("should use heading-m for V1 heading", async () => {
+      const result = render(PushDrawerInternalWrapper, {
+        props: {
+          testId: "test-drawer",
+          open: true,
+          version: "1",
+          heading: "Test Heading",
+        },
+      });
+
+      const heading = result.container.querySelector("goa-text");
+      await waitFor(() => {
+        expect(heading?.getAttribute("size")).toBe("heading-m");
+      });
+    });
+
+    it("should validate version prop on mount", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {
+          /* noop */
+        });
+
+      render(PushDrawerInternalWrapper, {
+        props: {
+          testId: "test-drawer",
+          open: true,
+          version: "3" as any,
+        },
+      });
+
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalled();
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
 });

--- a/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
@@ -12,18 +12,25 @@
 />
 
 <script lang="ts">
-  type DrawerState = "initial" | "open" | "closed" | "closing";
   import { onMount, onDestroy, tick } from "svelte";
-  import { dispatch } from "../../common/utils";
+  import { dispatch, typeValidator } from "../../common/utils";
+
+  type DrawerState = "initial" | "open" | "closed" | "closing";
+  type VersionType = "1" | "2";
+
+  const [Version, validateVersion] = typeValidator("Version", ["1", "2"]);
 
   export let testid: string | undefined = undefined;
   export let open: boolean = false;
   export let heading: string = "";
   export let width: string = "492px";
-  export let version: string | undefined = undefined;
+  export let version: VersionType = "1";
+
   let _contentEl: HTMLElement | null = null;
   let drawerState: DrawerState = "initial";
   let closingTimeout: number | null = null;
+  let _scrollPos: "top" | "middle" | "bottom" | null = null;
+  let _actionsSlotHasContent: boolean = false;
 
   $: if (open && drawerState !== "open") {
     drawerState = "open";
@@ -42,6 +49,7 @@
   }
 
   onMount(() => {
+    validateVersion(version);
     drawerState = open ? "open" : "closed";
     if (width.endsWith("%")) {
       console.error(
@@ -65,32 +73,104 @@
   };
 
   // Scrolling ---
-  let _scrollPos: "top" | "middle" | "bottom" | null = null;
-  let _actionsSlotHasContent: boolean = false;
-  async function checkActionsSlotContent() {
-    await tick();
-    _actionsSlotHasContent = !!$$slots.actions;
+  function checkActionsSlotContent() {
+    // Use requestAnimationFrame to let slot content distribute first
+    requestAnimationFrame(() => {
+      const actionsSlot = _contentEl?.querySelector(
+        'slot[name="actions"]',
+      ) as HTMLSlotElement | null;
+      if (actionsSlot) {
+        // Check if any assigned element has children (the actual actions).
+        // PushDrawer.svelte always sends a <span> wrapper, so we check
+        // if that span has children beyond its own empty <slot> element.
+        const assigned = actionsSlot.assignedElements();
+        _actionsSlotHasContent = assigned.some((el) => {
+          // The wrapper span from PushDrawer.svelte contains a <slot>.
+          // If that inner slot has assigned elements, there are real actions.
+          const innerSlot = el.querySelector("slot");
+          if (innerSlot) {
+            return (innerSlot as HTMLSlotElement).assignedElements().length > 0;
+          }
+          // Direct element without inner slot
+          return true;
+        });
+      }
+    });
   }
 
   $: if (open) {
     checkActionsSlotContent();
   }
 
+  // V2: Check initial scroll state when drawer opens
+  $: if (open && version === "2" && _contentEl) {
+    tick().then(() => {
+      const drawerContent = _contentEl?.querySelector(".drawer-content");
+      if (drawerContent) {
+        const { scrollTop, scrollHeight, clientHeight } = drawerContent;
+        _scrollPos = calculateScrollPos(
+          scrollTop,
+          scrollHeight,
+          clientHeight,
+          _scrollPos,
+        );
+      }
+    });
+  }
+
+  // Hysteresis threshold: prevents jitter when dynamic edge margin/height
+  // changes shift the scroll position slightly at boundaries.
+  const SCROLL_HYSTERESIS = 20;
+
+  function calculateScrollPos(
+    scrollTop: number,
+    scrollHeight: number,
+    clientHeight: number,
+    currentPos: "top" | "middle" | "bottom" | null,
+  ): "top" | "middle" | "bottom" | null {
+    const hasScroll = scrollHeight > clientHeight;
+    if (!hasScroll) return null;
+    const distFromTop = scrollTop;
+    const distFromBottom = scrollHeight - scrollTop - clientHeight;
+
+    // Use hysteresis: stay in current state unless we've moved past the threshold
+    if (currentPos === "top" && distFromTop < SCROLL_HYSTERESIS) return "top";
+    if (currentPos === "bottom" && distFromBottom < SCROLL_HYSTERESIS)
+      return "bottom";
+
+    if (distFromTop < 1) return "top";
+    if (distFromBottom < 1) return "bottom";
+    return "middle";
+  }
+
   function onScroll(e: Event) {
     const target = e.currentTarget as HTMLDivElement;
-    const hasScroll = target.scrollHeight > target.offsetHeight;
-    if (!open || !hasScroll) return;
+    if (!open) return;
 
-    // top
-    if (target.scrollTop == 0) {
-      _scrollPos = "top";
-    } else if (
-      // bottom
-      Math.abs(target.scrollHeight - target.scrollTop - target.offsetHeight) < 1
-    ) {
-      _scrollPos = "bottom";
+    if (version === "2") {
+      const { scrollTop, scrollHeight, clientHeight } = target;
+      _scrollPos = calculateScrollPos(
+        scrollTop,
+        scrollHeight,
+        clientHeight,
+        _scrollPos,
+      );
     } else {
-      _scrollPos = "middle";
+      const hasScroll = target.scrollHeight > target.offsetHeight;
+      if (!hasScroll) return;
+
+      const isAtTop = target.scrollTop == 0;
+      const isAtBottom =
+        Math.abs(target.scrollHeight - target.scrollTop - target.offsetHeight) <
+        1;
+
+      if (isAtTop) {
+        _scrollPos = "top";
+      } else if (isAtBottom) {
+        _scrollPos = "bottom";
+      } else {
+        _scrollPos = "middle";
+      }
     }
   }
 </script>
@@ -101,17 +181,39 @@
   class:open={!!open}
   class:closed={drawerState === "closed"}
   class:closing={drawerState === "closing"}
+  class:v2={version === "2"}
+  class:v2-scroll-top={version === "2" && _scrollPos === "top"}
+  class:v2-scroll-middle={version === "2" && _scrollPos === "middle"}
+  class:v2-scroll-bottom={version === "2" && _scrollPos === "bottom"}
   bind:this={_contentEl}
   aria-labelledby="goa-drawer-heading"
   style="--goa-push-drawer-width: {width};"
 >
-  <div id="goa-drawer-heading" class="drawer-header">
+  <div
+    id="goa-drawer-heading"
+    class="drawer-header"
+    class:v2-scrolled={version === "2" &&
+      (_scrollPos === "middle" || _scrollPos === "bottom")}
+  >
     <div class="drawer-default-header">
       {#if heading || $$slots.heading}
         {#if heading}
-          <goa-text size="heading-m" as="h3" mt="none" mb="none">
-            {heading}
-          </goa-text>
+          {#if version === "2"}
+            <goa-text
+              size={_scrollPos === "middle" || _scrollPos === "bottom"
+                ? "heading-xs"
+                : "heading-s"}
+              as="h3"
+              mt="2xs"
+              mb="none"
+            >
+              {heading}
+            </goa-text>
+          {:else}
+            <goa-text size="heading-m" as="h3" mt="none" mb="none">
+              {heading}
+            </goa-text>
+          {/if}
         {:else}
           <slot name="heading" />
         {/if}
@@ -145,6 +247,8 @@
       class="drawer-actions"
       data-testid="drawer-actions"
       class:empty-actions={!_actionsSlotHasContent}
+      class:v2-scrolled={version === "2" &&
+        (_scrollPos === "top" || _scrollPos === "middle")}
     >
       <slot name="actions" />
     </section>
@@ -155,6 +259,9 @@
   :host * {
     box-sizing: border-box;
   }
+
+  /* V2: No layout overrides — inherits V1's stretch behavior so
+     height: 100% resolves and flex pins header/actions correctly */
 
   @keyframes opening {
     0% {
@@ -188,9 +295,46 @@
     align-self: stretch;
     margin-left: var(--goa-drawer-padding);
     height: 100%; /* fill parent height */
+    overflow: hidden;
     border-radius: var(--goa-push-drawer-border-radius);
     background: var(--goa-color-greyscale-white);
     border: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
+  }
+
+  /* V2: Floating inset appearance, matching regular Drawer V2.
+     Default state (no overflow): offset + rounded on all edges. */
+  .goa-push-drawer.v2 {
+    margin: var(--goa-drawer-offset, 16px);
+    height: calc(100% - 2 * var(--goa-drawer-offset, 16px));
+    border-color: var(--goa-color-greyscale-150);
+    transition:
+      margin 0.2s ease,
+      border-radius 0.2s ease,
+      height 0.2s ease;
+  }
+
+  /* V2 dynamic edges: at top of scroll — top floating, bottom flush */
+  .goa-push-drawer.v2-scroll-top {
+    margin-bottom: 0;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    height: calc(100% - var(--goa-drawer-offset, 16px));
+  }
+
+  /* V2 dynamic edges: middle of scroll — both edges flush */
+  .goa-push-drawer.v2-scroll-middle {
+    margin-top: 0;
+    margin-bottom: 0;
+    border-radius: 0;
+    height: 100%;
+  }
+
+  /* V2 dynamic edges: at bottom of scroll — top flush, bottom floating */
+  .goa-push-drawer.v2-scroll-bottom {
+    margin-top: 0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    height: calc(100% - var(--goa-drawer-offset, 16px));
   }
 
   /* Shadow styles for scrollable content */
@@ -206,6 +350,11 @@
     box-shadow:
       inset 0 8px 8px -8px rgba(0, 0, 0, 0.2),
       inset 0 -8px 8px -8px rgba(0, 0, 0, 0.2);
+  }
+
+  /* V2: No scroll shadows on content */
+  .v2 .drawer-content {
+    box-shadow: none !important;
   }
 
   @starting-style {
@@ -242,6 +391,21 @@
     background: var(--goa-color-greyscale-white);
   }
 
+  /* V2: Header pinned via flex (not sticky), no border by default */
+  .v2 .drawer-header {
+    position: static;
+    flex: 0 0 auto;
+    gap: var(--goa-space-2xs);
+    border-bottom: none;
+  }
+
+  /* V2: Show header border + shadow when content is scrolled */
+  .drawer-header.v2-scrolled {
+    border-bottom: var(--goa-border-width-s) solid
+      var(--goa-color-greyscale-150);
+    box-shadow: var(--goa-shadow-shallow-below);
+  }
+
   .drawer-default-header {
     width: 100%;
     display: flex;
@@ -261,9 +425,29 @@
     background: var(--goa-color-greyscale-white);
   }
 
+  /* V2: Actions pinned via flex (not sticky), no border by default */
+  .v2 .drawer-actions {
+    position: static;
+    flex: 0 0 auto;
+    border-top: none;
+  }
+
+  /* V2: Show actions border + shadow when content has overflow */
+  .drawer-actions.v2-scrolled {
+    border-top: var(--goa-border-width-s) solid var(--goa-color-greyscale-150);
+    box-shadow: var(--goa-shadow-shallow-below);
+  }
+
   .drawer-actions.empty-actions {
     padding: 0;
     border-top: none;
+  }
+
+  /* V2: Collapse empty actions area (not display:none, which breaks slot distribution) */
+  .v2 .drawer-actions.empty-actions {
+    height: 0;
+    overflow: hidden;
+    flex-basis: 0;
   }
 
   .drawer-content {

--- a/libs/web-components/src/components/push-drawer/PushDrawerInternalWrapper.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawerInternalWrapper.svelte
@@ -5,6 +5,8 @@
   export let open: boolean = false;
   export let heading: string = "Test Heading";
   export let width: string = "999px";
+  export let version: string = "1";
+  export let showActions: boolean = true;
 
   function closeDrawer() {
     open = false;
@@ -18,10 +20,16 @@
 <button on:click={openDrawer} data-testid="openButton">Open</button>
 <button on:click={closeDrawer} data-testid="closeButton">Close</button>
 
-<PushDrawerInternal testid={testId} {open} {width} {heading}>
-  <div slot="actions">
-    <p>Action 1</p>
-    <p>Action 2</p>
-  </div>
-  <slot />
-</PushDrawerInternal>
+{#if showActions}
+  <PushDrawerInternal testid={testId} {open} {width} {heading} {version}>
+    <div slot="actions">
+      <p>Action 1</p>
+      <p>Action 2</p>
+    </div>
+    <slot />
+  </PushDrawerInternal>
+{:else}
+  <PushDrawerInternal testid={testId} {open} {width} {heading} {version}>
+    <slot />
+  </PushDrawerInternal>
+{/if}


### PR DESCRIPTION
## Summary
- V2 visual styling: heading-s, flex-based header/footer pinning, scroll-aware border + shadow indicators
- Floating inset margin using --goa-drawer-offset token, border color greyscale-150
- Dynamic edge transitions: visible edges get offset + rounded corners, scrolled edges go flush + square with 200ms ease transitions
- 20px scroll hysteresis prevents jitter at boundaries
- Heading shrinks from heading-s to heading-xs when top is flush (scrolled)
- V1 rendering completely unchanged
- Test page updated to app-shell layout matching real workspace usage

Closes #3580

https://github.com/user-attachments/assets/f4fd77f9-b615-4707-925b-ce819c694d61

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run test:pr` passes
- [ ] Open V2 push drawer in feat2469 test page, add content until it overflows
- [ ] Scroll within drawer: header/footer pin, content scrolls between them
- [ ] Verify dynamic edges: top floating at start, both flush in middle, bottom floating at end
- [ ] Transitions are smooth, no jitter at scroll boundaries
- [ ] V1 push drawer (bottom section) renders identically to before