### PR TITLE
fix(#3581): use dynamic content collection for nav instead of hardcoded list

### DIFF
--- a/docs/src/components/nav/ComponentsSubMenu.tsx
+++ b/docs/src/components/nav/ComponentsSubMenu.tsx
@@ -13,89 +13,7 @@ import {
 } from "@abgov/react-components/experimental";
 import { MenuSecondaryContent } from "./MenuSecondaryContent";
 import { useGroupShadowDomFixes } from "./useGroupShadowDomFixes";
-
-// Component categories - synced with content collection (visible components only)
-const COMPONENT_CATEGORIES = [
-  {
-    name: "Content layout",
-    slug: "content-layout",
-    components: [
-      { name: "Accordion", slug: "accordion" },
-      { name: "Container", slug: "container" },
-      { name: "Data Grid", slug: "data-grid" },
-      { name: "Details", slug: "details" },
-      { name: "Drawer", slug: "drawer" },
-      { name: "Hero banner", slug: "hero-banner" },
-      { name: "Page Block", slug: "page-block" },
-      { name: "Popover", slug: "popover" },
-      { name: "Table", slug: "table" },
-      { name: "Text", slug: "text" },
-    ],
-  },
-  {
-    name: "Feedback and alerts",
-    slug: "feedback-and-alerts",
-    components: [
-      { name: "Badge", slug: "badge" },
-      { name: "Callout", slug: "callout" },
-      { name: "Circular progress indicator", slug: "circular-progress" },
-      { name: "Filter chip", slug: "filter-chip" },
-      { name: "Linear progress indicator", slug: "linear-progress" },
-      { name: "Modal", slug: "modal" },
-      { name: "Notification banner", slug: "notification" },
-      { name: "Skeleton loader", slug: "skeleton" },
-      { name: "Temporary notification", slug: "temporary-notification" },
-      { name: "Tooltip", slug: "tooltip" },
-    ],
-  },
-  {
-    name: "Inputs and actions",
-    slug: "inputs-and-actions",
-    components: [
-      { name: "Button", slug: "button" },
-      { name: "Button group", slug: "button-group" },
-      { name: "Checkbox", slug: "checkbox" },
-      { name: "Checkbox list", slug: "checkbox-list" },
-      { name: "Date picker", slug: "date-picker" },
-      { name: "Dropdown", slug: "dropdown" },
-      { name: "File uploader", slug: "file-upload-input" },
-      { name: "Form", slug: "form" },
-      { name: "Icon button", slug: "icon-button" },
-      { name: "Input", slug: "input" },
-      { name: "Link Button", slug: "link-button" },
-      { name: "Menu button", slug: "menu-button" },
-      { name: "Radio", slug: "radio-group" },
-      { name: "Text area", slug: "text-area" },
-    ],
-  },
-  {
-    name: "Structure and navigation",
-    slug: "structure-and-navigation",
-    components: [
-      { name: "Footer", slug: "footer" },
-      { name: "Form stepper", slug: "form-stepper" },
-      { name: "Header", slug: "app-header" },
-      { name: "Microsite header", slug: "microsite-header" },
-      { name: "Pagination", slug: "pagination" },
-      { name: "Side menu", slug: "side-menu" },
-      { name: "Tabs", slug: "tabs" },
-      { name: "Work Side Menu", slug: "work-side-menu" },
-    ],
-  },
-  {
-    name: "Utilities",
-    slug: "utilities",
-    components: [
-      { name: "Block", slug: "block" },
-      { name: "Divider", slug: "divider" },
-      { name: "Form item", slug: "form-item" },
-      { name: "Grid", slug: "grid" },
-      { name: "Icons", slug: "icon" },
-      { name: "Link", slug: "link" },
-      { name: "Spacer", slug: "spacer" },
-    ],
-  },
-];
+import type { NavCategory } from "../../lib/nav-categories";
 
 interface ComponentsSubMenuProps {
   isOpen: boolean;
@@ -103,6 +21,7 @@ interface ComponentsSubMenuProps {
   onBack: () => void;
   onExpandMenu?: () => void;
   currentSlug?: string;
+  categories?: NavCategory[];
 }
 
 export function ComponentsSubMenu({
@@ -111,6 +30,7 @@ export function ComponentsSubMenu({
   onBack,
   onExpandMenu,
   currentSlug,
+  categories = [],
 }: ComponentsSubMenuProps) {
   const groupsRef = useRef<HTMLDivElement>(null);
   useGroupShadowDomFixes(groupsRef);
@@ -153,7 +73,7 @@ export function ComponentsSubMenu({
 
       {/* Component categories - using GoabxWorkSideMenuGroup for expandable sections */}
       <div ref={groupsRef}>
-        {COMPONENT_CATEGORIES.map((category) => {
+        {categories.map((category) => {
           // Auto-expand category if it contains the current component
           const containsCurrentComponent = category.components.some(
             (c) => c.slug === currentSlug,
@@ -196,7 +116,9 @@ export function ComponentsSubMenu({
         url="/"
         open={isOpen}
         onToggle={onToggle}
-        onNavigate={(path: string) => { if (path && !path.startsWith("/__")) window.location.href = path; }}
+        onNavigate={(path: string) => {
+          if (path && !path.startsWith("/__")) window.location.href = path;
+        }}
         primaryContent={primaryContent}
         secondaryContent={<MenuSecondaryContent isOpen={isOpen} />}
       />

--- a/docs/src/components/nav/index.ts
+++ b/docs/src/components/nav/index.ts
@@ -12,3 +12,4 @@
 export { ParentMenu, type MenuSection } from "./ParentMenu";
 export { ComponentsSubMenu } from "./ComponentsSubMenu";
 export { GetStartedSubMenu } from "./GetStartedSubMenu";
+export type { NavCategory } from "../../lib/nav-categories";

--- a/docs/src/pages/search.astro
+++ b/docs/src/pages/search.astro
@@ -11,10 +11,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import { SiteNav } from '../components/SiteNav';
 import { MobileHeader } from '../components/MobileHeader';
 import { SearchPage } from '../components/search';
+import { getNavCategories } from '../lib/nav-categories';
 
 // Get query from URL parameters
 const url = new URL(Astro.request.url);
 const initialQuery = url.searchParams.get('q') || '';
+const navCategories = await getNavCategories();
 ---
 
 <BaseLayout title="Search" description="Search the GoA Design System for components, patterns, and examples">
@@ -25,6 +27,7 @@ const initialQuery = url.searchParams.get('q') || '';
         <SiteNav
           client:only="react"
           initialSection="components"
+          categories={navCategories}
         />
       </aside>
 


### PR DESCRIPTION
## Summary
The side menu for components was using a hardcoded list, so any new component had to be manually added there too. This is how Push Drawer ended up missing from the nav despite having correct frontmatter.

The dynamic pipeline was already built and passing data through, it just wasn't being used at the last step. Now the side menu reads directly from the content collection, so new components show up automatically.

## Test plan
- [ ] Navigate to /components and verify all categories and components show in the side nav
- [ ] Confirm Push Drawer appears under Content Layout
- [ ] Verify hidden components don't appear
- [ ] Add a test MDX file with `category: utilities` and confirm it shows up in the nav automatically

Closes #3581