### PR TITLE
Add focus treatment comparison section to input documentation

### DIFF
--- a/docs/src/content/components/input.mdx
+++ b/docs/src/content/components/input.mdx
@@ -56,3 +56,59 @@ Input supports multiple HTML input types:
 - **Error** - When validation fails
 - **Disabled** - When input is not available
 - **Read-only** - When showing value without editing
+
+---
+
+## Focus treatment comparison
+
+Tab through all components below to compare focus ring styles.
+
+### Text area
+
+<goa-text-area version="2" name="focus-textarea" placeholder="Enter text here"></goa-text-area>
+
+### Dropdown
+
+<goa-dropdown version="2" name="focus-dropdown" placeholder="Select an option">
+  <goa-dropdown-item value="a" label="Option A"></goa-dropdown-item>
+  <goa-dropdown-item value="b" label="Option B"></goa-dropdown-item>
+  <goa-dropdown-item value="c" label="Option C"></goa-dropdown-item>
+</goa-dropdown>
+
+### Checkbox
+
+<goa-checkbox version="2" name="focus-checkbox" text="Check me"></goa-checkbox>
+
+### Radio group
+
+<goa-radio-group version="2" name="focus-radio">
+  <goa-radio-item value="1" label="Option 1"></goa-radio-item>
+  <goa-radio-item value="2" label="Option 2"></goa-radio-item>
+  <goa-radio-item value="3" label="Option 3"></goa-radio-item>
+</goa-radio-group>
+
+### Date picker
+
+<goa-date-picker version="2" name="focus-datepicker"></goa-date-picker>
+
+### Button
+
+<goa-button version="2" type="primary">Primary</goa-button>
+<goa-button version="2" type="secondary">Secondary</goa-button>
+<goa-button version="2" type="tertiary">Tertiary</goa-button>
+
+### Icon button
+
+<goa-icon-button version="2" icon="add"></goa-icon-button>
+
+### Link button
+
+<goa-link-button version="2">Link button</goa-link-button>
+
+### Filter chip
+
+<goa-filter-chip version="2" content="Filter chip"></goa-filter-chip>
+
+### Chip
+
+<goa-chip version="2" content="Chip"></goa-chip>


### PR DESCRIPTION
# Before (the change)

The input component documentation ended with a list of input states (error, disabled, read-only) without any visual reference for comparing focus ring styles across different component types.

# After (the change)

Added a new "Focus treatment comparison" section to the input documentation that includes interactive examples of multiple component types (text area, dropdown, checkbox, radio group, date picker, button variants, icon button, link button, filter chip, and chip) to allow users to tab through and visually compare focus ring styles across the component library.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Navigate to the input component documentation page
2. Scroll to the "Focus treatment comparison" section at the bottom
3. Use the Tab key to cycle through all interactive components and verify that focus rings are visible and consistent across all component types
4. Verify that all components render correctly with version="2" attribute

https://claude.ai/code/session_016u3kfjbpn2dsGqPByuamZW