### PR TITLE
(Test) - Add focus treatment comparison section to Input documentation

### DIFF
--- a/docs/src/content/components/input.mdx
+++ b/docs/src/content/components/input.mdx
@@ -56,3 +56,59 @@ Input supports multiple HTML input types:
 - **Error** - When validation fails
 - **Disabled** - When input is not available
 - **Read-only** - When showing value without editing
+
+---
+
+## Focus Treatment Comparison
+
+The following components are provided for tabbing through to compare focus treatments.
+
+### Text Area
+
+<goa-text-area version="2"></goa-text-area>
+
+### Dropdown
+
+<goa-dropdown version="2">
+  <goa-dropdown-item value="1" label="Option 1"></goa-dropdown-item>
+  <goa-dropdown-item value="2" label="Option 2"></goa-dropdown-item>
+  <goa-dropdown-item value="3" label="Option 3"></goa-dropdown-item>
+</goa-dropdown>
+
+### Checkbox
+
+<goa-checkbox version="2" name="focus-checkbox" text="Checkbox label"></goa-checkbox>
+
+### Radio Group
+
+<goa-radio-group version="2" name="focus-radio">
+  <goa-radio-item value="a" label="Option A"></goa-radio-item>
+  <goa-radio-item value="b" label="Option B"></goa-radio-item>
+  <goa-radio-item value="c" label="Option C"></goa-radio-item>
+</goa-radio-group>
+
+### Date Picker
+
+<goa-date-picker version="2"></goa-date-picker>
+
+### Button Variants
+
+<goa-button version="2" type="primary">Primary</goa-button>
+<goa-button version="2" type="secondary">Secondary</goa-button>
+<goa-button version="2" type="tertiary">Tertiary</goa-button>
+
+### Icon Button
+
+<goa-icon-button version="2" icon="close"></goa-icon-button>
+
+### Link Button
+
+<goa-link-button version="2">Link button</goa-link-button>
+
+### Filter Chip
+
+<goa-filter-chip version="2" content="Filter chip"></goa-filter-chip>
+
+### Chip
+
+<goa-chip version="2" content="Chip"></goa-chip>


### PR DESCRIPTION
# Before (the change)

The Input component documentation ended with a description of input states (error, disabled, read-only).

# After (the change)

Added a new "Focus Treatment Comparison" section to the Input documentation page that includes interactive examples of multiple form components (text area, dropdown, checkbox, radio group, date picker, buttons, chips, etc.) to allow users to tab through and visually compare focus treatments across different component types.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Navigate to the Input component documentation page
2. Scroll to the "Focus Treatment Comparison" section at the bottom
3. Tab through the interactive components to verify focus states are visible and consistent across all component types
4. Verify all components render correctly with `version="2"` attribute

https://claude.ai/code/session_012FwxZ8FVv4ZjPZsTXWpEPu