### PR TITLE
chore: Add focus treatment comparison section to Input docs

### DIFF
--- a/docs/src/content/components/input.mdx
+++ b/docs/src/content/components/input.mdx
@@ -56,3 +56,65 @@ Input supports multiple HTML input types:
 - **Error** - When validation fails
 - **Disabled** - When input is not available
 - **Read-only** - When showing value without editing
+
+---
+
+## Focus Treatment Comparison
+
+The following components are included to compare focus ring treatments across interactive elements. Tab through them to observe each component's focus state.
+
+### Text Area
+
+<goa-text-area version="2" name="textarea-focus-demo"></goa-text-area>
+
+### Dropdown
+
+<goa-dropdown version="2" name="dropdown-focus-demo">
+  <goa-dropdown-item value="option1" label="Option 1"></goa-dropdown-item>
+  <goa-dropdown-item value="option2" label="Option 2"></goa-dropdown-item>
+  <goa-dropdown-item value="option3" label="Option 3"></goa-dropdown-item>
+</goa-dropdown>
+
+### Checkbox
+
+<goa-checkbox version="2" name="checkbox-focus-demo" text="Checkbox label"></goa-checkbox>
+
+### Radio Group
+
+<goa-radio-group version="2" name="radio-focus-demo">
+  <goa-radio-item value="radio1" label="Radio option 1"></goa-radio-item>
+  <goa-radio-item value="radio2" label="Radio option 2"></goa-radio-item>
+  <goa-radio-item value="radio3" label="Radio option 3"></goa-radio-item>
+</goa-radio-group>
+
+### Date Picker
+
+<goa-date-picker version="2" name="datepicker-focus-demo"></goa-date-picker>
+
+### Button (Primary)
+
+<goa-button version="2" type="primary">Primary button</goa-button>
+
+### Button (Secondary)
+
+<goa-button version="2" type="secondary">Secondary button</goa-button>
+
+### Button (Tertiary)
+
+<goa-button version="2" type="tertiary">Tertiary button</goa-button>
+
+### Icon Button
+
+<goa-icon-button version="2" icon="add"></goa-icon-button>
+
+### Link Button
+
+<goa-link-button version="2">Link button</goa-link-button>
+
+### Filter Chip
+
+<goa-filter-chip version="2" content="Filter chip"></goa-filter-chip>
+
+### Chip
+
+<goa-chip version="2" content="Chip"></goa-chip>


### PR DESCRIPTION
# Before (the change)

The Input component documentation ended with a description of input states (error, disabled, read-only) without any visual reference for focus ring treatments across different interactive components.

# After (the change)

Added a new "Focus Treatment Comparison" section to the Input component documentation that includes interactive examples of focus ring treatments across multiple component types:
- Text Area
- Dropdown
- Checkbox
- Radio Group
- Date Picker
- Button variants (Primary, Secondary, Tertiary)
- Icon Button
- Link Button
- Filter Chip
- Chip

This section allows users to tab through components and observe how focus states are visually treated consistently across the design system.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Navigate to the Input component documentation page
2. Scroll to the "Focus Treatment Comparison" section at the bottom
3. Use the Tab key to cycle through each interactive component
4. Verify that focus rings are visible and consistent across all components
5. Confirm all components render correctly with version="2" attribute

https://claude.ai/code/session_01FCNgA7wHRFVDsykNFdhNhD