### PR TITLE
fix:Add focus treatment comparison section to input component docs

### DIFF
--- a/docs/src/content/components/input.mdx
+++ b/docs/src/content/components/input.mdx
@@ -56,3 +56,59 @@ Input supports multiple HTML input types:
 - **Error** - When validation fails
 - **Disabled** - When input is not available
 - **Read-only** - When showing value without editing
+
+---
+
+## Focus Treatment Comparison
+
+The following components are included for interactive comparison of focus treatments. Tab through them to compare styles.
+
+### Text Area
+
+<goa-text-area version="2"></goa-text-area>
+
+### Dropdown
+
+<goa-dropdown version="2">
+  <goa-dropdown-item value="option1" label="Option 1"></goa-dropdown-item>
+  <goa-dropdown-item value="option2" label="Option 2"></goa-dropdown-item>
+  <goa-dropdown-item value="option3" label="Option 3"></goa-dropdown-item>
+</goa-dropdown>
+
+### Checkbox
+
+<goa-checkbox version="2" name="example-checkbox" text="Checkbox label"></goa-checkbox>
+
+### Radio Group
+
+<goa-radio-group version="2" name="example-radio">
+  <goa-radio-item value="option1" label="Option 1"></goa-radio-item>
+  <goa-radio-item value="option2" label="Option 2"></goa-radio-item>
+  <goa-radio-item value="option3" label="Option 3"></goa-radio-item>
+</goa-radio-group>
+
+### Date Picker
+
+<goa-date-picker version="2" name="example-date"></goa-date-picker>
+
+### Button Variants
+
+<goa-button version="2" type="primary">Primary</goa-button>
+<goa-button version="2" type="secondary">Secondary</goa-button>
+<goa-button version="2" type="tertiary">Tertiary</goa-button>
+
+### Icon Button
+
+<goa-icon-button version="2" icon="add" arialabel="Add"></goa-icon-button>
+
+### Link Button
+
+<goa-link-button version="2">Link button</goa-link-button>
+
+### Filter Chip
+
+<goa-filter-chip version="2" content="Filter chip"></goa-filter-chip>
+
+### Chip
+
+<goa-chip version="2" content="Chip"></goa-chip>


### PR DESCRIPTION
# Before (the change)

The input component documentation ended with a brief description of input states (error, disabled, read-only).

# After (the change)

Added a new "Focus Treatment Comparison" section to the input component documentation that includes interactive examples of focus styles across multiple form components:
- Text Area
- Dropdown
- Checkbox
- Radio Group
- Date Picker
- Button variants (Primary, Secondary, Tertiary)
- Icon Button
- Link Button
- Filter Chip
- Chip

This section allows users to tab through the components and visually compare how focus states are treated consistently across the design system.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Navigate to the input component documentation page
2. Scroll to the "Focus Treatment Comparison" section at the bottom
3. Tab through each component to verify focus styles are visible and consistent
4. Verify all components render correctly with `version="2"` attribute

https://claude.ai/code/session_01UCvfZsGEWyjABJ6EHvLadP