### PR TITLE
feat(#3540): Add polyfill for anchor positioning

### DIFF
--- a/libs/react-components/specs/app-header-menu.browser.spec.tsx
+++ b/libs/react-components/specs/app-header-menu.browser.spec.tsx
@@ -53,10 +53,13 @@ describe("AppHeaderMenu", () => {
 
     // Close menu with Escape
     await userEvent.keyboard("{Escape}");
-    await vi.waitFor(() => {
-      const popoverContent = result.getByTestId("popover-content");
-      expect(popoverContent.element().checkVisibility()).toBeFalsy();
-    });
+    await vi.waitFor(
+      () => {
+        const popoverContent = result.getByTestId("popover-content");
+        expect(popoverContent.element().checkVisibility()).toBeFalsy();
+      },
+      { timeout: 10000 },
+    );
 
     // 2. Dismiss the notification banner
     const banner = result.getByTestId("test-banner");

--- a/libs/react-components/specs/menu-button.browser.spec.tsx
+++ b/libs/react-components/specs/menu-button.browser.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from "vitest-browser-react";
-import { vi } from "vitest";
+import { expect, describe, it, vi } from "vitest";
 import { GoabMenuAction, GoabMenuButton } from "../src";
 import { GoabxMenuButton, GoabxMenuAction } from "../src/experimental";
 
@@ -24,14 +24,20 @@ describe("MenuButton", () => {
 
     const result = render(<Component />);
     const menuButton = result.getByTestId("menu-button");
-    const menuAction = result.getByTestId(/menu-action-*/);
 
     // Test each menu action
     for (let i = 1; i <= 3; i++) {
+      const menuAction = result.getByTestId(`menu-action-${i}`);
+
       await menuButton.click();
 
+      // Wait for the menu to open
+      await vi.waitFor(() => {
+        expect(menuAction).toBeVisible();
+      });
+
       // Click the action
-      await menuAction.nth(i - 1).click();
+      await menuAction.click();
 
       // Verify the correct action was triggered
       await vi.waitFor(() => {
@@ -39,6 +45,11 @@ describe("MenuButton", () => {
           action: `action${i}`,
         });
         expect(onAction).toHaveBeenCalledTimes(i);
+      });
+
+      // Wait for the menu to close
+      await vi.waitFor(() => {
+        expect(menuAction).not.toBeVisible();
       });
     }
 
@@ -90,9 +101,11 @@ describe("MenuButton", () => {
     const secondAction = result.getByTestId("second-action");
 
     // open menu
+    console.log("[spec] Clicking menu button to open menu");
     await menuButton.click();
 
     // Click first action
+    console.log("[spec] Clicking first action");
     await firstAction.click();
 
     await vi.waitFor(() => {
@@ -103,9 +116,11 @@ describe("MenuButton", () => {
     });
 
     // Menu should close after clicking an action, so click again to reopen
+    console.log("[spec] Clicking menu button to reopen menu");
     await menuButton.click();
 
     // Click second action
+    console.log("[spec] Clicking second action");
     await secondAction.click();
 
     await vi.waitFor(() => {
@@ -159,7 +174,11 @@ describe("GoabxMenuButton", () => {
 
     const Component = () => {
       return (
-        <GoabxMenuButton leadingIcon="ellipsis-horizontal" testId="icon-menu" onAction={onAction}>
+        <GoabxMenuButton
+          leadingIcon="ellipsis-horizontal"
+          testId="icon-menu"
+          onAction={onAction}
+        >
           <GoabxMenuAction text="View" action="view" />
           <GoabxMenuAction text="Delete" action="delete" icon="trash" />
         </GoabxMenuButton>
@@ -200,12 +219,42 @@ describe("GoabxMenuButton", () => {
     });
   });
 
+  it("should render with variant destructive and correct background color", async () => {
+    const Component = () => {
+      return (
+        <GoabxMenuButton text="Destructive" variant="destructive">
+          <GoabxMenuAction text="Delete" action="delete" icon="trash" />
+        </GoabxMenuButton>
+      );
+    };
+
+    const result = render(<Component />);
+    const menuButton = result.getByText("Destructive");
+    expect(menuButton).toBeDefined();
+
+    await vi.waitFor(() => {
+      const button = menuButton
+        .element()
+        .closest("goa-button")
+        ?.shadowRoot?.querySelector("button");
+
+      expect(button).toBeDefined();
+      const styles = window.getComputedStyle(button!);
+      expect(styles.backgroundColor).toBe("rgb(218, 41, 28)");
+    });
+  });
+
   it("should render icon-only with size compact", async () => {
     const onAction = vi.fn();
 
     const Component = () => {
       return (
-        <GoabxMenuButton leadingIcon="ellipsis-horizontal" size="compact" testId="icon-compact-menu" onAction={onAction}>
+        <GoabxMenuButton
+          leadingIcon="ellipsis-horizontal"
+          size="compact"
+          testId="icon-compact-menu"
+          onAction={onAction}
+        >
           <GoabxMenuAction text="Assign" action="assign" />
           <GoabxMenuAction text="Delete" action="delete" icon="trash" />
         </GoabxMenuButton>

--- a/libs/react-components/specs/popover.browser.spec.tsx
+++ b/libs/react-components/specs/popover.browser.spec.tsx
@@ -121,12 +121,14 @@ describe("Popover", () => {
     const contentB = result.getByTestId("content-b");
 
     // Open Popover A
+    console.log("Clicking Target A to open Popover A");
     await targetA.click();
     await vi.waitFor(() => {
       expect(contentA).toBeVisible();
     });
 
     // Open Popover B — should auto-close Popover A
+    console.log("Clicking Target B to open Popover B (should close Popover A)");
     await targetB.click();
     await vi.waitFor(() => {
       expect(contentB).toBeVisible();

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -67,6 +67,10 @@
   // Private
   let _rootEl: HTMLElement;
   let _popoverEl: HTMLElement;
+  const _needsPositionPolyfill =
+    typeof document !== "undefined" &&
+    !("anchorName" in document.documentElement.style);
+  let _positionRafId: number | null = null;
 
   // Reactive
   let _targetEl: HTMLElement;
@@ -122,12 +126,64 @@
   });
 
   onDestroy(() => {
+    stopManualPositioning();
     window.removeEventListener("resize", updateAutoPosition);
     // true was passed when the listener was added, so it's necesary to be passed here as well
     window.removeEventListener("popstate", handleUrlChange, true);
   });
 
   // Functions
+
+  function updatePopoverPosition() {
+    if (!_isOpen || !_targetEl || !_popoverEl) return;
+
+    const targetRect = _targetEl.getBoundingClientRect();
+    const xOffset = hoffset ? parseFloat(hoffset) : 0;
+    const yOffset = voffset ? parseFloat(voffset) : 3;
+
+    // Recalculate auto position based on current viewport space
+    if (position === "auto") {
+      const popoverRect = _popoverEl.getBoundingClientRect();
+      const spaceAbove = targetRect.top;
+      const spaceBelow = window.innerHeight - targetRect.bottom;
+
+      _autoPosition =
+        spaceBelow < popoverRect.height && spaceAbove > spaceBelow
+          ? "above"
+          : "below";
+    }
+
+    const isAbove =
+      position === "above" ||
+      (position === "auto" && _autoPosition === "above");
+
+    if (isAbove) {
+      _popoverEl.style.top = `${targetRect.top - yOffset}px`;
+      _popoverEl.style.left = `${targetRect.left + xOffset}px`;
+      _popoverEl.style.transform = "translateY(-100%)";
+    } else {
+      _popoverEl.style.top = `${targetRect.bottom + yOffset}px`;
+      _popoverEl.style.left = `${targetRect.left + xOffset}px`;
+      _popoverEl.style.transform = "";
+    }
+  }
+
+  function startManualPositioning() {
+    if (!_needsPositionPolyfill) return;
+
+    const loop = () => {
+      updatePopoverPosition();
+      _positionRafId = requestAnimationFrame(loop);
+    };
+    _positionRafId = requestAnimationFrame(loop);
+  }
+
+  function stopManualPositioning() {
+    if (_positionRafId !== null) {
+      cancelAnimationFrame(_positionRafId);
+      _positionRafId = null;
+    }
+  }
 
   function isPopoverOpen(): boolean {
     try {
@@ -188,8 +244,7 @@
     }
   }
 
-  function handleNativeToggle(e: Event) {
-    const toggleEvent = e as Event & { newState?: "open" | "closed" };
+  function handleNativeToggle(toggleEvent: ToggleEvent) {
     if (toggleEvent.newState === "open") {
       _isOpen = true;
     } else if (toggleEvent.newState === "closed") {
@@ -205,8 +260,10 @@
     if (_isOpen) {
       dispatch(_rootEl, "_open", {}, { bubbles: true });
       requestAnimationFrame(updateAutoPosition); // same vs await tick(), make sure popover element is fully rendered before we measure its dimension
+      startManualPositioning();
     } else {
-      _targetEl.focus();
+      stopManualPositioning();
+      _targetEl?.focus();
       dispatch(_rootEl, "_close", {}, { bubbles: true });
     }
   }
@@ -214,6 +271,15 @@
   function closePopover() {
     if (_isOpen) {
       _popoverEl?.hidePopover(); // browser will fire and trigger handleNativeToggle
+      // If the browser doesn't support the API we have to trigger the toggle event manually.
+      if (_needsPositionPolyfill) {
+        const event = new ToggleEvent("toggle", {
+          bubbles: true,
+          newState: "closed",
+          oldState: "open",
+        });
+        handleNativeToggle(event); // in case the browser doesn't fire toggle event, we need to manually update the state
+      }
     }
   }
 
@@ -227,6 +293,16 @@
       _popoverEl.hidePopover();
       _isOpen = false;
     } else {
+      // If the Popover API is not supported, we need to manually close other
+      // popovers before opening a new one.
+      if (_needsPositionPolyfill) {
+        document.body.dispatchEvent(
+          new CustomEvent("goa:closePopover", {
+            detail: { target: _targetEl },
+            bubbles: true,
+          }),
+        );
+      }
       _popoverEl.showPopover();
       _isOpen = true;
       requestAnimationFrame(updateAutoPosition);
@@ -301,7 +377,10 @@
     style={styles(
       style("width", position !== "right" ? width : undefined),
       style("min-width", minwidth),
-      style("max-width", position !== "right" && width ? `max(${width}, ${maxwidth})` : maxwidth),
+      style(
+        "max-width",
+        position !== "right" && width ? `max(${width}, ${maxwidth})` : maxwidth,
+      ),
       style("padding", _padded ? "var(--goa-space-m)" : "0"),
     )}
   >
@@ -355,24 +434,29 @@
     filter: var(--goa-popover-shadow, none);
     border: var(--goa-popover-border, none);
     margin: 0;
-
-    position-anchor: --goa-popover-target;
-    inset-block-start: anchor(bottom);
-    inset-inline-start: anchor(left);
-    --popover-translate-x: var(--offset-left, 0);
-    --popover-translate-y: var(--offset-top, 3px);
-    translate: var(--popover-translate-x) var(--popover-translate-y);
+    inset: auto;
   }
 
-  .popover-content.position-above {
-    inset-block-start: anchor(top);
-    --popover-translate-y: calc(-100% - var(--offset-bottom, 3px));
-    position-try-fallbacks: none;
-  }
+  @supports (anchor-name: --a) {
+    .popover-content {
+      position-anchor: --goa-popover-target;
+      inset-block-start: anchor(bottom);
+      inset-inline-start: anchor(left);
+      --popover-translate-x: var(--offset-left, 0);
+      --popover-translate-y: var(--offset-top, 3px);
+      translate: var(--popover-translate-x) var(--popover-translate-y);
+    }
 
-  .popover-content.position-below {
-    inset-block-start: anchor(bottom);
-    --popover-translate-y: var(--offset-top, 3px);
+    .popover-content.position-above {
+      inset-block-start: anchor(top);
+      --popover-translate-y: calc(-100% - var(--offset-bottom, 3px));
+      position-try-fallbacks: none;
+    }
+
+    .popover-content.position-below {
+      inset-block-start: anchor(bottom);
+      --popover-translate-y: var(--offset-top, 3px);
+    }
   }
 
   .popover-content.position-right {

--- a/libs/web-components/vite.config.js
+++ b/libs/web-components/vite.config.js
@@ -8,7 +8,6 @@ import autoprefixer from "autoprefixer";
 import { postcssReplace } from "./utils/postcss-replace";
 
 export default defineConfig(({ mode }) => {
-
   const env = loadEnv(mode, process.cwd());
   const isDev = env.VITE_DEV === "true";
 
@@ -25,19 +24,19 @@ export default defineConfig(({ mode }) => {
           }),
           postcssReplace({
             pattern: /\(--mobile\)/g,
-            replaceWith: "(max-width: 623px)"
+            replaceWith: "(max-width: 623px)",
           }),
           postcssReplace({
             pattern: /\(--mobile\)/g,
-            replaceWith: "(max-width: 623px)"
+            replaceWith: "(max-width: 623px)",
           }),
           postcssReplace({
             pattern: /\(--mobile\)/g,
-            replaceWith: "(max-width: 623px)"
+            replaceWith: "(max-width: 623px)",
           }),
           postcssReplace({
             pattern: /\(--mobile\)/g,
-            replaceWith: "(max-width: 623px)"
+            replaceWith: "(max-width: 623px)",
           }),
           postcssReplace({
             pattern: /\(--not-mobile\)/g,
@@ -56,8 +55,8 @@ export default defineConfig(({ mode }) => {
             replaceWith: "(max-width: 1023px)",
           }),
           autoprefixer(),
-        ]
-      }
+        ],
+      },
     },
 
     plugins: [
@@ -98,7 +97,7 @@ export default defineConfig(({ mode }) => {
               return "index.css";
             }
             return info.name;
-          }
+          },
         },
         external: [],
       },
@@ -118,5 +117,5 @@ export default defineConfig(({ mode }) => {
         provider: "v8",
       },
     },
-  }
+  };
 });


### PR DESCRIPTION
This PR adds adds a polyfill for anchor positioning on older browsers like Safari <=18.3

<img width="1417" height="711" alt="image" src="https://github.com/user-attachments/assets/560a7d1c-dd1c-4c13-8960-c90849a973ac" />

# Before (the change)
On older browsers the Popover Anchor positioning doesn't work.

# After (the change)
Popover Anchor positioning should work on all browsers with JavaScript is enabled.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Use BrowserStack for testing:
- Test with Safari <=18.7
- Test with iOS Safari <=18.7