### PR TITLE
spike(#3347): sticky header utility classes

### DIFF
--- a/libs/web-components/src/assets/css/utils.css
+++ b/libs/web-components/src/assets/css/utils.css
@@ -1,0 +1,31 @@
+/**
+ * CSS Utilities
+ * Common utility classes used across components
+ */
+
+:root {
+  /* Sticky utility custom properties */
+  --sticky-top: 0;
+  --sticky-z-index: 10;
+  --scroll-container-height: auto;
+}
+
+/**
+ * Sticky Utility Classes
+ * Classes for creating sticky positioned elements
+ */
+
+/* Base sticky class - makes element stick to top of its scrollable parent */
+.sticky {
+  position: sticky;
+  top: var(--sticky-top);
+  z-index: var(--sticky-z-index);
+  width: 100%;
+}
+
+/* Base scroll container - ensures proper setup for sticky children */
+.scroll-container {
+  overflow-y: auto;
+  position: relative;
+  height: var(--scroll-container-height);
+}

--- a/libs/web-components/src/index.svelte
+++ b/libs/web-components/src/index.svelte
@@ -4,6 +4,7 @@
   import "./assets/css/reset.css";
   import "./assets/css/fonts.css";
   import "./assets/css/variables.css";
+  import "./assets/css/utils.css";
   import "./assets/css/components.css";
   import "@abgov/design-tokens/dist/tokens.css";
 </script>


### PR DESCRIPTION
This spike explores one sticky header idea: what if we used CSS utility classes?

```
<div class="scroll-container">
  <div class="sticky">
    <goab-container>This is sticky</goab-container>
  </div>
  <!-- tons of content goes here -->
</div>
```

### Benefits

- Lightweight & high performance
- Only uses CSS
- SImple and flexible

### Drawbacks

- Goes against our current Svelte component pattern
- Teams may have trouble implementing it if they don't know how `position: sticky` works
- Still needs JS to add shadows

Would more simply utility classes like this be useful for simple layout assistance?