### PR TITLE
feat(#3474): add in motion tokens to tokens page on docs site

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "docs",
       "version": "0.0.1",
       "dependencies": {
-        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@^2.0.0",
+        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@^2.1.1",
         "@abgov/react-components": "*",
         "@abgov/ui-components-common": "*",
         "@abgov/web-components": "*",
@@ -20,9 +20,9 @@
     },
     "node_modules/@abgov/design-tokens-v2": {
       "name": "@abgov/design-tokens",
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.0.0.tgz",
-      "integrity": "sha512-vmkM3AWHqlvBav1iPYhI9Y8ZTL2c3qTc3whaNdPTFlOpoC4LJR/oMQUgSeafLygSuAHrAr4iuTdK/CUbgVKHtA=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.1.1.tgz",
+      "integrity": "sha512-JpNFdkgFIkrIQTmQ8h/A91EF4qoaXDK9sL/gN5QE54xCr8LxUCpEtdHpUVDwVhk8cugLrp6klhQMw8yqWLrBoA=="
     },
     "node_modules/@abgov/react-components": {
       "version": "6.9.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@^2.0.0",
+    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@^2.1.1",
     "@abgov/react-components": "*",
     "@abgov/ui-components-common": "*",
     "@abgov/web-components": "*",

--- a/docs/src/components/TokensGrid.tsx
+++ b/docs/src/components/TokensGrid.tsx
@@ -47,7 +47,7 @@ interface TokensGridProps {
 // Badge type mapping for categories (using V2 extended colors)
 function getCategoryBadgeType(
   category: string,
-): "sky" | "pasture" | "sunset" | "lilac" | "prairie" | "dawn" {
+): "sky" | "pasture" | "sunset" | "lilac" | "prairie" | "dawn" | "success" {
   switch (category.toLowerCase()) {
     // Colors
     case "color":
@@ -64,6 +64,12 @@ function getCategoryBadgeType(
     case "fontvariationsettings":
     case "typography":
       return "sunset";
+    // Motion
+    case "motioncurve":
+    case "translate":
+    case "motionduration":
+    case "transition":
+      return "success";
     // Borders
     case "border":
     case "borderradius":
@@ -396,6 +402,30 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
             }}
           />
         </div>
+      );
+    }
+
+    // Motion curve tokens - show image representing the curve type
+    if (token.category === "motionCurve") {
+      const getMotionCurveImage = (name: string): "expressive" | "productive" | "expressive-exit" | "expressive-reveal" | "expressive-transform"  => {
+        if (name.endsWith("-expressive")) return "expressive";
+        if (name.endsWith("-productive")) return "productive";
+        if (name.endsWith("-expressive-exit")) return "expressive-exit";
+        if (name.endsWith("-expressive-reveal")) return "expressive-reveal";
+        if (name.endsWith("-expressive-transform")) return "expressive-transform";
+        return "expressive";
+      };
+      return (
+        <img
+          src={`/images/foundations/motion/${getMotionCurveImage(token.name)}.svg`}
+          alt={`${token.name} motion curve visualization`}
+          style={{
+            width: 40,
+            height: 40,
+            objectFit: "contain",
+          }}
+          title={token.value}
+        />
       );
     }
 

--- a/docs/src/lib/tokens.ts
+++ b/docs/src/lib/tokens.ts
@@ -282,6 +282,7 @@ export const FILTER_GROUPS: Record<string, string[]> = {
   Typography: ["fontFamily", "fontSize", "fontWeight", "lineHeight", "typography"],
   Icon: ["iconSize"],
   Opacity: ["opacity"],
+  Motion: ["motionCurve", "transition", "translate", "motionDuration"],
   Shadow: ["shadow"],
   Space: ["space"],
 };


### PR DESCRIPTION
# Summary
- Added the motion tokens (curve, translate, duration, and opacity) to the Tokens docs page.
- Curves come with images on the "Preview" column, while translate shows off a box in certain positions.
- "Motion" is now a filter.

## Steps needed to test
- [ ] Navigate to /tokens
- [ ] Ensure the "Motion" filter works.
- [ ] Search for any of the "motion", "translate", "duration" or "opacity" terms.
- [ ] Verify the CSS copy button works.
