### PR TITLE
fix(#3607): update the interaction area to just around the checkbox or radio input and label

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -232,6 +232,10 @@
           label="3498 Radio alignment"
           url="/bugs/3498"
         ></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item
+          label="3607 Radio and Checkbox Interaction Area"
+          url="/bugs/3607"
+        ></goabx-work-side-menu-item>
       </goabx-work-side-menu-group>
       <goabx-work-side-menu-group icon="star" heading="Features">
         <goabx-work-side-menu-item

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -48,6 +48,7 @@ import { Bug3384Component } from "../routes/bugs/3384/bug3384.component";
 import { Bug3450Component } from "../routes/bugs/3450/bug3450.component";
 import { Bug3497Component } from "../routes/bugs/3497/bug3497.component";
 import { Bug3498Component } from "../routes/bugs/3498/bug3498.component";
+import { Bug3607Component } from "../routes/bugs/3607/bug3607.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -137,6 +138,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3450", component: Bug3450Component },
   { path: "bugs/3497", component: Bug3497Component },
   { path: "bugs/3498", component: Bug3498Component },
+  { path: "bugs/3607", component: Bug3607Component },
 
   // Feature routes
   { path: "features/1328", component: Feat1328Component },

--- a/apps/prs/angular/src/routes/bugs/3607/bug3607.component.html
+++ b/apps/prs/angular/src/routes/bugs/3607/bug3607.component.html
@@ -1,0 +1,108 @@
+<div>
+  <h1>3607 Radio and Checkbox Interaction Area</h1>
+  <h2>Version 1</h2>
+  <goab-form-item label="How would you like to be contacted?" helpText="Select one option">
+    <goab-radio-group name="contactMethod" formControlName="contactMethod">
+      <goab-radio-item label="Email" value="email"  description="Receive updates via email"/>
+      <goab-radio-item value="phone" label="Phone"/>
+      <goab-radio-item value="text" label="Text message" [reveal]="textReveal">
+        <ng-template #textReveal>
+          <goab-form-item label="Mobile phone number">
+            <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-radio-item>
+    </goab-radio-group>
+  </goab-form-item>
+
+  <goab-form-item label="Select any interests you have" mt="xl">
+    <goab-checkbox-list name="contactMethods" formControlName="contactMethods">
+      <goab-checkbox name="travel" text="Travel" value="travel"
+        [description]="descriptionTemplate">
+        <ng-template #descriptionTemplate>
+          <span>Help text with a <a href="#">link</a>.</span>
+        </ng-template>
+      </goab-checkbox>
+      <goab-checkbox name="music" text="Music" value="music"/>
+      <goab-checkbox name="sports" text="Sports" value="sports"/>
+      <goab-checkbox name="other" text="Other" value="other" [reveal]="checkTextReveal">
+        <ng-template #checkTextReveal>
+          <goab-form-item label="Mobile phone number">
+            <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-checkbox>
+    </goab-checkbox-list>
+  </goab-form-item>
+
+  <h2>Version 2 (Experimental)</h2>
+  <h3>Regular size</h3>
+  <goabx-form-item label="How would you like to be contacted?" helpText="Select one option">
+    <goabx-radio-group name="contactMethod" formControlName="contactMethod">
+      <goabx-radio-item label="Email" value="email"  description="Receive updates via email"/>
+      <goabx-radio-item value="phone" label="Phone"/>
+      <goabx-radio-item value="text" label="Text message" [reveal]="textReveal">
+        <ng-template #textReveal>
+          <goabx-form-item label="Mobile phone number">
+            <goabx-input name="mobile" formControlName="phoneNumber"></goabx-input>
+          </goabx-form-item>
+        </ng-template>
+      </goabx-radio-item>
+    </goabx-radio-group>
+  </goabx-form-item>
+
+  <goabx-form-item label="Select any interests you have" mt="xl">
+    <goabx-checkbox-list name="contactMethods" formControlName="contactMethods">
+      <goabx-checkbox name="travel" text="Travel" value="travel"
+        [description]="descriptionTemplate">
+        <ng-template #descriptionTemplate>
+          <span>Help text with a <a href="#">link</a>.</span>
+        </ng-template>
+      </goabx-checkbox>
+      <goabx-checkbox name="music" text="Music" value="music"/>
+      <goabx-checkbox name="sports" text="Sports" value="sports"/>
+      <goabx-checkbox name="other" text="Other" value="other" [reveal]="checkTextReveal">
+        <ng-template #checkTextReveal>
+          <goabx-form-item label="Mobile phone number">
+            <goabx-input name="mobile" formControlName="phoneNumber"></goabx-input>
+          </goabx-form-item>
+        </ng-template>
+      </goabx-checkbox>
+    </goabx-checkbox-list>
+  </goabx-form-item>
+
+  <h3>Compact size</h3>
+  <goabx-form-item label="How would you like to be contacted?" helpText="Select one option">
+    <goabx-radio-group name="contactMethod" size="compact" formControlName="contactMethod">
+      <goabx-radio-item label="Email" value="email"  description="Receive updates via email"/>
+      <goabx-radio-item value="phone" label="Phone"/>
+      <goabx-radio-item value="text" label="Text message" [reveal]="textReveal">
+        <ng-template #textReveal>
+          <goabx-form-item label="Mobile phone number">
+            <goabx-input name="mobile" formControlName="phoneNumber"></goabx-input>
+          </goabx-form-item>
+        </ng-template>
+      </goabx-radio-item>
+    </goabx-radio-group>
+  </goabx-form-item>
+
+  <goabx-form-item label="Select any interests you have" mt="xl">
+    <goabx-checkbox-list name="contactMethods" size="compact" formControlName="contactMethods">
+      <goabx-checkbox name="travel" text="Travel" size="compact" value="travel"
+        [description]="descriptionTemplate">
+        <ng-template #descriptionTemplate>
+          <span>Help text with a <a href="#">link</a>.</span>
+        </ng-template>
+      </goabx-checkbox>
+      <goabx-checkbox name="music" text="Music" size="compact" value="music"/>
+      <goabx-checkbox name="sports" text="Sports" size="compact" value="sports"/>
+      <goabx-checkbox name="other" text="Other" size="compact" value="other" [reveal]="checkTextReveal">
+        <ng-template #checkTextReveal>
+          <goabx-form-item label="Mobile phone number">
+            <goabx-input name="mobile" formControlName="phoneNumber"></goabx-input>
+          </goabx-form-item>
+        </ng-template>
+      </goabx-checkbox>
+    </goabx-checkbox-list>
+  </goabx-form-item>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3607/bug3607.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3607/bug3607.component.ts
@@ -1,0 +1,38 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabFormItem,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabxCheckbox,
+  GoabxCheckboxList,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/angular-components";
+
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3607",
+  templateUrl: "./bug3607.component.html",
+  imports: [CommonModule,
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabFormItem,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabxCheckbox,
+  GoabxCheckboxList,
+  GoabxFormItem,
+  GoabxInput,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+],
+})
+export class Bug3607Component {}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -222,6 +222,10 @@ export function App() {
                   label="3450 Dropdown expanding inside Container"
                   url="/bugs/3450"
                 />
+                <GoabxWorkSideMenuItem
+                  label="3607 Radio and Checkbox Interaction Area"
+                  url="/bugs/3607"
+                />
               </GoabxWorkSideMenuGroup>
 
               <GoabxWorkSideMenuGroup icon="star" heading="Features">

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -50,6 +50,7 @@ import { Bug3384Route } from "./routes/bugs/bug3384";
 import { Bug3450Route } from "./routes/bugs/bug3450";
 import { Bug3497Route } from "./routes/bugs/bug3497";
 import { Bug3498Route } from "./routes/bugs/bug3498";
+import { Bug3607Route } from "./routes/bugs/bug3607";
 
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
@@ -147,6 +148,7 @@ root.render(
           <Route path="bugs/3450" element={<Bug3450Route />} />
           <Route path="bugs/3497" element={<Bug3497Route />} />
           <Route path="bugs/3498" element={<Bug3498Route />} />
+          <Route path="bugs/3607" element={<Bug3607Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3607.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3607.tsx
@@ -1,0 +1,249 @@
+import { useState } from 'react';
+import {
+  GoabFormItem,
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+} from "@abgov/react-components";
+import {
+  GoabxFormItem,
+  GoabxCheckbox,
+  GoabxCheckboxList,
+  GoabxInput,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+} from "@abgov/react-components/experimental";
+
+export function Bug3607Route() {
+  const [contactMethod, setContactMethod] = useState("");
+  const [contactMethodTwo, setContactMethodTwo] = useState("");
+  const [contactMethodThree, setContactMethodThree] = useState("");
+  const [checkboxSelection, setCheckboxSelection] = useState<string[]>([]);
+  const [checkboxSelectionTwo, setCheckboxSelectionTwo] = useState<string[]>([]);
+  const [checkboxSelectionThree, setCheckboxSelectionThree] = useState<string[]>([]);
+
+  return (
+     <div>
+      <h1>3607 - Radio and Checkbox Interaction Area</h1>
+      <h2>Version 1</h2>
+      <GoabFormItem
+        label="How would you like to be contacted?"
+        helpText="Select one option"
+      >
+        <GoabRadioGroup
+          name="contactMethod"
+          value={contactMethod}
+          onChange={(e) => setContactMethod(e.value)}
+        >
+          <GoabRadioItem
+            value="email-0"
+            description="Receive updates via email"
+            label="Email"
+          />
+          <GoabRadioItem
+            value="phone-0"
+            label="Phone"
+          />
+          <GoabRadioItem
+            value="text-0"
+            label="Text message"
+            reveal={
+              <GoabFormItem label="Mobile phone number">
+                <GoabInput name="mobilePhoneNumber" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabRadioGroup>
+      </GoabFormItem>
+
+      <GoabFormItem label="Select any interests you have" mt="xl">
+        <GoabCheckboxList
+          name="contactMethods"
+          value={checkboxSelection}
+          onChange={(e) => setCheckboxSelection(e.value || [])}
+        >
+          <GoabCheckbox
+            name="travel-0"
+            description={
+              <span>
+                Help text with as a description.
+              </span>
+            }
+            text="Travel"
+            value="travel-0"
+          />
+          <GoabCheckbox
+            name="music-0"
+            text="Music"
+            value="music-0"
+          />
+          <GoabCheckbox
+            name="sports-0"
+            text="Sports"
+            value="sports-0"
+          />
+          <GoabCheckbox
+            name="other-0"
+            text="Other"
+            value="other-0"
+            reveal={
+              <GoabFormItem label="Other field">
+                <GoabInput name="otherTextField" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabCheckboxList>
+      </GoabFormItem>
+
+      <h2>Version 2 (Experimental)</h2>
+      <h3>Regular size</h3>
+      <GoabxFormItem
+        label="How would you like to be contacted?"
+        helpText="Select one option"
+      >
+        <GoabxRadioGroup
+          name="contactMethod"
+          value={contactMethodTwo}
+          onChange={(e) => setContactMethodTwo(e.value)}
+        >
+          <GoabxRadioItem
+            value="email-1"
+            description="Receive updates via email"
+            label="Email"
+          />
+          <GoabxRadioItem
+            value="phone-1"
+            label="Phone"
+          />
+          <GoabxRadioItem
+            value="text-1"
+            label="Text message"
+            reveal={
+              <GoabxFormItem label="Mobile phone number">
+                <GoabxInput name="mobilePhoneNumber" value="" />
+              </GoabxFormItem>
+            }
+          />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
+
+      <GoabxFormItem label="Select any interests you have" mt="xl">
+        <GoabxCheckboxList
+          name="contactMethods"
+          value={checkboxSelectionTwo}
+          onChange={(e) => setCheckboxSelectionTwo(e.value || [])}
+        >
+          <GoabxCheckbox
+            name="travel-1"
+            description={
+              <span>
+                Help text with as a description.
+              </span>
+            }
+            text="Travel"
+            value="travel-1"
+          />
+          <GoabxCheckbox
+            name="music-1"
+            text="Music"
+            value="music-1"
+          />
+          <GoabxCheckbox
+            name="sports-1"
+            text="Sports"
+            value="sports-1"
+          />
+          <GoabxCheckbox
+            name="other-1"
+            text="Other"
+            value="other-1"
+            reveal={
+              <GoabxFormItem label="Other field">
+                <GoabxInput name="otherTextField" value="" />
+              </GoabxFormItem>
+            }
+          />
+        </GoabxCheckboxList>
+      </GoabxFormItem>
+
+      <h3>Compact size</h3>
+      <GoabxFormItem
+        label="How would you like to be contacted?"
+        helpText="Select one option"
+      >
+        <GoabxRadioGroup
+          size="compact"
+          name="contactMethodThree"
+          value={contactMethodThree}
+          onChange={(e) => setContactMethodThree(e.value)}
+        >
+          <GoabxRadioItem
+            value="email-2"
+            description="Receive updates via email"
+            label="Email"
+          />
+          <GoabxRadioItem
+            value="phone-2"
+            label="Phone"
+          />
+          <GoabxRadioItem
+            value="text-2"
+            label="Text message"
+            reveal={
+              <GoabxFormItem label="Mobile phone number">
+                <GoabxInput name="mobilePhoneNumber" value="" />
+              </GoabxFormItem>
+            }
+          />
+        </GoabxRadioGroup>
+      </GoabxFormItem>
+
+      <GoabxFormItem label="Select any interests you have" mt="xl">
+        <GoabxCheckboxList
+          size="compact"
+          name="contactMethods"
+          value={checkboxSelectionThree}
+          onChange={(e) => setCheckboxSelectionThree(e.value || [])}
+        >
+          <GoabxCheckbox
+            size="compact"
+            description={
+              <span>
+                Help text with as a description.
+              </span>
+            }
+            name="travel-2"
+            text="Travel"
+            value="travel-2"
+          />
+          <GoabxCheckbox
+            size="compact"
+            name="music-2"
+            text="Music"
+            value="music-2"
+          />
+          <GoabxCheckbox
+            size="compact"
+            name="sports-2"
+            text="Sports"
+            value="sports-2"
+          />
+          <GoabxCheckbox
+            size="compact"
+            name="other-2"
+            text="Other"
+            value="other-2"
+            reveal={
+              <GoabxFormItem label="Other field">
+                <GoabxInput name="otherTextField" value="" />
+              </GoabxFormItem>
+            }
+          />
+        </GoabxCheckboxList>
+      </GoabxFormItem>
+    </div>
+
+  );
+}

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -185,7 +185,8 @@
   function sendMountedMessage() {
     if (!name) return;
 
-    const checkboxEl = (_rootEl?.getRootNode() as ShadowRoot)?.host as HTMLElement;
+    const checkboxEl = (_rootEl?.getRootNode() as ShadowRoot)
+      ?.host as HTMLElement;
     const fromCheckboxList = checkboxEl?.closest("goa-checkbox-list") !== null;
 
     relay<FormFieldMountRelayDetail>(
@@ -291,7 +292,9 @@ max-width: ${maxwidth};
         value={`${value}`}
         aria-label={arialabel || text || name}
         aria-checked={isIndeterminate ? "mixed" : isChecked ? "true" : "false"}
-        aria-describedby={$$slots.description || description !== "" ? _descriptionId : null}
+        aria-describedby={$$slots.description || description !== ""
+          ? _descriptionId
+          : null}
         aria-invalid={_error ? "true" : "false"}
         on:change={onChange}
         on:focus={onFocus}
@@ -306,13 +309,7 @@ max-width: ${maxwidth};
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <rect
-            x="0"
-            y="0"
-            width="18"
-            height="3"
-            rx="1.4"
-          />
+          <rect x="0" y="0" width="18" height="3" rx="1.4" />
         </svg>
       {:else if isIndeterminate}
         <svg
@@ -380,7 +377,10 @@ max-width: ${maxwidth};
   }
 
   .root {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
     height: auto; /* Automatically adjusts to content */
     min-height: 0; /* Ensures no unnecessary minimum height */
     padding: 0; /* Remove padding if it's affecting height */
@@ -457,7 +457,7 @@ max-width: ${maxwidth};
   }
 
   .container::before {
-    content: '';
+    content: "";
     position: absolute;
     width: 44px;
     height: 44px;
@@ -652,6 +652,8 @@ max-width: ${maxwidth};
   }
 
   .compact .description {
-    margin-left: calc(var(--goa-checkbox-size) + var(--goa-checkbox-gap-compact));
+    margin-left: calc(
+      var(--goa-checkbox-size) + var(--goa-checkbox-gap-compact)
+    );
   }
 </style>

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -321,6 +321,8 @@
   .container {
     display: flex;
     flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
   }
 
   .radio:hover {


### PR DESCRIPTION
# Before (the change)
- Interaction area for checkbox or radio buttons exist beyond the label and input, where the user can click anywhere on the width of the checkbox or radio button.
<img width="1253" height="438" alt="image" src="https://github.com/user-attachments/assets/af091d36-39f5-4b36-8297-90ba82bf2dc5" />

# After (the change)
- Interaction now exists only on the label and input of checkbox or radio button.
<img width="537" height="215" alt="image" src="https://github.com/user-attachments/assets/6e5baa39-3436-4450-84b5-bf45c9fb83cc" />

## Steps needed to test
- [ ] Hover and interact over radio buttons and checkboxs and around it to see if they can toggle either button outside of the intended interaction area.