### PR TITLE
chore: don't run tests before publishing

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -47,6 +47,7 @@ jobs:
         run: npm run build:prod
 
       - name: Test
+        on: pull_request
         run: |
           if [ -d "./dist" ]; then
             npx playwright install --with-deps


### PR DESCRIPTION
Due to some flaky tests, there are times that changes are not being published due to one of the tests not passing when publishing that previously passed on the PR.


