### PR TITLE
eric fix(#3540): add manual positioning to Popover

### DIFF
--- a/libs/react-components/specs/app-header-menu.browser.spec.tsx
+++ b/libs/react-components/specs/app-header-menu.browser.spec.tsx
@@ -53,8 +53,8 @@ describe("AppHeaderMenu", () => {
 
     // Close menu with Escape
     await userEvent.keyboard("{Escape}");
+    const popoverContent = result.getByTestId("popover-content");
     await vi.waitFor(() => {
-      const popoverContent = result.getByTestId("popover-content");
       expect(popoverContent.element().checkVisibility()).toBeFalsy();
     });
 
@@ -66,7 +66,6 @@ describe("AppHeaderMenu", () => {
     // 3. Open menu again — should still work after banner is removed from DOM
     await menuTrigger.click();
     await vi.waitFor(() => {
-      const popoverContent = result.getByTestId("popover-content");
       expect(popoverContent.element().checkVisibility()).toBeTruthy();
     });
     expect(result.getByTestId("menu-item-1").element().checkVisibility()).toBeTruthy();

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -67,6 +67,10 @@
   // Private
   let _rootEl: HTMLElement;
   let _popoverEl: HTMLElement;
+  const _needsManualPositioning =
+    typeof document !== "undefined" &&
+    !("anchorName" in document.documentElement.style);
+  let _positionRafId: number | null = null;
 
   // Reactive
   let _targetEl: HTMLElement;
@@ -122,12 +126,66 @@
   });
 
   onDestroy(() => {
+    if (_needsManualPositioning || _positionRafId) {
+      stopManualPositioning();
+    }
     window.removeEventListener("resize", updateAutoPosition);
     // true was passed when the listener was added, so it's necesary to be passed here as well
     window.removeEventListener("popstate", handleUrlChange, true);
   });
 
   // Functions
+
+  function updatePopoverPosition() {
+    if (!_isOpen || !_targetEl || !_popoverEl) return;
+
+    const targetRect = _targetEl.getBoundingClientRect();
+    const xOffset = hoffset ? parseFloat(hoffset) : 0;
+    const yOffset = voffset ? parseFloat(voffset) : 3;
+
+    // Recalculate auto position based on current viewport space
+    if (position === "auto") {
+      const popoverRect = _popoverEl.getBoundingClientRect();
+      const spaceAbove = targetRect.top;
+      const spaceBelow = window.innerHeight - targetRect.bottom;
+
+      _autoPosition =
+        spaceBelow < popoverRect.height && spaceAbove > spaceBelow
+          ? "above"
+          : "below";
+    }
+
+    const isAbove =
+      position === "above" ||
+      (position === "auto" && _autoPosition === "above");
+
+    if (isAbove) {
+      _popoverEl.style.top = `${targetRect.top - yOffset}px`;
+      _popoverEl.style.left = `${targetRect.left + xOffset}px`;
+      _popoverEl.style.transform = "translateY(-100%)";
+    } else {
+      _popoverEl.style.top = `${targetRect.bottom + yOffset}px`;
+      _popoverEl.style.left = `${targetRect.left + xOffset}px`;
+      _popoverEl.style.transform = "";
+    }
+  }
+
+  function startManualPositioning() {
+    if (!_needsManualPositioning) return;
+
+    const loop = () => {
+      updatePopoverPosition();
+      _positionRafId = requestAnimationFrame(loop);
+    };
+    _positionRafId = requestAnimationFrame(loop);
+  }
+
+  function stopManualPositioning() {
+    if (_positionRafId !== null) {
+      cancelAnimationFrame(_positionRafId);
+      _positionRafId = null;
+    }
+  }
 
   function isPopoverOpen(): boolean {
     try {
@@ -188,8 +246,7 @@
     }
   }
 
-  function handleNativeToggle(e: Event) {
-    const toggleEvent = e as Event & { newState?: "open" | "closed" };
+  function handleNativeToggle(toggleEvent: ToggleEvent) {
     if (toggleEvent.newState === "open") {
       _isOpen = true;
     } else if (toggleEvent.newState === "closed") {
@@ -205,8 +262,14 @@
     if (_isOpen) {
       dispatch(_rootEl, "_open", {}, { bubbles: true });
       requestAnimationFrame(updateAutoPosition); // same vs await tick(), make sure popover element is fully rendered before we measure its dimension
+      if (_needsManualPositioning) {
+        startManualPositioning();
+      }
     } else {
-      _targetEl.focus();
+      if (_needsManualPositioning || _positionRafId) {
+        stopManualPositioning();
+      }
+      _targetEl?.focus();
       dispatch(_rootEl, "_close", {}, { bubbles: true });
     }
   }
@@ -214,6 +277,15 @@
   function closePopover() {
     if (_isOpen) {
       _popoverEl?.hidePopover(); // browser will fire and trigger handleNativeToggle
+      // If the browser doesn't support the API we have to trigger the toggle event manually.
+      if (_needsManualPositioning) {
+        const event = new ToggleEvent("toggle", {
+          bubbles: true,
+          newState: "closed",
+          oldState: "open",
+        });
+        handleNativeToggle(event); // in case the browser doesn't fire toggle event, we need to manually update the state
+      }
     }
   }
 
@@ -227,6 +299,11 @@
       _popoverEl.hidePopover();
       _isOpen = false;
     } else {
+      // If the Popover API is not supported, we need to manually close other
+      // popovers before opening a new one.
+      if (_needsManualPositioning) {
+        dispatch(document.body, "goa:closePopover", { target: _targetEl });
+      }
       _popoverEl.showPopover();
       _isOpen = true;
       requestAnimationFrame(updateAutoPosition);
@@ -234,11 +311,7 @@
   }
 
   function updateAutoPosition() {
-    if (!_isOpen || !_targetEl || !_popoverEl) {
-      return;
-    }
-
-    if (position !== "auto") {
+    if (position !== "auto" || !_isOpen || !_targetEl || !_popoverEl) {
       return;
     }
 
@@ -298,10 +371,14 @@
     class:position-below={position === "below" ||
       (position === "auto" && _autoPosition === "below")}
     class:position-right={position === "right"}
+    class:use-anchor-based-positioning={!_needsManualPositioning}
     style={styles(
       style("width", position !== "right" ? width : undefined),
       style("min-width", minwidth),
-      style("max-width", position !== "right" && width ? `max(${width}, ${maxwidth})` : maxwidth),
+      style(
+        "max-width",
+        position !== "right" && width ? `max(${width}, ${maxwidth})` : maxwidth,
+      ),
       style("padding", _padded ? "var(--goa-space-m)" : "0"),
     )}
   >
@@ -355,7 +432,6 @@
     filter: var(--goa-popover-shadow, none);
     border: var(--goa-popover-border, none);
     margin: 0;
-
     position-anchor: --goa-popover-target;
     inset-block-start: anchor(bottom);
     inset-inline-start: anchor(left);
@@ -364,7 +440,11 @@
     translate: var(--popover-translate-x) var(--popover-translate-y);
   }
 
-  .popover-content.position-above {
+  .popover-content.use-anchor-based-positioning {
+    inset-block-start: anchor(top);
+    --popover-translate-y: calc(-100% - var(--offset-bottom, 3px));
+  }
+  .popover-content.use-anchor-based-positioning.position-above {
     inset-block-start: anchor(top);
     --popover-translate-y: calc(-100% - var(--offset-bottom, 3px));
     position-try-fallbacks: none;


### PR DESCRIPTION
This PR adds manual positioning for a Popover when the browser does not support CSS anchor positioning.

# Before (the change)

The popover would work only on browsers that support Anchor Positioning. On browsers that do not support Anchor Positioning all popovers would appear in the top left corner of a page.

<img width="1417" height="711" alt="image" src="https://github.com/user-attachments/assets/ca4169e9-2e95-4e7d-b736-d8f58cd4c878" />

# After (the change)

The popover works on older browsers that do not support Anchor Positioning.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

- See this list for browsers and versions that do and do not support anchor positioning: https://caniuse.com/css-anchor-positioning
- Test with as many browsers that do and do not support anchor positioning as you can, especially in Browser Stack
- Ensure you test with **Safari 18.x** which is one of the more commonly used browsers on GoA websites
- One of the best places to test is in the Feat. 3478 PR test page:
  - http://localhost:4200/features/3478
  - http://localhost:4201/features/3478 