### PR TITLE
fix(#3541) - adjust modal so left side of Checkbox is not cut off

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -233,10 +233,18 @@
           url="/bugs/3498"
         ></goabx-work-side-menu-item>
         <goabx-work-side-menu-item
+          label="3541 Checkbox cut off on the left side in modal"
+          url="/bugs/3541"
+        ></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item
           label="3607 Radio and Checkbox Interaction Area"
           url="/bugs/3607"
         ></goabx-work-side-menu-item>
         <goabx-work-side-menu-item label="3505 Link Icon Click" url="/bugs/3505"></goabx-work-side-menu-item>
+        <goabx-work-side-menu-item
+          label="3541 Checkbox cut off on the left side in modal"
+          url="/bugs/3541"
+        ></goabx-work-side-menu-item>
       </goabx-work-side-menu-group>
       <goabx-work-side-menu-group icon="star" heading="Features">
         <goabx-work-side-menu-item

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -50,6 +50,7 @@ import { Bug3497Component } from "../routes/bugs/3497/bug3497.component";
 import { Bug3498Component } from "../routes/bugs/3498/bug3498.component";
 import { Bug3607Component } from "../routes/bugs/3607/bug3607.component";
 import { Bug3505Component } from "../routes/bugs/3505/bug3505.component";
+import { Bug3541Component } from "../routes/bugs/3541/bug3541.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -140,7 +141,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3497", component: Bug3497Component },
   { path: "bugs/3498", component: Bug3498Component },
   { path: "bugs/3607", component: Bug3607Component },
-
+  { path: "bugs/3541", component: Bug3541Component },
   { path: "bugs/3505", component: Bug3505Component },
   // Feature routes
   { path: "features/1328", component: Feat1328Component },

--- a/apps/prs/angular/src/routes/bugs/3541/bug3541.component.html
+++ b/apps/prs/angular/src/routes/bugs/3541/bug3541.component.html
@@ -1,0 +1,128 @@
+<div>
+  <h1>3541 - Checkbox cut off on the left side in modal</h1>
+  <h2>Version 1</h2>
+  <goab-button type="tertiary" leadingIcon="add" (onClick)="toggleModal()">Add another item</goab-button>
+  <goab-modal [open]="open" (onClose)="toggleModal()" heading="Add a new item" [actions]="actions">
+    <p>Fill in the information to create a new item</p>
+    <goab-form-item label="Type" mt="l">
+      <goab-dropdown (onChange)="updateType($event)" [value]="type">
+        <goab-dropdown-item value="1" label="Option 1"></goab-dropdown-item>
+        <goab-dropdown-item value="2" label="Option 2"></goab-dropdown-item>
+      </goab-dropdown>
+    </goab-form-item>
+    <goab-form-item label="How would you like to be contacted?" helpText="Select one option" mt="l">
+      <goab-radio-group name="contactMethodTwo" formControlName="contactMethodTwo">
+        <goab-radio-item label="Email" description="Receive updates via email" value="email" [reveal]="emailReveal">
+          <ng-template #emailReveal>
+            <goab-form-item label="Email address">
+              <goab-input name="email" formControlName="emailAddress"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-radio-item>
+        <goab-radio-item value="phone" label="Phone" [reveal]="phoneReveal">
+          <ng-template #phoneReveal>
+            <goab-form-item label="Phone number">
+              <goab-input name="phone" formControlName="phoneNumber"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-radio-item>
+        <goab-radio-item value="text" label="Text message" [reveal]="textReveal">
+          <ng-template #textReveal>
+            <goab-form-item label="Mobile phone number">
+              <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-radio-item>
+      </goab-radio-group>
+    </goab-form-item>
+    <goab-form-item label="Select interests" mt="l">
+      <goab-checkbox-list name="entryStatus">
+        <goab-checkbox name="sports" text="Sports"></goab-checkbox>
+        <goab-checkbox name="music" text="Music"></goab-checkbox>
+        <goab-checkbox name="travel" text="Travel"></goab-checkbox>
+        <goab-checkbox name="other" text="Other" [reveal]="phoneReveal">
+          <ng-template #phoneReveal>
+            <goab-form-item label="Please specify">
+              <goab-input name="other" formControlName="other"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-checkbox>
+      </goab-checkbox-list>
+    </goab-form-item>
+    <goab-form-item label="Name" mt="l">
+      <goab-input name="name" width="100%" (onChange)="updateName($event)" [value]="name"></goab-input>
+    </goab-form-item>
+    <goab-form-item label="Description" mt="l">
+      <goab-textarea name="description" width="100%" [rows]="3" (onChange)="updateDescription($event)" [value]="description"></goab-textarea>
+    </goab-form-item>
+    <ng-template #actions>
+      <goab-button-group alignment="end">
+        <goab-button type="tertiary" size="compact" (onClick)="toggleModal()">Cancel</goab-button>
+        <goab-button type="primary" size="compact" (onClick)="toggleModal()">Save new item</goab-button>
+      </goab-button-group>
+    </ng-template>
+  </goab-modal>
+
+  <h2>Version 2</h2>
+  <goabx-button type="tertiary" leadingIcon="add" (onClick)="toggleModalTwo()">Add another item</goabx-button>
+  <goabx-modal [open]="openTwo" (onClose)="toggleModalTwo()" heading="Add a new item" [actions]="actionsTwo">
+    <p>Fill in the information to create a new item</p>
+    <goabx-form-item label="Type" mt="l">
+      <goabx-dropdown (onChange)="updateType($event)" [value]="type">
+        <goabx-dropdown-item value="1" label="Option 1"></goabx-dropdown-item>
+        <goabx-dropdown-item value="2" label="Option 2"></goabx-dropdown-item>
+      </goabx-dropdown>
+    </goabx-form-item>
+    <goabx-form-item label="How would you like to be contacted?" helpText="Select one option" mt="l">
+      <goabx-radio-group name="contactMethodTwo" formControlName="contactMethodTwo">
+        <goabx-radio-item label="Email" description="Receive updates via email" value="email" [reveal]="emailReveal">
+          <ng-template #emailReveal>
+            <goabx-form-item label="Email address">
+              <goabx-input name="email" formControlName="emailAddress"></goabx-input>
+            </goabx-form-item>
+          </ng-template>
+        </goabx-radio-item>
+        <goabx-radio-item value="phone" label="Phone" [reveal]="phoneReveal">
+          <ng-template #phoneReveal>
+            <goabx-form-item label="Phone number">
+              <goabx-input name="phone" formControlName="phoneNumber"></goabx-input>
+            </goabx-form-item>
+          </ng-template>
+        </goabx-radio-item>
+        <goabx-radio-item value="text" label="Text message" [reveal]="textReveal">
+          <ng-template #textReveal>
+            <goabx-form-item label="Mobile phone number">
+              <goabx-input name="mobile" formControlName="phoneNumber"></goabx-input>
+            </goabx-form-item>
+          </ng-template>
+        </goabx-radio-item>
+      </goabx-radio-group>
+    </goabx-form-item>
+    <goabx-form-item label="Select interests" mt="l">
+      <goab-checkbox-list name="entryStatus">
+        <goabx-checkbox name="sports" text="Sports"></goabx-checkbox>
+        <goabx-checkbox name="music" text="Music"></goabx-checkbox>
+        <goabx-checkbox name="travel" text="Travel"></goabx-checkbox>
+        <goabx-checkbox name="other" text="Other" [reveal]="phoneReveal">
+          <ng-template #phoneReveal>
+            <goabx-form-item label="Please specify">
+              <goabx-input name="other" formControlName="other"></goabx-input>
+            </goabx-form-item>
+          </ng-template>
+        </goabx-checkbox>
+      </goab-checkbox-list>
+    </goabx-form-item>
+    <goabx-form-item label="Name" mt="l">
+      <goabx-input name="name" width="100%" (onChange)="updateName($event)" [value]="name"></goabx-input>
+    </goabx-form-item>
+    <goabx-form-item label="Description" mt="l">
+      <goabx-textarea name="description" width="100%" [rows]="3" (onChange)="updateDescription($event)" [value]="description"></goabx-textarea>
+    </goabx-form-item>
+    <ng-template #actionsTwo>
+      <goab-button-group alignment="end">
+        <goabx-button type="tertiary" size="compact" (onClick)="toggleModalTwo()">Cancel</goabx-button>
+        <goabx-button type="primary" size="compact" (onClick)="toggleModalTwo()">Save new item</goabx-button>
+      </goab-button-group>
+    </ng-template>
+  </goabx-modal>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3541/bug3541.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3541/bug3541.component.ts
@@ -1,0 +1,87 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabButton,
+  GoabCheckboxList,
+  GoabFormItem,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabInput,
+  GoabModal,
+  GoabTextArea,
+  GoabCheckbox,
+  GoabButtonGroup,
+  GoabxButton,
+  GoabxCheckboxList,
+  GoabxFormItem,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+  GoabxInput,
+  GoabxModal,
+  GoabxTextArea,
+  GoabxCheckbox
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3541",
+  templateUrl: "./bug3541.component.html",
+  imports: [CommonModule,
+  GoabButton,
+  GoabCheckboxList,
+  GoabFormItem,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabInput,
+  GoabModal,
+  GoabTextArea,
+  GoabCheckbox,
+  GoabButtonGroup,
+  GoabxButton,
+  GoabxCheckboxList,
+  GoabxFormItem,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+  GoabxInput,
+  GoabxModal,
+  GoabxTextArea,
+  GoabxCheckbox
+],
+})
+export class Bug3541Component {
+  open = false;
+  openTwo = false;
+  type: string | undefined = "";
+  name = "";
+  description = "";
+
+  toggleModal() {
+    this.open = !this.open;
+  }
+
+  toggleModalTwo() {
+    this.openTwo = !this.openTwo;
+  }
+
+  updateType(event: any) {
+    this.type = event.value;
+  }
+
+  updateName(event: any) {
+    this.name = event.value;
+  }
+
+  updateDescription(event: any) {
+    this.description = event.value;
+  }
+
+
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -230,6 +230,10 @@ export function App() {
                   label="3505 Link Icon Click"
                   url="/bugs/3505"
                 />
+                <GoabxWorkSideMenuItem
+                  label="3541 Checkbox cut off on the left side in modal"
+                  url="/bugs/3541"
+                />
               </GoabxWorkSideMenuGroup>
 
               <GoabxWorkSideMenuGroup icon="star" heading="Features">

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -50,6 +50,7 @@ import { Bug3384Route } from "./routes/bugs/bug3384";
 import { Bug3450Route } from "./routes/bugs/bug3450";
 import { Bug3497Route } from "./routes/bugs/bug3497";
 import { Bug3498Route } from "./routes/bugs/bug3498";
+import { Bug3541Route } from "./routes/bugs/bug3541";
 import { Bug3607Route } from "./routes/bugs/bug3607";
 import { Bug3505Route } from "./routes/bugs/bug3505";
 
@@ -151,6 +152,7 @@ root.render(
           <Route path="bugs/3498" element={<Bug3498Route />} />
           <Route path="bugs/3607" element={<Bug3607Route />} />
           <Route path="bugs/3505" element={<Bug3505Route />} />
+          <Route path="bugs/3541" element={<Bug3541Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3541.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3541.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react';
+import {
+  GoabButton,
+  GoabCheckboxList,
+  GoabFormItem,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabInput,
+  GoabModal,
+  GoabTextArea,
+  GoabCheckbox,
+  GoabButtonGroup,
+} from "@abgov/react-components";
+import {
+  GoabxButton,
+  GoabxCheckboxList,
+  GoabxFormItem,
+  GoabxDropdown,
+  GoabxDropdownItem,
+  GoabxRadioGroup,
+  GoabxRadioItem,
+  GoabxInput,
+  GoabxModal,
+  GoabxTextArea,
+  GoabxCheckbox
+} from "@abgov/react-components/experimental";
+
+export function Bug3541Route() {
+  const [openTwo, setOpenTwo] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [type, setType] = useState<string>();
+  const [name, setName] = useState<string>();
+  const [description, setDescription] = useState<string>();
+
+  return (
+     <div>
+      <h1>3541 - Checkbox cut off on the left side in modal</h1>
+      <h2>Version 1</h2>
+      <GoabButton type="tertiary" leadingIcon="add" onClick={() => setOpen(true)}>
+        Add another item
+      </GoabButton>
+      <GoabModal
+          heading="Add a new item"
+          open={open}
+          actions={
+            <GoabButtonGroup alignment="end">
+              <GoabButton type="secondary" size="compact">
+                Cancel
+              </GoabButton>
+              <GoabButton type="primary" size="compact" onClick={() => setOpen(false)}>
+                Save new item
+              </GoabButton>
+            </GoabButtonGroup>
+          }
+        >
+          <p>Fill in the information to create a new item</p>
+          <GoabFormItem label="Type" mt="l">
+            <GoabDropdown onChange={(e) => setType(e.value)} value={type}>
+              <GoabDropdownItem value="1" label="Option 1" />
+              <GoabDropdownItem value="2" label="Option 2" />
+            </GoabDropdown>
+          </GoabFormItem>
+          <GoabFormItem label="Contact preference" mt="l">
+            <GoabRadioGroup name="contact" value="">
+              <GoabRadioItem value="email" label="Email" />
+              <GoabRadioItem value="phone" label="Phone" />
+              <GoabRadioItem value="mail" label="Mail" />
+            </GoabRadioGroup>
+          </GoabFormItem>
+          <GoabFormItem helpText="Choose all that apply" error="Please select one" label="Contact preference 2" mt="l">
+            <GoabCheckboxList name="entryStatus">
+              <GoabCheckbox error={true} name="sports" text="Sports" />
+              <GoabCheckbox name="music" text="Music" />
+              <GoabCheckbox name="travel" text="Travel" />
+              <GoabCheckbox
+                name="other"
+                text="Other"
+                reveal={
+                  <GoabFormItem label="Please specify">
+                    <GoabInput name="other" value="" />
+                  </GoabFormItem>
+                }
+              />
+            </GoabCheckboxList>
+          </GoabFormItem>
+          <GoabFormItem label="Name" mt="l">
+            <GoabInput
+              onChange={(e) => setName(e.value)}
+              value={name}
+              name="name"
+              width="100%"
+            />
+          </GoabFormItem>
+          <GoabFormItem label="Description" mt="l">
+            <GoabTextArea
+              name="description"
+              rows={3}
+              width="100%"
+              onChange={(e) => setDescription(e.value)}
+              value={description}
+            />
+          </GoabFormItem>
+      </GoabModal>
+
+      <h2>Version 2</h2>
+      <GoabxButton type="tertiary" leadingIcon="add" onClick={() => setOpenTwo(true)}>
+        Add another item
+      </GoabxButton>
+      <GoabxModal
+          version="2"
+          heading="Add a new item"
+          open={openTwo}
+          actions={
+            <GoabButtonGroup alignment="end">
+              <GoabxButton version="2" type="secondary" size="compact">
+                Cancel
+              </GoabxButton>
+              <GoabxButton version="2" type="primary" size="compact" onClick={() => setOpenTwo(false)}>
+                Save new item
+              </GoabxButton>
+            </GoabButtonGroup>
+          }
+        >
+          <p>Fill in the information to create a new item</p>
+          <GoabxFormItem label="Type" mt="l">
+            <GoabxDropdown onChange={(e) => setType(e.value)} value={type}>
+              <GoabxDropdownItem value="1" label="Option 1" />
+              <GoabxDropdownItem value="2" label="Option 2" />
+            </GoabxDropdown>
+          </GoabxFormItem>
+          <GoabxFormItem label="Contact preference" mt="l">
+            <GoabxRadioGroup name="contact" value="">
+              <GoabxRadioItem value="email" label="Email" />
+              <GoabxRadioItem value="phone" label="Phone" />
+              <GoabxRadioItem value="mail" label="Mail" />
+            </GoabxRadioGroup>
+          </GoabxFormItem>
+          <GoabxFormItem helpText="Choose all that apply" error="Please select one" label="Contact preference 2" mt="l">
+            <GoabxCheckboxList name="entryStatus">
+              <GoabxCheckbox error={true} name="sports" text="Sports" />
+              <GoabxCheckbox name="music" text="Music" />
+              <GoabxCheckbox name="travel" text="Travel" />
+              <GoabxCheckbox
+                name="other"
+                text="Other"
+                reveal={
+                  <GoabxFormItem label="Please specify">
+                    <GoabxInput name="other" value="" />
+                  </GoabxFormItem>
+                }
+              />
+            </GoabxCheckboxList>
+          </GoabxFormItem>
+          <GoabxFormItem label="Name" mt="l">
+            <GoabxInput
+              onChange={(e) => setName(e.value)}
+              value={name}
+              name="name"
+              width="100%"
+            />
+          </GoabxFormItem>
+          <GoabxFormItem label="Description" mt="l">
+            <GoabxTextArea
+              name="description"
+              rows={3}
+              width="100%"
+              onChange={(e) => setDescription(e.value)}
+              value={description}
+            />
+          </GoabxFormItem>
+      </GoabxModal>
+    </div>
+
+  );
+}


### PR DESCRIPTION
# Before (the change)
On focus, left side of the checkbox gets cut off by the modal container.
<img width="648" height="244" alt="image" src="https://github.com/user-attachments/assets/0781f96f-c790-4f55-8cb3-bab3311b527a" />

# After (the change)
After adjusting the padding of the Modal and Scrollable container, the left side now displays on modal.
<img width="623" height="313" alt="image" src="https://github.com/user-attachments/assets/d6e4283d-594f-4c93-921a-0e5452e045af" />

## Steps needed to test
- [ ] Ensure that v1 styles for modal remains the same
- [ ] Confirm that checkbox left side does not get cut off by the side of the "scrollable" container.
- [ ] Check if checkbox left side still appears when modal has a scrollbar.