### PR TITLE
feat(#3676): show subcomponent APIs on parent component pages

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,11 +92,14 @@ githubUrl: https://github.com/...
 webComponentTag: goa-button
 reactClassName: GoabButton
 angularSelector: goab-button
-hidden: false # set true to hide from nav
+hidden: true # optional — hide from nav (used for subcomponents, deprecated, internal)
+subcomponent: true # optional — show API on parent component page
 ---
 ```
 
 The MDX body is usually empty. Any content you add appears at the bottom of the "Usage guidelines" tab.
+
+**Subcomponents:** Some components are children that developers compose with a parent (e.g., Tab inside Tabs, Footer Nav Section inside Footer). These have `hidden: true` (not in nav) and `subcomponent: true` (API shown on parent page). The parent discovers subcomponents via its `relatedComponents` array. See "Add a subcomponent" below for how this works.
 
 ### Guidance (`src/content/guidance/*.mdx`)
 
@@ -223,6 +226,66 @@ This is a common source of errors when writing configuration code since all thre
 
 4. The component appears in the nav and grid automatically. The side nav is built dynamically from the content collection — Astro queries all component MDX files, groups them by `category`, and passes the data to `ComponentsSubMenu` via `nav-categories.ts`. No hardcoded nav lists to update.
 
+### Add a subcomponent
+
+Subcomponents are child components that developers compose with a parent (e.g., `<goa-tab>` inside `<goa-tabs>`). Their API appears on the parent's Properties tab under a separate heading.
+
+**How it works:** The parent lists the subcomponent in its `relatedComponents`. The page template calls `getSubcomponents()`, which filters that list for entries with `subcomponent: true` and loads their extracted API data.
+
+**Example: Tabs and Tab**
+
+The parent (`tabs.mdx`) includes `tab` in its `relatedComponents`:
+
+```yaml
+# src/content/components/tabs.mdx
+---
+name: Tabs
+status: stable
+category: structure-and-navigation
+relatedComponents:
+  - tab # <-- this is how the parent discovers the subcomponent
+webComponentTag: goa-tabs
+---
+```
+
+The child (`tab.mdx`) marks itself as hidden and a subcomponent:
+
+```yaml
+# src/content/components/tab.mdx
+---
+name: Tab
+status: stable
+category: structure-and-navigation
+hidden: true # not shown in nav
+subcomponent: true # API appears on parent page
+relatedComponents:
+  - tabs
+webComponentTag: goa-tab
+---
+```
+
+Result: the Tabs page shows "Tab Props", "Tab Slots" (and "Tab Events" if any exist) with a "Subcomponent" badge on each heading.
+
+**To add a new subcomponent:**
+
+1. Create the subcomponent MDX file with `hidden: true` and `subcomponent: true`
+2. Add its slug to the parent's `relatedComponents` array
+3. Ensure API data exists. If the Svelte component has its own directory (`libs/web-components/src/components/my-sub/`), the extraction script handles it automatically. If it's a nested file inside the parent's directory (like `WorkSideMenuGroup.svelte` inside `work-side-menu/`), you need to manually create the API JSON in `generated/component-apis/my-sub.json`
+
+**Current subcomponent mappings:**
+
+| Parent         | Subcomponents                             |
+| -------------- | ----------------------------------------- |
+| Header         | App Header Menu                           |
+| File uploader  | File Upload Card                          |
+| Footer         | Footer Meta Section, Footer Nav Section   |
+| Form stepper   | Form Step                                 |
+| Menu button    | Menu Action                               |
+| Radio          | Radio Item                                |
+| Side menu      | Side Menu Group, Side Menu Heading        |
+| Tabs           | Tab                                       |
+| Work Side Menu | Work Side Menu Group, Work Side Menu Item |
+
 ### Hide a component from navigation
 
 Set `hidden: true` in the component's MDX frontmatter. It won't appear in the nav or component grid, but the page still exists if you visit the URL directly.
@@ -298,15 +361,16 @@ Place an SVG in `docs/public/thumbnails/<slug>.svg`. The components grid referen
 
 ## How component pages are assembled
 
-The page template (`src/pages/components/[slug].astro`) pulls from five sources:
+The page template (`src/pages/components/[slug].astro`) pulls from six sources:
 
 1. **MDX content** — renders the component's `.mdx` file (mostly frontmatter-driven)
 2. **Extracted API** — `getComponentApi(slug)` loads from `generated/component-apis/<slug>.json`
-3. **Guidance** — `getGuidanceForComponent(slug)` filters guidance where `appliesTo.components` includes this slug, then splits into usage vs accessibility topics
-4. **Examples** — `getExamplesForComponent(slug)` filters examples where `components` includes this slug
-5. **Configurations** — `getComponentConfigurations(slug)` looks up from the registry
+3. **Subcomponent APIs** — `getSubcomponents(relatedComponents)` finds entries with `subcomponent: true` and loads their API data
+4. **Guidance** — `getGuidanceForComponent(slug)` filters guidance where `appliesTo.components` includes this slug, then splits into usage vs accessibility topics
+5. **Examples** — `getExamplesForComponent(slug)` filters examples where `components` includes this slug
+6. **Configurations** — `getComponentConfigurations(slug)` looks up from the registry
 
-These are rendered into four tabs: Properties, Examples, Usage guidelines, Accessibility.
+These are rendered into four tabs: Properties (including subcomponent APIs), Examples, Usage guidelines, Accessibility.
 
 ---
 

--- a/docs/generated/component-apis/menu-action.json
+++ b/docs/generated/component-apis/menu-action.json
@@ -1,0 +1,37 @@
+{
+  "componentSlug": "menu-action",
+  "extractedFrom": "libs/web-components/src/components/menu-button/MenuAction.svelte",
+  "props": [
+    {
+      "name": "text",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Display text for the menu action."
+    },
+    {
+      "name": "action",
+      "type": "string",
+      "required": false,
+      "default": "default",
+      "description": "Action identifier included in the click event."
+    },
+    {
+      "name": "testId",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Sets a data-testid attribute for automated testing."
+    },
+    {
+      "name": "icon",
+      "type": "GoAIconType",
+      "typeLabel": "GoAIconType",
+      "required": false,
+      "default": null,
+      "description": "Icon displayed before the text."
+    }
+  ],
+  "events": [],
+  "slots": []
+}

--- a/docs/generated/component-apis/work-side-menu-group.json
+++ b/docs/generated/component-apis/work-side-menu-group.json
@@ -1,0 +1,42 @@
+{
+  "componentSlug": "work-side-menu-group",
+  "extractedFrom": "libs/web-components/src/components/work-side-menu/WorkSideMenuGroup.svelte",
+  "props": [
+    {
+      "name": "heading",
+      "type": "string",
+      "required": true,
+      "default": null,
+      "description": "The text displayed in the group heading."
+    },
+    {
+      "name": "icon",
+      "type": "GoAIconType",
+      "typeLabel": "GoAIconType",
+      "required": false,
+      "default": null,
+      "description": "Icon displayed before the group label. When omitted, no icon is rendered and no space is reserved."
+    },
+    {
+      "name": "testId",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Sets a data-testid attribute for automated testing."
+    },
+    {
+      "name": "open",
+      "type": "boolean",
+      "required": false,
+      "default": "false",
+      "description": "Whether the group is open."
+    }
+  ],
+  "events": [],
+  "slots": [
+    {
+      "name": "default",
+      "description": ""
+    }
+  ]
+}

--- a/docs/generated/component-apis/work-side-menu-item.json
+++ b/docs/generated/component-apis/work-side-menu-item.json
@@ -1,0 +1,70 @@
+{
+  "componentSlug": "work-side-menu-item",
+  "extractedFrom": "libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte",
+  "props": [
+    {
+      "name": "label",
+      "type": "string",
+      "required": true,
+      "default": null,
+      "description": "The text label displayed for the menu item."
+    },
+    {
+      "name": "url",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "The URL the menu item links to. Optional — when absent, renders as a button instead of a link."
+    },
+    {
+      "name": "badge",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Badge text displayed alongside the menu item (e.g., notification count)."
+    },
+    {
+      "name": "current",
+      "type": "boolean",
+      "required": false,
+      "default": "false",
+      "description": "When true, indicates this is the currently active menu item."
+    },
+    {
+      "name": "divider",
+      "type": "boolean",
+      "required": false,
+      "default": "false",
+      "description": "When true, displays a divider line above this menu item."
+    },
+    {
+      "name": "icon",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Icon displayed before the menu item label."
+    },
+    {
+      "name": "testId",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "Sets a data-testid attribute for automated testing."
+    },
+    {
+      "name": "type",
+      "type": "\"normal\" | \"emergency\" | \"success\"",
+      "values": ["normal", "emergency", "success"],
+      "required": false,
+      "default": "normal",
+      "description": "Sets the visual style of the badge. Use \"emergency\" for urgent items, \"success\" for positive status."
+    }
+  ],
+  "events": [],
+  "slots": [
+    {
+      "name": "popoverContent",
+      "description": "Content displayed in a popover panel beside the menu item."
+    }
+  ]
+}

--- a/docs/public/search-index.json
+++ b/docs/public/search-index.json
@@ -1,6882 +1,2750 @@
 [
   {
-    "id": "work-side-menu",
-    "title": "Work Side Menu",
-    "name": "Work Side Menu",
-    "description": "Side menu variant for worker applications.",
-    "content": "",
-    "component": "work-side-menu",
-    "filePath": "docs/src/content/components/work-side-menu.mdx",
-    "urlPath": "components/work-side-menu",
-    "tags": [],
     "type": "component",
-    "slug": "work-side-menu",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "tooltip",
-    "title": "Tooltip",
-    "name": "Tooltip",
-    "description": "A small popover that displays more information about an item.",
-    "content": "",
-    "component": "tooltip",
-    "filePath": "docs/src/content/components/tooltip.mdx",
-    "urlPath": "components/tooltip",
-    "tags": [],
-    "type": "component",
-    "slug": "tooltip",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "text",
-    "title": "Text",
-    "name": "Text",
-    "description": "Provides consistent sizing, spacing, and colour to written content.",
-    "content": "",
-    "component": "text",
-    "filePath": "docs/src/content/components/text.mdx",
-    "urlPath": "components/text",
-    "tags": [],
-    "type": "component",
-    "slug": "text",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "text-area",
-    "title": "Text area",
-    "name": "Text area",
-    "description": "A multi-line field where users can input and edit text.",
-    "content": "",
-    "component": "text-area",
-    "filePath": "docs/src/content/components/text-area.mdx",
-    "urlPath": "components/text-area",
-    "tags": [],
-    "type": "component",
-    "slug": "text-area",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "temporary-notification",
-    "title": "Temporary notification",
-    "name": "Temporary notification",
-    "description": "A notification that appears at the bottom of the screen.",
-    "content": "",
-    "component": "temporary-notification",
-    "filePath": "docs/src/content/components/temporary-notification.mdx",
-    "urlPath": "components/temporary-notification",
-    "tags": [],
-    "type": "component",
-    "slug": "temporary-notification",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "tabs",
-    "title": "Tabs",
-    "name": "Tabs",
-    "description": "Let users navigate between related sections of content, displaying one section at a time.",
-    "content": "",
-    "component": "tabs",
-    "filePath": "docs/src/content/components/tabs.mdx",
-    "urlPath": "components/tabs",
-    "tags": [],
-    "type": "component",
-    "slug": "tabs",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "table",
-    "title": "Table",
-    "name": "Table",
-    "description": "A set of structured data that is easy for a user to scan, examine, and compare.",
-    "content": "",
-    "component": "table",
-    "filePath": "docs/src/content/components/table.mdx",
-    "urlPath": "components/table",
-    "tags": [],
-    "type": "component",
-    "slug": "table",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "tab",
-    "title": "Tab",
-    "name": "Tab",
-    "description": "Individual tab within a tabs component.",
-    "content": "",
-    "component": "tab",
-    "filePath": "docs/src/content/components/tab.mdx",
-    "urlPath": "components/tab",
-    "tags": [],
-    "type": "component",
-    "slug": "tab",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "spinner",
-    "title": "Spinner",
-    "name": "Spinner",
-    "description": "Loading indicator for async operations.",
-    "content": "",
-    "component": "spinner",
-    "filePath": "docs/src/content/components/spinner.mdx",
-    "urlPath": "components/spinner",
-    "tags": [],
-    "type": "component",
-    "slug": "spinner",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "spacer",
-    "title": "Spacer",
-    "name": "Spacer",
-    "description": "Negative area between the components and the interface.",
-    "content": "",
-    "component": "spacer",
-    "filePath": "docs/src/content/components/spacer.mdx",
-    "urlPath": "components/spacer",
-    "tags": [],
-    "type": "component",
-    "slug": "spacer",
-    "status": "stable",
-    "category": "utilities"
-  },
-  {
-    "id": "skeleton",
-    "title": "Skeleton loader",
-    "name": "Skeleton loader",
-    "description": "Provide visual feedback to users while loading a content heavy page or page element.",
-    "content": "",
-    "component": "skeleton",
-    "filePath": "docs/src/content/components/skeleton.mdx",
-    "urlPath": "components/skeleton",
-    "tags": [],
-    "type": "component",
-    "slug": "skeleton",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "side-menu",
-    "title": "Side menu",
-    "name": "Side menu",
-    "description": "A side navigation that helps the user navigate between pages.",
-    "content": "",
-    "component": "side-menu",
-    "filePath": "docs/src/content/components/side-menu.mdx",
-    "urlPath": "components/side-menu",
-    "tags": [],
-    "type": "component",
-    "slug": "side-menu",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "side-menu-heading",
-    "title": "Side Menu Heading",
-    "name": "Side Menu Heading",
-    "description": "Section heading in side menu.",
-    "content": "",
-    "component": "side-menu-heading",
-    "filePath": "docs/src/content/components/side-menu-heading.mdx",
-    "urlPath": "components/side-menu-heading",
-    "tags": [],
-    "type": "component",
-    "slug": "side-menu-heading",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "side-menu-group",
-    "title": "Side Menu Group",
-    "name": "Side Menu Group",
-    "description": "Group of related side menu items.",
-    "content": "",
-    "component": "side-menu-group",
-    "filePath": "docs/src/content/components/side-menu-group.mdx",
-    "urlPath": "components/side-menu-group",
-    "tags": [],
-    "type": "component",
-    "slug": "side-menu-group",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "scrollable",
-    "title": "Scrollable",
-    "name": "Scrollable",
-    "description": "Container with overflow scrolling.",
-    "content": "",
-    "component": "scrollable",
-    "filePath": "docs/src/content/components/scrollable.mdx",
-    "urlPath": "components/scrollable",
-    "tags": [],
-    "type": "component",
-    "slug": "scrollable",
-    "status": "stable",
-    "category": "utilities"
-  },
-  {
-    "id": "radio-item",
-    "title": "Radio Item",
-    "name": "Radio Item",
-    "description": "Individual radio option within a group.",
-    "content": "",
-    "component": "radio-item",
-    "filePath": "docs/src/content/components/radio-item.mdx",
-    "urlPath": "components/radio-item",
-    "tags": [],
-    "type": "component",
-    "slug": "radio-item",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "radio-group",
-    "title": "Radio",
-    "name": "Radio",
-    "description": "Allow users to select one option from a set.",
-    "content": "",
-    "component": "radio-group",
-    "filePath": "docs/src/content/components/radio-group.mdx",
-    "urlPath": "components/radio-group",
-    "tags": [],
-    "type": "component",
-    "slug": "radio-group",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "popover",
-    "title": "Popover",
-    "name": "Popover",
-    "description": "A small overlay that opens on demand, used in other components.",
-    "content": "",
-    "component": "popover",
-    "filePath": "docs/src/content/components/popover.mdx",
-    "urlPath": "components/popover",
-    "tags": [],
-    "type": "component",
-    "slug": "popover",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "pagination",
-    "title": "Pagination",
-    "name": "Pagination",
-    "description": "Help users navigation between multiple pages or screens as part of a set.",
-    "content": "",
-    "component": "pagination",
-    "filePath": "docs/src/content/components/pagination.mdx",
-    "urlPath": "components/pagination",
-    "tags": [],
-    "type": "component",
-    "slug": "pagination",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "pages",
-    "title": "Pages",
-    "name": "Pages",
-    "description": "Container for paginated content views.",
-    "content": "",
-    "component": "pages",
-    "filePath": "docs/src/content/components/pages.mdx",
-    "urlPath": "components/pages",
-    "tags": [],
-    "type": "component",
-    "slug": "pages",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "page-block",
-    "title": "Page Block",
-    "name": "Page Block",
-    "description": "Full-width section with optional background.",
-    "content": "",
-    "component": "page-block",
-    "filePath": "docs/src/content/components/page-block.mdx",
-    "urlPath": "components/page-block",
-    "tags": [],
-    "type": "component",
-    "slug": "page-block",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "notification",
-    "title": "Notification banner",
-    "name": "Notification banner",
-    "description": "Display important page level information or notifications.",
-    "content": "",
-    "component": "notification",
-    "filePath": "docs/src/content/components/notification.mdx",
-    "urlPath": "components/notification",
-    "tags": [],
-    "type": "component",
-    "slug": "notification",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "modal",
-    "title": "Modal",
-    "name": "Modal",
-    "description": "An overlay that appears in front of all other content, and requires a user to take an action before continuing.",
-    "content": "",
-    "component": "modal",
-    "filePath": "docs/src/content/components/modal.mdx",
-    "urlPath": "components/modal",
-    "tags": [],
-    "type": "component",
-    "slug": "modal",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "microsite-header",
-    "title": "Microsite header",
-    "name": "Microsite header",
-    "description": "Communicate what stage the service is at, connect to Alberta.ca, and gather feedback on your service.",
-    "content": "",
-    "component": "microsite-header",
-    "filePath": "docs/src/content/components/microsite-header.mdx",
-    "urlPath": "components/microsite-header",
-    "tags": [],
-    "type": "component",
-    "slug": "microsite-header",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "menu-button",
-    "title": "Menu button",
-    "name": "Menu button",
-    "description": "A button with more than one action.",
-    "content": "",
-    "component": "menu-button",
-    "filePath": "docs/src/content/components/menu-button.mdx",
-    "urlPath": "components/menu-button",
-    "tags": [],
-    "type": "component",
-    "slug": "menu-button",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "link",
-    "title": "Link",
-    "name": "Link",
-    "description": "Wraps an anchor element to add icons or margins.",
-    "content": "",
-    "component": "link",
-    "filePath": "docs/src/content/components/link.mdx",
-    "urlPath": "components/link",
-    "tags": [],
-    "type": "component",
-    "slug": "link",
-    "status": "stable",
-    "category": "utilities"
-  },
-  {
-    "id": "link-button",
-    "title": "Link Button",
-    "name": "Link Button",
-    "description": "Button styled as a link for secondary actions.",
-    "content": "",
-    "component": "link-button",
-    "filePath": "docs/src/content/components/link-button.mdx",
-    "urlPath": "components/link-button",
-    "tags": [],
-    "type": "component",
-    "slug": "link-button",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "linear-progress",
-    "title": "Linear progress indicator",
-    "name": "Linear progress indicator",
-    "description": "Provide visual feedback to users while loading.",
-    "content": "",
-    "component": "linear-progress",
-    "filePath": "docs/src/content/components/linear-progress.mdx",
-    "urlPath": "components/linear-progress",
-    "tags": [],
-    "type": "component",
-    "slug": "linear-progress",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "input",
-    "title": "Input",
-    "name": "Input",
-    "description": "A single-line field where users can input and edit text.",
-    "content": "Capture text input from users in forms.\n\n## When to use\n\nUse Input when you need users to enter:\n- Short text answers (names, email addresses)\n- Numbers (phone numbers, quantities)\n- Dates and times\n- Search queries\n\n## When not to use\n\nDon't use Input when:\n- Users need to enter multiple lines of text (use Textarea)\n- Users need to select from predefined options (use Dropdown or Radio)\n- The input requires complex formatting (consider specialized components)\n\n## Types\n\nInput supports multiple HTML input types:\n\n- **text** - General text entry (default)\n- **email** - Email addresses with validation\n- **password** - Masked password entry\n- **number** - Numeric values with stepper\n- **date** - Date picker\n- **tel** - Phone numbers\n- **search** - Search with clear button\n\n## States\n\n- **Default** - Normal interactive state\n- **Focused** - When the input has keyboard focus\n- **Error** - When validation fails\n- **Disabled** - When input is not available\n- **Read-only** - When showing value without editing\n",
-    "component": "input",
-    "filePath": "docs/src/content/components/input.mdx",
-    "urlPath": "components/input",
-    "tags": [],
-    "type": "component",
-    "slug": "input",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "icon",
-    "title": "Icons",
-    "name": "Icons",
-    "description": "A simple and universal graphic symbol representing an action, object, or concept to help guide the user.",
-    "content": "",
-    "component": "icon",
-    "filePath": "docs/src/content/components/icon.mdx",
-    "urlPath": "components/icon",
-    "tags": [],
-    "type": "component",
-    "slug": "icon",
-    "status": "stable",
-    "category": "utilities"
-  },
-  {
-    "id": "icon-button",
-    "title": "Icon button",
-    "name": "Icon button",
-    "description": "A compact button with an icon and no text.",
-    "content": "",
-    "component": "icon-button",
-    "filePath": "docs/src/content/components/icon-button.mdx",
-    "urlPath": "components/icon-button",
-    "tags": [],
-    "type": "component",
-    "slug": "icon-button",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "hero-banner",
-    "title": "Hero banner",
-    "name": "Hero banner",
-    "description": "A visual band of text, including an image and a call to action.",
-    "content": "",
-    "component": "hero-banner",
-    "filePath": "docs/src/content/components/hero-banner.mdx",
-    "urlPath": "components/hero-banner",
-    "tags": [],
-    "type": "component",
-    "slug": "hero-banner",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "grid",
-    "title": "Grid",
-    "name": "Grid",
-    "description": "Arrange a number of components into a responsive grid pattern.",
-    "content": "",
-    "component": "grid",
-    "filePath": "docs/src/content/components/grid.mdx",
-    "urlPath": "components/grid",
-    "tags": [],
-    "type": "component",
-    "slug": "grid",
-    "status": "stable",
-    "category": "utilities"
-  },
-  {
-    "id": "form",
-    "title": "Form",
-    "name": "Form",
-    "description": "Container for form inputs and validation.",
-    "content": "",
-    "component": "form",
-    "filePath": "docs/src/content/components/form.mdx",
-    "urlPath": "components/form",
-    "tags": [],
-    "type": "component",
-    "slug": "form",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "form-stepper",
-    "title": "Form stepper",
-    "name": "Form stepper",
-    "description": "Provides a visual representation of a form through a series of steps.",
-    "content": "",
-    "component": "form-stepper",
-    "filePath": "docs/src/content/components/form-stepper.mdx",
-    "urlPath": "components/form-stepper",
-    "tags": [],
-    "type": "component",
-    "slug": "form-stepper",
-    "status": "deprecated",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "form-step",
-    "title": "Form Step",
-    "name": "Form Step",
-    "description": "Individual step in a multi-step form.",
-    "content": "",
-    "component": "form-step",
-    "filePath": "docs/src/content/components/form-step.mdx",
-    "urlPath": "components/form-step",
-    "tags": [],
-    "type": "component",
-    "slug": "form-step",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "form-item",
-    "title": "Form item",
-    "name": "Form item",
-    "description": "Wraps an input control with a text label, requirement label, helper text, and error text.",
-    "content": "",
-    "component": "form-item",
-    "filePath": "docs/src/content/components/form-item.mdx",
-    "urlPath": "components/form-item",
-    "tags": [],
-    "type": "component",
-    "slug": "form-item",
-    "status": "stable",
-    "category": "utilities"
-  },
-  {
-    "id": "footer",
-    "title": "Footer",
-    "name": "Footer",
-    "description": "Provides information related your service at the bottom of every page.",
-    "content": "",
-    "component": "footer",
-    "filePath": "docs/src/content/components/footer.mdx",
-    "urlPath": "components/footer",
-    "tags": [],
-    "type": "component",
-    "slug": "footer",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "footer-nav-section",
-    "title": "Footer Nav Section",
-    "name": "Footer Nav Section",
-    "description": "Navigation links section in footer.",
-    "content": "",
-    "component": "footer-nav-section",
-    "filePath": "docs/src/content/components/footer-nav-section.mdx",
-    "urlPath": "components/footer-nav-section",
-    "tags": [],
-    "type": "component",
-    "slug": "footer-nav-section",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "footer-meta-section",
-    "title": "Footer Meta Section",
-    "name": "Footer Meta Section",
-    "description": "Copyright and legal links in footer.",
-    "content": "",
-    "component": "footer-meta-section",
-    "filePath": "docs/src/content/components/footer-meta-section.mdx",
-    "urlPath": "components/footer-meta-section",
-    "tags": [],
-    "type": "component",
-    "slug": "footer-meta-section",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "focus-trap",
-    "title": "Focus Trap",
-    "name": "Focus Trap",
-    "description": "Trap focus within a container for accessibility.",
-    "content": "",
-    "component": "focus-trap",
-    "filePath": "docs/src/content/components/focus-trap.mdx",
-    "urlPath": "components/focus-trap",
-    "tags": [],
-    "type": "component",
-    "slug": "focus-trap",
-    "status": "stable",
-    "category": "utilities"
-  },
-  {
-    "id": "filter-chip",
-    "title": "Filter chip",
-    "name": "Filter chip",
-    "description": "Allow the user to enter information, filter content, and make selections.",
-    "content": "",
-    "component": "filter-chip",
-    "filePath": "docs/src/content/components/filter-chip.mdx",
-    "urlPath": "components/filter-chip",
-    "tags": [],
-    "type": "component",
-    "slug": "filter-chip",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "file-upload-input",
-    "title": "File uploader",
-    "name": "File uploader",
-    "description": "Help users select and upload a file.",
-    "content": "",
-    "component": "file-upload-input",
-    "filePath": "docs/src/content/components/file-upload-input.mdx",
-    "urlPath": "components/file-upload-input",
-    "tags": [],
-    "type": "component",
-    "slug": "file-upload-input",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "file-upload-card",
-    "title": "File Upload Card",
-    "name": "File Upload Card",
-    "description": "Display uploaded file with actions.",
-    "content": "",
-    "component": "file-upload-card",
-    "filePath": "docs/src/content/components/file-upload-card.mdx",
-    "urlPath": "components/file-upload-card",
-    "tags": [],
-    "type": "component",
-    "slug": "file-upload-card",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "dropdown",
-    "title": "Dropdown",
-    "name": "Dropdown",
-    "description": "Present a list of options to the user to select from.",
-    "content": "",
-    "component": "dropdown",
-    "filePath": "docs/src/content/components/dropdown.mdx",
-    "urlPath": "components/dropdown",
-    "tags": [],
-    "type": "component",
-    "slug": "dropdown",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "drawer",
-    "title": "Drawer",
-    "name": "Drawer",
-    "description": "A panel that slides in from the side of the screen to display additional content or actions without navigating away from the current view.",
-    "content": "",
-    "component": "drawer",
-    "filePath": "docs/src/content/components/drawer.mdx",
-    "urlPath": "components/drawer",
-    "tags": [],
-    "type": "component",
-    "slug": "drawer",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "divider",
-    "title": "Divider",
-    "name": "Divider",
-    "description": "Indicate a separation of layout, or to distinguish large chunks of information on a page.",
-    "content": "",
-    "component": "divider",
-    "filePath": "docs/src/content/components/divider.mdx",
-    "urlPath": "components/divider",
-    "tags": [],
-    "type": "component",
-    "slug": "divider",
-    "status": "stable",
-    "category": "utilities"
-  },
-  {
-    "id": "details",
-    "title": "Details",
-    "name": "Details",
-    "description": "Let users reveal more detailed information when they need it.",
-    "content": "",
-    "component": "details",
-    "filePath": "docs/src/content/components/details.mdx",
-    "urlPath": "components/details",
-    "tags": [],
-    "type": "component",
-    "slug": "details",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "date-picker",
-    "title": "Date picker",
-    "name": "Date picker",
-    "description": "Lets users select a date through a calendar without the need to manually type it in a field.",
-    "content": "",
-    "component": "date-picker",
-    "filePath": "docs/src/content/components/date-picker.mdx",
-    "urlPath": "components/date-picker",
-    "tags": [],
-    "type": "component",
-    "slug": "date-picker",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "data-grid",
-    "title": "Data Grid",
-    "name": "Data Grid",
-    "description": "Advanced table with sorting and selection.",
-    "content": "",
-    "component": "data-grid",
-    "filePath": "docs/src/content/components/data-grid.mdx",
-    "urlPath": "components/data-grid",
-    "tags": [],
-    "type": "component",
-    "slug": "data-grid",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "container",
-    "title": "Container",
-    "name": "Container",
-    "description": "Group information, create hierarchy, and show related information.",
-    "content": "",
-    "component": "container",
-    "filePath": "docs/src/content/components/container.mdx",
-    "urlPath": "components/container",
-    "tags": [],
-    "type": "component",
-    "slug": "container",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "circular-progress",
-    "title": "Circular progress indicator",
-    "name": "Circular progress indicator",
-    "description": "Provide feedback of progress to users while loading.",
-    "content": "",
-    "component": "circular-progress",
-    "filePath": "docs/src/content/components/circular-progress.mdx",
-    "urlPath": "components/circular-progress",
-    "tags": [],
-    "type": "component",
-    "slug": "circular-progress",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "chip",
-    "title": "Chip",
-    "name": "Chip",
-    "description": "Compact element for labels, tags, or selections.",
-    "content": "",
-    "component": "chip",
-    "filePath": "docs/src/content/components/chip.mdx",
-    "urlPath": "components/chip",
-    "tags": [],
-    "type": "component",
-    "slug": "chip",
-    "status": "deprecated",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "checkbox",
-    "title": "Checkbox",
-    "name": "Checkbox",
-    "description": "Let the user select one or more options.",
-    "content": "",
-    "component": "checkbox",
-    "filePath": "docs/src/content/components/checkbox.mdx",
-    "urlPath": "components/checkbox",
-    "tags": [],
-    "type": "component",
-    "slug": "checkbox",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "checkbox-list",
-    "title": "Checkbox list",
-    "name": "Checkbox list",
-    "description": "A multiple selection input.",
-    "content": "",
-    "component": "checkbox-list",
-    "filePath": "docs/src/content/components/checkbox-list.mdx",
-    "urlPath": "components/checkbox-list",
-    "tags": [],
-    "type": "component",
-    "slug": "checkbox-list",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "card",
-    "title": "Card",
-    "name": "Card",
-    "description": "Container for grouped related content.",
-    "content": "",
-    "component": "card",
-    "filePath": "docs/src/content/components/card.mdx",
-    "urlPath": "components/card",
-    "tags": [],
-    "type": "component",
-    "slug": "card",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "card-image",
-    "title": "Card Image",
-    "name": "Card Image",
-    "description": "Image display within a card.",
-    "content": "",
-    "component": "card-image",
-    "filePath": "docs/src/content/components/card-image.mdx",
-    "urlPath": "components/card-image",
-    "tags": [],
-    "type": "component",
-    "slug": "card-image",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "card-group",
-    "title": "Card Group",
-    "name": "Card Group",
-    "description": "Layout for multiple cards.",
-    "content": "",
-    "component": "card-group",
-    "filePath": "docs/src/content/components/card-group.mdx",
-    "urlPath": "components/card-group",
-    "tags": [],
-    "type": "component",
-    "slug": "card-group",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "card-content",
-    "title": "Card Content",
-    "name": "Card Content",
-    "description": "Content area within a card.",
-    "content": "",
-    "component": "card-content",
-    "filePath": "docs/src/content/components/card-content.mdx",
-    "urlPath": "components/card-content",
-    "tags": [],
-    "type": "component",
-    "slug": "card-content",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "card-actions",
-    "title": "Card Actions",
-    "name": "Card Actions",
-    "description": "Action buttons within a card footer.",
-    "content": "",
-    "component": "card-actions",
-    "filePath": "docs/src/content/components/card-actions.mdx",
-    "urlPath": "components/card-actions",
-    "tags": [],
-    "type": "component",
-    "slug": "card-actions",
-    "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "callout",
-    "title": "Callout",
-    "name": "Callout",
-    "description": "Communicate important information through a strong visual emphasis.",
-    "content": "",
-    "component": "callout",
-    "filePath": "docs/src/content/components/callout.mdx",
-    "urlPath": "components/callout",
-    "tags": [],
-    "type": "component",
-    "slug": "callout",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "calendar",
-    "title": "Calendar",
-    "name": "Calendar",
-    "description": "Visual calendar for date selection.",
-    "content": "",
-    "component": "calendar",
-    "filePath": "docs/src/content/components/calendar.mdx",
-    "urlPath": "components/calendar",
-    "tags": [],
-    "type": "component",
-    "slug": "calendar",
-    "status": "stable",
-    "category": "utilities"
-  },
-  {
-    "id": "button",
-    "title": "Button",
-    "name": "Button",
-    "description": "Carry out an important action or navigate to another page.",
-    "content": "",
-    "component": "button",
-    "filePath": "docs/src/content/components/button.mdx",
-    "urlPath": "components/button",
-    "tags": [],
-    "type": "component",
-    "slug": "button",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "button-group",
-    "title": "Button group",
-    "name": "Button group",
-    "description": "Display multiple related actions stacked or in a horizontal row to help with arrangement and spacing.",
-    "content": "",
-    "component": "button-group",
-    "filePath": "docs/src/content/components/button-group.mdx",
-    "urlPath": "components/button-group",
-    "tags": [],
-    "type": "component",
-    "slug": "button-group",
-    "status": "stable",
-    "category": "inputs-and-actions"
-  },
-  {
-    "id": "block",
-    "title": "Block",
-    "name": "Block",
-    "description": "Group components into a block with consistent space between.",
-    "content": "",
-    "component": "block",
-    "filePath": "docs/src/content/components/block.mdx",
-    "urlPath": "components/block",
-    "tags": [],
-    "type": "component",
-    "slug": "block",
-    "status": "stable",
-    "category": "utilities"
-  },
-  {
-    "id": "badge",
-    "title": "Badge",
-    "name": "Badge",
-    "description": "Small labels which hold small amounts of information, system feedback, or states.",
-    "content": "",
-    "component": "badge",
-    "filePath": "docs/src/content/components/badge.mdx",
-    "urlPath": "components/badge",
-    "tags": [],
-    "type": "component",
-    "slug": "badge",
-    "status": "stable",
-    "category": "feedback-and-alerts"
-  },
-  {
-    "id": "app-header",
-    "title": "Header",
-    "name": "Header",
-    "description": "Provide structure to help users find their way around the service.",
-    "content": "",
-    "component": "app-header",
-    "filePath": "docs/src/content/components/app-header.mdx",
-    "urlPath": "components/app-header",
-    "tags": [],
-    "type": "component",
-    "slug": "app-header",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
-    "id": "app-header-menu",
-    "title": "App Header Menu",
-    "name": "App Header Menu",
-    "description": "Menu items within the app header.",
-    "content": "",
-    "component": "app-header-menu",
-    "filePath": "docs/src/content/components/app-header-menu.mdx",
-    "urlPath": "components/app-header-menu",
-    "tags": [],
-    "type": "component",
-    "slug": "app-header-menu",
-    "status": "stable",
-    "category": "structure-and-navigation"
-  },
-  {
     "id": "accordion",
-    "title": "Accordion",
     "name": "Accordion",
     "description": "Let users show and hide sections of related content on a page.",
-    "content": "",
-    "component": "accordion",
-    "filePath": "docs/src/content/components/accordion.mdx",
-    "urlPath": "components/accordion",
-    "tags": [],
+    "status": "stable",
+    "category": "content-layout",
+    "tags": [
+      "expand",
+      "blind",
+      "collapse",
+      "content layout",
+      "expandable panel",
+      "expand"
+    ],
+    "slug": "accordion"
+  },
+  {
     "type": "component",
-    "slug": "accordion",
+    "id": "app-header",
+    "name": "Header",
+    "description": "Provide structure to help users find their way around the service.",
     "status": "stable",
-    "category": "content-layout"
-  },
-  {
-    "id": "example-warn-a-user-of-a-deadline",
-    "title": "Warn a user of a deadline",
-    "description": "Use a modal with important callout styling to warn users about time-sensitive deadlines that could affect their submission or action. ",
-    "content": "Use a modal with important callout styling to warn users about time-sensitive deadlines that could affect their submission or action.\n\n## When to use\n\nUse this pattern when:\n- Users are about to take an action with a time constraint\n- Missing a deadline could have significant consequences\n- The warning requires acknowledgment before proceeding\n\n## Considerations\n\n- Be specific about the deadline (time, date, timezone)\n- Explain the consequences of missing the deadline\n- Provide a clear acknowledgment action\n- Use the \"important\" callout variant for urgency\n- Keep the message concise but informative\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/warn-a-user-of-a-deadline/index.mdx",
-    "urlPath": "examples/warn-a-user-of-a-deadline",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "warn-a-user-of-a-deadline",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-type-to-create-a-new-filter",
-    "title": "Type to create a new filter",
-    "description": "Allow users to type custom filter values and create filter chips by pressing Enter, with the ability to remove chips using Backspace or by clicking them. ",
-    "content": "Allow users to type custom filter values and create filter chips by pressing Enter, with the ability to remove chips using Backspace or by clicking them.\n\n## When to use\n\nUse this pattern when:\n- Users need to create custom filter values not from a predefined list\n- Free-form text filtering is appropriate for the data\n- Users may want to quickly add multiple related filters\n\n## Considerations\n\n- Clear the input after a chip is created\n- Allow Backspace to delete the last chip when the input is empty\n- Provide visual feedback as chips are added\n- Consider input validation before creating chips\n- Show chips inline with the input for clear association\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/type-to-create-a-new-filter/index.mdx",
-    "urlPath": "examples/type-to-create-a-new-filter",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "type-to-create-a-new-filter",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-task-list-page",
-    "title": "Task list page",
-    "description": "A task list page provides a structure for multi-step services, showing users their progress through a series of tasks with clear status indicators. ",
-    "content": "A task list page provides a structure for multi-step services, showing users their progress through a series of tasks with clear status indicators.\n\n## When to use\n\nUse this pattern when:\n- A service has multiple distinct tasks or sections to complete\n- Users need to see their overall progress\n- Tasks can potentially be completed in different orders\n- Users may return to complete tasks over multiple sessions\n\n## Considerations\n\n- Group related actions into logical tasks\n- Show status badges for each task (Completed, In progress, Not started, Cannot start yet)\n- Include a summary callout showing how many sections are complete\n- Allow users to complete tasks in any order when possible\n- Clearly indicate when tasks have dependencies\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/task-list-page/index.mdx",
-    "urlPath": "examples/task-list-page",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "task-list-page",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-start-page",
-    "title": "Start page",
-    "description": "A start page is the front door to a government service for citizens. It provides essential information about the service and a clear call to action to begin. ",
-    "content": "A start page is the front door to a government service for citizens. It provides essential information about the service and a clear call to action to begin.\n\n## When to use\n\nUse this pattern when:\n- Creating the entry point for a citizen-facing government service\n- Citizens need to understand what the service does before starting\n- You need to communicate prerequisites, time estimates, or required documents\n\n## Considerations\n\n- Keep the overview concise and focused on what users can do\n- List what documents or information users will need\n- Include an estimated completion time\n- Use a prominent \"Get started\" or \"Start now\" button\n- Provide contact information and alternative ways to access the service below the main call to action\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/start-page/index.mdx",
-    "urlPath": "examples/start-page",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "start-page",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-sort-data-in-a-table",
-    "title": "Sort data in a table",
-    "description": "Enable column sorting in tables using sort headers, allowing workers to organize data by clicking column headers to toggle ascending/descending order. ",
-    "content": "Enable column sorting in tables using sort headers, allowing workers to organize data by clicking column headers to toggle ascending/descending order.\n\n## When to use\n\nUse this pattern when:\n- Workers need to organize tabular data by different columns\n- Data sets are large enough that sorting improves usability\n- Multiple columns could reasonably be used as sort criteria\n\n## Considerations\n\n- Indicate the current sort direction with visual cues\n- Set a sensible default sort order when the table loads\n- Consider which columns should be sortable based on data type\n- Numeric columns typically sort numerically, text columns alphabetically\n- Maintain sort state when data updates if appropriate\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/sort-data-in-a-table/index.mdx",
-    "urlPath": "examples/sort-data-in-a-table",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "sort-data-in-a-table",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-slotted-helper-text-in-a-form-item",
-    "title": "Slotted helper text in a form item",
-    "description": "Use the helpText slot in a form item to display formatted helper text with custom styling like bold, italic, or links. ",
-    "content": "Use the helpText slot in a form item to display formatted helper text with custom styling like bold, italic, or links.\n\n## When to use\n\nUse this pattern when:\n- You need to display helper text with custom formatting\n- Helper text requires links to additional resources\n- Standard string-based helper text is insufficient\n\n## Considerations\n\n- Keep helper text concise and relevant to the field\n- Use formatting to highlight important information\n- Ensure helper text is accessible to screen readers\n- Consider using links to provide additional guidance without cluttering the form\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/slotted-helper-text-in-a-form-item/index.mdx",
-    "urlPath": "examples/slotted-helper-text-in-a-form-item",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "slotted-helper-text-in-a-form-item",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-slotted-error-text-in-a-form-item",
-    "title": "Slotted error text in a form item",
-    "description": "Use the error slot in a form item to display formatted error messages with custom styling like bold or italic text. ",
-    "content": "Use the error slot in a form item to display formatted error messages with custom styling like bold or italic text.\n\n## When to use\n\nUse this pattern when:\n- You need to display error messages with custom formatting\n- Error text requires links, bold, or other inline styling\n- Standard string-based error messages are insufficient\n\n## Considerations\n\n- Keep error messages clear and actionable\n- Use formatting sparingly to highlight key information\n- Ensure error text is accessible and readable by screen readers\n- The input component should also have its error prop set to true for proper styling\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/slotted-error-text-in-a-form-item/index.mdx",
-    "urlPath": "examples/slotted-error-text-in-a-form-item",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "slotted-error-text-in-a-form-item",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-version-number",
-    "title": "Show version number",
-    "description": "Display version information in the microsite header using the version slot, allowing custom formatting and styling of version text. ",
-    "content": "Display version information in the microsite header using the version slot, allowing custom formatting and styling of version text.\n\n## When to use\n\nUse this pattern when:\n- You need to display a version number or status in the header\n- The service is in alpha or beta phase\n- You want to include formatted version information\n\n## Considerations\n\n- Use the version slot for custom version content with formatting\n- Keep version text concise and clear\n- Combine with header type (alpha, beta, live) to indicate service maturity\n- Version information should be easily scannable\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-version-number/index.mdx",
-    "urlPath": "examples/show-version-number",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-version-number",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-status-on-a-card",
-    "title": "Show status on a card",
-    "description": "Display status indicators on cards using badges in the actions slot, allowing workers to quickly see the priority or state of each item. ",
-    "content": "Display status indicators on cards using badges in the actions slot, allowing workers to quickly see the priority or state of each item.\n\n## When to use\n\nUse this pattern when:\n- Displaying items in a card-based layout that have status or priority levels\n- Workers need to quickly identify high-priority or important items\n- Status should be prominently visible in the card header area\n\n## Considerations\n\n- Use the actions slot to position the badge in the card header\n- Choose badge types that clearly communicate priority or status\n- Keep badge content concise (one or two words)\n- Ensure the card heading and badge work well together visually\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-status-on-a-card/index.mdx",
-    "urlPath": "examples/show-status-on-a-card",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-status-on-a-card",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-status-in-a-table",
-    "title": "Show status in a table",
-    "description": "Display status information within table rows using badges to provide clear visual indicators of item states like pending, complete, failed, or in progress. ",
-    "content": "Display status information within table rows using badges to provide clear visual indicators of item states like pending, complete, failed, or in progress.\n\n## When to use\n\nUse this pattern when:\n- Displaying lists of items that have different status states\n- Workers need to quickly scan and identify items requiring action\n- Status needs to be immediately visible alongside other item data\n\n## Considerations\n\n- Use consistent badge types for similar statuses across your application\n- Choose badge colors that clearly differentiate between states (success, warning, error, info)\n- Include action buttons to allow workers to act on items directly from the table\n- Align status badges consistently within the column\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-status-in-a-table/index.mdx",
-    "urlPath": "examples/show-status-in-a-table",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-status-in-a-table",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-quick-links",
-    "title": "Show quick links",
-    "description": "Use the app footer meta section to display essential quick links like feedback, accessibility, privacy, and contact information without the full navigation structure. ",
-    "content": "Use the app footer meta section to display essential quick links like feedback, accessibility, privacy, and contact information without the full navigation structure.\n\n## When to use\n\nUse this pattern when:\n- Building a simpler service that doesn't need full navigation\n- Essential utility links are required in the footer\n- The service needs quick access to feedback/contact\n- Full footer navigation would be excessive\n\n## Considerations\n\n- Keep the meta section links focused and essential\n- Include accessibility and privacy links as required\n- Order links by importance or frequency of use\n- Use consistent link text across government services\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-quick-links/index.mdx",
-    "urlPath": "examples/show-quick-links",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-quick-links",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-number-of-results-per-page",
-    "title": "Show number of results per page",
-    "description": "Combine pagination with a dropdown selector to let users control how many results appear per page, improving data browsing for different use cases. ",
-    "content": "Combine pagination with a dropdown selector to let users control how many results appear per page, improving data browsing for different use cases.\n\n## When to use\n\nUse this pattern when:\n- Displaying paginated data in tables\n- Users may want to see more or fewer items\n- Different tasks benefit from different page sizes\n- The total result count should be visible\n\n## Considerations\n\n- Show \"of X\" to indicate total results\n- Reset to page 1 when changing page size\n- Use reasonable default (10 is common)\n- Provide sensible options (10, 20, 30, etc.)\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-number-of-results-per-page/index.mdx",
-    "urlPath": "examples/show-number-of-results-per-page",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-number-of-results-per-page",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-multiple-tags-together",
-    "title": "Show multiple tags together",
-    "description": "Display multiple badges together using GoabBlock with tight spacing to show multiple statuses or categories for a single item. ",
-    "content": "Display multiple badges together using GoabBlock with tight spacing to show multiple statuses or categories for a single item.\n\n## When to use\n\nUse this pattern when:\n- An item has multiple statuses or categories\n- You need to show related metadata together\n- Visual grouping of badges improves scanning\n- Items can have multiple applicable labels\n\n## Considerations\n\n- Use `gap=\"xs\"` for tight spacing between badges\n- Keep badge count reasonable (2-4 typically)\n- Choose badge types that provide visual contrast\n- Consider reading order and importance\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-multiple-tags-together/index.mdx",
-    "urlPath": "examples/show-multiple-tags-together",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-multiple-tags-together",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-multiple-actions-in-a-compact-table",
-    "title": "Show multiple actions in a compact table",
-    "description": "Use icon buttons to provide multiple row actions in tables where space is limited, keeping the interface compact while maintaining accessibility through aria labels. ",
-    "content": "Use icon buttons to provide multiple row actions in tables where space is limited, keeping the interface compact while maintaining accessibility through aria labels.\n\n## When to use\n\nUse this pattern when:\n- Tables need multiple actions per row\n- Horizontal space is limited\n- Workers are familiar with icon meanings\n- Actions are common (edit, flag, send, etc.)\n\n## Considerations\n\n- Always include aria-label for accessibility\n- Use small size icon buttons for compact tables\n- Group related actions with GoabBlock\n- Ensure icons are universally understood\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-multiple-actions-in-a-compact-table/index.mdx",
-    "urlPath": "examples/show-multiple-actions-in-a-compact-table",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-multiple-actions-in-a-compact-table",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-more-information-to-help-answer-a-question",
-    "title": "Show more information to help answer a question",
-    "description": "Use the Details component to provide optional contextual help that explains why a question is being asked, helping users understand the purpose without cluttering the main form. ",
-    "content": "Use the Details component to provide optional contextual help that explains why a question is being asked, helping users understand the purpose without cluttering the main form.\n\n## When to use\n\nUse this pattern when:\n- Users may wonder why a question is being asked\n- Additional context helps users answer correctly\n- The information is optional and shouldn't distract\n- Following question page patterns for citizen services\n\n## Considerations\n\n- Place the details component after the question input\n- Use a clear heading like \"Why are we asking this question?\"\n- Keep the expanded content concise and helpful\n- Include helper text for the main question when appropriate\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-more-information-to-help-answer-a-question/index.mdx",
-    "urlPath": "examples/show-more-information-to-help-answer-a-question",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-more-information-to-help-answer-a-question",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-links-to-navigation-items",
-    "title": "Show links to navigation items",
-    "description": "Use the app footer to display comprehensive navigation links organized into sections, along with meta links for common utilities like privacy and accessibility. ",
-    "content": "Use the app footer to display comprehensive navigation links organized into sections, along with meta links for common utilities like privacy and accessibility.\n\n## When to use\n\nUse this pattern when:\n- Building a full-featured government service\n- Users need access to site-wide navigation in the footer\n- Meta links (privacy, accessibility, etc.) are required\n- Organizing footer links into logical categories helps navigation\n\n## Considerations\n\n- Group related links in the nav section\n- Keep meta section for utility links (privacy, accessibility, contact)\n- Control column layout with maxColumnCount prop\n- Ensure all links are properly labeled and functional\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-links-to-navigation-items/index.mdx",
-    "urlPath": "examples/show-links-to-navigation-items",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-links-to-navigation-items",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-full-date-in-a-tooltip",
-    "title": "Show full date in a tooltip",
-    "description": "Display relative time (like \"4 hours ago\") while providing the full date and time on hover via tooltip for users who need exact timestamps. ",
-    "content": "Display relative time (like \"4 hours ago\") while providing the full date and time on hover via tooltip for users who need exact timestamps.\n\n## When to use\n\nUse this pattern when:\n- Displaying relative time like \"4 hours ago\" or \"2 days ago\"\n- Users may need access to the exact date and time\n- Space is limited for full date display\n- Context cards or comments show timestamps\n\n## Considerations\n\n- Keep the relative time format consistent\n- Include both date and time in the tooltip\n- Style the hoverable text subtly (secondary color, smaller font)\n- Ensure tooltip is keyboard accessible\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-full-date-in-a-tooltip/index.mdx",
-    "urlPath": "examples/show-full-date-in-a-tooltip",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-full-date-in-a-tooltip",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-different-views-of-data-in-a-table",
-    "title": "Show different views of data in a table",
-    "description": "Use tabs to organize table data into different views based on status or category, showing counts in each tab to help workers quickly navigate to relevant items. ",
-    "content": "Use tabs to organize table data into different views based on status or category, showing counts in each tab to help workers quickly navigate to relevant items.\n\n## When to use\n\nUse this pattern when:\n- Workers need to view data filtered by status\n- Different subsets of data require focused attention\n- Quick access to counts of items in each category is helpful\n- Switching between views should preserve context\n\n## Considerations\n\n- Show counts in tab headers using badges\n- Maintain consistent table structure across tabs\n- Default to the most commonly used view\n- Consider which statuses need prominent display\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-different-views-of-data-in-a-table/index.mdx",
-    "urlPath": "examples/show-different-views-of-data-in-a-table",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-different-views-of-data-in-a-table",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-a-user-progress-when-the-time-is-unknown",
-    "title": "Show a user progress when the time is unknown",
-    "description": "Display indeterminate progress for operations where completion time cannot be estimated, such as complex searches or external system queries. ",
-    "content": "Display indeterminate progress for operations where completion time cannot be estimated, such as complex searches or external system queries.\n\n## When to use\n\nUse this pattern when:\n- The operation duration cannot be predicted\n- You're querying external systems with variable response times\n- Searching across multiple data sources\n- Users need to know something is happening but not a specific percentage\n\n## Considerations\n\n- Use `type=\"indeterminate\"` for unknown duration operations\n- Always provide a cancel option\n- Show success or failure notification when complete\n- Include meaningful context in the notification message\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-a-user-progress-when-the-time-is-unknown/index.mdx",
-    "urlPath": "examples/show-a-user-progress-when-the-time-is-unknown",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-a-user-progress-when-the-time-is-unknown",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-a-user-progress",
-    "title": "Show a user progress",
-    "description": "Display progress feedback during long-running operations like downloads, showing percentage completion with the ability to cancel and receive success confirmation. ",
-    "content": "Display progress feedback during long-running operations like downloads, showing percentage completion with the ability to cancel and receive success confirmation.\n\n## When to use\n\nUse this pattern when:\n- An operation takes more than a few seconds\n- Progress can be measured as a percentage (0-100%)\n- Users need the ability to cancel the operation\n- Success or failure confirmation is needed\n\n## Considerations\n\n- Always provide a cancel option for long operations\n- Show a success notification when complete\n- Use `type=\"progress\"` for operations with known duration\n- Handle errors gracefully with failure notifications\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-a-user-progress/index.mdx",
-    "urlPath": "examples/show-a-user-progress",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-a-user-progress",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions",
-    "title": "Show a simple progress indicator on a question page with multiple questions",
-    "description": "Show a simple progress indicator on a question page when grouping multiple related questions together. ",
-    "content": "Show a simple progress indicator on a question page when grouping multiple related questions together.\n\n## When to use\n\nUse this pattern when:\n- Grouping multiple related questions on a single page improves the user experience\n- The questions form a logical unit (e.g., personal information fields)\n- Users benefit from progress tracking across the form\n- A step-based indicator shows progress through form sections\n\n## Considerations\n\n- Display progress as \"Step X of Y\" when grouping questions into sections\n- Include a clear section heading that describes the group of questions\n- Use a subdued text color for the progress indicator\n- Include a back link for navigation to previous sections\n- Position related questions close together with consistent spacing\n- The `leadingContent` prop on inputs can add prefixes like country codes\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions/index.mdx",
-    "urlPath": "examples/show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-a-simple-progress-indicator-on-a-question-page",
-    "title": "Show a simple progress indicator on a question page",
-    "description": "Show a simple progress indicator on a question page to help users understand their progress through the form. ",
-    "content": "Show a simple progress indicator on a question page to help users understand their progress through the form.\n\n## When to use\n\nUse this pattern when:\n- Building a multi-question form where progress tracking helps users\n- Users benefit from knowing how many questions remain\n- The form has a linear flow with a known number of questions\n- Following the one-question-per-page pattern for government services\n\n## Considerations\n\n- Display progress as \"Question X of Y\" for clarity\n- Use a subdued text color for the progress indicator\n- Include a back link for navigation to previous questions\n- Position the progress indicator above the question\n- Keep the format consistent throughout the form\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-a-simple-progress-indicator-on-a-question-page/index.mdx",
-    "urlPath": "examples/show-a-simple-progress-indicator-on-a-question-page",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-a-simple-progress-indicator-on-a-question-page",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-a-section-title-on-a-question-page",
-    "title": "Show a section title on a question page",
-    "description": "Show a section title on a question page to help users understand which part of the form they are completing. ",
-    "content": "Show a section title on a question page to help users understand which part of the form they are completing.\n\n## When to use\n\nUse this pattern when:\n- Building multi-section forms where context helps users\n- Users need to know which category of questions they are answering\n- The form is divided into logical sections like \"Personal information\"\n- Following the one-question-per-page pattern for government services\n\n## Considerations\n\n- Use a subdued text color for the section title to differentiate from the question\n- Include a back link for navigation to previous questions\n- The section title should appear above the question\n- Use consistent spacing between the back link, section title, and question\n- Keep section titles concise and descriptive\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-a-section-title-on-a-question-page/index.mdx",
-    "urlPath": "examples/show-a-section-title-on-a-question-page",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-a-section-title-on-a-question-page",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-a-notification-with-an-action",
-    "title": "Show a notification with an action",
-    "description": "Show a temporary notification with an action button for user interaction. ",
-    "content": "Show a temporary notification with an action button for user interaction.\n\n## When to use\n\nUse this pattern when:\n- Users need to take action in response to a notification\n- Providing a quick way to navigate to related content\n- Showing activity notifications that users may want to respond to\n- The action should dismiss the notification when clicked\n\n## Considerations\n\n- Use `actionText` to set the button label in the notification\n- The `action` callback receives the notification UUID for dismissal\n- Use `TemporaryNotification.dismiss(uuid)` to close the notification programmatically\n- Keep action text short and clear (e.g., \"View\", \"Undo\", \"Open\")\n- Consider what happens if the user doesn't click the action before auto-dismiss\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-a-notification-with-an-action/index.mdx",
-    "urlPath": "examples/show-a-notification-with-an-action",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-a-notification-with-an-action",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-a-notification",
-    "title": "Show a notification",
-    "description": "Show a temporary notification to confirm an action was completed successfully. ",
-    "content": "Show a temporary notification to confirm an action was completed successfully.\n\n## When to use\n\nUse this pattern when:\n- Confirming that a save operation completed successfully\n- Providing immediate feedback after a user action\n- The notification should automatically dismiss after a few seconds\n- Users need non-intrusive confirmation of their action\n\n## Considerations\n\n- Use the `type` option to indicate the nature of the notification (success, information, etc.)\n- Import `TemporaryNotification` from `@abgov/ui-components-common`\n- Include a `<GoabTemporaryNotificationCtrl />` component in your app to render notifications\n- Keep notification messages concise and action-oriented\n- Notifications auto-dismiss after a default duration\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-a-notification/index.mdx",
-    "urlPath": "examples/show-a-notification",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-a-notification",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-a-list-to-help-answer-a-question",
-    "title": "Show a list to help answer a question",
-    "description": "Show a list to help answer a question using an expandable details component. ",
-    "content": "Show a list to help answer a question using an expandable details component.\n\n## When to use\n\nUse this pattern when:\n- Users need clarification about what items qualify for a question\n- You want to provide examples of what to include or exclude\n- The guidance content would clutter the form if always visible\n- Users can make better decisions with reference information\n\n## Considerations\n\n- Place the details component after the form question it relates to\n- Use clear headings within the details to organize content\n- Include both \"examples of\" and \"do not include\" lists when relevant\n- Keep the details heading phrased as a question to indicate it provides clarification\n- Ensure the expanded content is easy to scan with clear formatting\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-a-list-to-help-answer-a-question/index.mdx",
-    "urlPath": "examples/show-a-list-to-help-answer-a-question",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-a-list-to-help-answer-a-question",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-show-a-label-on-an-icon-only-button",
-    "title": "Show a label on an icon only button",
-    "description": "Show a label on an icon-only button using a tooltip to improve discoverability. ",
-    "content": "Show a label on an icon-only button using a tooltip to improve discoverability.\n\n## When to use\n\nUse this pattern when:\n- Using icon buttons without visible text labels\n- Users might not recognize what an icon means\n- You want to provide context for icon-only actions\n- Building toolbars or action bars with multiple icon buttons\n\n## Considerations\n\n- Always include an `ariaLabel` on icon buttons for screen reader accessibility\n- Tooltips provide visual context but should not be the only way to understand the action\n- Keep tooltip content short and descriptive\n- Group related icon buttons together using a button group\n- Consider using text labels instead of tooltips for critical actions\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/show-a-label-on-an-icon-only-button/index.mdx",
-    "urlPath": "examples/show-a-label-on-an-icon-only-button",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "show-a-label-on-an-icon-only-button",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-set-the-status-of-step-on-a-form-stepper",
-    "title": "Set the status of step on a form stepper",
-    "description": "Set the status of each step on a form stepper to indicate completion progress. ",
-    "content": "Set the status of each step on a form stepper to indicate completion progress.\n\n## When to use\n\nUse this pattern when:\n- Building multi-step forms that need visual progress indication\n- Users need to see which steps are complete, incomplete, or not started\n- You want to provide clear navigation through a complex form process\n- Form completion status needs to be tracked and displayed\n\n## Considerations\n\n- The status property accepts \"complete\", \"incomplete\", or \"not-started\" values\n- Status is controlled by the application based on form completion\n- Consider updating step status as users complete each section\n- Provide clear Previous/Next navigation to move between steps\n- The form stepper can be clicked to navigate directly to completed steps\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/set-the-status-of-step-on-a-form-stepper/index.mdx",
-    "urlPath": "examples/set-the-status-of-step-on-a-form-stepper",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "set-the-status-of-step-on-a-form-stepper",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-set-a-specific-tab-to-be-active",
-    "title": "Set a specific tab to be active",
-    "description": "Set a specific tab to be active on page load using the initialTab property. ",
-    "content": "Set a specific tab to be active on page load using the initialTab property.\n\n## When to use\n\nUse this pattern when:\n- You want to load a specific tab as the default active tab\n- Users should start viewing a particular tab based on context\n- Deep linking to specific tab content is required\n- Showing priority content like items requiring attention\n\n## Considerations\n\n- The `initialTab` property uses zero-based indexing (0 = first tab, 1 = second tab, etc.)\n- Consider which tab provides the most relevant content for users on initial load\n- Badge counts in tab headings help users understand the volume of items in each tab\n- Ensure tab content is accessible and keyboard navigable\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/set-a-specific-tab-to-be-active/index.mdx",
-    "urlPath": "examples/set-a-specific-tab-to-be-active",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "set-a-specific-tab-to-be-active",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-set-a-max-width-on-a-long-radio-item",
-    "title": "Set a max width on a long radio item",
-    "description": "Set a max width on a long radio item to control line wrapping. ",
-    "content": "Set a max width on a long radio item to control line wrapping.\n\n## When to use\n\nUse this pattern when:\n- You have radio options with long labels that need width control\n- You want to prevent radio items from becoming too wide on large screens\n- You need consistent radio item sizing across different viewport sizes\n\n## Considerations\n\n- The `maxWidth` property accepts CSS width values like \"300px\" or \"20ch\"\n- Consider the reading experience when setting max widths\n- Ensure the max width still allows for readable label text\n- Use consistent max widths across similar form elements for visual harmony\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/set-a-max-width-on-a-long-radio-item/index.mdx",
-    "urlPath": "examples/set-a-max-width-on-a-long-radio-item",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "set-a-max-width-on-a-long-radio-item",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-select-one-or-more-from-a-list-of-options",
-    "title": "Select one or more from a list of options",
-    "description": "Use checkboxes to let users select one or more options from a list when multiple selections are valid. ",
-    "content": "Use checkboxes to let users select one or more options from a list when multiple selections are valid.\n\n## When to use\n\nUse this pattern when:\n- Users can select multiple options from a predefined list\n- All options that apply should be selected\n- The list of options is relatively short (up to ~7 items)\n- Each option is independent of the others\n\n## Considerations\n\n- Use clear, concise labels for each option\n- Include help text like \"Choose all that apply\" to indicate multiple selection\n- Consider the order of options (most common first, alphabetical, etc.)\n- For longer lists, consider a different component like multi-select dropdown\n- Ensure adequate touch targets for mobile users\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/select-one-or-more-from-a-list-of-options/index.mdx",
-    "urlPath": "examples/select-one-or-more-from-a-list-of-options",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "select-one-or-more-from-a-list-of-options",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-search",
-    "title": "Search",
-    "description": "A search input pattern with a search icon and button for users to find content or filter results. ",
-    "content": "A search input pattern with a search icon and button for users to find content or filter results.\n\n## When to use\n\nUse this pattern when:\n- Users need to search through content or data\n- Filtering a list or table by text input\n- Providing a site-wide or section search\n- Quick access to specific records is needed\n\n## Considerations\n\n- Include a leading search icon for clear affordance\n- Use an explicit search button for clarity\n- Consider search suggestions or autocomplete for large datasets\n- Provide clear feedback when no results are found\n- Keep the search input appropriately sized for expected query length\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/search/index.mdx",
-    "urlPath": "examples/search",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "search",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-review-page",
-    "title": "Review page",
-    "description": "A review page where users can check their answers before submitting a form, with options to change individual responses. ",
-    "content": "A review page where users can check their answers before submitting a form, with options to change individual responses.\n\n## When to use\n\nUse this pattern when:\n- Users need to review their form answers before submission\n- At the end of a multi-step form or wizard\n- Before finalizing applications or important submissions\n- When accuracy of submitted information is critical\n\n## Considerations\n\n- Display all answered questions with current values\n- Provide \"Change\" links for each answer\n- Show \"Not provided\" for skipped optional questions\n- Include visually hidden text in change links for accessibility\n- Consider grouping related answers under section headings\n- For large forms, consider review pages at the end of each section\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/review-page/index.mdx",
-    "urlPath": "examples/review-page",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "review-page",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-review-and-action",
-    "title": "Review and action",
-    "description": "A side-by-side layout for workers to review case details while taking an action, commonly used in case management and approval workflows. ",
-    "content": "A side-by-side layout for workers to review case details while taking an action, commonly used in case management and approval workflows.\n\n## When to use\n\nUse this pattern when:\n- Workers need to review information while making decisions\n- Processing applications, requests, or case files\n- The decision requires context from existing case data\n- Actions like approve, deny, or escalate are needed\n\n## Considerations\n\n- Place read-only review information on the left\n- Place action form controls on the right\n- Use containers to group related information\n- Provide clear labels for all case details\n- Include reason fields when denying requests\n- Consider responsive behavior for smaller screens\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/review-and-action/index.mdx",
-    "urlPath": "examples/review-and-action",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "review-and-action",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-reveal-input-based-on-a-selection",
-    "title": "Reveal input based on a selection",
-    "description": "Progressively reveal additional form fields based on user selections, reducing visual complexity while gathering necessary information. ",
-    "content": "Progressively reveal additional form fields based on user selections, reducing visual complexity while gathering necessary information.\n\n## When to use\n\nUse this pattern when:\n- Additional information is only needed for certain options\n- You want to reduce initial form complexity\n- Follow-up questions depend on user choices\n- Creating a more focused, less overwhelming form experience\n\n## Considerations\n\n- The revealed input should appear directly below the triggering selection\n- Use clear labels that explain what information is needed\n- Ensure the reveal animation is smooth and noticeable\n- Consider what happens to data if the user changes their selection\n- Works with both radio groups (single selection) and checkboxes (multiple selections)\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/reveal-input-based-on-a-selection/index.mdx",
-    "urlPath": "examples/reveal-input-based-on-a-selection",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "reveal-input-based-on-a-selection",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-result-page",
-    "title": "Result page",
-    "description": "A result page shown after form submission to confirm success, provide next steps, and offer relevant contact information. ",
-    "content": "A result page shown after form submission to confirm success, provide next steps, and offer relevant contact information.\n\n## When to use\n\nUse this pattern when:\n- A user has submitted a form or application\n- You need to confirm successful completion of a process\n- There is important follow-up information to communicate\n- Users need reference numbers or confirmation details\n\n## Considerations\n\n- Include a reference number if applicable\n- Clearly explain what happens next and when\n- Provide a way to save or print the confirmation\n- Include service contact information for questions\n- Link to feedback forms and related services\n- Keep the success message clear and reassuring\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/result-page/index.mdx",
-    "urlPath": "examples/result-page",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "result-page",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-reset-date-picker-field",
-    "title": "Reset date picker field",
-    "description": "Allow users to programmatically set or clear a date picker field value, useful for reset functionality or setting default dates. ",
-    "content": "Allow users to programmatically set or clear a date picker field value, useful for reset functionality or setting default dates.\n\n## When to use\n\nUse this pattern when:\n- Users need to clear a date field to start over\n- You need to set a default or suggested date value\n- Providing quick actions to modify date values\n- Building forms with reset functionality\n\n## Considerations\n\n- Provide clear button labels indicating the action\n- Consider whether clearing should also reset validation state\n- The date picker should update immediately when set or cleared\n- Consider providing a confirmation for clearing important dates\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/reset-date-picker-field/index.mdx",
-    "urlPath": "examples/reset-date-picker-field",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "reset-date-picker-field",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-require-user-action-before-continuing",
-    "title": "Require user action before continuing",
-    "description": "Use a modal dialog to require users to confirm an action before proceeding, especially for irreversible operations or important decision points. ",
-    "content": "Use a modal dialog to require users to confirm an action before proceeding, especially for irreversible operations or important decision points.\n\n## When to use\n\nUse this pattern when:\n- The user is about to perform an action that cannot be undone\n- Navigation will cause data loss or prevent returning\n- Important information needs acknowledgment before proceeding\n- Users should confirm before submitting important forms\n\n## Considerations\n\n- Clearly explain the consequences of continuing\n- Provide a way to go back or cancel\n- Use clear, action-oriented button labels\n- Keep the modal content concise and focused\n- Ensure the primary action stands out from secondary options\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/require-user-action-before-continuing/index.mdx",
-    "urlPath": "examples/require-user-action-before-continuing",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "require-user-action-before-continuing",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-remove-a-filter",
-    "title": "Remove a filter",
-    "description": "Allow users to remove active filters by clicking on filter chips, providing clear visual feedback and dynamic updates to filtered results. ",
-    "content": "Allow users to remove active filters by clicking on filter chips, providing clear visual feedback and dynamic updates to filtered results.\n\n## When to use\n\nUse this pattern when:\n- Users have applied filters that need to be removable\n- You want to show active filter state clearly\n- Filters should be easy to remove with a single click\n\n## Considerations\n\n- Each chip should clearly indicate what filter it represents\n- Provide visual feedback when removing filters\n- Results should update immediately when a filter is removed\n- Consider adding an \"x\" icon or clear affordance to indicate removeability\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/remove-a-filter/index.mdx",
-    "urlPath": "examples/remove-a-filter",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "remove-a-filter",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-question-page",
-    "title": "Question page",
-    "description": "A question page pattern that presents one question at a time to help users focus, reduce cognitive load, and navigate complex forms more easily. ",
-    "content": "A question page pattern that presents one question at a time to help users focus, reduce cognitive load, and navigate complex forms more easily.\n\n## When to use\n\nUse this pattern when:\n- Building multi-step forms or wizards\n- Asking users for information that requires focused attention\n- The form has branching logic based on user responses\n- You want to reduce cognitive load and errors\n\n## Considerations\n\n- Each page should contain one idea: one question, one decision, or one piece of information\n- Progress indicators are optional - test without one first\n- The pattern helps with mobile responsiveness and accessibility\n- Enables automatic saving and better error handling\n- Consider adaptive questioning where subsequent questions depend on previous answers\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/question-page/index.mdx",
-    "urlPath": "examples/question-page",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "question-page",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-public-form",
-    "title": "Public form",
-    "description": "The public form pattern provides a structure for citizen-facing form experiences, emphasizing simplicity, accessibility, and low cognitive load. ",
-    "content": "The public form pattern provides a structure for citizen-facing form experiences, emphasizing simplicity, accessibility, and low cognitive load.\n\n## When to use\n\nUse this pattern when:\n- Designing a public service for citizens\n- Building forms that should be simple and intuitive\n- Users need to make informed decisions while completing the form\n- The service should accommodate users who use it infrequently\n\n## Considerations\n\n- Follow the \"one idea per page\" principle to reduce cognitive load\n- Break complex forms into multiple pages with single questions\n- Use task list pages for longer processes with multiple sections\n- Consider using simple progress indicators rather than horizontal steppers\n- Ensure all form elements meet WCAG 2.2 AA accessibility standards\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/public-form/index.mdx",
-    "urlPath": "examples/public-form",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "public-form",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-link-to-an-external-page",
-    "title": "Link to an external page",
-    "description": "Use an external link indicator to show users when a link will take them to a different website. ",
-    "content": "Use an external link indicator to show users when a link will take them to a different website.\n\n## When to use\n\nUse this pattern when:\n- Linking to websites outside your service\n- Users should be aware they're leaving the current site\n- Providing references to external resources\n- Following accessibility best practices for external links\n\n## Considerations\n\n- Use the \"open\" trailing icon to indicate external links\n- Consider whether the link should open in a new tab\n- Ensure the link text clearly describes the destination\n- External links should be used sparingly and with purpose\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/link-to-an-external-page/index.mdx",
-    "urlPath": "examples/link-to-an-external-page",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "link-to-an-external-page",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-link-the-user-to-give-feedback-to-the-service",
-    "title": "Link the user to give feedback to the service",
-    "description": "Use the microsite header's feedback functionality to collect user feedback during alpha or beta phases of a service. ",
-    "content": "Use the microsite header's feedback functionality to collect user feedback during alpha or beta phases of a service.\n\n## When to use\n\nUse this pattern when:\n- Your service is in alpha or beta phase\n- You want to actively collect user feedback\n- Building a citizen-facing government service\n- The service is still being developed and improved\n\n## Considerations\n\n- Use the `onFeedbackClick` handler to define feedback behavior\n- Consider linking to a feedback form or opening a modal\n- The feedback link appears automatically on alpha/beta headers\n- Ensure the feedback mechanism is accessible and easy to use\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/link-the-user-to-give-feedback-to-the-service/index.mdx",
-    "urlPath": "examples/link-the-user-to-give-feedback-to-the-service",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "link-the-user-to-give-feedback-to-the-service",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-include-descriptions-for-items-in-a-checkbox-list",
-    "title": "Include descriptions for items in a checkbox list",
-    "description": "Add descriptive text to radio button options to help users understand the implications of each choice. ",
-    "content": "Add descriptive text to radio button options to help users understand the implications of each choice.\n\n## When to use\n\nUse this pattern when:\n- Radio options need additional explanation\n- Users might not understand the difference between options\n- Each option has specific implications or requirements\n- Providing context helps users make informed decisions\n\n## Considerations\n\n- Keep descriptions concise but informative\n- Ensure the label and description work together\n- Use consistent description length across options\n- Consider whether all options need descriptions or just some\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/include-descriptions-for-items-in-a-checkbox-list/index.mdx",
-    "urlPath": "examples/include-descriptions-for-items-in-a-checkbox-list",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "include-descriptions-for-items-in-a-checkbox-list",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-include-a-link-in-the-helper-text-of-an-option",
-    "title": "Include a link in the helper text of an option",
-    "description": "Add links within the description text of checkbox options to provide additional context or resources while users are making selections. ",
-    "content": "Add links within the description text of checkbox options to provide additional context or resources while users are making selections.\n\n## When to use\n\nUse this pattern when:\n- Checkbox options need additional context via links\n- Users might need more information before making a selection\n- Linking to terms, policies, or detailed explanations\n- The link is directly relevant to the specific option\n\n## Considerations\n\n- Keep description text concise even with links\n- Ensure link text is descriptive and accessible\n- Consider whether the link should open in a new tab\n- Use the description prop (React) or ng-template (Angular) for custom content\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/include-a-link-in-the-helper-text-of-an-option/index.mdx",
-    "urlPath": "examples/include-a-link-in-the-helper-text-of-an-option",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "include-a-link-in-the-helper-text-of-an-option",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-hide-and-show-many-sections-of-information",
-    "title": "Hide and show many sections of information",
-    "description": "Allow users to expand and collapse multiple accordion sections, with a button to show or hide all sections at once. ",
-    "content": "Allow users to expand and collapse multiple accordion sections, with a button to show or hide all sections at once.\n\n## When to use\n\nUse this pattern when:\n- Presenting FAQ-style content\n- Users need to scan multiple sections quickly\n- Content is long and would benefit from progressive disclosure\n- Providing a \"show all\" and \"hide all\" option improves usability\n\n## Considerations\n\n- Track the open state of each accordion individually\n- Update the button text based on whether all sections are expanded or collapsed\n- Consider keyboard accessibility for the expand/collapse all functionality\n- Accordion headings should be descriptive and scannable\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/hide-and-show-many-sections-of-information/index.mdx",
-    "urlPath": "examples/hide-and-show-many-sections-of-information",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "hide-and-show-many-sections-of-information",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-hero-banner-with-actions",
-    "title": "Hero banner with actions",
-    "description": "Create a hero banner with a call-to-action button to guide users toward the primary task on a landing page. ",
-    "content": "Create a hero banner with a call-to-action button to guide users toward the primary task on a landing page.\n\n## When to use\n\nUse this pattern when:\n- Creating a landing page for a service\n- You need a prominent call-to-action\n- Introducing users to a service or feature\n- Building a start page for public forms\n\n## Considerations\n\n- Use the \"start\" button type for primary actions\n- Keep the banner text concise and action-oriented\n- The actions slot positions the button appropriately\n- Ensure the heading clearly describes the service purpose\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/hero-banner-with-actions/index.mdx",
-    "urlPath": "examples/hero-banner-with-actions",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "hero-banner-with-actions",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-header-with-navigation",
-    "title": "Header with navigation",
-    "description": "Implement a standard application header with navigation menus, search functionality, and sign-in links for government services. ",
-    "content": "Implement a standard application header with navigation menus, search functionality, and sign-in links for government services.\n\n## When to use\n\nUse this pattern when:\n- Building a government service application\n- You need consistent navigation across pages\n- Users need access to search, support, and authentication\n- Following the GoA header pattern\n\n## Considerations\n\n- Use the microsite header above the app header for government branding\n- Group related navigation items under dropdown menus\n- Include a sign-in link with the \"interactive\" class for proper styling\n- Consider mobile responsiveness for navigation items\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/header-with-navigation/index.mdx",
-    "urlPath": "examples/header-with-navigation",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "header-with-navigation",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-header-with-menu-click-event",
-    "title": "Header with menu click event",
-    "description": "Handle custom menu click behavior in the app header, allowing you to intercept the mobile menu button click and implement custom functionality like custom navigation drawers. ",
-    "content": "Handle custom menu click behavior in the app header, allowing you to intercept the mobile menu button click and implement custom functionality like custom navigation drawers.\n\n## When to use\n\nUse this pattern when:\n- You need custom behavior when the mobile menu button is clicked\n- Building a custom navigation drawer or sidebar\n- The standard header menu behavior needs to be overridden\n- You want to control menu visibility programmatically\n\n## Considerations\n\n- Use the `fullMenuBreakpoint` prop to control when the hamburger menu appears\n- The `onMenuClick` handler fires when the menu button is clicked\n- Consider accessibility when implementing custom menu behavior\n- Test across different device widths to ensure proper behavior\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/header-with-menu-click-event/index.mdx",
-    "urlPath": "examples/header-with-menu-click-event",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "header-with-menu-click-event",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-group-related-questions-together-on-a-question-page",
-    "title": "Group related questions together on a question page",
-    "description": "Group related form fields together on a single page to collect address information from users, making it easier to complete logically connected questions at once. ",
-    "content": "Group related form fields together on a single page to collect address information from users, making it easier to complete logically connected questions at once.\n\n## When to use\n\nUse this pattern when:\n- Collecting address or contact information\n- Form fields are logically related and should be completed together\n- Users need context between related fields\n- Following a question page pattern in a multi-step form\n\n## Considerations\n\n- Use clear, descriptive labels for each form field\n- Include a back link for navigation in multi-step forms\n- Consider adding a section title and subtitle to provide context\n- Use appropriate input widths based on expected content length\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/group-related-questions-together-on-a-question-page/index.mdx",
-    "urlPath": "examples/group-related-questions-together-on-a-question-page",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "group-related-questions-together-on-a-question-page",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-give-context-before-asking-a-long-answer-question",
-    "title": "Give context before asking a long answer question",
-    "description": "Provide context and guidance before a long-answer text field to help users provide relevant information. ",
-    "content": "Provide context and guidance before a long-answer text field to help users provide relevant information.\n\n## When to use\n\nUse this pattern when:\n- Asking open-ended questions that require detailed responses\n- Users may not know what information is most helpful to provide\n- You want to encourage more useful and complete answers\n- Building citizen-facing forms with benefit inquiries or support requests\n\n## Considerations\n\n- Explain the purpose of the question briefly\n- Use a Details component to provide additional guidance without cluttering the form\n- Set appropriate character limits with `maxCount` and `countBy` props\n- Keep instructions focused on what will help process their request\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/give-context-before-asking-a-long-answer-question/index.mdx",
-    "urlPath": "examples/give-context-before-asking-a-long-answer-question",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "give-context-before-asking-a-long-answer-question",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-give-background-information-before-asking-a-question",
-    "title": "Give background information before asking a question",
-    "description": "Provide explanatory context before asking a question to help users understand what is being asked. ",
-    "content": "Provide explanatory context before asking a question to help users understand what is being asked.\n\n## When to use\n\nUse this pattern when:\n- The question requires domain knowledge to answer correctly\n- Terms need clarification for users unfamiliar with the subject\n- Providing context will reduce confusion and incorrect answers\n- Building citizen-facing forms where accessibility of information is important\n\n## Considerations\n\n- Place context information before the question, not after\n- Use clear, plain language that citizens can understand\n- Suggest where users can get additional help if needed\n- Keep explanatory text focused and relevant to the question\n- Use appropriate heading hierarchy for screen reader accessibility\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/give-background-information-before-asking-a-question/index.mdx",
-    "urlPath": "examples/give-background-information-before-asking-a-question",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "give-background-information-before-asking-a-question",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-form-stepper-with-controlled-navigation",
-    "title": "Form stepper with controlled navigation",
-    "description": "Create a multi-step form with controlled navigation using Previous/Next buttons. ",
-    "content": "Create a multi-step form with controlled navigation using Previous/Next buttons.\n\n## When to use\n\nUse this pattern when:\n- A form is too long to display on a single page\n- You want to guide users through a sequential process\n- Steps must be completed in order before proceeding\n- Users should not be able to skip ahead to incomplete steps\n\n## Considerations\n\n- Set an initial `step` value >= 1 to enable controlled mode\n- Steps that are \"Not started\" will not be clickable\n- Use Previous/Next buttons to control navigation programmatically\n- Validate step completion before allowing navigation forward\n- Consider showing skeleton content while loading step data\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/form-stepper-with-controlled-navigation/index.mdx",
-    "urlPath": "examples/form-stepper-with-controlled-navigation",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "form-stepper-with-controlled-navigation",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-filter-data-in-a-table",
-    "title": "Filter data in a table",
-    "description": "Enable users to filter table data using search input and filter chips. ",
-    "content": "Enable users to filter table data using search input and filter chips.\n\n## When to use\n\nUse this pattern when:\n- Users need to narrow down large datasets\n- Multiple filters can be applied simultaneously\n- Filters should be visible and easily removable\n- You want to provide real-time filtering feedback\n\n## Considerations\n\n- Validate filter input to prevent empty or duplicate filters\n- Show applied filters as removable chips for visibility\n- Provide a \"Clear all\" option when multiple filters are applied\n- Display a \"No results found\" message when filters return empty results\n- Use case-insensitive matching for better user experience\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/filter-data-in-a-table/index.mdx",
-    "urlPath": "examples/filter-data-in-a-table",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "filter-data-in-a-table",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-expand-or-collapse-part-of-a-form",
-    "title": "Expand or collapse part of a form",
-    "description": "Use accordions to organize form review sections that users can expand or collapse. ",
-    "content": "Use accordions to organize form review sections that users can expand or collapse.\n\n## When to use\n\nUse this pattern when:\n- Presenting a review summary of form sections before submission\n- Users need to verify information across multiple categories\n- Sections contain detailed information that may not need constant visibility\n- You want to highlight sections that have been updated\n\n## Considerations\n\n- Use `headingContent` to add badges or status indicators to section headers\n- Use definition lists (`<dl>`) for structured label/value pairs\n- Apply consistent spacing with CSS custom properties\n- Consider defaulting important or recently updated sections to expanded state\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/expand-or-collapse-part-of-a-form/index.mdx",
-    "urlPath": "examples/expand-or-collapse-part-of-a-form",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "expand-or-collapse-part-of-a-form",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-dynamically-change-items-in-a-dropdown-list",
-    "title": "Dynamically change items in a dropdown list",
-    "description": "Update dropdown options based on the selection in another dropdown (cascading/dependent dropdowns). ",
-    "content": "Update dropdown options based on the selection in another dropdown (cascading/dependent dropdowns).\n\n## When to use\n\nUse this pattern when:\n- Options in one dropdown depend on the selection in another\n- You need to filter available choices based on a category\n- Building hierarchical selection interfaces (e.g., country/state/city)\n\n## Considerations\n\n- Use `mountType=\"reset\"` to clear and repopulate dropdown items\n- Generate unique keys for items to ensure proper re-rendering\n- Provide placeholder text to guide users when no selection is made\n- Consider loading states if data fetching is required\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/dynamically-change-items-in-a-dropdown-list/index.mdx",
-    "urlPath": "examples/dynamically-change-items-in-a-dropdown-list",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "dynamically-change-items-in-a-dropdown-list",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-dynamically-add-an-item-to-a-dropdown-list",
-    "title": "Dynamically add an item to a dropdown list",
-    "description": "Allow users to add new items to a dropdown list dynamically. ",
-    "content": "Allow users to add new items to a dropdown list dynamically.\n\n## When to use\n\nUse this pattern when:\n- Users need to add custom options to a predefined list\n- The list of options can grow based on user input\n- You want to provide flexibility while maintaining structure\n\n## Considerations\n\n- Use the `mountType` prop to control where new items appear (prepend or append)\n- Validate input before adding to prevent empty or duplicate entries\n- Provide a reset option to restore the original list\n- Show clear feedback when items are added successfully\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/dynamically-add-an-item-to-a-dropdown-list/index.mdx",
-    "urlPath": "examples/dynamically-add-an-item-to-a-dropdown-list",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "dynamically-add-an-item-to-a-dropdown-list",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-display-user-information",
-    "title": "Display user information",
-    "description": "Display user contact information and related data using containers with clear visual hierarchy. ",
-    "content": "Display user contact information and related data using containers with clear visual hierarchy.\n\n## When to use\n\nUse this pattern when:\n- Showing user profile or contact information\n- Displaying assigned advisor or representative details\n- Presenting upcoming dates or deadlines in a structured format\n- Creating summary views of user-related data\n\n## Considerations\n\n- Use containers to group related information\n- Apply consistent typography for labels and values\n- Use the `accent=\"thick\"` variant for important information sections\n- Include actions (like \"Add to calendar\") when relevant\n- Use tables with striped rows for date lists to improve scanability\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/display-user-information/index.mdx",
-    "urlPath": "examples/display-user-information",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "display-user-information",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-display-numbers-in-a-table-so-they-can-be-scanned-easily",
-    "title": "Display numbers in a table so they can be scanned easily",
-    "description": "Right-align numeric columns in tables to make them easier to scan and compare. ",
-    "content": "Right-align numeric columns in tables to make them easier to scan and compare.\n\n## When to use\n\nUse this pattern when:\n- Displaying numeric data in table columns (IDs, amounts, counts)\n- Users need to quickly scan and compare values\n- The table contains a mix of text and numeric data\n\n## Considerations\n\n- Use the `goa-table-number-header` class on `<th>` elements for numeric column headers\n- Use the `goa-table-number-column` class on `<td>` elements for numeric data cells\n- Right-alignment helps users visually compare magnitudes of numbers\n- Consider consistent decimal formatting for financial data\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/display-numbers-in-a-table-so-they-can-be-scanned-easily/index.mdx",
-    "urlPath": "examples/display-numbers-in-a-table-so-they-can-be-scanned-easily",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "display-numbers-in-a-table-so-they-can-be-scanned-easily",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-disabled-button-with-a-required-field",
-    "title": "Disabled button with a required field",
-    "description": "Disable a submit button until required form fields are completed. ",
-    "content": "Disable a submit button until required form fields are completed.\n\n## When to use\n\nUse this pattern when:\n- A form has required fields that must be filled before submission\n- You want to provide visual feedback that the form is incomplete\n- Preventing invalid form submissions is important\n\n## Considerations\n\n- Ensure the disabled state is visually distinct and accessible\n- Consider showing validation messages when users try to interact with disabled buttons\n- Use the `requirement=\"required\"` prop on form items to indicate mandatory fields\n- Enable the button as soon as all required fields have valid values\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/disabled-button-with-a-required-field/index.mdx",
-    "urlPath": "examples/disabled-button-with-a-required-field",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "disabled-button-with-a-required-field",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-copy-to-clipboard",
-    "title": "Copy to clipboard",
-    "description": "Allow users to quickly copy text or data to their clipboard with a single click. ",
-    "content": "Allow users to quickly copy text or data to their clipboard with a single click.\n\n## When to use\n\nUse this pattern when:\n- Users need to copy values like tokens, codes, or IDs\n- Quick access to copy functionality improves workflow\n- The copied value is clearly visible alongside the copy action\n- Users benefit from instant feedback when copying\n\n## Considerations\n\n- Show visual feedback (\"Copied\") when the copy action succeeds\n- Use a tooltip to indicate the copy action before and after clicking\n- Position the copy button near the content being copied\n- Reset the \"Copied\" state after a short delay\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/copy-to-clipboard/index.mdx",
-    "urlPath": "examples/copy-to-clipboard",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "copy-to-clipboard",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-confirm-that-an-application-was-submitted",
-    "title": "Confirm that an application was submitted",
-    "description": "Display a confirmation screen to indicate successful application submission. ",
-    "content": "Display a confirmation screen to indicate successful application submission.\n\n## When to use\n\nUse this pattern when:\n- A user has successfully completed an application or form\n- You need to confirm the submission was received\n- Users need a confirmation number for their records\n- You want to provide next steps after submission\n\n## Considerations\n\n- Use a success callout to clearly indicate success\n- Include a confirmation number users can reference later\n- Mention where a confirmation email will be sent\n- Provide clear next steps and navigation options\n- Include contact information for questions\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/confirm-that-an-application-was-submitted/index.mdx",
-    "urlPath": "examples/confirm-that-an-application-was-submitted",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "confirm-that-an-application-was-submitted",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-confirm-before-navigating-away",
-    "title": "Confirm before navigating away",
-    "description": "Prompt the user in a modal before navigating to a new route to preserve context. ",
-    "content": "Prompt the user in a modal before navigating to a new route to preserve context.\n\n## When to use\n\nUse this pattern when:\n- The user has unsaved changes that would be lost\n- Navigation would interrupt an important workflow\n- You need to confirm the user's intent to leave the page\n- Context or data would be lost on navigation\n\n## Considerations\n\n- Allow users to cancel and stay on the current page\n- Use setTimeout for route changes after modal closes for smooth transitions\n- The secondary button should cancel the navigation\n- The primary button confirms the route change\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/confirm-before-navigating-away/index.mdx",
-    "urlPath": "examples/confirm-before-navigating-away",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "confirm-before-navigating-away",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-confirm-a-destructive-action",
-    "title": "Confirm a destructive action",
-    "description": "Confirm a destructive action like deletion to prevent accidental data loss. ",
-    "content": "Confirm a destructive action like deletion to prevent accidental data loss.\n\n## When to use\n\nUse this pattern when:\n- A user is about to delete data permanently\n- The action cannot be undone\n- You need to prevent accidental destructive actions\n- Data loss would have significant impact\n\n## Considerations\n\n- Use the destructive button variant to emphasize the danger\n- Clearly state that the action cannot be undone\n- Provide a cancel option that's easy to access\n- Use a tertiary button with a trash icon for the initial action\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/confirm-a-destructive-action/index.mdx",
-    "urlPath": "examples/confirm-a-destructive-action",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "confirm-a-destructive-action",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-confirm-a-change",
-    "title": "Confirm a change",
-    "description": "Ask the user to confirm a proposed change before it is applied. ",
-    "content": "Ask the user to confirm a proposed change before it is applied.\n\n## When to use\n\nUse this pattern when:\n- A user has made changes that need explicit confirmation\n- You want to show a before/after comparison\n- The change includes additional options like an effective date\n- Users should have the opportunity to undo the change\n\n## Considerations\n\n- Show clear before and after states for the change\n- Provide an \"undo\" option alongside the confirm action\n- Include any relevant additional inputs (like effective date)\n- Use a secondary button for the cancel/undo action\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/confirm-a-change/index.mdx",
-    "urlPath": "examples/confirm-a-change",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "confirm-a-change",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-communicate-a-future-service-outage",
-    "title": "Communicate a future service outage",
-    "description": "Display a clear message to inform users about an upcoming service outage, including the date, time, and expected impact on service availability. ",
-    "content": "Display a clear message to inform users about an upcoming service outage, including the date, time, and expected impact on service availability.\n\n## When to use\n\nUse this pattern when:\n- Scheduled maintenance will affect service availability\n- Users need advance notice about system downtime\n- You need to communicate specific dates and times for an outage\n- Users should know how to get support during the outage\n\n## Considerations\n\n- Use the \"important\" notification type to draw attention\n- Include specific dates, times, and duration of the outage\n- Provide contact information for questions or concerns\n- Place the notification prominently on affected pages\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/communicate-a-future-service-outage/index.mdx",
-    "urlPath": "examples/communicate-a-future-service-outage",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "communicate-a-future-service-outage",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-card-view-of-case-files",
-    "title": "Card view of case files",
-    "description": "Present a visual overview of individual case files in a card format for scanning and access. ",
-    "content": "Present a visual overview of individual case files in a card format for scanning and access.\n\n## When to use\n\nUse this pattern when:\n- Displaying a list of case files or records that workers need to manage\n- Each record has a status that needs to be clearly visible\n- Users need quick access to view or edit individual records\n- Showing summary information with actions for each item\n\n## Considerations\n\n- Use badges to clearly indicate the status of each case\n- Provide consistent action buttons (Edit, View) based on the case status\n- Include key identifying information like dates and fiscal years\n- Consider responsive layout for smaller screens\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/card-view-of-case-files/index.mdx",
-    "urlPath": "examples/card-view-of-case-files",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "card-view-of-case-files",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-card-grid",
-    "title": "Card grid",
-    "description": "Display multiple cards in a grid layout, each containing related content or actions. ",
-    "content": "Display multiple cards in a grid layout, each containing related content or actions.\n\n## When to use\n\nUse this pattern when:\n- Presenting multiple related items in a scannable format\n- Creating a dashboard or landing page with navigable sections\n- Users need to choose between several options or services\n- Content can be grouped into discrete, equally-weighted items\n\n## Considerations\n\n- Use consistent card heights where possible for visual alignment\n- Link titles should clearly describe where the user will navigate\n- Keep descriptions concise to maintain scannability\n- Use the grid's minChildWidth to ensure cards wrap appropriately on smaller screens\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/card-grid/index.mdx",
-    "urlPath": "examples/card-grid",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "card-grid",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-button-with-icon",
-    "title": "Button with Icon",
-    "description": "Shows how to add leading or trailing icons to buttons for enhanced visual communication. ",
-    "content": "Shows how to add leading or trailing icons to buttons for enhanced visual communication.\n\n## Use cases\n\n- Back navigation buttons with arrow icon\n- Add buttons with plus icon\n- Download buttons with download icon\n- External link buttons with external icon\n\n## Considerations\n\n- Keep icon and text semantically aligned\n- Don't use icons just for decoration\n- Leading icons for actions that \"go back\" or \"add\"\n- Trailing icons for actions that \"go forward\" or \"external\"\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/button-with-icon/index.mdx",
-    "urlPath": "examples/button-with-icon",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "button-with-icon",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-basic-page-layout",
-    "title": "Basic page layout",
-    "description": "A basic page template to use as a starting point. ",
-    "content": "A basic page template to use as a starting point.\n\n## When to use\n\nUse this pattern when:\n- Starting a new government service or application\n- You need a standard page structure with header and footer\n- Building pages that need consistent layout across your service\n\n## Considerations\n\n- Include both microsite header and app header for proper government branding\n- Use page-block to constrain content width appropriately\n- The skeleton loaders show content areas during loading states\n- Always include an app footer for consistent navigation and required links\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/basic-page-layout/index.mdx",
-    "urlPath": "examples/basic-page-layout",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "basic-page-layout",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-ask-a-user-one-question-at-a-time",
-    "title": "Ask a user one question at a time",
-    "description": "Ask a user one question at a time. ",
-    "content": "Ask a user one question at a time.\n\n## When to use\n\nUse this pattern when:\n- Building a public-facing form for citizens\n- You want to reduce cognitive load by focusing on one question\n- The question requires careful consideration from the user\n- Following the one-question-per-page pattern for government services\n\n## Considerations\n\n- Include a back link to allow users to navigate to previous questions\n- Use a large label size to make the question prominent\n- Provide help text when the question may need clarification\n- Use a clear call-to-action button to progress\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/ask-a-user-one-question-at-a-time/index.mdx",
-    "urlPath": "examples/ask-a-user-one-question-at-a-time",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "ask-a-user-one-question-at-a-time",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-ask-a-user-for-dollar-amounts",
-    "title": "Ask a user for dollar amounts",
-    "description": "Prompt users to enter monetary values using a consistent input format that supports validation and currency symbols. ",
-    "content": "Prompt users to enter monetary values using a consistent input format that supports validation and currency symbols.\n\n## When to use\n\nUse this pattern when:\n- Collecting cost or expense information\n- Users need to enter multiple monetary values\n- You want consistent currency formatting\n\n## Considerations\n\n- Use the `leadingContent` prop to show the $ symbol\n- Consider if decimal places are needed\n- Group related amounts together\n- Provide clear labels for each amount field\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/ask-a-user-for-dollar-amounts/index.mdx",
-    "urlPath": "examples/ask-a-user-for-dollar-amounts",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "ask-a-user-for-dollar-amounts",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-ask-a-user-for-direct-deposit-information",
-    "title": "Ask a user for direct deposit information",
-    "description": "Gather banking details from users to enable direct deposit, including account number and financial institution information. ",
-    "content": "Gather banking details from users to enable direct deposit, including account number and financial institution information.\n\n## When to use\n\nUse this pattern when:\n- Setting up direct deposit for payments or refunds\n- Collecting banking information for recurring transactions\n- Users need to provide financial institution details\n\n## Considerations\n\n- Provide clear help text about where to find each number\n- Use the details component to show visual guidance (cheque image)\n- Set appropriate field widths based on expected input length\n- Be clear about security and how the information will be used\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/ask-a-user-for-direct-deposit-information/index.mdx",
-    "urlPath": "examples/ask-a-user-for-direct-deposit-information",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "ask-a-user-for-direct-deposit-information",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-ask-a-user-for-an-indian-registration-number",
-    "title": "Ask a user for an Indian registration number",
-    "description": "Request a user's Indian registration number with appropriate validation and context. ",
-    "content": "Request a user's Indian registration number with appropriate validation and context.\n\n## When to use\n\nUse this pattern when:\n- Collecting Indigenous identity information\n- The registration number is required for benefits or services\n- You need to validate the format (3-digit band, up to 5-digit family, 2-digit position)\n\n## Considerations\n\n- Use separate fields for each component of the number\n- Set appropriate field widths to hint at expected input length\n- Provide clear help text for each field\n- Be respectful of the cultural significance of this information\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/ask-a-user-for-an-indian-registration-number/index.mdx",
-    "urlPath": "examples/ask-a-user-for-an-indian-registration-number",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "ask-a-user-for-an-indian-registration-number",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-ask-a-user-for-an-address",
-    "title": "Ask a user for an address",
-    "description": "Collect a complete mailing address from the user, including fields like street, city, and postal code. ",
-    "content": "Collect a complete mailing address from the user, including fields like street, city, and postal code.\n\n## When to use\n\nUse this pattern when:\n- Collecting mailing addresses for correspondence\n- Gathering location information for services\n- Users need to provide physical address details\n\n## Considerations\n\n- Pre-select the most common province/territory\n- Use appropriate field widths (postal code is always 7 characters)\n- Consider address autocomplete for improved UX\n- Group related fields (province and postal code on same row)\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/ask-a-user-for-an-address/index.mdx",
-    "urlPath": "examples/ask-a-user-for-an-address",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "ask-a-user-for-an-address",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-ask-a-user-for-a-birthday",
-    "title": "Ask a user for a birthday",
-    "description": "Asks for a user's birthday using the date picker component. ",
-    "content": "Asks for a user's birthday using the date picker component.\n\n## When to use\n\nUse this pattern when you need to collect a date of birth for:\n- Age verification\n- Identity confirmation\n- Benefits eligibility\n\n## Considerations\n\n- Consider whether you really need exact birthday vs just year or age range\n- The date picker provides a consistent, accessible date selection experience\n- Users can type the date directly or use the calendar picker\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/ask-a-user-for-a-birthday/index.mdx",
-    "urlPath": "examples/ask-a-user-for-a-birthday",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "ask-a-user-for-a-birthday",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-ask-a-long-answer-question-with-a-maximum-word-count",
-    "title": "Ask a long answer question with a maximum word count",
-    "description": "Restrict a long answer input to a maximum number of words or characters. ",
-    "content": "Restrict a long answer input to a maximum number of words or characters.\n\n## When to use\n\nUse this pattern when:\n- Collecting open-ended responses\n- You need to limit response length\n- Users benefit from seeing remaining word count\n\n## Considerations\n\n- Choose between word count or character count based on the use case\n- Provide clear guidance on expected response length\n- Show remaining count to help users gauge their response\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/ask-a-long-answer-question-with-a-maximum-word-count/index.mdx",
-    "urlPath": "examples/ask-a-long-answer-question-with-a-maximum-word-count",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "ask-a-long-answer-question-with-a-maximum-word-count",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-add-another-item-in-a-modal",
-    "title": "Add another item in a modal",
-    "description": "Add a new item within a modal window without navigating away from the current context. ",
-    "content": "Add a new item within a modal window without navigating away from the current context.\n\n## When to use\n\nUse this pattern when:\n- Adding items to an existing list\n- The form is short and focused\n- Users need to stay in context of the main view\n\n## Considerations\n\n- Keep modal forms focused and brief\n- Provide clear cancel and save actions\n- Validate input before allowing save\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/add-another-item-in-a-modal/index.mdx",
-    "urlPath": "examples/add-another-item-in-a-modal",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "add-another-item-in-a-modal",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-add-and-edit-lots-of-filters",
-    "title": "Add and edit lots of filters",
-    "description": "Add and edit filters using a drawer. This pattern is useful when you have many filter options that would clutter the main interface. ",
-    "content": "Add and edit filters using a drawer. This pattern is useful when you have many filter options that would clutter the main interface.\n\n## When to use\n\nUse this pattern when:\n- There are many filter options to manage\n- Filters need to persist across sessions\n- Users need to see current filter state while editing\n\n## Considerations\n\n- Group related filters together\n- Provide clear apply/reset actions\n- Show active filter count on the trigger button\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/add-and-edit-lots-of-filters/index.mdx",
-    "urlPath": "examples/add-and-edit-lots-of-filters",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "add-and-edit-lots-of-filters",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-add-a-record-using-a-drawer",
-    "title": "Add a record using a drawer",
-    "description": "Add a record using a drawer. The drawer slides in from the side to allow data entry without navigating away from the current view. ",
-    "content": "Add a record using a drawer. The drawer slides in from the side to allow data entry without navigating away from the current view.\n\n## When to use\n\nUse this pattern when:\n- Adding records to a list or table\n- The form is secondary to the main content\n- Users need to see the main view while entering data\n\n## Considerations\n\n- Keep the drawer width appropriate for the form content\n- Provide clear save/cancel actions\n- Consider validation before closing\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/add-a-record-using-a-drawer/index.mdx",
-    "urlPath": "examples/add-a-record-using-a-drawer",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "add-a-record-using-a-drawer",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "example-add-a-filter-chip",
-    "title": "Add a filter chip",
-    "description": "Allow users to apply filters using selectable chips, which visually represent active filters and can be removed to update results dynamically. ",
-    "content": "Allow users to apply filters using selectable chips, which visually represent active filters and can be removed to update results dynamically.\n\n## When to use\n\nUse this pattern when:\n- Users need to apply multiple filters to a dataset\n- Filters should be visible and easily removable\n- You want to show active filter state clearly\n\n## Considerations\n\n- Each chip should clearly indicate what filter it represents\n- Provide visual feedback when adding/removing filters\n- Consider the order of chips (most recent, alphabetical, etc.)\n",
-    "component": "",
-    "filePath": "docs/src/content/examples/add-a-filter-chip/index.mdx",
-    "urlPath": "examples/add-a-filter-chip",
-    "tags": [
-      "example",
-      "pattern"
-    ],
-    "type": "example",
-    "slug": "add-a-filter-chip",
-    "status": "published",
-    "categories": []
-  },
-  {
-    "id": "tokens-color",
-    "title": "Color Tokens",
-    "description": "Color design tokens for text, backgrounds, borders, interactive elements, and status indicators",
-    "content": "--goa-color-interactive-default --goa-color-interactive-secondary --goa-color-interactive-hover --goa-color-interactive-secondary-hover --goa-color-interactive-disabled --goa-color-interactive-error --goa-color-interactive-error-hover --goa-color-interactive-error-disabled --goa-color-interactive-focus --goa-color-interactive-focus-black --goa-color-interactive-visited --goa-color-brand-default --goa-color-brand-dark --goa-color-brand-light --goa-color-text-default --goa-color-text-secondary --goa-color-text-light --goa-color-text-disabled --goa-color-info-default --goa-color-info-light --goa-color-info-dark --goa-color-info-background --goa-color-info-border --goa-color-info-text --goa-color-info-textDark --goa-color-info-textInverse --goa-color-warning-default --goa-color-warning-light --goa-color-warning-dark --goa-color-warning-background --goa-color-warning-border --goa-color-warning-text --goa-color-warning-textDark --goa-color-important-default --goa-color-important-light --goa-color-important-dark --goa-color-important-background --goa-color-important-border --goa-color-important-text --goa-color-important-text-dark --goa-color-emergency-default --goa-color-emergency-light --goa-color-emergency-dark --goa-color-emergency-background --goa-color-emergency-border --goa-color-emergency-text --goa-color-emergency-textDark --goa-color-emergency-textInverse --goa-color-success-default --goa-color-success-light --goa-color-success-dark --goa-color-success-background --goa-color-success-border --goa-color-success-text --goa-color-success-textDark --goa-color-success-textInverse --goa-color-critical-default --goa-color-greyscale-50 --goa-color-greyscale-100 --goa-color-greyscale-150 --goa-color-greyscale-200 --goa-color-greyscale-300 --goa-color-greyscale-400 --goa-color-greyscale-500 --goa-color-greyscale-600 --goa-color-greyscale-700 --goa-color-greyscale-800 --goa-color-greyscale-black --goa-color-greyscale-white --goa-color-extended-sky-default --goa-color-extended-sky-light --goa-color-extended-sky-border --goa-color-extended-sky-text --goa-color-extended-pasture-default --goa-color-extended-pasture-light --goa-color-extended-pasture-border --goa-color-extended-pasture-text --goa-color-extended-sunset-default --goa-color-extended-sunset-light --goa-color-extended-sunset-border --goa-color-extended-sunset-text --goa-color-extended-dawn-default --goa-color-extended-dawn-light --goa-color-extended-dawn-border --goa-color-extended-dawn-text --goa-color-extended-lilac-default --goa-color-extended-lilac-light --goa-color-extended-lilac-border --goa-color-extended-lilac-text --goa-color-extended-prairie-default --goa-color-extended-prairie-light --goa-color-extended-prairie-border --goa-color-extended-prairie-text",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "color",
-      "design token",
-      "palette",
-      "theme"
-    ],
-    "type": "token",
-    "slug": "color",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-default",
-    "title": "--goa-color-interactive-default",
-    "name": "--goa-color-interactive-default",
-    "description": "color token: interactive default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-default",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-secondary",
-    "title": "--goa-color-interactive-secondary",
-    "name": "--goa-color-interactive-secondary",
-    "description": "color token: interactive secondary",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-secondary",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-hover",
-    "title": "--goa-color-interactive-hover",
-    "name": "--goa-color-interactive-hover",
-    "description": "color token: interactive hover",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-hover",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-secondary-hover",
-    "title": "--goa-color-interactive-secondary-hover",
-    "name": "--goa-color-interactive-secondary-hover",
-    "description": "color token: interactive secondary hover",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-secondary-hover",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-disabled",
-    "title": "--goa-color-interactive-disabled",
-    "name": "--goa-color-interactive-disabled",
-    "description": "color token: interactive disabled",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-disabled",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-error",
-    "title": "--goa-color-interactive-error",
-    "name": "--goa-color-interactive-error",
-    "description": "color token: interactive error",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-error",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-error-hover",
-    "title": "--goa-color-interactive-error-hover",
-    "name": "--goa-color-interactive-error-hover",
-    "description": "color token: interactive error hover",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-error-hover",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-error-disabled",
-    "title": "--goa-color-interactive-error-disabled",
-    "name": "--goa-color-interactive-error-disabled",
-    "description": "color token: interactive error disabled",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-error-disabled",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-focus",
-    "title": "--goa-color-interactive-focus",
-    "name": "--goa-color-interactive-focus",
-    "description": "color token: interactive focus",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-focus",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-focus-black",
-    "title": "--goa-color-interactive-focus-black",
-    "name": "--goa-color-interactive-focus-black",
-    "description": "color token: interactive focus black",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-focus-black",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-interactive-visited",
-    "title": "--goa-color-interactive-visited",
-    "name": "--goa-color-interactive-visited",
-    "description": "color token: interactive visited",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-interactive-visited",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-brand-default",
-    "title": "--goa-color-brand-default",
-    "name": "--goa-color-brand-default",
-    "description": "color token: brand default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-brand-default",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-brand-dark",
-    "title": "--goa-color-brand-dark",
-    "name": "--goa-color-brand-dark",
-    "description": "color token: brand dark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-brand-dark",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-brand-light",
-    "title": "--goa-color-brand-light",
-    "name": "--goa-color-brand-light",
-    "description": "color token: brand light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-brand-light",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-text-default",
-    "title": "--goa-color-text-default",
-    "name": "--goa-color-text-default",
-    "description": "color token: text default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-text-default",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-text-secondary",
-    "title": "--goa-color-text-secondary",
-    "name": "--goa-color-text-secondary",
-    "description": "color token: text secondary",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-text-secondary",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-text-light",
-    "title": "--goa-color-text-light",
-    "name": "--goa-color-text-light",
-    "description": "color token: text light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-text-light",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-text-disabled",
-    "title": "--goa-color-text-disabled",
-    "name": "--goa-color-text-disabled",
-    "description": "color token: text disabled",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-text-disabled",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-info-default",
-    "title": "--goa-color-info-default",
-    "name": "--goa-color-info-default",
-    "description": "color token: info default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-info-default",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-info-light",
-    "title": "--goa-color-info-light",
-    "name": "--goa-color-info-light",
-    "description": "color token: info light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-info-light",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-info-dark",
-    "title": "--goa-color-info-dark",
-    "name": "--goa-color-info-dark",
-    "description": "color token: info dark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-info-dark",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-info-background",
-    "title": "--goa-color-info-background",
-    "name": "--goa-color-info-background",
-    "description": "color token: info background",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-info-background",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-info-border",
-    "title": "--goa-color-info-border",
-    "name": "--goa-color-info-border",
-    "description": "color token: info border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-info-border",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-info-text",
-    "title": "--goa-color-info-text",
-    "name": "--goa-color-info-text",
-    "description": "color token: info text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-info-text",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-info-textDark",
-    "title": "--goa-color-info-textDark",
-    "name": "--goa-color-info-textDark",
-    "description": "color token: info textDark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-info-textDark",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-info-textInverse",
-    "title": "--goa-color-info-textInverse",
-    "name": "--goa-color-info-textInverse",
-    "description": "color token: info textInverse",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-info-textInverse",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-warning-default",
-    "title": "--goa-color-warning-default",
-    "name": "--goa-color-warning-default",
-    "description": "color token: warning default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-warning-default",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-warning-light",
-    "title": "--goa-color-warning-light",
-    "name": "--goa-color-warning-light",
-    "description": "color token: warning light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-warning-light",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-warning-dark",
-    "title": "--goa-color-warning-dark",
-    "name": "--goa-color-warning-dark",
-    "description": "color token: warning dark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-warning-dark",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-warning-background",
-    "title": "--goa-color-warning-background",
-    "name": "--goa-color-warning-background",
-    "description": "color token: warning background",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-warning-background",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-warning-border",
-    "title": "--goa-color-warning-border",
-    "name": "--goa-color-warning-border",
-    "description": "color token: warning border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-warning-border",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-warning-text",
-    "title": "--goa-color-warning-text",
-    "name": "--goa-color-warning-text",
-    "description": "color token: warning text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-warning-text",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-warning-textDark",
-    "title": "--goa-color-warning-textDark",
-    "name": "--goa-color-warning-textDark",
-    "description": "color token: warning textDark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-warning-textDark",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-important-default",
-    "title": "--goa-color-important-default",
-    "name": "--goa-color-important-default",
-    "description": "color token: important default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-important-default",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-important-light",
-    "title": "--goa-color-important-light",
-    "name": "--goa-color-important-light",
-    "description": "color token: important light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-important-light",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-important-dark",
-    "title": "--goa-color-important-dark",
-    "name": "--goa-color-important-dark",
-    "description": "color token: important dark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-important-dark",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-important-background",
-    "title": "--goa-color-important-background",
-    "name": "--goa-color-important-background",
-    "description": "color token: important background",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-important-background",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-important-border",
-    "title": "--goa-color-important-border",
-    "name": "--goa-color-important-border",
-    "description": "color token: important border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-important-border",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-important-text",
-    "title": "--goa-color-important-text",
-    "name": "--goa-color-important-text",
-    "description": "color token: important text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-important-text",
-    "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-important-text-dark",
-    "title": "--goa-color-important-text-dark",
-    "name": "--goa-color-important-text-dark",
-    "description": "color token: important text dark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "structure-and-navigation",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "app header",
+      "global navigation",
+      "header",
+      "header and navigation",
+      "main navigation",
+      "navigation header",
+      "navigation menu",
+      "primary navigation",
+      "service header",
+      "structure and navigation",
+      "top navigation"
     ],
-    "type": "token",
-    "slug": "color-important-text-dark",
-    "status": "stable",
-    "category": "color"
+    "slug": "app-header"
   },
   {
-    "id": "token-color-emergency-default",
-    "title": "--goa-color-emergency-default",
-    "name": "--goa-color-emergency-default",
-    "description": "color token: emergency default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-emergency-default",
+    "type": "component",
+    "id": "badge",
+    "name": "Badge",
+    "description": "Small labels which hold small amounts of information, system feedback, or states.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-emergency-light",
-    "title": "--goa-color-emergency-light",
-    "name": "--goa-color-emergency-light",
-    "description": "color token: emergency light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "feedback-and-alerts",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "feedback and alerts",
+      "label",
+      "lozenge",
+      "status",
+      "tag",
+      "token"
     ],
-    "type": "token",
-    "slug": "color-emergency-light",
-    "status": "stable",
-    "category": "color"
+    "slug": "badge"
   },
   {
-    "id": "token-color-emergency-dark",
-    "title": "--goa-color-emergency-dark",
-    "name": "--goa-color-emergency-dark",
-    "description": "color token: emergency dark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-emergency-dark",
+    "type": "component",
+    "id": "block",
+    "name": "Block",
+    "description": "Group components into a block with consistent space between.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-emergency-background",
-    "title": "--goa-color-emergency-background",
-    "name": "--goa-color-emergency-background",
-    "description": "color token: emergency background",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "utilities",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "utility"
     ],
-    "type": "token",
-    "slug": "color-emergency-background",
-    "status": "stable",
-    "category": "color"
+    "slug": "block"
   },
   {
-    "id": "token-color-emergency-border",
-    "title": "--goa-color-emergency-border",
-    "name": "--goa-color-emergency-border",
-    "description": "color token: emergency border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-emergency-border",
+    "type": "component",
+    "id": "button-group",
+    "name": "Button group",
+    "description": "Display multiple related actions stacked or in a horizontal row to help with arrangement and spacing.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-emergency-text",
-    "title": "--goa-color-emergency-text",
-    "name": "--goa-color-emergency-text",
-    "description": "color token: emergency text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "action",
+      "inputs and actions",
+      "submit"
     ],
-    "type": "token",
-    "slug": "color-emergency-text",
-    "status": "stable",
-    "category": "color"
+    "slug": "button-group"
   },
   {
-    "id": "token-color-emergency-textDark",
-    "title": "--goa-color-emergency-textDark",
-    "name": "--goa-color-emergency-textDark",
-    "description": "color token: emergency textDark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-emergency-textDark",
+    "type": "component",
+    "id": "button",
+    "name": "Button",
+    "description": "Carry out an important action or navigate to another page.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-emergency-textInverse",
-    "title": "--goa-color-emergency-textInverse",
-    "name": "--goa-color-emergency-textInverse",
-    "description": "color token: emergency textInverse",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "action",
+      "inputs and actions",
+      "submit"
     ],
-    "type": "token",
-    "slug": "color-emergency-textInverse",
-    "status": "stable",
-    "category": "color"
+    "slug": "button"
   },
   {
-    "id": "token-color-success-default",
-    "title": "--goa-color-success-default",
-    "name": "--goa-color-success-default",
-    "description": "color token: success default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-success-default",
+    "type": "component",
+    "id": "callout",
+    "name": "Callout",
+    "description": "Communicate important information through a strong visual emphasis.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-success-light",
-    "title": "--goa-color-success-light",
-    "name": "--goa-color-success-light",
-    "description": "color token: success light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "feedback-and-alerts",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "alert",
+      "feedback and alerts",
+      "show more information"
     ],
-    "type": "token",
-    "slug": "color-success-light",
-    "status": "stable",
-    "category": "color"
+    "slug": "callout"
   },
   {
-    "id": "token-color-success-dark",
-    "title": "--goa-color-success-dark",
-    "name": "--goa-color-success-dark",
-    "description": "color token: success dark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-success-dark",
+    "type": "component",
+    "id": "checkbox-list",
+    "name": "Checkbox list",
+    "description": "A multiple selection input.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-success-background",
-    "title": "--goa-color-success-background",
-    "name": "--goa-color-success-background",
-    "description": "color token: success background",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "checkbox",
+      "input",
+      "inputs and actions"
     ],
-    "type": "token",
-    "slug": "color-success-background",
-    "status": "stable",
-    "category": "color"
+    "slug": "checkbox-list"
   },
   {
-    "id": "token-color-success-border",
-    "title": "--goa-color-success-border",
-    "name": "--goa-color-success-border",
-    "description": "color token: success border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-success-border",
+    "type": "component",
+    "id": "checkbox",
+    "name": "Checkbox",
+    "description": "Let the user select one or more options.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-success-text",
-    "title": "--goa-color-success-text",
-    "name": "--goa-color-success-text",
-    "description": "color token: success text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "checklist",
+      "input",
+      "inputs and actions",
+      "options"
     ],
-    "type": "token",
-    "slug": "color-success-text",
-    "status": "stable",
-    "category": "color"
+    "slug": "checkbox"
   },
   {
-    "id": "token-color-success-textDark",
-    "title": "--goa-color-success-textDark",
-    "name": "--goa-color-success-textDark",
-    "description": "color token: success textDark",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-success-textDark",
+    "type": "component",
+    "id": "circular-progress",
+    "name": "Circular progress indicator",
+    "description": "Provide feedback of progress to users while loading.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-success-textInverse",
-    "title": "--goa-color-success-textInverse",
-    "name": "--goa-color-success-textInverse",
-    "description": "color token: success textInverse",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "feedback-and-alerts",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "feedback and alerts",
+      "loading",
+      "loader",
+      "loading indicator",
+      "progress spinner",
+      "process timer",
+      "spinner"
     ],
-    "type": "token",
-    "slug": "color-success-textInverse",
-    "status": "stable",
-    "category": "color"
+    "slug": "circular-progress"
   },
   {
-    "id": "token-color-critical-default",
-    "title": "--goa-color-critical-default",
-    "name": "--goa-color-critical-default",
-    "description": "color token: critical default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-critical-default",
+    "type": "component",
+    "id": "container",
+    "name": "Container",
+    "description": "Group information, create hierarchy, and show related information.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-greyscale-50",
-    "title": "--goa-color-greyscale-50",
-    "name": "--goa-color-greyscale-50",
-    "description": "color token: greyscale 50",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "content-layout",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "card",
+      "content",
+      "content layout",
+      "group",
+      "structure"
     ],
-    "type": "token",
-    "slug": "color-greyscale-50",
-    "status": "stable",
-    "category": "color"
+    "slug": "container"
   },
   {
-    "id": "token-color-greyscale-100",
-    "title": "--goa-color-greyscale-100",
-    "name": "--goa-color-greyscale-100",
-    "description": "color token: greyscale 100",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-greyscale-100",
+    "type": "component",
+    "id": "data-grid",
+    "name": "Data Grid",
+    "description": "Advanced table with sorting and selection.",
     "status": "stable",
-    "category": "color"
+    "category": "content-layout",
+    "tags": [],
+    "slug": "data-grid"
   },
   {
-    "id": "token-color-greyscale-150",
-    "title": "--goa-color-greyscale-150",
-    "name": "--goa-color-greyscale-150",
-    "description": "color token: greyscale 150",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-greyscale-150",
+    "type": "component",
+    "id": "date-picker",
+    "name": "Date picker",
+    "description": "Lets users select a date through a calendar without the need to manually type it in a field.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-greyscale-200",
-    "title": "--goa-color-greyscale-200",
-    "name": "--goa-color-greyscale-200",
-    "description": "color token: greyscale 200",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "calendar",
+      "date",
+      "date picker",
+      "inputs and actions",
+      "input"
     ],
-    "type": "token",
-    "slug": "color-greyscale-200",
-    "status": "stable",
-    "category": "color"
+    "slug": "date-picker"
   },
   {
-    "id": "token-color-greyscale-300",
-    "title": "--goa-color-greyscale-300",
-    "name": "--goa-color-greyscale-300",
-    "description": "color token: greyscale 300",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-greyscale-300",
+    "type": "component",
+    "id": "details",
+    "name": "Details",
+    "description": "Let users reveal more detailed information when they need it.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-greyscale-400",
-    "title": "--goa-color-greyscale-400",
-    "name": "--goa-color-greyscale-400",
-    "description": "color token: greyscale 400",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "content-layout",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "accordion details",
+      "additional info",
+      "additional information",
+      "content layout",
+      "detail accordion",
+      "details expander",
+      "details toggle",
+      "disclosure",
+      "expand",
+      "expander",
+      "expanding detail",
+      "expandable details",
+      "expandable help text",
+      "more info",
+      "see more",
+      "show more",
+      "show more information"
     ],
-    "type": "token",
-    "slug": "color-greyscale-400",
-    "status": "stable",
-    "category": "color"
+    "slug": "details"
   },
   {
-    "id": "token-color-greyscale-500",
-    "title": "--goa-color-greyscale-500",
-    "name": "--goa-color-greyscale-500",
-    "description": "color token: greyscale 500",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-greyscale-500",
+    "type": "component",
+    "id": "divider",
+    "name": "Divider",
+    "description": "Indicate a separation of layout, or to distinguish large chunks of information on a page.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-greyscale-600",
-    "title": "--goa-color-greyscale-600",
-    "name": "--goa-color-greyscale-600",
-    "description": "color token: greyscale 600",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "utilities",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "dividing line",
+      "page divider",
+      "utilities"
     ],
-    "type": "token",
-    "slug": "color-greyscale-600",
-    "status": "stable",
-    "category": "color"
+    "slug": "divider"
   },
   {
-    "id": "token-color-greyscale-700",
-    "title": "--goa-color-greyscale-700",
-    "name": "--goa-color-greyscale-700",
-    "description": "color token: greyscale 700",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-greyscale-700",
+    "type": "component",
+    "id": "drawer",
+    "name": "Drawer",
+    "description": "A panel that slides in from the side of the screen to display additional content or actions without navigating away from the current view.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-greyscale-800",
-    "title": "--goa-color-greyscale-800",
-    "name": "--goa-color-greyscale-800",
-    "description": "color token: greyscale 800",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "content-layout",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "sections",
+      "structure and navigation",
+      "sheet",
+      "sidesheet",
+      "sidepanel"
     ],
-    "type": "token",
-    "slug": "color-greyscale-800",
-    "status": "stable",
-    "category": "color"
+    "slug": "drawer"
   },
   {
-    "id": "token-color-greyscale-black",
-    "title": "--goa-color-greyscale-black",
-    "name": "--goa-color-greyscale-black",
-    "description": "color token: greyscale black",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-greyscale-black",
+    "type": "component",
+    "id": "dropdown",
+    "name": "Dropdown",
+    "description": "Present a list of options to the user to select from.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-greyscale-white",
-    "title": "--goa-color-greyscale-white",
-    "name": "--goa-color-greyscale-white",
-    "description": "color token: greyscale white",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "inputs and actions",
+      "select",
+      "single select dropdown"
     ],
-    "type": "token",
-    "slug": "color-greyscale-white",
-    "status": "stable",
-    "category": "color"
+    "slug": "dropdown"
   },
   {
-    "id": "token-color-extended-sky-default",
-    "title": "--goa-color-extended-sky-default",
-    "name": "--goa-color-extended-sky-default",
-    "description": "color token: extended sky default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-sky-default",
+    "type": "component",
+    "id": "file-upload-input",
+    "name": "File uploader",
+    "description": "Help users select and upload a file.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-extended-sky-light",
-    "title": "--goa-color-extended-sky-light",
-    "name": "--goa-color-extended-sky-light",
-    "description": "color token: extended sky light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "drag and drop",
+      "file upload",
+      "inputs and actions",
+      "uploader"
     ],
-    "type": "token",
-    "slug": "color-extended-sky-light",
-    "status": "stable",
-    "category": "color"
+    "slug": "file-upload-input"
   },
   {
-    "id": "token-color-extended-sky-border",
-    "title": "--goa-color-extended-sky-border",
-    "name": "--goa-color-extended-sky-border",
-    "description": "color token: extended sky border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-sky-border",
+    "type": "component",
+    "id": "filter-chip",
+    "name": "Filter chip",
+    "description": "Allow the user to enter information, filter content, and make selections.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-extended-sky-text",
-    "title": "--goa-color-extended-sky-text",
-    "name": "--goa-color-extended-sky-text",
-    "description": "color token: extended sky text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "feedback-and-alerts",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "inputs and actions",
+      "pill"
     ],
-    "type": "token",
-    "slug": "color-extended-sky-text",
-    "status": "stable",
-    "category": "color"
+    "slug": "filter-chip"
   },
   {
-    "id": "token-color-extended-pasture-default",
-    "title": "--goa-color-extended-pasture-default",
-    "name": "--goa-color-extended-pasture-default",
-    "description": "color token: extended pasture default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-pasture-default",
+    "type": "component",
+    "id": "footer",
+    "name": "Footer",
+    "description": "Provides information related your service at the bottom of every page.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-extended-pasture-light",
-    "title": "--goa-color-extended-pasture-light",
-    "name": "--goa-color-extended-pasture-light",
-    "description": "color token: extended pasture light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "structure-and-navigation",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "page footer",
+      "structure and navigation"
     ],
-    "type": "token",
-    "slug": "color-extended-pasture-light",
-    "status": "stable",
-    "category": "color"
+    "slug": "footer"
   },
   {
-    "id": "token-color-extended-pasture-border",
-    "title": "--goa-color-extended-pasture-border",
-    "name": "--goa-color-extended-pasture-border",
-    "description": "color token: extended pasture border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-pasture-border",
+    "type": "component",
+    "id": "form-item",
+    "name": "Form item",
+    "description": "Wraps an input control with a text label, requirement label, helper text, and error text.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-extended-pasture-text",
-    "title": "--goa-color-extended-pasture-text",
-    "name": "--goa-color-extended-pasture-text",
-    "description": "color token: extended pasture text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "utilities",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "form",
+      "input",
+      "inputs and actions"
     ],
-    "type": "token",
-    "slug": "color-extended-pasture-text",
-    "status": "stable",
-    "category": "color"
+    "slug": "form-item"
   },
   {
-    "id": "token-color-extended-sunset-default",
-    "title": "--goa-color-extended-sunset-default",
-    "name": "--goa-color-extended-sunset-default",
-    "description": "color token: extended sunset default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "type": "component",
+    "id": "form-stepper",
+    "name": "Form stepper",
+    "description": "Provides a visual representation of a form through a series of steps.",
+    "status": "deprecated",
+    "category": "structure-and-navigation",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "form stepper",
+      "horizontal step navigation",
+      "process overview",
+      "progress indicator",
+      "steps",
+      "structure and navigation",
+      "wizard"
     ],
-    "type": "token",
-    "slug": "color-extended-sunset-default",
-    "status": "stable",
-    "category": "color"
+    "slug": "form-stepper"
   },
   {
-    "id": "token-color-extended-sunset-light",
-    "title": "--goa-color-extended-sunset-light",
-    "name": "--goa-color-extended-sunset-light",
-    "description": "color token: extended sunset light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-sunset-light",
+    "type": "component",
+    "id": "form",
+    "name": "Form",
+    "description": "Container for form inputs and validation.",
     "status": "stable",
-    "category": "color"
+    "category": "inputs-and-actions",
+    "tags": [],
+    "slug": "form"
   },
   {
-    "id": "token-color-extended-sunset-border",
-    "title": "--goa-color-extended-sunset-border",
-    "name": "--goa-color-extended-sunset-border",
-    "description": "color token: extended sunset border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-sunset-border",
+    "type": "component",
+    "id": "grid",
+    "name": "Grid",
+    "description": "Arrange a number of components into a responsive grid pattern.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-extended-sunset-text",
-    "title": "--goa-color-extended-sunset-text",
-    "name": "--goa-color-extended-sunset-text",
-    "description": "color token: extended sunset text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "utilities",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "utilities"
     ],
-    "type": "token",
-    "slug": "color-extended-sunset-text",
-    "status": "stable",
-    "category": "color"
+    "slug": "grid"
   },
   {
-    "id": "token-color-extended-dawn-default",
-    "title": "--goa-color-extended-dawn-default",
-    "name": "--goa-color-extended-dawn-default",
-    "description": "color token: extended dawn default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-dawn-default",
+    "type": "component",
+    "id": "hero-banner",
+    "name": "Hero banner",
+    "description": "A visual band of text, including an image and a call to action.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-extended-dawn-light",
-    "title": "--goa-color-extended-dawn-light",
-    "name": "--goa-color-extended-dawn-light",
-    "description": "color token: extended dawn light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "content-layout",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "promotion banner",
+      "hero panel",
+      "structure and navigation"
     ],
-    "type": "token",
-    "slug": "color-extended-dawn-light",
-    "status": "stable",
-    "category": "color"
+    "slug": "hero-banner"
   },
   {
-    "id": "token-color-extended-dawn-border",
-    "title": "--goa-color-extended-dawn-border",
-    "name": "--goa-color-extended-dawn-border",
-    "description": "color token: extended dawn border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-dawn-border",
+    "type": "component",
+    "id": "icon-button",
+    "name": "Icon button",
+    "description": "A compact button with an icon and no text.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-extended-dawn-text",
-    "title": "--goa-color-extended-dawn-text",
-    "name": "--goa-color-extended-dawn-text",
-    "description": "color token: extended dawn text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "action",
+      "inputs and actions",
+      "submit"
     ],
-    "type": "token",
-    "slug": "color-extended-dawn-text",
-    "status": "stable",
-    "category": "color"
+    "slug": "icon-button"
   },
   {
-    "id": "token-color-extended-lilac-default",
-    "title": "--goa-color-extended-lilac-default",
-    "name": "--goa-color-extended-lilac-default",
-    "description": "color token: extended lilac default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-lilac-default",
+    "type": "component",
+    "id": "icon",
+    "name": "Icons",
+    "description": "A simple and universal graphic symbol representing an action, object, or concept to help guide the user.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-extended-lilac-light",
-    "title": "--goa-color-extended-lilac-light",
-    "name": "--goa-color-extended-lilac-light",
-    "description": "color token: extended lilac light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "utilities",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "utilities"
     ],
-    "type": "token",
-    "slug": "color-extended-lilac-light",
-    "status": "stable",
-    "category": "color"
+    "slug": "icon"
   },
   {
-    "id": "token-color-extended-lilac-border",
-    "title": "--goa-color-extended-lilac-border",
-    "name": "--goa-color-extended-lilac-border",
-    "description": "color token: extended lilac border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-lilac-border",
+    "type": "component",
+    "id": "input",
+    "name": "Input",
+    "description": "A single-line field where users can input and edit text.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-extended-lilac-text",
-    "title": "--goa-color-extended-lilac-text",
-    "name": "--goa-color-extended-lilac-text",
-    "description": "color token: extended lilac text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "inputs and actions",
+      "text field",
+      "text box",
+      "search",
+      "text input"
     ],
-    "type": "token",
-    "slug": "color-extended-lilac-text",
-    "status": "stable",
-    "category": "color"
+    "slug": "input"
   },
   {
-    "id": "token-color-extended-prairie-default",
-    "title": "--goa-color-extended-prairie-default",
-    "name": "--goa-color-extended-prairie-default",
-    "description": "color token: extended prairie default",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-prairie-default",
+    "type": "component",
+    "id": "linear-progress",
+    "name": "Linear progress indicator",
+    "description": "Provide visual feedback to users while loading.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "token-color-extended-prairie-light",
-    "title": "--goa-color-extended-prairie-light",
-    "name": "--goa-color-extended-prairie-light",
-    "description": "color token: extended prairie light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "feedback-and-alerts",
     "tags": [
-      "token",
-      "design token",
-      "color"
+      "progress",
+      "feedback and alerts",
+      "loading",
+      "loader",
+      "loading indicator",
+      "process timer"
     ],
-    "type": "token",
-    "slug": "color-extended-prairie-light",
-    "status": "stable",
-    "category": "color"
+    "slug": "linear-progress"
   },
   {
-    "id": "token-color-extended-prairie-border",
-    "title": "--goa-color-extended-prairie-border",
-    "name": "--goa-color-extended-prairie-border",
-    "description": "color token: extended prairie border",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-prairie-border",
+    "type": "component",
+    "id": "link-button",
+    "name": "Link Button",
+    "description": "Button styled as a link for secondary actions.",
     "status": "stable",
-    "category": "color"
+    "category": "inputs-and-actions",
+    "tags": [],
+    "slug": "link-button"
   },
   {
-    "id": "token-color-extended-prairie-text",
-    "title": "--goa-color-extended-prairie-text",
-    "name": "--goa-color-extended-prairie-text",
-    "description": "color token: extended prairie text",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "color"
-    ],
-    "type": "token",
-    "slug": "color-extended-prairie-text",
+    "type": "component",
+    "id": "link",
+    "name": "Link",
+    "description": "Wraps an anchor element to add icons or margins.",
     "status": "stable",
-    "category": "color"
-  },
-  {
-    "id": "tokens-opacity",
-    "title": "Opacity Tokens",
-    "description": "Opacity values for overlays, disabled states, and transparency effects",
-    "content": "--goa-opacity-page-transparent --goa-opacity-page-full --goa-opacity-background-modal --goa-opacity-background-loading",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "utilities",
     "tags": [
-      "token",
-      "opacity",
-      "transparency",
-      "design token"
+      "utilities",
+      "text"
     ],
-    "type": "token",
-    "slug": "opacity",
-    "status": "stable",
-    "category": "opacity"
+    "slug": "link"
   },
   {
-    "id": "token-opacity-page-transparent",
-    "title": "--goa-opacity-page-transparent",
-    "name": "--goa-opacity-page-transparent",
-    "description": "opacity token: page transparent",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "opacity"
-    ],
-    "type": "token",
-    "slug": "opacity-page-transparent",
+    "type": "component",
+    "id": "menu-button",
+    "name": "Menu button",
+    "description": "A button with more than one action.",
     "status": "stable",
-    "category": "opacity"
-  },
-  {
-    "id": "token-opacity-page-full",
-    "title": "--goa-opacity-page-full",
-    "name": "--goa-opacity-page-full",
-    "description": "opacity token: page full",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "opacity"
+      "menu button",
+      "split button"
     ],
-    "type": "token",
-    "slug": "opacity-page-full",
-    "status": "stable",
-    "category": "opacity"
+    "slug": "menu-button"
   },
   {
-    "id": "token-opacity-background-modal",
-    "title": "--goa-opacity-background-modal",
-    "name": "--goa-opacity-background-modal",
-    "description": "opacity token: background modal",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "opacity"
-    ],
-    "type": "token",
-    "slug": "opacity-background-modal",
+    "type": "component",
+    "id": "microsite-header",
+    "name": "Microsite header",
+    "description": "Communicate what stage the service is at, connect to Alberta.ca, and gather feedback on your service.",
     "status": "stable",
-    "category": "opacity"
-  },
-  {
-    "id": "token-opacity-background-loading",
-    "title": "--goa-opacity-background-loading",
-    "name": "--goa-opacity-background-loading",
-    "description": "opacity token: background loading",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "structure-and-navigation",
     "tags": [
-      "token",
-      "design token",
-      "opacity"
+      "banner",
+      "development header",
+      "feedback bar",
+      "microheader",
+      "microsite banner",
+      "service header",
+      "service bar",
+      "service stage banner",
+      "service state banner",
+      "status bar",
+      "structure and navigation"
     ],
-    "type": "token",
-    "slug": "opacity-background-loading",
-    "status": "stable",
-    "category": "opacity"
+    "slug": "microsite-header"
   },
   {
-    "id": "tokens-borderRadius",
-    "title": "Border Radius Tokens",
-    "description": "Border radius values for rounded corners on cards, buttons, and containers",
-    "content": "--goa-borderRadius-none --goa-borderRadius-xs --goa-borderRadius-s --goa-borderRadius-m --goa-borderRadius-l --goa-borderRadius-xl --goa-borderRadius-2xl --goa-borderRadius-3xl --goa-borderRadius-round",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "border",
-      "radius",
-      "corners",
-      "design token"
-    ],
-    "type": "token",
-    "slug": "borderRadius",
+    "type": "component",
+    "id": "modal",
+    "name": "Modal",
+    "description": "An overlay that appears in front of all other content, and requires a user to take an action before continuing.",
     "status": "stable",
-    "category": "borderRadius"
-  },
-  {
-    "id": "token-borderRadius-none",
-    "title": "--goa-borderRadius-none",
-    "name": "--goa-borderRadius-none",
-    "description": "border radius token: none",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "feedback-and-alerts",
     "tags": [
-      "token",
-      "design token",
-      "borderRadius"
+      "feedback and alerts",
+      "popup modal",
+      "popup box",
+      "modal dialog",
+      "show more information"
     ],
-    "type": "token",
-    "slug": "borderRadius-none",
-    "status": "stable",
-    "category": "borderRadius"
+    "slug": "modal"
   },
   {
-    "id": "token-borderRadius-xs",
-    "title": "--goa-borderRadius-xs",
-    "name": "--goa-borderRadius-xs",
-    "description": "border radius token: xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "borderRadius"
-    ],
-    "type": "token",
-    "slug": "borderRadius-xs",
+    "type": "component",
+    "id": "notification",
+    "name": "Notification banner",
+    "description": "Display important page level information or notifications.",
     "status": "stable",
-    "category": "borderRadius"
-  },
-  {
-    "id": "token-borderRadius-s",
-    "title": "--goa-borderRadius-s",
-    "name": "--goa-borderRadius-s",
-    "description": "border radius token: s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "feedback-and-alerts",
     "tags": [
-      "token",
-      "design token",
-      "borderRadius"
+      "alert banner",
+      "banner",
+      "feedback and alerts"
     ],
-    "type": "token",
-    "slug": "borderRadius-s",
-    "status": "stable",
-    "category": "borderRadius"
+    "slug": "notification"
   },
   {
-    "id": "token-borderRadius-m",
-    "title": "--goa-borderRadius-m",
-    "name": "--goa-borderRadius-m",
-    "description": "border radius token: m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "borderRadius"
-    ],
-    "type": "token",
-    "slug": "borderRadius-m",
+    "type": "component",
+    "id": "page-block",
+    "name": "Page Block",
+    "description": "Full-width section with optional background.",
     "status": "stable",
-    "category": "borderRadius"
+    "category": "content-layout",
+    "tags": [],
+    "slug": "page-block"
   },
   {
-    "id": "token-borderRadius-l",
-    "title": "--goa-borderRadius-l",
-    "name": "--goa-borderRadius-l",
-    "description": "border radius token: l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "borderRadius"
-    ],
-    "type": "token",
-    "slug": "borderRadius-l",
+    "type": "component",
+    "id": "pagination",
+    "name": "Pagination",
+    "description": "Help users navigation between multiple pages or screens as part of a set.",
     "status": "stable",
-    "category": "borderRadius"
-  },
-  {
-    "id": "token-borderRadius-xl",
-    "title": "--goa-borderRadius-xl",
-    "name": "--goa-borderRadius-xl",
-    "description": "border radius token: xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "structure-and-navigation",
     "tags": [
-      "token",
-      "design token",
-      "borderRadius"
+      "pager",
+      "pagination controls",
+      "structure and navigation"
     ],
-    "type": "token",
-    "slug": "borderRadius-xl",
-    "status": "stable",
-    "category": "borderRadius"
+    "slug": "pagination"
   },
   {
-    "id": "token-borderRadius-2xl",
-    "title": "--goa-borderRadius-2xl",
-    "name": "--goa-borderRadius-2xl",
-    "description": "border radius token: 2xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "borderRadius"
-    ],
-    "type": "token",
-    "slug": "borderRadius-2xl",
+    "type": "component",
+    "id": "popover",
+    "name": "Popover",
+    "description": "A small overlay that opens on demand, used in other components.",
     "status": "stable",
-    "category": "borderRadius"
-  },
-  {
-    "id": "token-borderRadius-3xl",
-    "title": "--goa-borderRadius-3xl",
-    "name": "--goa-borderRadius-3xl",
-    "description": "border radius token: 3xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "content-layout",
     "tags": [
-      "token",
-      "design token",
-      "borderRadius"
+      "content layout",
+      "show more information"
     ],
-    "type": "token",
-    "slug": "borderRadius-3xl",
-    "status": "stable",
-    "category": "borderRadius"
+    "slug": "popover"
   },
   {
-    "id": "token-borderRadius-round",
-    "title": "--goa-borderRadius-round",
-    "name": "--goa-borderRadius-round",
-    "description": "border radius token: round",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "borderRadius"
-    ],
-    "type": "token",
-    "slug": "borderRadius-round",
+    "type": "component",
+    "id": "push-drawer",
+    "name": "Push Drawer",
+    "description": "A panel that pushes the main page content aside on desktop, falling back to an overlay drawer on smaller screens.",
     "status": "stable",
-    "category": "borderRadius"
-  },
-  {
-    "id": "tokens-borderWidth",
-    "title": "Border Width Tokens",
-    "description": "Border width values for outlines, dividers, and component borders",
-    "content": "--goa-borderWidth-none --goa-borderWidth-2xs --goa-borderWidth-xs --goa-borderWidth-s --goa-borderWidth-m --goa-borderWidth-l --goa-borderWidth-xl",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "content-layout",
     "tags": [
-      "token",
-      "border",
-      "width",
-      "stroke",
-      "design token"
+      "sections",
+      "structure and navigation",
+      "drawer",
+      "sidebar",
+      "panel"
     ],
-    "type": "token",
-    "slug": "borderWidth",
-    "status": "stable",
-    "category": "borderWidth"
+    "slug": "push-drawer"
   },
   {
-    "id": "token-borderWidth-none",
-    "title": "--goa-borderWidth-none",
-    "name": "--goa-borderWidth-none",
-    "description": "border width token: none",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "borderWidth"
-    ],
-    "type": "token",
-    "slug": "borderWidth-none",
+    "type": "component",
+    "id": "radio-group",
+    "name": "Radio",
+    "description": "Allow users to select one option from a set.",
     "status": "stable",
-    "category": "borderWidth"
-  },
-  {
-    "id": "token-borderWidth-2xs",
-    "title": "--goa-borderWidth-2xs",
-    "name": "--goa-borderWidth-2xs",
-    "description": "border width token: 2xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "borderWidth"
+      "inputs and actions",
+      "option button",
+      "radio button group",
+      "radio buttons"
     ],
-    "type": "token",
-    "slug": "borderWidth-2xs",
-    "status": "stable",
-    "category": "borderWidth"
+    "slug": "radio-group"
   },
   {
-    "id": "token-borderWidth-xs",
-    "title": "--goa-borderWidth-xs",
-    "name": "--goa-borderWidth-xs",
-    "description": "border width token: xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "borderWidth"
-    ],
-    "type": "token",
-    "slug": "borderWidth-xs",
+    "type": "component",
+    "id": "side-menu",
+    "name": "Side menu",
+    "description": "A side navigation that helps the user navigate between pages.",
     "status": "stable",
-    "category": "borderWidth"
-  },
-  {
-    "id": "token-borderWidth-s",
-    "title": "--goa-borderWidth-s",
-    "name": "--goa-borderWidth-s",
-    "description": "border width token: s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "structure-and-navigation",
     "tags": [
-      "token",
-      "design token",
-      "borderWidth"
+      "secondary navigation",
+      "side nav",
+      "side bar",
+      "structure and navigation"
     ],
-    "type": "token",
-    "slug": "borderWidth-s",
-    "status": "stable",
-    "category": "borderWidth"
+    "slug": "side-menu"
   },
   {
-    "id": "token-borderWidth-m",
-    "title": "--goa-borderWidth-m",
-    "name": "--goa-borderWidth-m",
-    "description": "border width token: m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "borderWidth"
-    ],
-    "type": "token",
-    "slug": "borderWidth-m",
+    "type": "component",
+    "id": "skeleton",
+    "name": "Skeleton loader",
+    "description": "Provide visual feedback to users while loading a content heavy page or page element.",
     "status": "stable",
-    "category": "borderWidth"
-  },
-  {
-    "id": "token-borderWidth-l",
-    "title": "--goa-borderWidth-l",
-    "name": "--goa-borderWidth-l",
-    "description": "border width token: l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "feedback-and-alerts",
     "tags": [
-      "token",
-      "design token",
-      "borderWidth"
+      "content layout",
+      "loading"
     ],
-    "type": "token",
-    "slug": "borderWidth-l",
-    "status": "stable",
-    "category": "borderWidth"
+    "slug": "skeleton"
   },
   {
-    "id": "token-borderWidth-xl",
-    "title": "--goa-borderWidth-xl",
-    "name": "--goa-borderWidth-xl",
-    "description": "border width token: xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "borderWidth"
-    ],
-    "type": "token",
-    "slug": "borderWidth-xl",
+    "type": "component",
+    "id": "spacer",
+    "name": "Spacer",
+    "description": "Negative area between the components and the interface.",
     "status": "stable",
-    "category": "borderWidth"
-  },
-  {
-    "id": "tokens-space",
-    "title": "Spacing Tokens",
-    "description": "Spacing values for margins, padding, and gaps between elements",
-    "content": "--goa-space-none --goa-space-3xs --goa-space-2xs --goa-space-xs --goa-space-s --goa-space-m --goa-space-l --goa-space-xl --goa-space-2xl --goa-space-3xl --goa-space-4xl --goa-space-fill",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "utilities",
     "tags": [
-      "token",
-      "space",
-      "spacing",
+      "gap",
       "margin",
       "padding",
-      "gap",
-      "design token"
+      "space",
+      "utilities"
     ],
-    "type": "token",
-    "slug": "space",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-none",
-    "title": "--goa-space-none",
-    "name": "--goa-space-none",
-    "description": "spacing token: none",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-none",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-3xs",
-    "title": "--goa-space-3xs",
-    "name": "--goa-space-3xs",
-    "description": "spacing token: 3xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-3xs",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-2xs",
-    "title": "--goa-space-2xs",
-    "name": "--goa-space-2xs",
-    "description": "spacing token: 2xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-2xs",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-xs",
-    "title": "--goa-space-xs",
-    "name": "--goa-space-xs",
-    "description": "spacing token: xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-xs",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-s",
-    "title": "--goa-space-s",
-    "name": "--goa-space-s",
-    "description": "spacing token: s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-s",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-m",
-    "title": "--goa-space-m",
-    "name": "--goa-space-m",
-    "description": "spacing token: m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-m",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-l",
-    "title": "--goa-space-l",
-    "name": "--goa-space-l",
-    "description": "spacing token: l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-l",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-xl",
-    "title": "--goa-space-xl",
-    "name": "--goa-space-xl",
-    "description": "spacing token: xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-xl",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-2xl",
-    "title": "--goa-space-2xl",
-    "name": "--goa-space-2xl",
-    "description": "spacing token: 2xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-2xl",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-3xl",
-    "title": "--goa-space-3xl",
-    "name": "--goa-space-3xl",
-    "description": "spacing token: 3xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-3xl",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-4xl",
-    "title": "--goa-space-4xl",
-    "name": "--goa-space-4xl",
-    "description": "spacing token: 4xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-4xl",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "token-space-fill",
-    "title": "--goa-space-fill",
-    "name": "--goa-space-fill",
-    "description": "spacing token: fill",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "space"
-    ],
-    "type": "token",
-    "slug": "space-fill",
-    "status": "stable",
-    "category": "space"
-  },
-  {
-    "id": "tokens-iconSize",
-    "title": "Icon Size Tokens",
-    "description": "Standard icon sizes for consistent iconography across the design system",
-    "content": "--goa-iconSize-1 --goa-iconSize-2 --goa-iconSize-3 --goa-iconSize-4 --goa-iconSize-5 --goa-iconSize-6 --goa-iconSize-xs --goa-iconSize-s --goa-iconSize-m --goa-iconSize-l --goa-iconSize-xl",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "icon",
-      "size",
-      "design token"
-    ],
-    "type": "token",
-    "slug": "iconSize",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-1",
-    "title": "--goa-iconSize-1",
-    "name": "--goa-iconSize-1",
-    "description": "icon size token: 1",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-1",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-2",
-    "title": "--goa-iconSize-2",
-    "name": "--goa-iconSize-2",
-    "description": "icon size token: 2",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-2",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-3",
-    "title": "--goa-iconSize-3",
-    "name": "--goa-iconSize-3",
-    "description": "icon size token: 3",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-3",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-4",
-    "title": "--goa-iconSize-4",
-    "name": "--goa-iconSize-4",
-    "description": "icon size token: 4",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-4",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-5",
-    "title": "--goa-iconSize-5",
-    "name": "--goa-iconSize-5",
-    "description": "icon size token: 5",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-5",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-6",
-    "title": "--goa-iconSize-6",
-    "name": "--goa-iconSize-6",
-    "description": "icon size token: 6",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-6",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-xs",
-    "title": "--goa-iconSize-xs",
-    "name": "--goa-iconSize-xs",
-    "description": "icon size token: xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-xs",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-s",
-    "title": "--goa-iconSize-s",
-    "name": "--goa-iconSize-s",
-    "description": "icon size token: s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-s",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-m",
-    "title": "--goa-iconSize-m",
-    "name": "--goa-iconSize-m",
-    "description": "icon size token: m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-m",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-l",
-    "title": "--goa-iconSize-l",
-    "name": "--goa-iconSize-l",
-    "description": "icon size token: l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-l",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "token-iconSize-xl",
-    "title": "--goa-iconSize-xl",
-    "name": "--goa-iconSize-xl",
-    "description": "icon size token: xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "iconSize"
-    ],
-    "type": "token",
-    "slug": "iconSize-xl",
-    "status": "stable",
-    "category": "iconSize"
-  },
-  {
-    "id": "tokens-shadow",
-    "title": "Shadow Tokens",
-    "description": "Box shadow values for elevation and depth effects on cards and modals",
-    "content": "--goa-shadow-100 --goa-shadow-150 --goa-shadow-200 --goa-shadow-300 --goa-shadow-400 --goa-shadow-500 --goa-shadow-600 --goa-shadow-modal --goa-shadow-raised-light --goa-shadow-raised-heavy --goa-shadow-shallow-above --goa-shadow-shallow-below",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "shadow",
-      "elevation",
-      "depth",
-      "design token"
-    ],
-    "type": "token",
-    "slug": "shadow",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-100",
-    "title": "--goa-shadow-100",
-    "name": "--goa-shadow-100",
-    "description": "shadow token: 100",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-100",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-150",
-    "title": "--goa-shadow-150",
-    "name": "--goa-shadow-150",
-    "description": "shadow token: 150",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-150",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-200",
-    "title": "--goa-shadow-200",
-    "name": "--goa-shadow-200",
-    "description": "shadow token: 200",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-200",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-300",
-    "title": "--goa-shadow-300",
-    "name": "--goa-shadow-300",
-    "description": "shadow token: 300",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-300",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-400",
-    "title": "--goa-shadow-400",
-    "name": "--goa-shadow-400",
-    "description": "shadow token: 400",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-400",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-500",
-    "title": "--goa-shadow-500",
-    "name": "--goa-shadow-500",
-    "description": "shadow token: 500",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-500",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-600",
-    "title": "--goa-shadow-600",
-    "name": "--goa-shadow-600",
-    "description": "shadow token: 600",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-600",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-modal",
-    "title": "--goa-shadow-modal",
-    "name": "--goa-shadow-modal",
-    "description": "shadow token: modal",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-modal",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-raised-light",
-    "title": "--goa-shadow-raised-light",
-    "name": "--goa-shadow-raised-light",
-    "description": "shadow token: raised light",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-raised-light",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-raised-heavy",
-    "title": "--goa-shadow-raised-heavy",
-    "name": "--goa-shadow-raised-heavy",
-    "description": "shadow token: raised heavy",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-raised-heavy",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-shallow-above",
-    "title": "--goa-shadow-shallow-above",
-    "name": "--goa-shadow-shallow-above",
-    "description": "shadow token: shallow above",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-shallow-above",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "token-shadow-shallow-below",
-    "title": "--goa-shadow-shallow-below",
-    "name": "--goa-shadow-shallow-below",
-    "description": "shadow token: shallow below",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "shadow"
-    ],
-    "type": "token",
-    "slug": "shadow-shallow-below",
-    "status": "stable",
-    "category": "shadow"
-  },
-  {
-    "id": "tokens-lineHeight",
-    "title": "Line Height Tokens",
-    "description": "Line height values for readable text and proper vertical rhythm",
-    "content": "--goa-lineHeight-1 --goa-lineHeight-2 --goa-lineHeight-3 --goa-lineHeight-4 --goa-lineHeight-5 --goa-lineHeight-6 --goa-lineHeight-7 --goa-lineHeight-8 --goa-lineHeight-05",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "line",
-      "height",
-      "leading",
-      "typography",
-      "design token"
-    ],
-    "type": "token",
-    "slug": "lineHeight",
-    "status": "stable",
-    "category": "lineHeight"
-  },
-  {
-    "id": "token-lineHeight-1",
-    "title": "--goa-lineHeight-1",
-    "name": "--goa-lineHeight-1",
-    "description": "line height token: 1",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "lineHeight"
-    ],
-    "type": "token",
-    "slug": "lineHeight-1",
-    "status": "stable",
-    "category": "lineHeight"
-  },
-  {
-    "id": "token-lineHeight-2",
-    "title": "--goa-lineHeight-2",
-    "name": "--goa-lineHeight-2",
-    "description": "line height token: 2",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "lineHeight"
-    ],
-    "type": "token",
-    "slug": "lineHeight-2",
-    "status": "stable",
-    "category": "lineHeight"
-  },
-  {
-    "id": "token-lineHeight-3",
-    "title": "--goa-lineHeight-3",
-    "name": "--goa-lineHeight-3",
-    "description": "line height token: 3",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "lineHeight"
-    ],
-    "type": "token",
-    "slug": "lineHeight-3",
-    "status": "stable",
-    "category": "lineHeight"
-  },
-  {
-    "id": "token-lineHeight-4",
-    "title": "--goa-lineHeight-4",
-    "name": "--goa-lineHeight-4",
-    "description": "line height token: 4",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "lineHeight"
-    ],
-    "type": "token",
-    "slug": "lineHeight-4",
-    "status": "stable",
-    "category": "lineHeight"
-  },
-  {
-    "id": "token-lineHeight-5",
-    "title": "--goa-lineHeight-5",
-    "name": "--goa-lineHeight-5",
-    "description": "line height token: 5",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "lineHeight"
-    ],
-    "type": "token",
-    "slug": "lineHeight-5",
-    "status": "stable",
-    "category": "lineHeight"
-  },
-  {
-    "id": "token-lineHeight-6",
-    "title": "--goa-lineHeight-6",
-    "name": "--goa-lineHeight-6",
-    "description": "line height token: 6",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "lineHeight"
-    ],
-    "type": "token",
-    "slug": "lineHeight-6",
-    "status": "stable",
-    "category": "lineHeight"
-  },
-  {
-    "id": "token-lineHeight-7",
-    "title": "--goa-lineHeight-7",
-    "name": "--goa-lineHeight-7",
-    "description": "line height token: 7",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "lineHeight"
-    ],
-    "type": "token",
-    "slug": "lineHeight-7",
-    "status": "stable",
-    "category": "lineHeight"
-  },
-  {
-    "id": "token-lineHeight-8",
-    "title": "--goa-lineHeight-8",
-    "name": "--goa-lineHeight-8",
-    "description": "line height token: 8",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "lineHeight"
-    ],
-    "type": "token",
-    "slug": "lineHeight-8",
-    "status": "stable",
-    "category": "lineHeight"
-  },
-  {
-    "id": "token-lineHeight-05",
-    "title": "--goa-lineHeight-05",
-    "name": "--goa-lineHeight-05",
-    "description": "line height token: 05",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "lineHeight"
-    ],
-    "type": "token",
-    "slug": "lineHeight-05",
-    "status": "stable",
-    "category": "lineHeight"
-  },
-  {
-    "id": "tokens-fontFamily",
-    "title": "Font Family Tokens",
-    "description": "Font family values for the design system typefaces",
-    "content": "--goa-fontFamily-sans --goa-fontFamily-number",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "font",
-      "family",
-      "typeface",
-      "design token"
-    ],
-    "type": "token",
-    "slug": "fontFamily",
-    "status": "stable",
-    "category": "fontFamily"
-  },
-  {
-    "id": "token-fontFamily-sans",
-    "title": "--goa-fontFamily-sans",
-    "name": "--goa-fontFamily-sans",
-    "description": "font family token: sans",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontFamily"
-    ],
-    "type": "token",
-    "slug": "fontFamily-sans",
-    "status": "stable",
-    "category": "fontFamily"
-  },
-  {
-    "id": "token-fontFamily-number",
-    "title": "--goa-fontFamily-number",
-    "name": "--goa-fontFamily-number",
-    "description": "font family token: number",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontFamily"
-    ],
-    "type": "token",
-    "slug": "fontFamily-number",
-    "status": "stable",
-    "category": "fontFamily"
-  },
-  {
-    "id": "tokens-fontSize",
-    "title": "Font Size Tokens",
-    "description": "Font size values for text hierarchy and responsive typography",
-    "content": "--goa-fontSize-1 --goa-fontSize-2 --goa-fontSize-3 --goa-fontSize-4 --goa-fontSize-5 --goa-fontSize-6 --goa-fontSize-7 --goa-fontSize-8 --goa-fontSize-9 --goa-fontSize-10 --goa-fontSize-05",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "font",
-      "size",
-      "typography",
-      "design token"
-    ],
-    "type": "token",
-    "slug": "fontSize",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-1",
-    "title": "--goa-fontSize-1",
-    "name": "--goa-fontSize-1",
-    "description": "font size token: 1",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-1",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-2",
-    "title": "--goa-fontSize-2",
-    "name": "--goa-fontSize-2",
-    "description": "font size token: 2",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-2",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-3",
-    "title": "--goa-fontSize-3",
-    "name": "--goa-fontSize-3",
-    "description": "font size token: 3",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-3",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-4",
-    "title": "--goa-fontSize-4",
-    "name": "--goa-fontSize-4",
-    "description": "font size token: 4",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-4",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-5",
-    "title": "--goa-fontSize-5",
-    "name": "--goa-fontSize-5",
-    "description": "font size token: 5",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-5",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-6",
-    "title": "--goa-fontSize-6",
-    "name": "--goa-fontSize-6",
-    "description": "font size token: 6",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-6",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-7",
-    "title": "--goa-fontSize-7",
-    "name": "--goa-fontSize-7",
-    "description": "font size token: 7",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-7",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-8",
-    "title": "--goa-fontSize-8",
-    "name": "--goa-fontSize-8",
-    "description": "font size token: 8",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-8",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-9",
-    "title": "--goa-fontSize-9",
-    "name": "--goa-fontSize-9",
-    "description": "font size token: 9",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-9",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-10",
-    "title": "--goa-fontSize-10",
-    "name": "--goa-fontSize-10",
-    "description": "font size token: 10",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-10",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "token-fontSize-05",
-    "title": "--goa-fontSize-05",
-    "name": "--goa-fontSize-05",
-    "description": "font size token: 05",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontSize"
-    ],
-    "type": "token",
-    "slug": "fontSize-05",
-    "status": "stable",
-    "category": "fontSize"
-  },
-  {
-    "id": "tokens-fontWeight",
-    "title": "Font Weight Tokens",
-    "description": "Font weight values for text emphasis and hierarchy",
-    "content": "--goa-fontWeight-regular --goa-fontWeight-medium --goa-fontWeight-semiBold --goa-fontWeight-bold",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "font",
-      "weight",
-      "bold",
-      "design token"
-    ],
-    "type": "token",
-    "slug": "fontWeight",
-    "status": "stable",
-    "category": "fontWeight"
-  },
-  {
-    "id": "token-fontWeight-regular",
-    "title": "--goa-fontWeight-regular",
-    "name": "--goa-fontWeight-regular",
-    "description": "font weight token: regular",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontWeight"
-    ],
-    "type": "token",
-    "slug": "fontWeight-regular",
-    "status": "stable",
-    "category": "fontWeight"
-  },
-  {
-    "id": "token-fontWeight-medium",
-    "title": "--goa-fontWeight-medium",
-    "name": "--goa-fontWeight-medium",
-    "description": "font weight token: medium",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontWeight"
-    ],
-    "type": "token",
-    "slug": "fontWeight-medium",
-    "status": "stable",
-    "category": "fontWeight"
-  },
-  {
-    "id": "token-fontWeight-semiBold",
-    "title": "--goa-fontWeight-semiBold",
-    "name": "--goa-fontWeight-semiBold",
-    "description": "font weight token: semiBold",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontWeight"
-    ],
-    "type": "token",
-    "slug": "fontWeight-semiBold",
-    "status": "stable",
-    "category": "fontWeight"
-  },
-  {
-    "id": "token-fontWeight-bold",
-    "title": "--goa-fontWeight-bold",
-    "name": "--goa-fontWeight-bold",
-    "description": "font weight token: bold",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "fontWeight"
-    ],
-    "type": "token",
-    "slug": "fontWeight-bold",
-    "status": "stable",
-    "category": "fontWeight"
-  },
-  {
-    "id": "tokens-letterSpacing",
-    "title": "Letter Spacing Tokens",
-    "description": "Letter spacing values for text tracking adjustments",
-    "content": "--goa-letterSpacing-3xs --goa-letterSpacing-2xs --goa-letterSpacing-xs --goa-letterSpacing-s --goa-letterSpacing-m --goa-letterSpacing-l --goa-letterSpacing-xl --goa-letterSpacing-2xl --goa-letterSpacing-mobile-3xs --goa-letterSpacing-mobile-2xs --goa-letterSpacing-mobile-xs --goa-letterSpacing-mobile-s --goa-letterSpacing-mobile-m --goa-letterSpacing-mobile-l --goa-letterSpacing-mobile-xl --goa-letterSpacing-mobile-2xl",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "letter",
-      "spacing",
-      "tracking",
-      "typography",
-      "design token"
-    ],
-    "type": "token",
-    "slug": "letterSpacing",
-    "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-3xs",
-    "title": "--goa-letterSpacing-3xs",
-    "name": "--goa-letterSpacing-3xs",
-    "description": "letter spacing token: 3xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-3xs",
-    "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-2xs",
-    "title": "--goa-letterSpacing-2xs",
-    "name": "--goa-letterSpacing-2xs",
-    "description": "letter spacing token: 2xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-2xs",
-    "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-xs",
-    "title": "--goa-letterSpacing-xs",
-    "name": "--goa-letterSpacing-xs",
-    "description": "letter spacing token: xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-xs",
-    "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-s",
-    "title": "--goa-letterSpacing-s",
-    "name": "--goa-letterSpacing-s",
-    "description": "letter spacing token: s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-s",
-    "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-m",
-    "title": "--goa-letterSpacing-m",
-    "name": "--goa-letterSpacing-m",
-    "description": "letter spacing token: m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-m",
-    "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-l",
-    "title": "--goa-letterSpacing-l",
-    "name": "--goa-letterSpacing-l",
-    "description": "letter spacing token: l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-l",
-    "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-xl",
-    "title": "--goa-letterSpacing-xl",
-    "name": "--goa-letterSpacing-xl",
-    "description": "letter spacing token: xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-xl",
-    "status": "stable",
-    "category": "letterSpacing"
+    "slug": "spacer"
   },
   {
-    "id": "token-letterSpacing-2xl",
-    "title": "--goa-letterSpacing-2xl",
-    "name": "--goa-letterSpacing-2xl",
-    "description": "letter spacing token: 2xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-2xl",
+    "type": "component",
+    "id": "table",
+    "name": "Table",
+    "description": "A set of structured data that is easy for a user to scan, examine, and compare.",
     "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-mobile-3xs",
-    "title": "--goa-letterSpacing-mobile-3xs",
-    "name": "--goa-letterSpacing-mobile-3xs",
-    "description": "letter spacing token: mobile 3xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "content-layout",
     "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
+      "data table",
+      "content layout",
+      "interactive table",
+      "sortable table"
     ],
-    "type": "token",
-    "slug": "letterSpacing-mobile-3xs",
-    "status": "stable",
-    "category": "letterSpacing"
+    "slug": "table"
   },
   {
-    "id": "token-letterSpacing-mobile-2xs",
-    "title": "--goa-letterSpacing-mobile-2xs",
-    "name": "--goa-letterSpacing-mobile-2xs",
-    "description": "letter spacing token: mobile 2xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-mobile-2xs",
+    "type": "component",
+    "id": "tabs",
+    "name": "Tabs",
+    "description": "Let users navigate between related sections of content, displaying one section at a time.",
     "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-mobile-xs",
-    "title": "--goa-letterSpacing-mobile-xs",
-    "name": "--goa-letterSpacing-mobile-xs",
-    "description": "letter spacing token: mobile xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "structure-and-navigation",
     "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
+      "sections",
+      "structure and navigation",
+      "tabbed interface"
     ],
-    "type": "token",
-    "slug": "letterSpacing-mobile-xs",
-    "status": "stable",
-    "category": "letterSpacing"
+    "slug": "tabs"
   },
   {
-    "id": "token-letterSpacing-mobile-s",
-    "title": "--goa-letterSpacing-mobile-s",
-    "name": "--goa-letterSpacing-mobile-s",
-    "description": "letter spacing token: mobile s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-mobile-s",
+    "type": "component",
+    "id": "temporary-notification",
+    "name": "Temporary notification",
+    "description": "A notification that appears at the bottom of the screen.",
     "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-mobile-m",
-    "title": "--goa-letterSpacing-mobile-m",
-    "name": "--goa-letterSpacing-mobile-m",
-    "description": "letter spacing token: mobile m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "feedback-and-alerts",
     "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
+      "snackbar",
+      "toast",
+      "temporary notification"
     ],
-    "type": "token",
-    "slug": "letterSpacing-mobile-m",
-    "status": "stable",
-    "category": "letterSpacing"
+    "slug": "temporary-notification"
   },
   {
-    "id": "token-letterSpacing-mobile-l",
-    "title": "--goa-letterSpacing-mobile-l",
-    "name": "--goa-letterSpacing-mobile-l",
-    "description": "letter spacing token: mobile l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-mobile-l",
+    "type": "component",
+    "id": "text-area",
+    "name": "Text area",
+    "description": "A multi-line field where users can input and edit text.",
     "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "token-letterSpacing-mobile-xl",
-    "title": "--goa-letterSpacing-mobile-xl",
-    "name": "--goa-letterSpacing-mobile-xl",
-    "description": "letter spacing token: mobile xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "inputs-and-actions",
     "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
+      "inputs and actions",
+      "long answer input field",
+      "multi line text input",
+      "multiple text box",
+      "text box",
+      "text input area"
     ],
-    "type": "token",
-    "slug": "letterSpacing-mobile-xl",
-    "status": "stable",
-    "category": "letterSpacing"
+    "slug": "text-area"
   },
   {
-    "id": "token-letterSpacing-mobile-2xl",
-    "title": "--goa-letterSpacing-mobile-2xl",
-    "name": "--goa-letterSpacing-mobile-2xl",
-    "description": "letter spacing token: mobile 2xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "letterSpacing"
-    ],
-    "type": "token",
-    "slug": "letterSpacing-mobile-2xl",
+    "type": "component",
+    "id": "text",
+    "name": "Text",
+    "description": "Provides consistent sizing, spacing, and colour to written content.",
     "status": "stable",
-    "category": "letterSpacing"
-  },
-  {
-    "id": "tokens-typography",
-    "title": "Typography Tokens",
-    "description": "Typography presets combining font family, size, weight, and line height",
-    "content": "--goa-typography-heading-2xs --goa-typography-heading-xs --goa-typography-heading-s --goa-typography-heading-m --goa-typography-heading-l --goa-typography-heading-xl --goa-typography-heading-2xl --goa-typography-body-xs --goa-typography-body-s --goa-typography-body-m --goa-typography-body-l --goa-typography-number-s --goa-typography-number-m --goa-typography-number-l --goa-typography-mobile-heading-2xs --goa-typography-mobile-heading-xs --goa-typography-mobile-heading-s --goa-typography-mobile-heading-m --goa-typography-mobile-heading-l --goa-typography-mobile-heading-xl --goa-typography-mobile-heading-2xl --goa-typography-mobile-body-xs --goa-typography-mobile-body-s --goa-typography-mobile-body-m --goa-typography-mobile-body-l --goa-typography-mobile-number-s --goa-typography-mobile-number-m --goa-typography-mobile-number-l",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
+    "category": "content-layout",
     "tags": [
-      "token",
-      "typography",
-      "font",
       "text",
-      "heading",
       "body",
-      "design token"
+      "copy"
     ],
-    "type": "token",
-    "slug": "typography",
-    "status": "stable",
-    "category": "typography"
+    "slug": "text"
   },
   {
-    "id": "token-typography-heading-2xs",
-    "title": "--goa-typography-heading-2xs",
-    "name": "--goa-typography-heading-2xs",
-    "description": "typography token: heading 2xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
-    ],
-    "type": "token",
-    "slug": "typography-heading-2xs",
+    "type": "component",
+    "id": "tooltip",
+    "name": "Tooltip",
+    "description": "A small popover that displays more information about an item.",
     "status": "stable",
-    "category": "typography"
+    "category": "feedback-and-alerts",
+    "tags": [
+      "feedback and alerts"
+    ],
+    "slug": "tooltip"
   },
   {
-    "id": "token-typography-heading-xs",
-    "title": "--goa-typography-heading-xs",
-    "name": "--goa-typography-heading-xs",
-    "description": "typography token: heading xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
-    ],
-    "type": "token",
-    "slug": "typography-heading-xs",
+    "type": "component",
+    "id": "work-side-menu",
+    "name": "Work Side Menu",
+    "description": "Side menu variant for worker applications.",
     "status": "stable",
-    "category": "typography"
+    "category": "structure-and-navigation",
+    "tags": [],
+    "slug": "work-side-menu"
   },
   {
-    "id": "token-typography-heading-s",
-    "title": "--goa-typography-heading-s",
-    "name": "--goa-typography-heading-s",
-    "description": "typography token: heading s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "add-a-filter-chip",
+    "title": "Add a filter chip",
+    "description": "Allow users to apply filters using selectable chips, which visually represent active filters and can be removed to update results dynamically.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
     ],
-    "type": "token",
-    "slug": "typography-heading-s",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "filtering",
+      "chips",
+      "dynamic"
+    ],
+    "components": [
+      "filter-chip",
+      "button"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "add-a-filter-chip"
   },
   {
-    "id": "token-typography-heading-m",
-    "title": "--goa-typography-heading-m",
-    "name": "--goa-typography-heading-m",
-    "description": "typography token: heading m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "add-a-record-using-a-drawer",
+    "title": "Add a record using a drawer",
+    "description": "Add a record using a drawer. The drawer slides in from the side to allow data entry without navigating away from the current view.",
+    "status": "published",
+    "categories": [
+      "structure-and-navigation"
     ],
-    "type": "token",
-    "slug": "typography-heading-m",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "drawer",
+      "forms",
+      "records",
+      "data-entry"
+    ],
+    "components": [
+      "drawer",
+      "button",
+      "button-group",
+      "form-item",
+      "dropdown",
+      "input",
+      "radio-group",
+      "block"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "add-a-record-using-a-drawer"
   },
   {
-    "id": "token-typography-heading-l",
-    "title": "--goa-typography-heading-l",
-    "name": "--goa-typography-heading-l",
-    "description": "typography token: heading l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "add-and-edit-lots-of-filters",
+    "title": "Add and edit lots of filters",
+    "description": "Add and edit filters using a drawer. This pattern is useful when you have many filter options that would clutter the main interface.",
+    "status": "published",
+    "categories": [
+      "structure-and-navigation"
     ],
-    "type": "token",
-    "slug": "typography-heading-l",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "filtering",
+      "drawer",
+      "forms",
+      "data-management"
+    ],
+    "components": [
+      "drawer",
+      "button",
+      "button-group",
+      "form-item",
+      "checkbox-list",
+      "checkbox",
+      "dropdown",
+      "radio-group"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "add-and-edit-lots-of-filters"
   },
   {
-    "id": "token-typography-heading-xl",
-    "title": "--goa-typography-heading-xl",
-    "name": "--goa-typography-heading-xl",
-    "description": "typography token: heading xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "add-another-item-in-a-modal",
+    "title": "Add another item in a modal",
+    "description": "Add a new item within a modal window without navigating away from the current context.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
     ],
-    "type": "token",
-    "slug": "typography-heading-xl",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "modal",
+      "forms",
+      "data-entry"
+    ],
+    "components": [
+      "modal",
+      "button",
+      "button-group",
+      "form-item",
+      "dropdown",
+      "input",
+      "text-area"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "add-another-item-in-a-modal"
   },
   {
-    "id": "token-typography-heading-2xl",
-    "title": "--goa-typography-heading-2xl",
-    "name": "--goa-typography-heading-2xl",
-    "description": "typography token: heading 2xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "ask-a-long-answer-question-with-a-maximum-word-count",
+    "title": "Ask a long answer question with a maximum word count",
+    "description": "Restrict a long answer input to a maximum number of words or characters.",
+    "status": "published",
+    "categories": [
+      "forms"
     ],
-    "type": "token",
-    "slug": "typography-heading-2xl",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "forms",
+      "text-area",
+      "validation",
+      "word-count"
+    ],
+    "components": [
+      "form-item",
+      "text-area"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "ask-a-long-answer-question-with-a-maximum-word-count"
   },
   {
-    "id": "token-typography-body-xs",
-    "title": "--goa-typography-body-xs",
-    "name": "--goa-typography-body-xs",
-    "description": "typography token: body xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "ask-a-user-for-a-birthday",
+    "title": "Ask a user for a birthday",
+    "description": "Asks for a user's birthday using the date picker component.",
+    "status": "published",
+    "categories": [
+      "forms"
     ],
-    "type": "token",
-    "slug": "typography-body-xs",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "forms",
+      "date-input",
+      "ask-a-user-for"
+    ],
+    "components": [
+      "form-item",
+      "date-picker"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "ask-a-user-for-a-birthday"
   },
   {
-    "id": "token-typography-body-s",
-    "title": "--goa-typography-body-s",
-    "name": "--goa-typography-body-s",
-    "description": "typography token: body s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "ask-a-user-for-an-address",
+    "title": "Ask a user for an address",
+    "description": "Collect a complete mailing address from the user, including fields like street, city, and postal code.",
+    "status": "published",
+    "categories": [
+      "forms"
     ],
-    "type": "token",
-    "slug": "typography-body-s",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "forms",
+      "address",
+      "location"
+    ],
+    "components": [
+      "form-item",
+      "input",
+      "dropdown",
+      "block",
+      "button",
+      "button-group",
+      "text"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "ask-a-user-for-an-address"
   },
   {
-    "id": "token-typography-body-m",
-    "title": "--goa-typography-body-m",
-    "name": "--goa-typography-body-m",
-    "description": "typography token: body m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "ask-a-user-for-an-indian-registration-number",
+    "title": "Ask a user for an Indian registration number",
+    "description": "Request a user's Indian registration number with appropriate validation and context.",
+    "status": "published",
+    "categories": [
+      "forms"
     ],
-    "type": "token",
-    "slug": "typography-body-m",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "forms",
+      "identity",
+      "registration"
+    ],
+    "components": [
+      "form-item",
+      "input",
+      "block"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "ask-a-user-for-an-indian-registration-number"
   },
   {
-    "id": "token-typography-body-l",
-    "title": "--goa-typography-body-l",
-    "name": "--goa-typography-body-l",
-    "description": "typography token: body l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "ask-a-user-for-direct-deposit-information",
+    "title": "Ask a user for direct deposit information",
+    "description": "Gather banking details from users to enable direct deposit, including account number and financial institution information.",
+    "status": "published",
+    "categories": [
+      "forms"
     ],
-    "type": "token",
-    "slug": "typography-body-l",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "forms",
+      "banking",
+      "financial"
+    ],
+    "components": [
+      "form-item",
+      "input",
+      "details",
+      "text"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "ask-a-user-for-direct-deposit-information"
   },
   {
-    "id": "token-typography-number-s",
-    "title": "--goa-typography-number-s",
-    "name": "--goa-typography-number-s",
-    "description": "typography token: number s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "ask-a-user-for-dollar-amounts",
+    "title": "Ask a user for dollar amounts",
+    "description": "Prompt users to enter monetary values using a consistent input format that supports validation and currency symbols.",
+    "status": "published",
+    "categories": [
+      "forms"
     ],
-    "type": "token",
-    "slug": "typography-number-s",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "forms",
+      "currency",
+      "financial"
+    ],
+    "components": [
+      "form-item",
+      "input"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "ask-a-user-for-dollar-amounts"
   },
   {
-    "id": "token-typography-number-m",
-    "title": "--goa-typography-number-m",
-    "name": "--goa-typography-number-m",
-    "description": "typography token: number m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "ask-a-user-one-question-at-a-time",
+    "title": "Ask a user one question at a time",
+    "description": "Ask a user one question at a time.",
+    "status": "published",
+    "categories": [
+      "forms"
     ],
-    "type": "token",
-    "slug": "typography-number-m",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "forms",
+      "questions",
+      "public-form"
+    ],
+    "components": [
+      "form-item",
+      "radio-group",
+      "radio-item",
+      "button"
+    ],
+    "scale": "page",
+    "userType": "citizen",
+    "slug": "ask-a-user-one-question-at-a-time"
   },
   {
-    "id": "token-typography-number-l",
-    "title": "--goa-typography-number-l",
-    "name": "--goa-typography-number-l",
-    "description": "typography token: number l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "basic-page-layout",
+    "title": "Basic page layout",
+    "description": "A basic page template to use as a starting point.",
+    "status": "published",
+    "categories": [
+      "content-layout"
     ],
-    "type": "token",
-    "slug": "typography-number-l",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "layout",
+      "page-structure",
+      "template"
+    ],
+    "components": [
+      "app-header",
+      "footer",
+      "page-block",
+      "skeleton",
+      "grid"
+    ],
+    "scale": "page",
+    "userType": "both",
+    "slug": "basic-page-layout"
   },
   {
-    "id": "token-typography-mobile-heading-2xs",
-    "title": "--goa-typography-mobile-heading-2xs",
-    "name": "--goa-typography-mobile-heading-2xs",
-    "description": "typography token: mobile heading 2xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "button-with-icon",
+    "title": "Button with Icon",
+    "description": "Shows how to add leading or trailing icons to buttons for enhanced visual communication.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
     ],
-    "type": "token",
-    "slug": "typography-mobile-heading-2xs",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "icons",
+      "buttons",
+      "actions"
+    ],
+    "components": [
+      "button",
+      "button-group",
+      "icon"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "button-with-icon"
   },
   {
-    "id": "token-typography-mobile-heading-xs",
-    "title": "--goa-typography-mobile-heading-xs",
-    "name": "--goa-typography-mobile-heading-xs",
-    "description": "typography token: mobile heading xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "card-grid",
+    "title": "Card grid",
+    "description": "Display multiple cards in a grid layout, each containing related content or actions.",
+    "status": "published",
+    "categories": [
+      "content-layout"
     ],
-    "type": "token",
-    "slug": "typography-mobile-heading-xs",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "cards",
+      "grid",
+      "navigation",
+      "dashboard"
+    ],
+    "components": [
+      "container",
+      "grid",
+      "link",
+      "text"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "card-grid"
   },
   {
-    "id": "token-typography-mobile-heading-s",
-    "title": "--goa-typography-mobile-heading-s",
-    "name": "--goa-typography-mobile-heading-s",
-    "description": "typography token: mobile heading s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "card-view-of-case-files",
+    "title": "Card view of case files",
+    "description": "Present a visual overview of individual case files in a card format for scanning and access.",
+    "status": "published",
+    "categories": [
+      "content-layout"
     ],
-    "type": "token",
-    "slug": "typography-mobile-heading-s",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "cards",
+      "case-management",
+      "status",
+      "list"
+    ],
+    "components": [
+      "container",
+      "block",
+      "badge",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "card-view-of-case-files"
   },
   {
-    "id": "token-typography-mobile-heading-m",
-    "title": "--goa-typography-mobile-heading-m",
-    "name": "--goa-typography-mobile-heading-m",
-    "description": "typography token: mobile heading m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "communicate-a-future-service-outage",
+    "title": "Communicate a future service outage",
+    "description": "Display a clear message to inform users about an upcoming service outage, including the date, time, and expected impact on service availability.",
+    "status": "published",
+    "categories": [
+      "feedback-and-alerts"
     ],
-    "type": "token",
-    "slug": "typography-mobile-heading-m",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "notification",
+      "maintenance",
+      "alerts",
+      "system-status"
+    ],
+    "components": [
+      "notification"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "communicate-a-future-service-outage"
   },
   {
-    "id": "token-typography-mobile-heading-l",
-    "title": "--goa-typography-mobile-heading-l",
-    "name": "--goa-typography-mobile-heading-l",
-    "description": "typography token: mobile heading l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "confirm-a-change",
+    "title": "Confirm a change",
+    "description": "Ask the user to confirm a proposed change before it is applied.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
     ],
-    "type": "token",
-    "slug": "typography-mobile-heading-l",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "modal",
+      "confirmation",
+      "forms",
+      "changes"
+    ],
+    "components": [
+      "modal",
+      "button",
+      "button-group",
+      "container",
+      "form-item",
+      "date-picker"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "confirm-a-change"
   },
   {
-    "id": "token-typography-mobile-heading-xl",
-    "title": "--goa-typography-mobile-heading-xl",
-    "name": "--goa-typography-mobile-heading-xl",
-    "description": "typography token: mobile heading xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "confirm-a-destructive-action",
+    "title": "Confirm a destructive action",
+    "description": "Confirm a destructive action like deletion to prevent accidental data loss.",
+    "status": "published",
+    "categories": [
+      "feedback-and-alerts"
     ],
-    "type": "token",
-    "slug": "typography-mobile-heading-xl",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "modal",
+      "confirmation",
+      "delete",
+      "destructive"
+    ],
+    "components": [
+      "modal",
+      "button",
+      "button-group"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "confirm-a-destructive-action"
   },
   {
-    "id": "token-typography-mobile-heading-2xl",
-    "title": "--goa-typography-mobile-heading-2xl",
-    "name": "--goa-typography-mobile-heading-2xl",
-    "description": "typography token: mobile heading 2xl",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "confirm-before-navigating-away",
+    "title": "Confirm before navigating away",
+    "description": "Prompt the user in a modal before navigating to a new route to preserve context.",
+    "status": "published",
+    "categories": [
+      "feedback-and-alerts"
     ],
-    "type": "token",
-    "slug": "typography-mobile-heading-2xl",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "modal",
+      "navigation",
+      "confirmation",
+      "routing"
+    ],
+    "components": [
+      "modal",
+      "button",
+      "button-group"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "confirm-before-navigating-away"
   },
   {
-    "id": "token-typography-mobile-body-xs",
-    "title": "--goa-typography-mobile-body-xs",
-    "name": "--goa-typography-mobile-body-xs",
-    "description": "typography token: mobile body xs",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "confirm-that-an-application-was-submitted",
+    "title": "Confirm that an application was submitted",
+    "description": "Display a confirmation screen to indicate successful application submission.",
+    "status": "published",
+    "categories": [
+      "feedback-and-alerts"
     ],
-    "type": "token",
-    "slug": "typography-mobile-body-xs",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "confirmation",
+      "success",
+      "callout",
+      "application"
+    ],
+    "components": [
+      "callout",
+      "button",
+      "button-group"
+    ],
+    "scale": "page",
+    "userType": "citizen",
+    "slug": "confirm-that-an-application-was-submitted"
   },
   {
-    "id": "token-typography-mobile-body-s",
-    "title": "--goa-typography-mobile-body-s",
-    "name": "--goa-typography-mobile-body-s",
-    "description": "typography token: mobile body s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "copy-to-clipboard",
+    "title": "Copy to clipboard",
+    "description": "Allow users to quickly copy text or data to their clipboard with a single click.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
     ],
-    "type": "token",
-    "slug": "typography-mobile-body-s",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "clipboard",
+      "copy",
+      "tooltip",
+      "icon-button"
+    ],
+    "components": [
+      "block",
+      "icon-button",
+      "tooltip"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "copy-to-clipboard"
   },
   {
-    "id": "token-typography-mobile-body-m",
-    "title": "--goa-typography-mobile-body-m",
-    "name": "--goa-typography-mobile-body-m",
-    "description": "typography token: mobile body m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "disabled-button-with-a-required-field",
+    "title": "Disabled button with a required field",
+    "description": "Disable a submit button until required form fields are completed.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
     ],
-    "type": "token",
-    "slug": "typography-mobile-body-m",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "button",
+      "form",
+      "validation",
+      "disabled",
+      "required"
+    ],
+    "components": [
+      "button",
+      "button-group",
+      "form-item",
+      "input"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "disabled-button-with-a-required-field"
   },
   {
-    "id": "token-typography-mobile-body-l",
-    "title": "--goa-typography-mobile-body-l",
-    "name": "--goa-typography-mobile-body-l",
-    "description": "typography token: mobile body l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "display-numbers-in-a-table-so-they-can-be-scanned-easily",
+    "title": "Display numbers in a table so they can be scanned easily",
+    "description": "Right-align numeric columns in tables to make them easier to scan and compare.",
+    "status": "published",
+    "categories": [
+      "content-layout"
     ],
-    "type": "token",
-    "slug": "typography-mobile-body-l",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "table",
+      "numbers",
+      "data",
+      "alignment",
+      "scanning"
+    ],
+    "components": [
+      "table"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "display-numbers-in-a-table-so-they-can-be-scanned-easily"
   },
   {
-    "id": "token-typography-mobile-number-s",
-    "title": "--goa-typography-mobile-number-s",
-    "name": "--goa-typography-mobile-number-s",
-    "description": "typography token: mobile number s",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "display-user-information",
+    "title": "Display user information",
+    "description": "Display user contact information and related data using containers with clear visual hierarchy.",
+    "status": "published",
+    "categories": [
+      "content-layout"
     ],
-    "type": "token",
-    "slug": "typography-mobile-number-s",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "container",
+      "user-info",
+      "contact",
+      "profile",
+      "table"
+    ],
+    "components": [
+      "container",
+      "block",
+      "button",
+      "table",
+      "text"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "display-user-information"
   },
   {
-    "id": "token-typography-mobile-number-m",
-    "title": "--goa-typography-mobile-number-m",
-    "name": "--goa-typography-mobile-number-m",
-    "description": "typography token: mobile number m",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "dynamically-add-an-item-to-a-dropdown-list",
+    "title": "Dynamically add an item to a dropdown list",
+    "description": "Allow users to add new items to a dropdown list dynamically.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
     ],
-    "type": "token",
-    "slug": "typography-mobile-number-m",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "dropdown",
+      "dynamic",
+      "form",
+      "input",
+      "radio"
+    ],
+    "components": [
+      "dropdown",
+      "dropdown-item",
+      "form-item",
+      "input",
+      "button"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "dynamically-add-an-item-to-a-dropdown-list"
   },
   {
-    "id": "token-typography-mobile-number-l",
-    "title": "--goa-typography-mobile-number-l",
-    "name": "--goa-typography-mobile-number-l",
-    "description": "typography token: mobile number l",
-    "content": "",
-    "component": "",
-    "filePath": "design-tokens",
-    "urlPath": "tokens",
-    "tags": [
-      "token",
-      "design token",
-      "typography"
+    "type": "example",
+    "id": "dynamically-change-items-in-a-dropdown-list",
+    "title": "Dynamically change items in a dropdown list",
+    "description": "Update dropdown options based on the selection in another dropdown (cascading/dependent dropdowns).",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
     ],
-    "type": "token",
-    "slug": "typography-mobile-number-l",
-    "status": "stable",
-    "category": "typography"
+    "tags": [
+      "dropdown",
+      "dynamic",
+      "cascading",
+      "dependent",
+      "form"
+    ],
+    "components": [
+      "dropdown",
+      "dropdown-item",
+      "form-item"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "dynamically-change-items-in-a-dropdown-list"
   },
   {
-    "id": "get-started",
-    "title": "Get started",
-    "name": "Get started",
-    "description": "Introduction to the GoA Design System early adopters program",
-    "content": "",
-    "component": "",
-    "filePath": "docs/src/pages/get-started",
-    "urlPath": "get-started",
-    "tags": [
-      "get started",
-      "introduction",
-      "onboarding"
+    "type": "example",
+    "id": "expand-or-collapse-part-of-a-form",
+    "title": "Expand or collapse part of a form",
+    "description": "Use accordions to organize form review sections that users can expand or collapse.",
+    "status": "published",
+    "categories": [
+      "forms"
     ],
-    "type": "page",
-    "slug": "get-started",
-    "status": "stable",
-    "category": "get started"
+    "tags": [
+      "accordion",
+      "form",
+      "review",
+      "collapsible",
+      "badge"
+    ],
+    "components": [
+      "accordion",
+      "badge"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "expand-or-collapse-part-of-a-form"
   },
   {
-    "id": "get-started-developers",
-    "title": "Get started as a developer",
-    "name": "Get started as a developer",
-    "description": "Developer onboarding: package setup, template repo, branches, and compatibility",
-    "content": "",
-    "component": "",
-    "filePath": "docs/src/pages/get-started/developers",
-    "urlPath": "get-started/developers",
-    "tags": [
-      "get started",
-      "developer",
-      "setup",
-      "installation",
-      "packages",
-      "npm"
+    "type": "example",
+    "id": "filter-a-list-using-a-push-drawer",
+    "title": "Filter a list using a push drawer",
+    "description": "Use a push drawer to house filters alongside a list of records. The push drawer keeps the filter controls accessible while users can still see and interact with the filtered results.",
+    "status": "published",
+    "categories": [
+      "content-layout"
     ],
-    "type": "page",
-    "slug": "get-started/developers",
-    "status": "stable",
-    "category": "get started"
+    "tags": [
+      "push-drawer",
+      "filters",
+      "list",
+      "search"
+    ],
+    "components": [
+      "push-drawer",
+      "button",
+      "table",
+      "badge",
+      "checkbox",
+      "checkbox-list",
+      "dropdown",
+      "form-item"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "filter-a-list-using-a-push-drawer"
   },
   {
-    "id": "get-started-designers",
-    "title": "Get started as a designer",
-    "name": "Get started as a designer",
-    "description": "Designer onboarding: Figma libraries, BETA components, and illustration requests",
-    "content": "",
-    "component": "",
-    "filePath": "docs/src/pages/get-started/designers",
-    "urlPath": "get-started/designers",
-    "tags": [
-      "get started",
-      "designer",
-      "figma",
-      "libraries",
-      "illustrations"
+    "type": "example",
+    "id": "filter-data-in-a-table",
+    "title": "Filter data in a table",
+    "description": "Enable users to filter table data using search input and filter chips.",
+    "status": "published",
+    "categories": [
+      "structure-and-navigation"
     ],
-    "type": "page",
-    "slug": "get-started/designers",
-    "status": "stable",
-    "category": "get started"
+    "tags": [
+      "table",
+      "filter",
+      "search",
+      "chips",
+      "data"
+    ],
+    "components": [
+      "table",
+      "filter-chip",
+      "input",
+      "button",
+      "block",
+      "form-item",
+      "badge",
+      "text"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "filter-data-in-a-table"
+  },
+  {
+    "type": "example",
+    "id": "form-stepper-with-controlled-navigation",
+    "title": "Form stepper with controlled navigation",
+    "description": "Create a multi-step form with controlled navigation using Previous/Next buttons.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "stepper",
+      "form",
+      "wizard",
+      "multi-step",
+      "navigation",
+      "pages"
+    ],
+    "components": [
+      "form-stepper",
+      "form-step",
+      "pages",
+      "button",
+      "skeleton",
+      "spacer"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "form-stepper-with-controlled-navigation"
+  },
+  {
+    "type": "example",
+    "id": "give-background-information-before-asking-a-question",
+    "title": "Give background information before asking a question",
+    "description": "Provide explanatory context before asking a question to help users understand what is being asked.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "form",
+      "question",
+      "context",
+      "radio",
+      "citizen-facing"
+    ],
+    "components": [
+      "form-item",
+      "radio-group",
+      "radio-item",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "give-background-information-before-asking-a-question"
+  },
+  {
+    "type": "example",
+    "id": "give-context-before-asking-a-long-answer-question",
+    "title": "Give context before asking a long answer question",
+    "description": "Provide context and guidance before a long-answer text field to help users provide relevant information.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "form",
+      "text-area",
+      "question",
+      "context",
+      "details",
+      "citizen-facing"
+    ],
+    "components": [
+      "text-area",
+      "form-item",
+      "details",
+      "button",
+      "button-group"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "give-context-before-asking-a-long-answer-question"
+  },
+  {
+    "type": "example",
+    "id": "group-related-questions-together-on-a-question-page",
+    "title": "Group related questions together on a question page",
+    "description": "Group related form fields together on a single page to collect address information from users, making it easier to complete logically connected questions at once.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "forms",
+      "address",
+      "question-page"
+    ],
+    "components": [
+      "form-item",
+      "input",
+      "dropdown",
+      "dropdown-item",
+      "button"
+    ],
+    "scale": "page",
+    "userType": "citizen",
+    "slug": "group-related-questions-together-on-a-question-page"
+  },
+  {
+    "type": "example",
+    "id": "header-with-navigation",
+    "title": "Header with navigation",
+    "description": "An application header with navigation links, grouped menu items, and a user account menu.",
+    "status": "published",
+    "categories": [
+      "structure-and-navigation"
+    ],
+    "tags": [
+      "header",
+      "navigation",
+      "menu"
+    ],
+    "components": [
+      "app-header",
+      "app-header-menu"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "header-with-navigation"
+  },
+  {
+    "type": "example",
+    "id": "hero-banner-with-actions",
+    "title": "Hero banner with actions",
+    "description": "Create a hero banner with a call-to-action button to guide users toward the primary task on a landing page.",
+    "status": "published",
+    "categories": [
+      "content-layout"
+    ],
+    "tags": [
+      "hero",
+      "banner",
+      "cta",
+      "landing"
+    ],
+    "components": [
+      "hero-banner",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "hero-banner-with-actions"
+  },
+  {
+    "type": "example",
+    "id": "hide-and-show-many-sections-of-information",
+    "title": "Hide and show many sections of information",
+    "description": "Allow users to expand and collapse multiple accordion sections, with a button to show or hide all sections at once.",
+    "status": "published",
+    "categories": [
+      "content-layout"
+    ],
+    "tags": [
+      "accordion",
+      "expand",
+      "collapse",
+      "faq"
+    ],
+    "components": [
+      "accordion",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "hide-and-show-many-sections-of-information"
+  },
+  {
+    "type": "example",
+    "id": "include-a-link-in-the-helper-text-of-an-option",
+    "title": "Include a link in the helper text of an option",
+    "description": "Add links within the description text of checkbox options to provide additional context or resources while users are making selections.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "checkbox",
+      "helper-text",
+      "links",
+      "forms"
+    ],
+    "components": [
+      "checkbox",
+      "form-item"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "include-a-link-in-the-helper-text-of-an-option"
+  },
+  {
+    "type": "example",
+    "id": "include-descriptions-for-items-in-a-checkbox-list",
+    "title": "Include descriptions for items in a checkbox list",
+    "description": "Add descriptive text to radio button options to help users understand the implications of each choice.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "radio",
+      "descriptions",
+      "forms"
+    ],
+    "components": [
+      "form-item",
+      "radio-group",
+      "radio-item"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "include-descriptions-for-items-in-a-checkbox-list"
+  },
+  {
+    "type": "example",
+    "id": "link-the-user-to-give-feedback-to-the-service",
+    "title": "Link the user to give feedback to the service",
+    "description": "Use the microsite header's feedback functionality to collect user feedback during alpha or beta phases of a service.",
+    "status": "published",
+    "categories": [
+      "feedback-and-alerts"
+    ],
+    "tags": [
+      "feedback",
+      "microsite-header",
+      "alpha",
+      "beta"
+    ],
+    "components": [
+      "microsite-header"
+    ],
+    "scale": "interaction",
+    "userType": "citizen",
+    "slug": "link-the-user-to-give-feedback-to-the-service"
+  },
+  {
+    "type": "example",
+    "id": "link-to-an-external-page",
+    "title": "Link to an external page",
+    "description": "Use an external link indicator to show users when a link will take them to a different website.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "link",
+      "external",
+      "navigation"
+    ],
+    "components": [
+      "link"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "link-to-an-external-page"
+  },
+  {
+    "type": "example",
+    "id": "public-form",
+    "title": "Public form",
+    "description": "The public form pattern provides a structure for citizen-facing form experiences, emphasizing simplicity, accessibility, and low cognitive load.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "form",
+      "public",
+      "citizen",
+      "pattern"
+    ],
+    "components": [],
+    "scale": "product",
+    "userType": "citizen",
+    "slug": "public-form"
+  },
+  {
+    "type": "example",
+    "id": "question-page",
+    "title": "Question page",
+    "description": "A question page pattern that presents one question at a time to help users focus, reduce cognitive load, and navigate complex forms more easily.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "forms",
+      "question",
+      "wizard",
+      "one-thing-per-page"
+    ],
+    "components": [
+      "form-item",
+      "input",
+      "button",
+      "button-group"
+    ],
+    "scale": "page",
+    "userType": "citizen",
+    "slug": "question-page"
+  },
+  {
+    "type": "example",
+    "id": "remove-a-filter",
+    "title": "Remove a filter",
+    "description": "Allow users to remove active filters by clicking on filter chips, providing clear visual feedback and dynamic updates to filtered results.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "filtering",
+      "chips",
+      "remove"
+    ],
+    "components": [
+      "filter-chip"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "remove-a-filter"
+  },
+  {
+    "type": "example",
+    "id": "require-user-action-before-continuing",
+    "title": "Require user action before continuing",
+    "description": "Use a modal dialog to require users to confirm an action before proceeding, especially for irreversible operations or important decision points.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "modal",
+      "confirmation",
+      "warning",
+      "action"
+    ],
+    "components": [
+      "modal",
+      "button",
+      "button-group"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "require-user-action-before-continuing"
+  },
+  {
+    "type": "example",
+    "id": "reset-date-picker-field",
+    "title": "Reset date picker field",
+    "description": "Allow users to programmatically set or clear a date picker field value, useful for reset functionality or setting default dates.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "date-picker",
+      "form",
+      "reset",
+      "clear"
+    ],
+    "components": [
+      "date-picker",
+      "form-item",
+      "button",
+      "button-group"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "reset-date-picker-field"
+  },
+  {
+    "type": "example",
+    "id": "result-page",
+    "title": "Result page",
+    "description": "A result page shown after form submission to confirm success, provide next steps, and offer relevant contact information.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "confirmation",
+      "success",
+      "completion",
+      "forms"
+    ],
+    "components": [
+      "block",
+      "callout"
+    ],
+    "scale": "page",
+    "userType": "citizen",
+    "slug": "result-page"
+  },
+  {
+    "type": "example",
+    "id": "reveal-input-based-on-a-selection",
+    "title": "Reveal input based on a selection",
+    "description": "Progressively reveal additional form fields based on user selections, reducing visual complexity while gathering necessary information.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "conditional",
+      "reveal",
+      "radio",
+      "checkbox",
+      "progressive-disclosure"
+    ],
+    "components": [
+      "radio-group",
+      "radio-item",
+      "checkbox",
+      "form-item",
+      "input"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "reveal-input-based-on-a-selection"
+  },
+  {
+    "type": "example",
+    "id": "review-and-action",
+    "title": "Review and action",
+    "description": "A side-by-side layout for workers to review case details while taking an action, commonly used in case management and approval workflows.",
+    "status": "published",
+    "categories": [
+      "structure-and-navigation"
+    ],
+    "tags": [
+      "review",
+      "action",
+      "container",
+      "case-management",
+      "worker"
+    ],
+    "components": [
+      "container",
+      "grid",
+      "block",
+      "form-item",
+      "radio-group",
+      "dropdown",
+      "text-area",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "review-and-action"
+  },
+  {
+    "type": "example",
+    "id": "review-page",
+    "title": "Review page",
+    "description": "A review page where users can check their answers before submitting a form, with options to change individual responses.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "review",
+      "check-answers",
+      "forms",
+      "submission"
+    ],
+    "components": [
+      "table",
+      "button",
+      "button-group"
+    ],
+    "scale": "page",
+    "userType": "citizen",
+    "slug": "review-page"
+  },
+  {
+    "type": "example",
+    "id": "search",
+    "title": "Search",
+    "description": "A search input pattern with a search icon and button for users to find content or filter results.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "search",
+      "input",
+      "filtering"
+    ],
+    "components": [
+      "input",
+      "button",
+      "block",
+      "form-item"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "search"
+  },
+  {
+    "type": "example",
+    "id": "select-one-or-more-from-a-list-of-options",
+    "title": "Select one or more from a list of options",
+    "description": "Use checkboxes to let users select one or more options from a list when multiple selections are valid.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "checkbox",
+      "selection",
+      "multiple",
+      "form"
+    ],
+    "components": [
+      "checkbox",
+      "form-item"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "select-one-or-more-from-a-list-of-options"
+  },
+  {
+    "type": "example",
+    "id": "set-a-max-width-on-a-long-radio-item",
+    "title": "Set a max width on a long radio item",
+    "description": "Set a max width on a long radio item to control line wrapping.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "radio",
+      "forms",
+      "layout"
+    ],
+    "components": [
+      "form-item",
+      "radio-group",
+      "radio-item"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "set-a-max-width-on-a-long-radio-item"
+  },
+  {
+    "type": "example",
+    "id": "set-a-specific-tab-to-be-active",
+    "title": "Set a specific tab to be active",
+    "description": "Set a specific tab to be active on page load using the initialTab property.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "tabs",
+      "navigation",
+      "tables"
+    ],
+    "components": [
+      "tabs",
+      "tab",
+      "table",
+      "badge",
+      "button"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "set-a-specific-tab-to-be-active"
+  },
+  {
+    "type": "example",
+    "id": "set-the-status-of-step-on-a-form-stepper",
+    "title": "Set the status of step on a form stepper",
+    "description": "Set the status of each step on a form stepper to indicate completion progress.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "forms",
+      "stepper",
+      "multi-step",
+      "navigation"
+    ],
+    "components": [
+      "form-stepper",
+      "form-step",
+      "pages",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "set-the-status-of-step-on-a-form-stepper"
+  },
+  {
+    "type": "example",
+    "id": "show-a-label-on-an-icon-only-button",
+    "title": "Show a label on an icon only button",
+    "description": "Show a label on an icon-only button using a tooltip to improve discoverability.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "buttons",
+      "icons",
+      "accessibility",
+      "tooltip"
+    ],
+    "components": [
+      "icon-button",
+      "tooltip",
+      "button-group"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "show-a-label-on-an-icon-only-button"
+  },
+  {
+    "type": "example",
+    "id": "show-a-list-to-help-answer-a-question",
+    "title": "Show a list to help answer a question",
+    "description": "Show a list to help answer a question using an expandable details component.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "forms",
+      "details",
+      "guidance",
+      "help"
+    ],
+    "components": [
+      "form-item",
+      "radio-group",
+      "radio-item",
+      "details",
+      "block"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "show-a-list-to-help-answer-a-question"
+  },
+  {
+    "type": "example",
+    "id": "show-a-notification",
+    "title": "Show a notification",
+    "description": "Show a temporary notification to confirm an action was completed successfully.",
+    "status": "published",
+    "categories": [
+      "feedback-and-alerts"
+    ],
+    "tags": [
+      "notification",
+      "feedback",
+      "success",
+      "toast"
+    ],
+    "components": [
+      "temporary-notification",
+      "button"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "show-a-notification"
+  },
+  {
+    "type": "example",
+    "id": "show-a-notification-with-an-action",
+    "title": "Show a notification with an action",
+    "description": "Show a temporary notification with an action button for user interaction.",
+    "status": "published",
+    "categories": [
+      "feedback-and-alerts"
+    ],
+    "tags": [
+      "notification",
+      "feedback",
+      "action",
+      "toast"
+    ],
+    "components": [
+      "temporary-notification",
+      "button"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "show-a-notification-with-an-action"
+  },
+  {
+    "type": "example",
+    "id": "show-a-section-title-on-a-question-page",
+    "title": "Show a section title on a question page",
+    "description": "Show a section title on a question page to help users understand which part of the form they are completing.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "forms",
+      "questions",
+      "navigation",
+      "section"
+    ],
+    "components": [
+      "form-item",
+      "radio-group",
+      "radio-item",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "show-a-section-title-on-a-question-page"
+  },
+  {
+    "type": "example",
+    "id": "show-a-simple-progress-indicator-on-a-question-page",
+    "title": "Show a simple progress indicator on a question page",
+    "description": "Show a simple progress indicator on a question page to help users understand their progress through the form.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "forms",
+      "questions",
+      "progress",
+      "navigation"
+    ],
+    "components": [
+      "form-item",
+      "radio-group",
+      "radio-item",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "show-a-simple-progress-indicator-on-a-question-page"
+  },
+  {
+    "type": "example",
+    "id": "show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions",
+    "title": "Show a simple progress indicator on a question page with multiple questions",
+    "description": "Show a simple progress indicator on a question page when grouping multiple related questions together.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "forms",
+      "questions",
+      "progress",
+      "navigation",
+      "multi-question"
+    ],
+    "components": [
+      "form-item",
+      "input",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "show-a-simple-progress-indicator-on-a-question-page-with-multiple-questions"
+  },
+  {
+    "type": "example",
+    "id": "show-a-user-progress",
+    "title": "Show a user progress",
+    "description": "Display progress feedback during long-running operations like downloads, showing percentage completion with the ability to cancel and receive success confirmation.",
+    "status": "published",
+    "categories": [
+      "feedback-and-alerts"
+    ],
+    "tags": [
+      "progress",
+      "notification",
+      "download",
+      "feedback"
+    ],
+    "components": [
+      "temporary-notification",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "show-a-user-progress"
+  },
+  {
+    "type": "example",
+    "id": "show-a-user-progress-when-the-time-is-unknown",
+    "title": "Show a user progress when the time is unknown",
+    "description": "Display indeterminate progress for operations where completion time cannot be estimated, such as complex searches or external system queries.",
+    "status": "published",
+    "categories": [
+      "feedback-and-alerts"
+    ],
+    "tags": [
+      "progress",
+      "notification",
+      "indeterminate",
+      "search",
+      "feedback"
+    ],
+    "components": [
+      "temporary-notification",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "show-a-user-progress-when-the-time-is-unknown"
+  },
+  {
+    "type": "example",
+    "id": "show-different-views-of-data-in-a-table",
+    "title": "Show different views of data in a table",
+    "description": "Use tabs to organize table data into different views based on status or category, showing counts in each tab to help workers quickly navigate to relevant items.",
+    "status": "published",
+    "categories": [
+      "content-layout"
+    ],
+    "tags": [
+      "table",
+      "tabs",
+      "filtering",
+      "status",
+      "data-views"
+    ],
+    "components": [
+      "tabs",
+      "tab",
+      "table",
+      "badge",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "show-different-views-of-data-in-a-table"
+  },
+  {
+    "type": "example",
+    "id": "show-full-date-in-a-tooltip",
+    "title": "Show full date in a tooltip",
+    "description": "Display relative time (like \"4 hours ago\") while providing the full date and time on hover via tooltip for users who need exact timestamps.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "tooltip",
+      "date",
+      "relative-time",
+      "hover"
+    ],
+    "components": [
+      "tooltip",
+      "container"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "show-full-date-in-a-tooltip"
+  },
+  {
+    "type": "example",
+    "id": "show-links-to-navigation-items",
+    "title": "Show links to navigation items",
+    "description": "Use the app footer to display comprehensive navigation links organized into sections, along with meta links for common utilities like privacy and accessibility.",
+    "status": "published",
+    "categories": [
+      "structure-and-navigation"
+    ],
+    "tags": [
+      "footer",
+      "navigation",
+      "links",
+      "sitemap"
+    ],
+    "components": [
+      "footer",
+      "footer-nav-section",
+      "footer-meta-section"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "show-links-to-navigation-items"
+  },
+  {
+    "type": "example",
+    "id": "show-more-information-to-help-answer-a-question",
+    "title": "Show more information to help answer a question",
+    "description": "Use the Details component to provide optional contextual help that explains why a question is being asked, helping users understand the purpose without cluttering the main form.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "form",
+      "details",
+      "help",
+      "question-page",
+      "expandable"
+    ],
+    "components": [
+      "details",
+      "form-item",
+      "radio-group",
+      "radio-item",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "citizen",
+    "slug": "show-more-information-to-help-answer-a-question"
+  },
+  {
+    "type": "example",
+    "id": "show-multiple-actions-in-a-compact-table",
+    "title": "Show multiple actions in a compact table",
+    "description": "Use icon buttons to provide multiple row actions in tables where space is limited, keeping the interface compact while maintaining accessibility through aria labels.",
+    "status": "published",
+    "categories": [
+      "content-layout"
+    ],
+    "tags": [
+      "table",
+      "icon-button",
+      "actions",
+      "compact",
+      "worker-ui"
+    ],
+    "components": [
+      "table",
+      "icon-button",
+      "badge",
+      "block"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "show-multiple-actions-in-a-compact-table"
+  },
+  {
+    "type": "example",
+    "id": "show-multiple-tags-together",
+    "title": "Show multiple tags together",
+    "description": "Display multiple badges together using GoabBlock with tight spacing to show multiple statuses or categories for a single item.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "badge",
+      "tags",
+      "status",
+      "grouping"
+    ],
+    "components": [
+      "badge",
+      "block"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "show-multiple-tags-together"
+  },
+  {
+    "type": "example",
+    "id": "show-number-of-results-per-page",
+    "title": "Show number of results per page",
+    "description": "Combine pagination with a dropdown selector to let users control how many results appear per page, improving data browsing for different use cases.",
+    "status": "published",
+    "categories": [
+      "content-layout"
+    ],
+    "tags": [
+      "pagination",
+      "table",
+      "dropdown",
+      "results",
+      "per-page"
+    ],
+    "components": [
+      "pagination",
+      "dropdown",
+      "dropdown-item",
+      "table",
+      "block",
+      "spacer"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "show-number-of-results-per-page"
+  },
+  {
+    "type": "example",
+    "id": "show-quick-links",
+    "title": "Show quick links",
+    "description": "Use the app footer meta section to display essential quick links like feedback, accessibility, privacy, and contact information without the full navigation structure.",
+    "status": "published",
+    "categories": [
+      "structure-and-navigation"
+    ],
+    "tags": [
+      "footer",
+      "navigation",
+      "meta-links",
+      "quick-access"
+    ],
+    "components": [
+      "footer",
+      "footer-meta-section"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "show-quick-links"
+  },
+  {
+    "type": "example",
+    "id": "show-status-in-a-table",
+    "title": "Show status in a table",
+    "description": "Display status information within table rows using badges to provide clear visual indicators of item states like pending, complete, failed, or in progress.",
+    "status": "published",
+    "categories": [
+      "content-layout"
+    ],
+    "tags": [
+      "table",
+      "badge",
+      "status"
+    ],
+    "components": [
+      "table",
+      "badge",
+      "button"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "show-status-in-a-table"
+  },
+  {
+    "type": "example",
+    "id": "show-status-on-a-card",
+    "title": "Show status on a card",
+    "description": "Display status indicators on cards using badges in the actions slot, allowing workers to quickly see the priority or state of each item.",
+    "status": "published",
+    "categories": [
+      "content-layout"
+    ],
+    "tags": [
+      "card",
+      "container",
+      "badge",
+      "status"
+    ],
+    "components": [
+      "container",
+      "badge"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "show-status-on-a-card"
+  },
+  {
+    "type": "example",
+    "id": "show-version-number",
+    "title": "Show version number",
+    "description": "Display version information in the microsite header using the version slot, allowing custom formatting and styling of version text.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "microsite-header",
+      "version",
+      "alpha",
+      "beta"
+    ],
+    "components": [
+      "microsite-header"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "show-version-number"
+  },
+  {
+    "type": "example",
+    "id": "slotted-error-text-in-a-form-item",
+    "title": "Slotted error text in a form item",
+    "description": "Use the error slot in a form item to display formatted error messages with custom styling like bold or italic text.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "form",
+      "form-item",
+      "error",
+      "validation",
+      "slot"
+    ],
+    "components": [
+      "form-item",
+      "input"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "slotted-error-text-in-a-form-item"
+  },
+  {
+    "type": "example",
+    "id": "slotted-helper-text-in-a-form-item",
+    "title": "Slotted helper text in a form item",
+    "description": "Use the helpText slot in a form item to display formatted helper text with custom styling like bold, italic, or links.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "form",
+      "form-item",
+      "helper-text",
+      "slot"
+    ],
+    "components": [
+      "form-item",
+      "input"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "slotted-helper-text-in-a-form-item"
+  },
+  {
+    "type": "example",
+    "id": "sort-data-in-a-table",
+    "title": "Sort data in a table",
+    "description": "Enable column sorting in tables using sort headers, allowing workers to organize data by clicking column headers to toggle ascending/descending order.",
+    "status": "published",
+    "categories": [
+      "content-layout"
+    ],
+    "tags": [
+      "table",
+      "sorting",
+      "data"
+    ],
+    "components": [
+      "table",
+      "table-sort-header"
+    ],
+    "scale": "task",
+    "userType": "worker",
+    "slug": "sort-data-in-a-table"
+  },
+  {
+    "type": "example",
+    "id": "start-page",
+    "title": "Start page",
+    "description": "A start page is the front door to a government service for citizens. It provides essential information about the service and a clear call to action to begin.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "page",
+      "service",
+      "start",
+      "citizen"
+    ],
+    "components": [
+      "button"
+    ],
+    "scale": "page",
+    "userType": "citizen",
+    "slug": "start-page"
+  },
+  {
+    "type": "example",
+    "id": "task-list-page",
+    "title": "Task list page",
+    "description": "A task list page provides a structure for multi-step services, showing users their progress through a series of tasks with clear status indicators.",
+    "status": "published",
+    "categories": [
+      "forms"
+    ],
+    "tags": [
+      "page",
+      "task-list",
+      "progress",
+      "form"
+    ],
+    "components": [
+      "table",
+      "badge",
+      "callout"
+    ],
+    "scale": "page",
+    "userType": "both",
+    "slug": "task-list-page"
+  },
+  {
+    "type": "example",
+    "id": "type-to-create-a-new-filter",
+    "title": "Type to create a new filter",
+    "description": "Allow users to type custom filter values and create filter chips by pressing Enter, with the ability to remove chips using Backspace or by clicking them.",
+    "status": "published",
+    "categories": [
+      "inputs-and-actions"
+    ],
+    "tags": [
+      "filter-chip",
+      "input",
+      "dynamic",
+      "keyboard"
+    ],
+    "components": [
+      "filter-chip",
+      "input",
+      "form-item",
+      "container"
+    ],
+    "scale": "interaction",
+    "userType": "both",
+    "slug": "type-to-create-a-new-filter"
+  },
+  {
+    "type": "example",
+    "id": "warn-a-user-of-a-deadline",
+    "title": "Warn a user of a deadline",
+    "description": "Use a modal with important callout styling to warn users about time-sensitive deadlines that could affect their submission or action.",
+    "status": "published",
+    "categories": [
+      "feedback-and-alerts"
+    ],
+    "tags": [
+      "modal",
+      "warning",
+      "deadline",
+      "callout"
+    ],
+    "components": [
+      "modal",
+      "button",
+      "button-group"
+    ],
+    "scale": "task",
+    "userType": "both",
+    "slug": "warn-a-user-of-a-deadline"
+  },
+  {
+    "type": "example",
+    "id": "workspace",
+    "title": "Workspace",
+    "description": "The workspace is for productivity-focused services used by service delivery staff as a daily tool to review information, manage records, and complete tasks. The design prioritizes productivity, efficiency, and accuracy so staff can move through their work quickly while ensuring the best outcome for citizens and government.<br><span style=\"display:block;height:0.5rem\"></span>Workspaces should be adapted to fit each service's context and user needs. The reference example is a starting point to expand on, not a rigid template.",
+    "status": "published",
+    "categories": [
+      "structure-and-navigation"
+    ],
+    "tags": [
+      "workspace",
+      "worker",
+      "service",
+      "case-management",
+      "dashboard",
+      "pattern"
+    ],
+    "components": [
+      "work-side-menu",
+      "table",
+      "badge",
+      "tabs",
+      "container",
+      "accordion",
+      "drawer",
+      "button",
+      "block"
+    ],
+    "scale": "product",
+    "userType": "worker",
+    "slug": "workspace"
   }
 ]

--- a/docs/src/components/PropsTable.astro
+++ b/docs/src/components/PropsTable.astro
@@ -12,10 +12,13 @@ interface Props {
   events?: EventDefinition[];
   slots?: SlotDefinition[];
   headingPrefix?: string;
+  idPrefix?: string;
+  badge?: string;
 }
 
-const { props = [], events = [], slots = [], headingPrefix = "" } = Astro.props;
+const { props = [], events = [], slots = [], headingPrefix = "", idPrefix = "", badge = "" } = Astro.props;
 const prefix = headingPrefix ? `${headingPrefix} ` : "";
+const idBase = idPrefix ? `${idPrefix}-` : (headingPrefix ? `${headingPrefix.toLowerCase().replace(/\s+/g, "-")}-` : "");
 
 // Filter slots: hide "default" slots with no description (adds noise, no value)
 // Keep named slots even without descriptions (the name itself is useful info)
@@ -69,7 +72,10 @@ const finalProps = combinedMarginProp
 
 {finalProps.length > 0 && (
   <div class="api-section">
-    <h3 id={prefix ? `${headingPrefix.toLowerCase().replace(/\s+/g, "-")}-props` : "props"}>{prefix}Props</h3>
+    <div class="api-heading">
+      <h3 id={`${idBase}props`}>{prefix}Props</h3>
+      {badge && <goa-badge version="2" type="default" emphasis="subtle" icon="false" content={badge}></goa-badge>}
+    </div>
     <goa-container version="2" type="interactive">
       <goa-data-grid keyboard-nav="layout" keyboard-icon="false">
         {finalProps.map((prop, index) => {
@@ -112,7 +118,10 @@ const finalProps = combinedMarginProp
 
 {events.length > 0 && (
   <div class="api-section">
-    <h3 id={prefix ? `${headingPrefix.toLowerCase().replace(/\s+/g, "-")}-events` : "events"}>{prefix}Events</h3>
+    <div class="api-heading">
+      <h3 id={`${idBase}events`}>{prefix}Events</h3>
+      {badge && <goa-badge version="2" type="default" emphasis="subtle" icon="false" content={badge}></goa-badge>}
+    </div>
     <goa-container version="2" type="interactive">
       <goa-data-grid keyboard-nav="layout" keyboard-icon="false">
         {events.map((event) => (
@@ -141,7 +150,10 @@ const finalProps = combinedMarginProp
 
 {meaningfulSlots.length > 0 && (
   <div class="api-section">
-    <h3 id={prefix ? `${headingPrefix.toLowerCase().replace(/\s+/g, "-")}-slots` : "slots"}>{prefix}Slots</h3>
+    <div class="api-heading">
+      <h3 id={`${idBase}slots`}>{prefix}Slots</h3>
+      {badge && <goa-badge version="2" type="default" emphasis="subtle" icon="false" content={badge}></goa-badge>}
+    </div>
     <goa-container version="2" type="interactive">
       <goa-data-grid keyboard-nav="layout" keyboard-icon="false">
         {meaningfulSlots.map((slot) => (
@@ -168,6 +180,17 @@ const finalProps = combinedMarginProp
     font: var(--goa-typography-heading-s);
     margin-bottom: var(--goa-space-m);
     color: var(--goa-color-text-default);
+  }
+
+  .api-heading {
+    display: flex;
+    align-items: center;
+    gap: var(--goa-space-m);
+    margin-bottom: var(--goa-space-m);
+  }
+
+  .api-heading h3 {
+    margin-bottom: 0;
   }
 
   .prop-row {

--- a/docs/src/content/components/app-header-menu.mdx
+++ b/docs/src/content/components/app-header-menu.mdx
@@ -4,6 +4,7 @@ description: Menu items within the app header.
 status: stable
 category: structure-and-navigation
 hidden: true
+subcomponent: true
 relatedComponents:
   - app-header
 webComponentTag: goa-app-header-menu

--- a/docs/src/content/components/file-upload-card.mdx
+++ b/docs/src/content/components/file-upload-card.mdx
@@ -4,6 +4,7 @@ description: Display uploaded file with actions.
 status: stable
 category: inputs-and-actions
 hidden: true
+subcomponent: true
 relatedComponents:
   - file-upload-input
 webComponentTag: goa-file-upload-card

--- a/docs/src/content/components/footer-meta-section.mdx
+++ b/docs/src/content/components/footer-meta-section.mdx
@@ -4,6 +4,7 @@ description: Copyright and legal links in footer.
 status: stable
 category: structure-and-navigation
 hidden: true
+subcomponent: true
 relatedComponents:
   - footer
 webComponentTag: goa-footer-meta-section

--- a/docs/src/content/components/footer-nav-section.mdx
+++ b/docs/src/content/components/footer-nav-section.mdx
@@ -4,6 +4,7 @@ description: Navigation links section in footer.
 status: stable
 category: structure-and-navigation
 hidden: true
+subcomponent: true
 relatedComponents:
   - footer
   - link

--- a/docs/src/content/components/form-step.mdx
+++ b/docs/src/content/components/form-step.mdx
@@ -4,6 +4,7 @@ description: Individual step in a multi-step form.
 status: stable
 category: inputs-and-actions
 hidden: true
+subcomponent: true
 relatedComponents:
   - form-stepper
 webComponentTag: goa-form-step

--- a/docs/src/content/components/menu-action.mdx
+++ b/docs/src/content/components/menu-action.mdx
@@ -1,0 +1,11 @@
+---
+name: Menu Action
+description: Individual action item within a menu button.
+status: stable
+category: inputs-and-actions
+hidden: true
+subcomponent: true
+relatedComponents:
+  - menu-button
+webComponentTag: goa-menu-action
+---

--- a/docs/src/content/components/menu-button.mdx
+++ b/docs/src/content/components/menu-button.mdx
@@ -8,6 +8,7 @@ tags:
   - split button
 relatedComponents:
   - button
+  - menu-action
   - popover
 figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=69366-164803
 githubUrl: https://github.com/GovAlta/ui-components/labels/Multi%20action%20button

--- a/docs/src/content/components/radio-item.mdx
+++ b/docs/src/content/components/radio-item.mdx
@@ -4,6 +4,7 @@ description: Individual radio option within a group.
 status: stable
 category: inputs-and-actions
 hidden: true
+subcomponent: true
 relatedComponents:
   - radio-group
 webComponentTag: goa-radio-item

--- a/docs/src/content/components/side-menu-group.mdx
+++ b/docs/src/content/components/side-menu-group.mdx
@@ -4,6 +4,7 @@ description: Group of related side menu items.
 status: stable
 category: structure-and-navigation
 hidden: true
+subcomponent: true
 relatedComponents:
   - side-menu
   - side-menu-heading

--- a/docs/src/content/components/side-menu-heading.mdx
+++ b/docs/src/content/components/side-menu-heading.mdx
@@ -4,6 +4,7 @@ description: Section heading in side menu.
 status: stable
 category: structure-and-navigation
 hidden: true
+subcomponent: true
 relatedComponents:
   - side-menu
   - side-menu-group

--- a/docs/src/content/components/tab.mdx
+++ b/docs/src/content/components/tab.mdx
@@ -4,6 +4,7 @@ description: Individual tab within a tabs component.
 status: stable
 category: structure-and-navigation
 hidden: true
+subcomponent: true
 relatedComponents:
   - tabs
 webComponentTag: goa-tab

--- a/docs/src/content/components/work-side-menu-group.mdx
+++ b/docs/src/content/components/work-side-menu-group.mdx
@@ -1,0 +1,11 @@
+---
+name: Work Side Menu Group
+description: Collapsible group of items within the work side menu.
+status: stable
+category: structure-and-navigation
+hidden: true
+subcomponent: true
+relatedComponents:
+  - work-side-menu
+webComponentTag: goa-work-side-menu-group
+---

--- a/docs/src/content/components/work-side-menu-item.mdx
+++ b/docs/src/content/components/work-side-menu-item.mdx
@@ -1,0 +1,11 @@
+---
+name: Work Side Menu Item
+description: Individual menu item within the work side menu.
+status: stable
+category: structure-and-navigation
+hidden: true
+subcomponent: true
+relatedComponents:
+  - work-side-menu
+webComponentTag: goa-work-side-menu-item
+---

--- a/docs/src/content/components/work-side-menu.mdx
+++ b/docs/src/content/components/work-side-menu.mdx
@@ -5,10 +5,9 @@ status: stable
 category: structure-and-navigation
 relatedComponents:
   - side-menu
+  - work-side-menu-group
+  - work-side-menu-item
 webComponentTag: goa-work-side-menu
 reactClassName: GoabWorkSideMenu
 angularSelector: goab-work-side-menu
-childComponents:
-  - slug: work-side-menu-item
-    name: Work Side Menu Item
 ---

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -36,18 +36,9 @@ const components = defineCollection({
     reactClassName: z.string().optional(),
     angularSelector: z.string().optional(),
 
-    // Child components (shown on same page under separate headings)
-    childComponents: z
-      .array(
-        z.object({
-          slug: z.string(),
-          name: z.string(),
-        }),
-      )
-      .optional(),
-
     // Visibility
     hidden: z.boolean().optional(), // Hide from navigation and public views
+    subcomponent: z.boolean().optional(), // Show API on parent component page
   }),
 });
 

--- a/docs/src/lib/content-queries.ts
+++ b/docs/src/lib/content-queries.ts
@@ -1,4 +1,4 @@
-import { getCollection, type CollectionEntry } from 'astro:content';
+import { getCollection, type CollectionEntry } from "astro:content";
 
 // Types for extracted API data
 export interface PropDefinition {
@@ -43,14 +43,14 @@ export interface ComponentApi {
 
 // Load all component API JSON files at build time using Vite glob import
 const apiModules = import.meta.glob<{ default: ComponentApi }>(
-  '../../generated/component-apis/*.json',
-  { eager: true }
+  "../../generated/component-apis/*.json",
+  { eager: true },
 );
 
 // Build lookup map: slug -> ComponentApi
 const apiBySlug = new Map<string, ComponentApi>();
 for (const [path, module] of Object.entries(apiModules)) {
-  const slug = path.split('/').pop()?.replace('.json', '');
+  const slug = path.split("/").pop()?.replace(".json", "");
   if (slug && module.default) {
     apiBySlug.set(slug, module.default);
   }
@@ -72,12 +72,12 @@ export async function getComponentApi(slug: string): Promise<ComponentApi | null
  * Get all guidance that applies to a specific component
  */
 export async function getGuidanceForComponent(
-  componentSlug: string
-): Promise<CollectionEntry<'guidance'>[]> {
-  const allGuidance = await getCollection('guidance');
+  componentSlug: string,
+): Promise<CollectionEntry<"guidance">[]> {
+  const allGuidance = await getCollection("guidance");
 
-  return allGuidance.filter(guidance =>
-    guidance.data.appliesTo?.components?.includes(componentSlug)
+  return allGuidance.filter((guidance) =>
+    guidance.data.appliesTo?.components?.includes(componentSlug),
   );
 }
 
@@ -85,22 +85,20 @@ export async function getGuidanceForComponent(
  * Get all examples that use a specific component
  */
 export async function getExamplesForComponent(
-  componentSlug: string
-): Promise<CollectionEntry<'examples'>[]> {
-  const allExamples = await getCollection('examples');
+  componentSlug: string,
+): Promise<CollectionEntry<"examples">[]> {
+  const allExamples = await getCollection("examples");
 
-  return allExamples.filter(example =>
-    example.data.components.includes(componentSlug)
-  );
+  return allExamples.filter((example) => example.data.components.includes(componentSlug));
 }
 
 /**
  * Group guidance by topic for page section rendering
  */
 export function groupGuidanceByTopic(
-  guidance: CollectionEntry<'guidance'>[]
-): Record<string, CollectionEntry<'guidance'>[]> {
-  const grouped: Record<string, CollectionEntry<'guidance'>[]> = {};
+  guidance: CollectionEntry<"guidance">[],
+): Record<string, CollectionEntry<"guidance">[]> {
+  const grouped: Record<string, CollectionEntry<"guidance">[]> = {};
 
   for (const item of guidance) {
     const topic = item.data.topic;
@@ -114,19 +112,27 @@ export function groupGuidanceByTopic(
 }
 
 // Topic categories for organizing guidance (must match schema in config.ts)
-export const USAGE_TOPICS = ['types', 'states', 'sizing', 'icons', 'positioning', 'content', 'other'] as const;
-export const ACCESSIBILITY_TOPICS = ['screen-readers', 'keyboard', 'focus'] as const;
+export const USAGE_TOPICS = [
+  "types",
+  "states",
+  "sizing",
+  "icons",
+  "positioning",
+  "content",
+  "other",
+] as const;
+export const ACCESSIBILITY_TOPICS = ["screen-readers", "keyboard", "focus"] as const;
 
 /**
  * Separate guidance into usage and accessibility categories
  */
-export function categorizeGuidance(guidance: CollectionEntry<'guidance'>[]) {
-  const usageGuidance = guidance.filter(g =>
-    USAGE_TOPICS.includes(g.data.topic as typeof USAGE_TOPICS[number])
+export function categorizeGuidance(guidance: CollectionEntry<"guidance">[]) {
+  const usageGuidance = guidance.filter((g) =>
+    USAGE_TOPICS.includes(g.data.topic as (typeof USAGE_TOPICS)[number]),
   );
 
-  const accessibilityGuidance = guidance.filter(g =>
-    ACCESSIBILITY_TOPICS.includes(g.data.topic as typeof ACCESSIBILITY_TOPICS[number])
+  const accessibilityGuidance = guidance.filter((g) =>
+    ACCESSIBILITY_TOPICS.includes(g.data.topic as (typeof ACCESSIBILITY_TOPICS)[number]),
   );
 
   return {
@@ -140,35 +146,35 @@ export function categorizeGuidance(guidance: CollectionEntry<'guidance'>[]) {
  */
 export async function getContentByTag(tag: string) {
   const [components, guidance, examples] = await Promise.all([
-    getCollection('components'),
-    getCollection('guidance'),
-    getCollection('examples'),
+    getCollection("components"),
+    getCollection("guidance"),
+    getCollection("examples"),
   ]);
 
   return {
-    components: components.filter(c => c.data.tags?.includes(tag)),
-    guidance: guidance.filter(g => g.data.tags?.includes(tag)),
-    examples: examples.filter(e => e.data.tags?.includes(tag)),
+    components: components.filter((c) => c.data.tags?.includes(tag)),
+    guidance: guidance.filter((g) => g.data.tags?.includes(tag)),
+    examples: examples.filter((e) => e.data.tags?.includes(tag)),
   };
 }
 
 /**
  * Get all visible components (excludes hidden)
  */
-export async function getVisibleComponents(): Promise<CollectionEntry<'components'>[]> {
-  const allComponents = await getCollection('components');
-  return allComponents.filter(c => !c.data.hidden);
+export async function getVisibleComponents(): Promise<CollectionEntry<"components">[]> {
+  const allComponents = await getCollection("components");
+  return allComponents.filter((c) => !c.data.hidden);
 }
 
 /**
  * Get related components from a component entry (excludes hidden)
  */
 export async function getRelatedComponents(
-  relatedSlugs: string[]
-): Promise<CollectionEntry<'components'>[]> {
-  const allComponents = await getCollection('components');
+  relatedSlugs: string[],
+): Promise<CollectionEntry<"components">[]> {
+  const allComponents = await getCollection("components");
 
-  return allComponents.filter(c => {
+  return allComponents.filter((c) => {
     if (c.data.hidden) return false;
     const slug = c.data.slug || c.slug;
     return relatedSlugs.includes(slug);
@@ -176,11 +182,40 @@ export async function getRelatedComponents(
 }
 
 /**
+ * Get subcomponents for a parent component by filtering its relatedComponents
+ * for entries marked with subcomponent: true
+ */
+export async function getSubcomponents(
+  relatedSlugs: string[] | undefined,
+): Promise<Array<{ name: string; slug: string; api: ComponentApi }>> {
+  if (!relatedSlugs?.length) return [];
+
+  const allComponents = await getCollection("components");
+  const results = [];
+
+  for (const slug of relatedSlugs) {
+    const entry = allComponents.find((c) => (c.data.slug || c.slug) === slug);
+    if (!entry) {
+      console.warn(`getSubcomponents: slug "${slug}" not found in components collection`);
+      continue;
+    }
+    if (!entry.data.subcomponent) continue;
+
+    const api = await getComponentApi(slug);
+    if (!api) continue;
+
+    results.push({ name: entry.data.name, slug, api });
+  }
+
+  return results;
+}
+
+/**
  * Format topic name for display
  */
 export function formatTopicName(topic: string): string {
   return topic
-    .split('-')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }

--- a/docs/src/pages/components/[slug].astro
+++ b/docs/src/pages/components/[slug].astro
@@ -10,6 +10,7 @@ import {
   getComponentApi,
   getGuidanceForComponent,
   getExamplesForComponent,
+  getSubcomponents,
   categorizeGuidance,
 } from '../../lib/content-queries';
 import { getComponentConfigurations } from '../../data/configurations';
@@ -32,14 +33,8 @@ const { Content } = await render(component);
 // 2. Get the extracted API
 const api = await getComponentApi(slug);
 
-// 2b. Get child component APIs (if any)
-const childComponents = component.data.childComponents ?? [];
-const childApis = await Promise.all(
-  childComponents.map(async (child: { slug: string; name: string }) => ({
-    name: child.name,
-    api: await getComponentApi(child.slug),
-  }))
-);
+// 2b. Get subcomponent APIs (discovered via relatedComponents + subcomponent flag)
+const subcomponents = await getSubcomponents(component.data.relatedComponents);
 
 // 3. Query related guidance
 const allGuidance = await getGuidanceForComponent(slug);
@@ -121,10 +116,9 @@ const githubIssuesUrl = `https://github.com/GovAlta/ui-components/issues?q=is%3A
             API documentation is automatically extracted from the component source code.
           </goa-callout>
         )}
-        {childApis.map(({ name, api: childApi }) => childApi && (
-          <div class="child-component-api">
-            <h2>{name}</h2>
-            <PropsTable props={childApi.props} events={childApi.events} slots={childApi.slots} headingPrefix={name} />
+        {subcomponents.map((sub) => (
+          <div class="subcomponent-section">
+            <PropsTable props={sub.api.props} events={sub.api.events} slots={sub.api.slots} headingPrefix={sub.name} idPrefix={sub.slug} badge="Subcomponent" />
           </div>
         ))}
       </TabContentWrapper>
@@ -207,18 +201,9 @@ const githubIssuesUrl = `https://github.com/GovAlta/ui-components/issues?q=is%3A
     max-width: 688px;
   }
 
-  /* Child component API sections */
-  .child-component-api {
-    margin-top: var(--goa-space-2xl);
-    padding-top: var(--goa-space-xl);
-    border-top: 1px solid var(--goa-color-greyscale-200);
-  }
-
-  .child-component-api h2 {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin-bottom: var(--goa-space-l);
-    color: var(--goa-color-text-default, #333);
+  /* Subcomponent API sections */
+  .subcomponent-section {
+    margin-top: var(--goa-space-xl);
   }
 
   /* No configurations fallback */


### PR DESCRIPTION
## Summary

- Subcomponent props, events, and slots now appear on parent component pages in the Properties tab
- Each section heading is prefixed with the subcomponent name (e.g., "Tab Props") and has a "Subcomponent" badge
- New `subcomponent: true` field in MDX frontmatter, discovered via parent's `relatedComponents`
- New MDX scaffolds and API JSON for work-side-menu-group and work-side-menu-item

Closes #3676

## Test plan

- [ ] Visit Tabs page, verify Tab Props and Tab Slots appear with Subcomponent badges
- [ ] Visit Footer page, verify Footer Meta Section and Footer Nav Section APIs appear
- [ ] Visit Work Side Menu page, verify Work Side Menu Group and Work Side Menu Item APIs appear
- [ ] Visit Side Menu page, verify Side Menu Group and Side Menu Heading APIs appear
- [ ] Verify TOC sidebar shows prefixed headings (e.g., "Tab Props", "Tab Slots")
- [ ] Verify components without subcomponents (e.g., Button) are unaffected
- [ ] Run `npm run build` from docs/ to confirm clean build

---

### Before
<img width="1341" height="1058" alt="image" src="https://github.com/user-attachments/assets/c961ce4d-68ef-46a0-b206-7b58301b0129" />

### After
<img width="1341" height="1545" alt="image" src="https://github.com/user-attachments/assets/37a8bdb1-5581-4da9-82c1-684431480aa6" />
