### PR TITLE
fix(#3614): fix the padding and unhandled IconSizes

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -236,7 +236,14 @@
           label="3607 Radio and Checkbox Interaction Area"
           url="/bugs/3607"
         ></goab-work-side-menu-item>
-        <goab-work-side-menu-item label="3505 Link Icon Click" url="/bugs/3505"></goab-work-side-menu-item>
+        <goab-work-side-menu-item
+          label="3505 Link Icon Click"
+          url="/bugs/3505"
+        ></goab-work-side-menu-item>
+        <goab-work-side-menu-item
+          label="3614 IconButton Hitboxes"
+          url="/bugs/3614"
+        ></goab-work-side-menu-item>
       </goab-work-side-menu-group>
       <goab-work-side-menu-group icon="star" heading="Features">
         <goab-work-side-menu-item

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -50,6 +50,7 @@ import { Bug3497Component } from "../routes/bugs/3497/bug3497.component";
 import { Bug3498Component } from "../routes/bugs/3498/bug3498.component";
 import { Bug3607Component } from "../routes/bugs/3607/bug3607.component";
 import { Bug3505Component } from "../routes/bugs/3505/bug3505.component";
+import { Bug3614Component } from "../routes/bugs/3614/bug3614.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -140,6 +141,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3497", component: Bug3497Component },
   { path: "bugs/3498", component: Bug3498Component },
   { path: "bugs/3607", component: Bug3607Component },
+  { path: "bugs/3614", component: Bug3614Component },
 
   { path: "bugs/3505", component: Bug3505Component },
   // Feature routes

--- a/apps/prs/angular/src/routes/bugs/3614/bug3614.component.html
+++ b/apps/prs/angular/src/routes/bugs/3614/bug3614.component.html
@@ -1,0 +1,136 @@
+<goab-text tag="h1" mt="m">Bug #3614: IconButton Hitboxes</goab-text>
+
+<goab-block>
+  <goab-details heading="Issue Description" [open]="true">
+    <goab-link trailingIcon="open">
+      <a
+        href="https://github.com/GovAlta/ui-components/issues/3614"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        View on GitHub
+      </a>
+    </goab-link>
+    <goab-text tag="p">
+      Icon buttons at <code>2xsmall</code> and <code>xsmall</code> sizes do not render as
+      square buttons - they show as weird rounded rectangles. The clickable area has a
+      non-square aspect ratio, which is inconsistent with the larger sizes
+      (<code>small</code>, <code>medium</code>, <code>large</code>, <code>xlarge</code>)
+      that all render as squares.
+    </goab-text>
+  </goab-details>
+</goab-block>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<goab-text tag="h2">Test Cases</goab-text>
+
+<goab-text tag="h3">Test 1: Named sizes (2xsmall to xlarge)</goab-text>
+<goab-text tag="p">
+  All sizes should render as square buttons with consistent aspect ratios.
+</goab-text>
+<goab-block gap="s" direction="row" alignment="center">
+  <goab-icon-button
+    icon="settings"
+    size="2xsmall"
+    arialabel="Settings"
+  ></goab-icon-button>
+  <goab-icon-button icon="settings" size="xsmall" arialabel="Settings"></goab-icon-button>
+  <goab-icon-button icon="settings" size="small" arialabel="Settings"></goab-icon-button>
+  <goab-icon-button icon="settings" size="medium" arialabel="Settings"></goab-icon-button>
+  <goab-icon-button icon="settings" size="large" arialabel="Settings"></goab-icon-button>
+  <goab-icon-button icon="settings" size="xlarge" arialabel="Settings"></goab-icon-button>
+</goab-block>
+
+<goab-text tag="h3" mt="l">Test 2: Numeric sizes (1 to 6)</goab-text>
+<goab-text tag="p">All numeric sizes should also render as square buttons.</goab-text>
+<goab-block gap="s" direction="row" alignment="center">
+  <goab-icon-button icon="settings" size="1" arialabel="Settings"></goab-icon-button>
+  <goab-icon-button icon="settings" size="2" arialabel="Settings"></goab-icon-button>
+  <goab-icon-button icon="settings" size="3" arialabel="Settings"></goab-icon-button>
+  <goab-icon-button icon="settings" size="4" arialabel="Settings"></goab-icon-button>
+  <goab-icon-button icon="settings" size="5" arialabel="Settings"></goab-icon-button>
+  <goab-icon-button icon="settings" size="6" arialabel="Settings"></goab-icon-button>
+</goab-block>
+
+<goab-text tag="h3" mt="l">Test 3: Other Components that use IconButton</goab-text>
+<goab-text tag="p">
+  Testing various components that use IconButton internally. Verify that the icon buttons
+  within these components render with correct square hitboxes.
+</goab-text>
+
+<goab-text tag="h4" mt="m">Dropdown</goab-text>
+<goab-text tag="p">
+  The dropdown toggle button should have a properly sized square hitbox.
+</goab-text>
+<goab-block gap="m" direction="row">
+  <goab-dropdown
+    [value]="dropdownValue"
+    (onChange)="dropdownValue = $event.value || ''"
+    placeholder="Select an option"
+    width="250px"
+  >
+    <goab-dropdown-item value="option1" label="Option 1"></goab-dropdown-item>
+    <goab-dropdown-item value="option2" label="Option 2"></goab-dropdown-item>
+    <goab-dropdown-item value="option3" label="Option 3"></goab-dropdown-item>
+  </goab-dropdown>
+</goab-block>
+
+<goab-text tag="h4" mt="m">Filter Chips</goab-text>
+<goab-text tag="p">
+  The v2 FilterChip uses IconButton. The close/remove icon button on each chip should look
+  normal.
+</goab-text>
+<goab-block gap="s" direction="row">
+  @for (chip of chips; track chip) {
+    <goab-filter-chip [content]="chip" (onClick)="removeChip(chip)"></goab-filter-chip>
+  }
+</goab-block>
+
+<goab-text tag="h4" mt="m">Menu Button</goab-text>
+<goab-text tag="p">
+  The dropdown arrow icon button should have a square hitbox.
+</goab-text>
+<goab-block gap="m" direction="row">
+  <goab-menu-button text="Actions" type="secondary">
+    <goab-menu-action text="Edit" action="edit" icon="pencil"></goab-menu-action>
+    <goab-menu-action text="Delete" action="delete" icon="trash"></goab-menu-action>
+    <goab-menu-action text="Archive" action="archive" icon="archive"></goab-menu-action>
+  </goab-menu-button>
+</goab-block>
+
+<goab-text tag="h4" mt="m">Modal</goab-text>
+<goab-text tag="p">
+  The close icon button in the modal header should be a square hitbox.
+</goab-text>
+<goab-block>
+  <goab-button type="secondary" (onClick)="modalOpen = true">Open Modal</goab-button>
+  <goab-modal
+    heading="Test Modal"
+    [open]="modalOpen"
+    (onClose)="modalOpen = false"
+    [actions]="modalActions"
+  >
+    <goab-text tag="p">
+      Check that the close (X) icon button in the top-right corner has a square hitbox.
+    </goab-text>
+  </goab-modal>
+  <ng-template #modalActions>
+    <goab-button (onClick)="modalOpen = false">Close</goab-button>
+  </ng-template>
+</goab-block>
+
+<goab-text tag="h4" mt="m">Input with Trailing Icon</goab-text>
+<goab-text tag="p">The trailing icon button should have a square hitbox.</goab-text>
+<goab-block gap="m" direction="column">
+  <goab-input
+    name="search-input"
+    [value]="inputValue"
+    (onChange)="inputValue = $event.value"
+    trailingIcon="close"
+    trailingIconAriaLabel="Clear input"
+    (onTrailingIconClick)="inputValue = ''"
+    placeholder="The X is an icon button - check its hitbox!"
+    width="350px"
+  ></goab-input>
+</goab-block>

--- a/apps/prs/angular/src/routes/bugs/3614/bug3614.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3614/bug3614.component.ts
@@ -1,0 +1,51 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabBlock,
+  GoabButton,
+  GoabDetails,
+  GoabDivider,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabIconButton,
+  GoabInput,
+  GoabLink,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabModal,
+  GoabText,
+  GoabFilterChip,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3614",
+  templateUrl: "./bug3614.component.html",
+  imports: [
+    CommonModule,
+    GoabBlock,
+    GoabButton,
+    GoabDetails,
+    GoabDivider,
+    GoabDropdown,
+    GoabDropdownItem,
+    GoabIconButton,
+    GoabInput,
+    GoabLink,
+    GoabMenuAction,
+    GoabMenuButton,
+    GoabModal,
+    GoabText,
+    GoabFilterChip,
+  ],
+})
+export class Bug3614Component {
+  dropdownValue = "";
+  inputValue = "";
+  modalOpen = false;
+  chips = ["Alpha", "Beta", "Gamma"];
+
+  removeChip(chip: string) {
+    this.chips = this.chips.filter((c) => c !== chip);
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -229,6 +229,10 @@ export function App() {
                   label="3505 Link Icon Click"
                   url="/bugs/3505"
                 />
+                <GoabWorkSideMenuItem
+                  label="3614 IconButton Hitboxes"
+                  url="/bugs/3614"
+                />
               </GoabWorkSideMenuGroup>
 
               <GoabWorkSideMenuGroup icon="star" heading="Features">

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -52,6 +52,7 @@ import { Bug3497Route } from "./routes/bugs/bug3497";
 import { Bug3498Route } from "./routes/bugs/bug3498";
 import { Bug3607Route } from "./routes/bugs/bug3607";
 import { Bug3505Route } from "./routes/bugs/bug3505";
+import { Bug3614Route } from "./routes/bugs/bug3614";
 
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
@@ -151,6 +152,7 @@ root.render(
           <Route path="bugs/3498" element={<Bug3498Route />} />
           <Route path="bugs/3607" element={<Bug3607Route />} />
           <Route path="bugs/3505" element={<Bug3505Route />} />
+          <Route path="bugs/3614" element={<Bug3614Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3614.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3614.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import {
+  GoabBlock,
+  GoabButton,
+  GoabText,
+  GoabDivider,
+  GoabDetails,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFilterChip,
+  GoabInput,
+  GoabIconButton,
+  GoabLink,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabModal,
+} from "@abgov/react-components";
+
+export function Bug3614Route() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [dropdownValue, setDropdownValue] = useState("");
+  const [inputValue, setInputValue] = useState("");
+  const [chips, setChips] = useState(["Alpha", "Beta", "Gamma"]);
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug #3614: IconButton Hitboxes
+      </GoabText>
+
+      <GoabBlock>
+        <GoabDetails heading="Issue Description" open>
+          <GoabLink trailingIcon="open">
+            <a
+              href="https://github.com/GovAlta/ui-components/issues/3614"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              View on GitHub
+            </a>
+          </GoabLink>
+          <GoabText tag="p">
+            Icon buttons at <code>2xsmall</code> and <code>xsmall</code> sizes do not
+            render as square buttons - they show as weird rounded rectangles. The
+            clickable area has a non-square aspect ratio, which is inconsistent with the
+            larger sizes (<code>small</code>, <code>medium</code>, <code>large</code>,{" "}
+            <code>xlarge</code>) that all render as squares.
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      <GoabText tag="h3">Test 1: Named sizes (2xsmall to xlarge)</GoabText>
+      <GoabText tag="p">
+        All sizes should render as square buttons with consistent aspect ratios.
+      </GoabText>
+      <GoabBlock gap="s" direction="row" alignment="center">
+        <GoabIconButton icon="settings" size="2xsmall" ariaLabel="Settings" />
+        <GoabIconButton icon="settings" size="xsmall" ariaLabel="Settings" />
+        <GoabIconButton icon="settings" size="small" ariaLabel="Settings" />
+        <GoabIconButton icon="settings" size="medium" ariaLabel="Settings" />
+        <GoabIconButton icon="settings" size="large" ariaLabel="Settings" />
+        <GoabIconButton icon="settings" size="xlarge" ariaLabel="Settings" />
+      </GoabBlock>
+
+      <GoabText tag="h3" mt="l">
+        Test 2: Numeric sizes (1 to 6)
+      </GoabText>
+      <GoabText tag="p">All numeric sizes should also render as square buttons.</GoabText>
+      <GoabBlock gap="s" direction="row" alignment="center">
+        <GoabIconButton icon="settings" size="1" ariaLabel="Settings" />
+        <GoabIconButton icon="settings" size="2" ariaLabel="Settings" />
+        <GoabIconButton icon="settings" size="3" ariaLabel="Settings" />
+        <GoabIconButton icon="settings" size="4" ariaLabel="Settings" />
+        <GoabIconButton icon="settings" size="5" ariaLabel="Settings" />
+        <GoabIconButton icon="settings" size="6" ariaLabel="Settings" />
+      </GoabBlock>
+
+      <GoabText tag="h3" mt="l">
+        Test 3: Other Components that use IconButton
+      </GoabText>
+      <GoabText tag="p">
+        Testing various components that use IconButton internally. Verify that the icon
+        buttons within these components render with correct square hitboxes.
+      </GoabText>
+
+      <GoabText tag="h4" mt="m">
+        Dropdown
+      </GoabText>
+      <GoabText tag="p">
+        The dropdown toggle button should have a properly sized square hitbox.
+      </GoabText>
+      <GoabBlock gap="m" direction="row">
+        <GoabDropdown
+          value={dropdownValue}
+          onChange={(detail) => setDropdownValue(detail.value as string)}
+          placeholder="Select an option"
+          width="250px"
+        >
+          <GoabDropdownItem value="option1" label="Option 1" />
+          <GoabDropdownItem value="option2" label="Option 2" />
+          <GoabDropdownItem value="option3" label="Option 3" />
+        </GoabDropdown>
+      </GoabBlock>
+
+      <GoabText tag="h4" mt="m">
+        Dropdown v2
+      </GoabText>
+      <GoabText tag="p">
+        The dropdown toggle button should have a properly sized square hitbox.
+      </GoabText>
+      <GoabBlock gap="m" direction="row">
+        <GoabDropdown
+          value={dropdownValue}
+          onChange={(detail) => setDropdownValue(detail.value as string)}
+          placeholder="Select an option"
+          width="250px"
+        >
+          <GoabDropdownItem value="option1" label="Option 1" />
+          <GoabDropdownItem value="option2" label="Option 2" />
+          <GoabDropdownItem value="option3" label="Option 3" />
+        </GoabDropdown>
+      </GoabBlock>
+      <GoabText tag="h4" mt="m">
+        Filter Chips
+      </GoabText>
+      <GoabText tag="p">
+        The v2 FilterChip uses IconButton. The close/remove icon button on each chip
+        should look normal.
+      </GoabText>
+      <GoabBlock gap="s" direction="row">
+        {chips.map((chip) => (
+          <GoabFilterChip
+            key={chip}
+            content={chip}
+            onClick={() => setChips((prev) => prev.filter((c) => c !== chip))}
+          />
+        ))}
+      </GoabBlock>
+
+      <GoabText tag="h4" mt="m">
+        Menu Button
+      </GoabText>
+      <GoabText tag="p">
+        The dropdown arrow icon button should have a square hitbox.
+      </GoabText>
+      <GoabBlock gap="m" direction="row">
+        <GoabMenuButton text="Actions" type="secondary">
+          <GoabMenuAction text="Edit" action="edit" icon="pencil" />
+          <GoabMenuAction text="Delete" action="delete" icon="trash" />
+          <GoabMenuAction text="Archive" action="archive" icon="archive" />
+        </GoabMenuButton>
+      </GoabBlock>
+
+      <GoabText tag="h4" mt="m">
+        Modal
+      </GoabText>
+      <GoabText tag="p">
+        The close icon button in the modal header should be a square hitbox.
+      </GoabText>
+      <GoabBlock>
+        <GoabButton type="secondary" onClick={() => setModalOpen(true)}>
+          Open Modal
+        </GoabButton>
+        <GoabModal
+          heading="Test Modal"
+          open={modalOpen}
+          onClose={() => setModalOpen(false)}
+          actions={<GoabButton onClick={() => setModalOpen(false)}>Close</GoabButton>}
+        >
+          <GoabText tag="p">
+            Check that the close (X) icon button in the top-right corner has a square
+            hitbox.
+          </GoabText>
+        </GoabModal>
+      </GoabBlock>
+
+      <GoabText tag="h4" mt="m">
+        Input with Trailing Icon
+      </GoabText>
+      <GoabText tag="p">The trailing icon button should have a square hitbox.</GoabText>
+      <GoabBlock gap="m" direction="column">
+        <GoabInput
+          name="search-input"
+          value={inputValue}
+          onChange={(detail) => setInputValue(detail.value)}
+          trailingIcon="close"
+          trailingIconAriaLabel="Clear input"
+          onTrailingIconClick={() => setInputValue("")}
+          placeholder="The X is an icon button - check its hitbox!"
+          width="350px"
+        />
+      </GoabBlock>
+    </div>
+  );
+}
+
+export default Bug3614Route;

--- a/libs/web-components/src/components/icon-button/IconButton.svelte
+++ b/libs/web-components/src/components/icon-button/IconButton.svelte
@@ -1,10 +1,12 @@
-<svelte:options customElement={{
-  tag: "goa-icon-button",
-  props: {
-    actionArg: { type: "String", attribute: "action-arg"},
-    actionArgs: { type: "Object", attribute: "action-args"},
-  }
-}} />
+<svelte:options
+  customElement={{
+    tag: "goa-icon-button",
+    props: {
+      actionArg: { type: "String", attribute: "action-arg" },
+      actionArgs: { type: "Object", attribute: "action-args" },
+    },
+  }}
+/>
 
 <script lang="ts">
   import { typeValidator, toBoolean, dispatch } from "../../common/utils";
@@ -70,7 +72,9 @@
     );
 
     if (action) {
-      dispatch(e.target as Element, action, actionArg || actionArgs, { bubbles: true });
+      dispatch(e.target as Element, action, actionArg || actionArgs, {
+        bubbles: true,
+      });
     }
   }
 
@@ -89,10 +93,30 @@
       );
     }
   });
+
+  // To reduce the number of CSS classes, convert the numeric sizes to their corresponding named sizes.
+  function normalizeIconSize(size: IconSize): string {
+    switch (size) {
+      case "1":
+        return "2xsmall";
+      case "2":
+        return "xsmall";
+      case "3":
+        return "small";
+      case "4":
+        return "medium";
+      case "5":
+        return "large";
+      case "6":
+        return "xlarge";
+      default:
+        return size;
+    }
+  }
 </script>
 
 <button
-  class={`goa-icon-button goa-icon-button--${size} ${css}`}
+  class={`goa-icon-button goa-icon-button--${normalizeIconSize(size)} ${css}`}
   style={calculateMargin(mt, mr, mb, ml)}
   {title}
   disabled={isDisabled}
@@ -116,15 +140,21 @@
     outline: none !important;
   }
 
+  .goa-icon-button--2xsmall,
+  .goa-icon-button--xsmall,
   .goa-icon-button--small {
-    padding: var(--goa-icon-button-small-padding, var(--goa-icon-button-medium-padding));
+    padding: var(
+      --goa-icon-button-small-padding,
+      var(--goa-icon-button-medium-padding)
+    );
   }
 
   .goa-icon-button--medium {
     padding: var(--goa-icon-button-medium-padding);
   }
 
-  .goa-icon-button--large {
+  .goa-icon-button--large,
+  .goa-icon-button--xlarge {
     padding: var(--goa-icon-button-large-padding);
   }
 
@@ -136,10 +166,14 @@
     background: transparent;
     cursor: pointer;
     border: none;
-    border-radius: var(--goa-icon-button-border-radius, var(--goa-icon-button-medium-border-radius));
-    transition: background-color 0.2s ease-in-out,
-    color 0.2s ease-in-out,
-    transform 0.1s ease-in-out;
+    border-radius: var(
+      --goa-icon-button-border-radius,
+      var(--goa-icon-button-medium-border-radius)
+    );
+    transition:
+      background-color 0.2s ease-in-out,
+      color 0.2s ease-in-out,
+      transform 0.1s ease-in-out;
   }
 
   button:active {
@@ -151,7 +185,11 @@
   }
 
   button:focus-visible {
-    box-shadow: 0 0 0 var(--goa-icon-button-focus-border-width, 3px) var(--goa-icon-button-focus-border-color, var(--goa-color-interactive-focus));
+    box-shadow: 0 0 0 var(--goa-icon-button-focus-border-width, 3px)
+      var(
+        --goa-icon-button-focus-border-color,
+        var(--goa-color-interactive-focus)
+      );
     outline: none;
   }
 
@@ -195,8 +233,14 @@
   }
 
   .dark:disabled {
-    color: var(--goa-icon-button-dark-disabled-color, var(--goa-icon-button-dark-disabled-color-bg));
-    fill: var(--goa-icon-button-dark-disabled-color, var(--goa-icon-button-dark-disabled-color-bg));
+    color: var(
+      --goa-icon-button-dark-disabled-color,
+      var(--goa-icon-button-dark-disabled-color-bg)
+    );
+    fill: var(
+      --goa-icon-button-dark-disabled-color,
+      var(--goa-icon-button-dark-disabled-color-bg)
+    );
   }
 
   /*  Type: nocolor (same as dark, not documented) */
@@ -254,5 +298,4 @@
   .inverted:active {
     background-color: var(--goa-icon-button-light-hover-color-bg);
   }
-
 </style>


### PR DESCRIPTION
# Before (the change)

Inconsistent button focus values, including this weird grey rectangular focus box:

<img width="1856" height="620" alt="image" src="https://github.com/user-attachments/assets/1ad601be-ea8a-4a7d-b75c-d1cca5056e97" />

# After (the change)

Buttons have consistent focus box padding around them for all valid IconSizes:

<img width="693" height="145" alt="image" src="https://github.com/user-attachments/assets/5c8ac1cd-f8c2-463e-8524-af33ad86d24c" />

**Notes:**
- The story mentions that `2xsmall `and `xsmall`, but the `xlarge `was also not handled.
- IconSizes also includes the numbers 1-6. This PR includes a method to style those correctly also.

Also, design-tokens exports only three padding styles for IconButton: small, medium and large. IconButton groups the three padding styles into the following IconSizes:

| IconSize | design-token |
| --- | --- |
| 2xsmall | `--goa-icon-button-small-padding` |
| xsmall| `--goa-icon-button-small-padding` |
| small| `--goa-icon-button-small-padding` |
| medium| `--goa-icon-button-medium-padding` |
| large| `--goa-icon-button-large-padding` |
| xlarge| `--goa-icon-button-large-padding` |

The sizes are consistent enough, and also we don't want the touch-targets on mobile to get too small or large.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

http://localhost:4200/bugs/3614