### PR TITLE
fix(#3685): adjust width of "reveal" slot for checkbox and radio buttons

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -244,6 +244,10 @@
           label="3614 IconButton Hitboxes"
           url="/bugs/3614"
         ></goab-work-side-menu-item>
+        <goab-work-side-menu-item
+        label="3685 Checkbox & Radio: Reveal width not aligned with item"
+        url="/bugs/3685"
+        ></goab-work-side-menu-item>
       </goab-work-side-menu-group>
       <goab-work-side-menu-group icon="star" heading="Features">
         <goab-work-side-menu-item

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -51,6 +51,7 @@ import { Bug3498Component } from "../routes/bugs/3498/bug3498.component";
 import { Bug3607Component } from "../routes/bugs/3607/bug3607.component";
 import { Bug3505Component } from "../routes/bugs/3505/bug3505.component";
 import { Bug3614Component } from "../routes/bugs/3614/bug3614.component";
+import { Bug3685Component } from "../routes/bugs/3685/bug3685.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -144,6 +145,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3614", component: Bug3614Component },
 
   { path: "bugs/3505", component: Bug3505Component },
+  { path: "bugs/3685", component: Bug3685Component },
   // Feature routes
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1383", component: Feat1383Component },

--- a/apps/prs/angular/src/routes/bugs/3685/bug3685.component.html
+++ b/apps/prs/angular/src/routes/bugs/3685/bug3685.component.html
@@ -1,0 +1,230 @@
+<div>
+  <h1>3685 - Checkbox & Radio: Reveal width not aligned with item</h1>
+  <h2>Version 1</h2>
+  <goab-button type="tertiary" leadingIcon="add" (onClick)="toggleModal()">Add another item</goab-button>
+  <goab-modal [open]="open" (onClose)="toggleModal()" heading="Add a new item" [actions]="actions">
+    <p>Fill in the information to create a new item</p>
+    <goab-form-item label="Type" mt="l">
+      <goab-dropdown (onChange)="updateType($event)" [value]="type">
+        <goab-dropdown-item value="1" label="Option 1"></goab-dropdown-item>
+        <goab-dropdown-item value="2" label="Option 2"></goab-dropdown-item>
+      </goab-dropdown>
+    </goab-form-item>
+    <goab-form-item label="How would you like to be contacted?" helpText="Select one option" mt="l">
+      <goab-radio-group name="contactMethodTwo" formControlName="contactMethodTwo">
+        <goab-radio-item label="Email" description="Receive updates via email" value="email" [reveal]="emailReveal">
+          <ng-template #emailReveal>
+            <goab-form-item label="Email address">
+              <goab-input name="email" formControlName="emailAddress"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-radio-item>
+        <goab-radio-item value="phone" label="Phone" [reveal]="phoneReveal">
+          <ng-template #phoneReveal>
+            <goab-form-item label="Phone number">
+              <goab-input name="phone" formControlName="phoneNumber"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-radio-item>
+        <goab-radio-item value="text" label="Text message" [reveal]="textReveal">
+          <ng-template #textReveal>
+            <goab-form-item label="Mobile phone number">
+              <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-radio-item>
+      </goab-radio-group>
+    </goab-form-item>
+    <goab-form-item label="Select interests" mt="l">
+      <goab-checkbox-list name="entryStatus">
+        <goab-checkbox name="sports" text="Sports"></goab-checkbox>
+        <goab-checkbox name="music" text="Music"></goab-checkbox>
+        <goab-checkbox name="travel" text="Travel"></goab-checkbox>
+        <goab-checkbox name="other" text="Other" [reveal]="phoneReveal">
+          <ng-template #phoneReveal>
+            <goab-form-item label="Please specify">
+              <goab-input name="other" formControlName="other"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-checkbox>
+      </goab-checkbox-list>
+    </goab-form-item>
+    <goab-form-item label="Name" mt="l">
+      <goab-input name="name" width="100%" (onChange)="updateName($event)" [value]="name"></goab-input>
+    </goab-form-item>
+    <goab-form-item label="Description" mt="l">
+      <goab-textarea name="description" width="100%" [rows]="3" (onChange)="updateDescription($event)" [value]="description"></goab-textarea>
+    </goab-form-item>
+    <ng-template #actions>
+      <goab-button-group alignment="end">
+        <goab-button type="tertiary" size="compact" (onClick)="toggleModal()">Cancel</goab-button>
+        <goab-button type="primary" size="compact" (onClick)="toggleModal()">Save new item</goab-button>
+      </goab-button-group>
+    </ng-template>
+  </goab-modal>
+  <goab-form-item label="How would you like to be contacted?" helpText="Select one option">
+    <goab-radio-group name="contactMethod" formControlName="contactMethod">
+      <goab-radio-item label="Email" value="email"  description="Receive updates via email"/>
+      <goab-radio-item value="phone" label="Phone"/>
+      <goab-radio-item value="text" label="Text message" [reveal]="textReveal">
+        <ng-template #textReveal>
+          <goab-form-item label="Mobile phone number">
+            <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-radio-item>
+    </goab-radio-group>
+  </goab-form-item>
+
+  <goab-form-item label="Select any interests you have" mt="xl">
+    <goab-checkbox-list name="contactMethods" formControlName="contactMethods">
+      <goab-checkbox name="travel" text="Travel" value="travel"
+        [description]="descriptionTemplate">
+        <ng-template #descriptionTemplate>
+          <span>Help text with a <a href="#">link</a>.</span>
+        </ng-template>
+      </goab-checkbox>
+      <goab-checkbox name="music" text="Music" value="music"/>
+      <goab-checkbox name="sports" text="Sports" value="sports"/>
+      <goab-checkbox name="other" text="Other" value="other" [reveal]="checkTextReveal">
+        <ng-template #checkTextReveal>
+          <goab-form-item label="Mobile phone number">
+            <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-checkbox>
+    </goab-checkbox-list>
+  </goab-form-item>
+
+  <h2>Version 2 (Experimental)</h2>
+  <goab-button type="tertiary" leadingIcon="add" (onClick)="toggleModalTwo()">Add another item</goab-button>
+  <goab-modal [open]="openTwo" (onClose)="toggleModalTwo()" heading="Add a new item" [actions]="actionsTwo">
+    <p>Fill in the information to create a new item</p>
+    <goab-form-item label="Type" mt="l">
+      <goab-dropdown (onChange)="updateType($event)" [value]="type">
+        <goab-dropdown-item value="1" label="Option 1"></goab-dropdown-item>
+        <goab-dropdown-item value="2" label="Option 2"></goab-dropdown-item>
+      </goab-dropdown>
+    </goab-form-item>
+    <goab-form-item label="How would you like to be contacted?" helpText="Select one option" mt="l">
+      <goab-radio-group name="contactMethodTwo" formControlName="contactMethodTwo">
+        <goab-radio-item label="Email" description="Receive updates via email" value="email" [reveal]="emailReveal">
+          <ng-template #emailReveal>
+            <goab-form-item label="Email address">
+              <goab-input name="email" formControlName="emailAddress"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-radio-item>
+        <goab-radio-item value="phone" label="Phone" [reveal]="phoneReveal">
+          <ng-template #phoneReveal>
+            <goab-form-item label="Phone number">
+              <goab-input name="phone" formControlName="phoneNumber"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-radio-item>
+        <goab-radio-item value="text" label="Text message" [reveal]="textReveal">
+          <ng-template #textReveal>
+            <goab-form-item label="Mobile phone number">
+              <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-radio-item>
+      </goab-radio-group>
+    </goab-form-item>
+    <goab-form-item label="Select interests" mt="l">
+      <goab-checkbox-list name="entryStatus">
+        <goab-checkbox name="sports" text="Sports"></goab-checkbox>
+        <goab-checkbox name="music" text="Music"></goab-checkbox>
+        <goab-checkbox name="travel" text="Travel"></goab-checkbox>
+        <goab-checkbox name="other" text="Other" [reveal]="phoneReveal">
+          <ng-template #phoneReveal>
+            <goab-form-item label="Please specify">
+              <goab-input name="other" formControlName="other"></goab-input>
+            </goab-form-item>
+          </ng-template>
+        </goab-checkbox>
+      </goab-checkbox-list>
+    </goab-form-item>
+    <goab-form-item label="Name" mt="l">
+      <goab-input name="name" width="100%" (onChange)="updateName($event)" [value]="name"></goab-input>
+    </goab-form-item>
+    <goab-form-item label="Description" mt="l">
+      <goab-textarea name="description" width="100%" [rows]="3" (onChange)="updateDescription($event)" [value]="description"></goab-textarea>
+    </goab-form-item>
+    <ng-template #actionsTwo>
+      <goab-button-group alignment="end">
+        <goab-button type="tertiary" size="compact" (onClick)="toggleModalTwo()">Cancel</goab-button>
+        <goab-button type="primary" size="compact" (onClick)="toggleModalTwo()">Save new item</goab-button>
+      </goab-button-group>
+    </ng-template>
+  </goab-modal>
+  <h3>Regular size</h3>
+  <goab-form-item label="How would you like to be contacted?" helpText="Select one option">
+    <goab-radio-group name="contactMethod" formControlName="contactMethod">
+      <goab-radio-item label="Email" value="email"  description="Receive updates via email"/>
+      <goab-radio-item value="phone" label="Phone"/>
+      <goab-radio-item value="text" label="Text message" [reveal]="textReveal">
+        <ng-template #textReveal>
+          <goab-form-item label="Mobile phone number">
+            <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-radio-item>
+    </goab-radio-group>
+  </goab-form-item>
+
+  <goab-form-item label="Select any interests you have" mt="xl">
+    <goab-checkbox-list name="contactMethods" formControlName="contactMethods">
+      <goab-checkbox name="travel" text="Travel" value="travel"
+        [description]="descriptionTemplate">
+        <ng-template #descriptionTemplate>
+          <span>Help text with a <a href="#">link</a>.</span>
+        </ng-template>
+      </goab-checkbox>
+      <goab-checkbox name="music" text="Music" value="music"/>
+      <goab-checkbox name="sports" text="Sports" value="sports"/>
+      <goab-checkbox name="other" text="Other" value="other" [reveal]="checkTextReveal">
+        <ng-template #checkTextReveal>
+          <goab-form-item label="Mobile phone number">
+            <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-checkbox>
+    </goab-checkbox-list>
+  </goab-form-item>
+
+  <h3>Compact size</h3>
+  <goab-form-item label="How would you like to be contacted?" helpText="Select one option">
+    <goab-radio-group name="contactMethod" size="compact" formControlName="contactMethod">
+      <goab-radio-item label="Email" value="email"  description="Receive updates via email"/>
+      <goab-radio-item value="phone" label="Phone"/>
+      <goab-radio-item value="text" label="Text message" [reveal]="textReveal">
+        <ng-template #textReveal>
+          <goab-form-item label="Mobile phone number">
+            <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-radio-item>
+    </goab-radio-group>
+  </goab-form-item>
+
+  <goab-form-item label="Select any interests you have" mt="xl">
+    <goab-checkbox-list name="contactMethods" size="compact" formControlName="contactMethods">
+      <goab-checkbox name="travel" text="Travel" size="compact" value="travel"
+        [description]="descriptionTemplate">
+        <ng-template #descriptionTemplate>
+          <span>Help text with a <a href="#">link</a>.</span>
+        </ng-template>
+      </goab-checkbox>
+      <goab-checkbox name="music" text="Music" size="compact" value="music"/>
+      <goab-checkbox name="sports" text="Sports" size="compact" value="sports"/>
+      <goab-checkbox name="other" text="Other" size="compact" value="other" [reveal]="checkTextReveal">
+        <ng-template #checkTextReveal>
+          <goab-form-item label="Mobile phone number">
+            <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
+          </goab-form-item>
+        </ng-template>
+      </goab-checkbox>
+    </goab-checkbox-list>
+  </goab-form-item>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3685/bug3685.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3685/bug3685.component.ts
@@ -1,0 +1,65 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabButton,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabModal,
+  GoabTextArea,
+  GoabButtonGroup,
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabFormItem,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+} from "@abgov/angular-components";
+
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3685",
+  templateUrl: "./bug3685.component.html",
+  imports: [CommonModule,
+  GoabButton,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabModal,
+  GoabTextArea,
+  GoabButtonGroup,
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabFormItem,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+],
+})
+export class Bug3685Component {
+  open = false;
+  openTwo = false;
+  type: string | undefined = "";
+  name = "";
+  description = "";
+
+  toggleModal() {
+    this.open = !this.open;
+  }
+
+  toggleModalTwo() {
+    this.openTwo = !this.openTwo;
+  }
+
+  updateType(event: any) {
+    this.type = event.value;
+  }
+
+  updateName(event: any) {
+    this.name = event.value;
+  }
+
+  updateDescription(event: any) {
+    this.description = event.value;
+  }
+
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -233,6 +233,10 @@ export function App() {
                   label="3614 IconButton Hitboxes"
                   url="/bugs/3614"
                 />
+                <GoabWorkSideMenuItem
+                  label="3685 Checkbox & Radio: Reveal width not aligned with item"
+                  url="/bugs/3685"
+                />
               </GoabWorkSideMenuGroup>
 
               <GoabWorkSideMenuGroup icon="star" heading="Features">

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -53,6 +53,7 @@ import { Bug3498Route } from "./routes/bugs/bug3498";
 import { Bug3607Route } from "./routes/bugs/bug3607";
 import { Bug3505Route } from "./routes/bugs/bug3505";
 import { Bug3614Route } from "./routes/bugs/bug3614";
+import { Bug3685Route } from "./routes/bugs/bug3685";
 
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
@@ -153,6 +154,7 @@ root.render(
           <Route path="bugs/3607" element={<Bug3607Route />} />
           <Route path="bugs/3505" element={<Bug3505Route />} />
           <Route path="bugs/3614" element={<Bug3614Route />} />
+          <Route path="bugs/3685" element={<Bug3685Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3685.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3685.tsx
@@ -1,0 +1,476 @@
+import { useState } from 'react';
+import {
+  GoabFormItem,
+  GoabButton,
+  GoabButtonGroup,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabModal,
+  GoabInput,
+  GoabRadioGroup,
+  GoabTextArea,
+  GoabRadioItem,
+} from "@abgov/react-components";
+
+export function Bug3685Route() {
+  const [open, setOpen] = useState(false);
+  const [openTwo, setOpenTwo] = useState(false);
+  const [type, setType] = useState<string>();
+  const [name, setName] = useState<string>();
+  const [description, setDescription] = useState<string>();
+  const [contactMethod, setContactMethod] = useState("");
+  const [contactMethodTwo, setContactMethodTwo] = useState("");
+  const [contactMethodThree, setContactMethodThree] = useState("");
+  const [checkboxSelection, setCheckboxSelection] = useState<string[]>([]);
+  const [checkboxSelectionTwo, setCheckboxSelectionTwo] = useState<string[]>([]);
+  const [checkboxSelectionThree, setCheckboxSelectionThree] = useState<string[]>([]);
+
+  return (
+     <div>
+      <h1>3685 - Checkbox & Radio: Reveal width not aligned with item</h1>
+      <h2>Version 1</h2>
+
+      <GoabButton type="tertiary" leadingIcon="add" onClick={() => setOpen(true)}>
+        Add another item
+      </GoabButton>
+      <GoabModal
+          heading="Add a new item"
+          open={open}
+          actions={
+            <GoabButtonGroup alignment="end">
+              <GoabButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
+                Cancel
+              </GoabButton>
+              <GoabButton type="primary" size="compact" onClick={() => setOpen(false)}>
+                Save new item
+              </GoabButton>
+            </GoabButtonGroup>
+          }
+        >
+          <p>Fill in the information to create a new item</p>
+          <GoabFormItem label="Type" mt="l">
+            <GoabDropdown onChange={(e) => setType(e.value)} value={type}>
+              <GoabDropdownItem value="1" label="Option 1" />
+              <GoabDropdownItem value="2" label="Option 2" />
+            </GoabDropdown>
+          </GoabFormItem>
+          <GoabFormItem label="Name" mt="l">
+            <GoabInput
+              onChange={(e) => setName(e.value)}
+              value={name}
+              name="name"
+              width="100%"
+            />
+          </GoabFormItem>
+          <GoabFormItem
+          label="How would you like to be contacted?"
+          helpText="Select one option"
+          mt="xl"
+        >
+        <GoabRadioGroup
+          name="contactMethod"
+          value={contactMethodTwo}
+          onChange={(e) => setContactMethodTwo(e.value)}
+        >
+          <GoabRadioItem
+            value="email-1"
+            description="Receive updates via email"
+            label="Email"
+          />
+          <GoabRadioItem
+            value="phone-1"
+            label="Phone"
+          />
+          <GoabRadioItem
+            value="text-1"
+            label="Text message"
+            reveal={
+              <GoabFormItem label="Mobile phone number">
+                <GoabInput name="mobilePhoneNumber" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabRadioGroup>
+      </GoabFormItem>
+
+      <GoabFormItem label="Select any interests you have" mt="xl">
+        <GoabCheckboxList
+          name="contactMethods"
+          value={checkboxSelectionTwo}
+          onChange={(e) => setCheckboxSelectionTwo(e.value || [])}
+        >
+          <GoabCheckbox
+            name="travel-1"
+            description={
+              <span>
+                Help text with as a description.
+              </span>
+            }
+            text="Travel"
+            value="travel-1"
+          />
+          <GoabCheckbox
+            name="music-1"
+            text="Music"
+            value="music-1"
+          />
+          <GoabCheckbox
+            name="sports-1"
+            text="Sports"
+            value="sports-1"
+          />
+          <GoabCheckbox
+            name="other-1"
+            text="Other"
+            value="other-1"
+            reveal={
+              <GoabFormItem label="Other field">
+                <GoabInput name="otherTextField" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabCheckboxList>
+      </GoabFormItem>
+          <GoabFormItem label="Description" mt="l">
+            <GoabTextArea
+              name="description"
+              rows={3}
+              width="100%"
+              onChange={(e) => setDescription(e.value)}
+              value={description}
+            />
+          </GoabFormItem>
+      </GoabModal>
+      <GoabFormItem
+        label="How would you like to be contacted?"
+        helpText="Select one option"
+      >
+        <GoabRadioGroup
+          name="contactMethod"
+          value={contactMethod}
+          onChange={(e) => setContactMethod(e.value)}
+        >
+          <GoabRadioItem
+            value="email-0"
+            description="Receive updates via email"
+            label="Email"
+          />
+          <GoabRadioItem
+            value="phone-0"
+            label="Phone"
+          />
+          <GoabRadioItem
+            value="text-0"
+            label="Text message"
+            reveal={
+              <GoabFormItem label="Mobile phone number">
+                <GoabInput name="mobilePhoneNumber" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabRadioGroup>
+      </GoabFormItem>
+
+      <GoabFormItem label="Select any interests you have" mt="xl">
+        <GoabCheckboxList
+          name="contactMethods"
+          value={checkboxSelection}
+          onChange={(e) => setCheckboxSelection(e.value || [])}
+        >
+          <GoabCheckbox
+            name="travel-0"
+            description={
+              <span>
+                Help text with as a description.
+              </span>
+            }
+            text="Travel"
+            value="travel-0"
+          />
+          <GoabCheckbox
+            name="music-0"
+            text="Music"
+            value="music-0"
+          />
+          <GoabCheckbox
+            name="sports-0"
+            text="Sports"
+            value="sports-0"
+          />
+          <GoabCheckbox
+            name="other-0"
+            text="Other"
+            value="other-0"
+            reveal={
+              <GoabFormItem label="Other field">
+                <GoabInput name="otherTextField" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabCheckboxList>
+      </GoabFormItem>
+
+      <h2>Version 2 (Experimental)</h2>
+      <h3>Regular size</h3>
+
+      <GoabButton type="tertiary" leadingIcon="add" onClick={() => setOpenTwo(true)}>
+        Add another item
+      </GoabButton>
+      <GoabModal
+          heading="Add a new item"
+          open={openTwo}
+          actions={
+            <GoabButtonGroup alignment="end">
+              <GoabButton type="tertiary" size="compact" onClick={() => setOpenTwo(false)}>
+                Cancel
+              </GoabButton>
+              <GoabButton type="primary" size="compact" onClick={() => setOpenTwo(false)}>
+                Save new item
+              </GoabButton>
+            </GoabButtonGroup>
+          }
+        >
+          <p>Fill in the information to create a new item</p>
+          <GoabFormItem label="Type" mt="l">
+            <GoabDropdown onChange={(e) => setType(e.value)} value={type}>
+              <GoabDropdownItem value="1" label="Option 1" />
+              <GoabDropdownItem value="2" label="Option 2" />
+            </GoabDropdown>
+          </GoabFormItem>
+          <GoabFormItem label="Name" mt="l">
+            <GoabInput
+              onChange={(e) => setName(e.value)}
+              value={name}
+              name="name"
+              width="100%"
+            />
+          </GoabFormItem>
+          <GoabFormItem
+          label="How would you like to be contacted?"
+          helpText="Select one option"
+          mt="xl"
+        >
+        <GoabRadioGroup
+          name="contactMethod"
+          value={contactMethodTwo}
+          onChange={(e) => setContactMethodTwo(e.value)}
+        >
+          <GoabRadioItem
+            value="email-1"
+            description="Receive updates via email"
+            label="Email"
+          />
+          <GoabRadioItem
+            value="phone-1"
+            label="Phone"
+          />
+          <GoabRadioItem
+            value="text-1"
+            label="Text message"
+            reveal={
+              <GoabFormItem label="Mobile phone number">
+                <GoabInput name="mobilePhoneNumber" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabRadioGroup>
+      </GoabFormItem>
+
+      <GoabFormItem label="Select any interests you have" mt="xl">
+        <GoabCheckboxList
+          name="contactMethods"
+          value={checkboxSelectionTwo}
+          onChange={(e) => setCheckboxSelectionTwo(e.value || [])}
+        >
+          <GoabCheckbox
+            name="travel-1"
+            description={
+              <span>
+                Help text with as a description.
+              </span>
+            }
+            text="Travel"
+            value="travel-1"
+          />
+          <GoabCheckbox
+            name="music-1"
+            text="Music"
+            value="music-1"
+          />
+          <GoabCheckbox
+            name="sports-1"
+            text="Sports"
+            value="sports-1"
+          />
+          <GoabCheckbox
+            name="other-1"
+            text="Other"
+            value="other-1"
+            reveal={
+              <GoabFormItem label="Other field">
+                <GoabInput name="otherTextField" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabCheckboxList>
+      </GoabFormItem>
+          <GoabFormItem label="Description" mt="l">
+            <GoabTextArea
+              name="description"
+              rows={3}
+              width="100%"
+              onChange={(e) => setDescription(e.value)}
+              value={description}
+            />
+          </GoabFormItem>
+      </GoabModal>
+      <GoabFormItem
+        label="How would you like to be contacted?"
+        helpText="Select one option"
+      >
+        <GoabRadioGroup
+          name="contactMethod"
+          value={contactMethodTwo}
+          onChange={(e) => setContactMethodTwo(e.value)}
+        >
+          <GoabRadioItem
+            value="email-1"
+            description="Receive updates via email"
+            label="Email"
+          />
+          <GoabRadioItem
+            value="phone-1"
+            label="Phone"
+          />
+          <GoabRadioItem
+            value="text-1"
+            label="Text message"
+            reveal={
+              <GoabFormItem label="Mobile phone number">
+                <GoabInput name="mobilePhoneNumber" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabRadioGroup>
+      </GoabFormItem>
+
+      <GoabFormItem label="Select any interests you have" mt="xl">
+        <GoabCheckboxList
+          name="contactMethods"
+          value={checkboxSelectionTwo}
+          onChange={(e) => setCheckboxSelectionTwo(e.value || [])}
+        >
+          <GoabCheckbox
+            name="travel-1"
+            description={
+              <span>
+                Help text with as a description.
+              </span>
+            }
+            text="Travel"
+            value="travel-1"
+          />
+          <GoabCheckbox
+            name="music-1"
+            text="Music"
+            value="music-1"
+          />
+          <GoabCheckbox
+            name="sports-1"
+            text="Sports"
+            value="sports-1"
+          />
+          <GoabCheckbox
+            name="other-1"
+            text="Other"
+            value="other-1"
+            reveal={
+              <GoabFormItem label="Other field">
+                <GoabInput name="otherTextField" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabCheckboxList>
+      </GoabFormItem>
+
+      <h3>Compact size</h3>
+      <GoabFormItem
+        label="How would you like to be contacted?"
+        helpText="Select one option"
+      >
+        <GoabRadioGroup
+          size="compact"
+          name="contactMethodThree"
+          value={contactMethodThree}
+          onChange={(e) => setContactMethodThree(e.value)}
+        >
+          <GoabRadioItem
+            value="email-2"
+            description="Receive updates via email"
+            label="Email"
+          />
+          <GoabRadioItem
+            value="phone-2"
+            label="Phone"
+          />
+          <GoabRadioItem
+            value="text-2"
+            label="Text message"
+            reveal={
+              <GoabFormItem label="Mobile phone number">
+                <GoabInput name="mobilePhoneNumber" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabRadioGroup>
+      </GoabFormItem>
+
+      <GoabFormItem label="Select any interests you have" mt="xl">
+        <GoabCheckboxList
+          size="compact"
+          name="contactMethods"
+          value={checkboxSelectionThree}
+          onChange={(e) => setCheckboxSelectionThree(e.value || [])}
+        >
+          <GoabCheckbox
+            size="compact"
+            description={
+              <span>
+                Help text with as a description.
+              </span>
+            }
+            name="travel-2"
+            text="Travel"
+            value="travel-2"
+          />
+          <GoabCheckbox
+            size="compact"
+            name="music-2"
+            text="Music"
+            value="music-2"
+          />
+          <GoabCheckbox
+            size="compact"
+            name="sports-2"
+            text="Sports"
+            value="sports-2"
+          />
+          <GoabCheckbox
+            size="compact"
+            name="other-2"
+            text="Other"
+            value="other-2"
+            reveal={
+              <GoabFormItem label="Other field">
+                <GoabInput name="otherTextField" value="" />
+              </GoabFormItem>
+            }
+          />
+        </GoabCheckboxList>
+      </GoabFormItem>
+    </div>
+
+  );
+}

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -380,7 +380,6 @@ max-width: ${maxwidth};
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    align-items: flex-start;
     height: auto; /* Automatically adjusts to content */
     min-height: 0; /* Ensures no unnecessary minimum height */
     padding: 0; /* Remove padding if it's affecting height */
@@ -402,6 +401,7 @@ max-width: ${maxwidth};
   label {
     display: flex;
     cursor: pointer;
+    align-self: flex-start;
   }
 
   /* Hover style when the user hovers over the label */
@@ -439,6 +439,7 @@ max-width: ${maxwidth};
     border-left: 4px solid var(--goa-color-greyscale-200);
     padding: var(--goa-space-m);
     margin: var(--goa-space-2xs) 0 0 calc(var(--goa-space-s) - 2px);
+    box-sizing: border-box;
   }
 
   /* Container */

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -310,7 +310,7 @@
 <style>
   .radio {
     display: inline-flex;
-    align-items: flex-start;
+    align-self: flex-start;
   }
 
   label.radio {
@@ -322,7 +322,6 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    align-items: flex-start;
   }
 
   .radio:hover {
@@ -393,11 +392,13 @@
     padding: var(--goa-radio-reveal-padding, var(--goa-space-m));
     margin: var(--goa-radio-reveal-margin, var(--goa-space-2xs) 0 0 calc(var(--goa-space-s) - 2px));
     border-left: var(--goa-radio-reveal-border, 4px solid var(--goa-color-greyscale-200));
+    box-sizing: border-box;
   }
 
   .radio.v2 ~ .reveal.visible.has-content {
     padding: var(--goa-radio-reveal-padding, var(--goa-space-l));
     border-left: var(--goa-radio-reveal-border, 1px solid var(--goa-color-greyscale-200));
+    width: calc(100% - calc(var(--goa-space-s) - 1px));
   }
 
   .radio.v2.compact ~ .reveal.visible.has-content {

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -398,7 +398,6 @@
   .radio.v2 ~ .reveal.visible.has-content {
     padding: var(--goa-radio-reveal-padding, var(--goa-space-l));
     border-left: var(--goa-radio-reveal-border, 1px solid var(--goa-color-greyscale-200));
-    width: calc(100% - calc(var(--goa-space-s) - 1px));
   }
 
   .radio.v2.compact ~ .reveal.visible.has-content {


### PR DESCRIPTION
# Before (the change)
The fix for the "interactive area" bug on radio buttons and checkboxes caused the "reveal" area width to not be in line with the width of the radio/checkbox area. More noticeable on mobile.
<img width="346" height="598" alt="image" src="https://github.com/user-attachments/assets/ca205e53-e0a2-4008-8623-1f530fda5482" />

# After (the change)
Set the width of the checkbox and radio button (depending on version) as well as adding a box sizing of border box.
<img width="316" height="566" alt="image" src="https://github.com/user-attachments/assets/3201271f-1439-4463-8289-409c0f44e657" />

## Steps needed to test
- [ ] Check on both DS version 1 and 2 if width is in line with Radio Button and Checkboxes
- [ ] Confirm width to work on modal (where I first noticed the issue)