### PR TITLE
fix(#3635): add in new color token for input leading icon

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -249,7 +249,11 @@
             label="3685 Checkbox & Radio: Reveal width not aligned with item"
             url="/bugs/3685"
           ></goab-work-side-menu-item>
-        </goab-work-side-menu-group>
+          <goab-work-side-menu-item
+          label="3635 Input Leading icon color"
+          url="/bugs/3635"
+        ></goab-work-side-menu-item>
+      </goab-work-side-menu-group>
         <goab-work-side-menu-group icon="star" heading="Features">
           <goab-work-side-menu-item
             label="1328"

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -52,6 +52,7 @@ import { Bug3607Component } from "../routes/bugs/3607/bug3607.component";
 import { Bug3505Component } from "../routes/bugs/3505/bug3505.component";
 import { Bug3614Component } from "../routes/bugs/3614/bug3614.component";
 import { Bug3685Component } from "../routes/bugs/3685/bug3685.component";
+import { Bug3635Component } from "../routes/bugs/3635/bug3635.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -146,6 +147,7 @@ export const appRoutes: Route[] = [
 
   { path: "bugs/3505", component: Bug3505Component },
   { path: "bugs/3685", component: Bug3685Component },
+  { path: "bugs/3635", component: Bug3635Component },
   // Feature routes
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1383", component: Feat1383Component },

--- a/apps/prs/angular/src/routes/bugs/3635/bug3635.component.html
+++ b/apps/prs/angular/src/routes/bugs/3635/bug3635.component.html
@@ -1,0 +1,19 @@
+<goab-text tag="h1">Bug 3635 - Input: Leading icon color</goab-text>
+
+<goab-form-item label="Leading Icon Input" mb="xl">
+  <goab-input
+    name="autocomplete-test-v2"
+    leadingIcon="search"
+    (onBlur)="inputBlur($event)"
+    [value]="inputValue"
+  />
+</goab-form-item>
+<goab-form-item label="Leading Icon Input - Compact" mb="xl">
+  <goab-input
+    name="autocomplete-test-v2"
+    leadingIcon="search"
+    size="compact"
+    (onBlur)="inputBlur($event)"
+    [value]="inputValue"
+  />
+</goab-form-item>

--- a/apps/prs/angular/src/routes/bugs/3635/bug3635.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3635/bug3635.component.ts
@@ -1,0 +1,21 @@
+import { Component } from "@angular/core";
+import {
+  GoabInput,
+  GoabFormItem,
+  GoabText,
+  GoabInputOnBlurDetail,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3635",
+  templateUrl: "./bug3635.component.html",
+  imports: [GoabInput, GoabText, GoabFormItem],
+})
+export class Bug3635Component {
+  inputValue = "";
+
+  inputBlur(details: GoabInputOnBlurDetail) {
+    this.inputValue = details.value;
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -237,6 +237,10 @@ export function App() {
                   label="3685 Checkbox & Radio: Reveal width not aligned with item"
                   url="/bugs/3685"
                 />
+                <GoabWorkSideMenuItem
+                  label="3635 Input Leading icon color"
+                  url="/bugs/3635"
+                />
               </GoabWorkSideMenuGroup>
 
               <GoabWorkSideMenuGroup icon="star" heading="Features">

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -54,6 +54,7 @@ import { Bug3607Route } from "./routes/bugs/bug3607";
 import { Bug3505Route } from "./routes/bugs/bug3505";
 import { Bug3614Route } from "./routes/bugs/bug3614";
 import { Bug3685Route } from "./routes/bugs/bug3685";
+import { Bug3635Route } from "./routes/bugs/bug3635";
 
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
@@ -155,6 +156,7 @@ root.render(
           <Route path="bugs/3505" element={<Bug3505Route />} />
           <Route path="bugs/3614" element={<Bug3614Route />} />
           <Route path="bugs/3685" element={<Bug3685Route />} />
+          <Route path="bugs/3635" element={<Bug3635Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3635.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3635.tsx
@@ -1,0 +1,34 @@
+import { GoabText, GoabFormItem, GoabInput } from "@abgov/react-components";
+import { GoabInputOnBlurDetail } from "@abgov/ui-components-common";
+import { useState } from "react";
+
+export function Bug3635Route() {
+  const [inputValue, setInputValue] = useState<string>("");
+
+  function inputBlur(details: GoabInputOnBlurDetail) {
+    setInputValue(details.value);
+  }
+
+  return (
+    <>
+      <GoabText tag="h1">Bug 3635 - Input: Leading icon color</GoabText>
+      <GoabFormItem label="Leading Icon Input" mb="xl">
+        <GoabInput
+          name="autocomplete-test-v2"
+          leadingIcon="search"
+          onBlur={(e) => inputBlur(e)}
+          value={inputValue}
+        />
+      </GoabFormItem>
+      <GoabFormItem label="Leading Icon Input - Compact" mb="xl">
+        <GoabInput
+          name="autocomplete-test-v2"
+          size="compact"
+          leadingIcon="search"
+          onBlur={(e) => inputBlur(e)}
+          value={inputValue}
+        />
+      </GoabFormItem>
+    </>
+  );
+}

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -591,6 +591,11 @@
     margin-right: var(--goa-text-input-padding-lr);
   }
 
+  .leading-icon,
+  .trailing-icon {
+    color: var(--goa-text-input-color-icon);
+  }
+
   .trailing-icon-button {
     margin-right: var(--goa-text-input-padding-lr);
   }


### PR DESCRIPTION
# Before (the change)
The colour of the leading icon shared the same colour as the input text.

<img width="453" height="233" alt="image" src="https://github.com/user-attachments/assets/a2901d6c-0451-4720-a0d0-7ab4271217b1" />

# After (the change)
With the new token added, the leading icon is lighter than the input text.

<img width="445" height="227" alt="image" src="https://github.com/user-attachments/assets/6bfba565-b4b9-4208-b4b8-6b64cb7deb3a" />

## Steps needed to test
- [ ] Confirm that v2 input, both default and compact sizes, are both using the  `--goa-text-input-colour-icon` design token.
