### PR TITLE
[don't test] app header popover dropdowns missing border-radius

### DIFF
--- a/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
+++ b/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
@@ -189,7 +189,7 @@
       class="app-header-menu-popover"
       context="menu"
       focusborderwidth="0"
-      borderradius={_isV2Navigation ? "8" : "0"}
+      borderradius={_isV2Navigation ? "var(--goa-border-radius-xl)" : "0"}
       padded="false"
       tabindex="-1"
       maxwidth="16rem"

--- a/libs/web-components/src/components/app-header/AppHeader.svelte
+++ b/libs/web-components/src/components/app-header/AppHeader.svelte
@@ -536,7 +536,7 @@
         context="menu-toggle-area"
         minwidth="16rem"
         focusborderwidth="0"
-        borderradius="4"
+        borderradius="var(--goa-border-radius-xl)"
         padded="false"
         tabindex="-1"
         height="full"


### PR DESCRIPTION
## Summary

Fixes #3659

- **AppHeaderMenu** (V2 nav dropdown) passed `borderradius="8"` and **AppHeader** (tablet menu popover) passed `borderradius="4"` to the Popover component. These are unitless CSS values — `border-radius: 8` is invalid CSS (non-zero values require a unit), so the browser silently discarded the declaration, resulting in no visible border-radius.
- Replaced both with `var(--goa-border-radius-xl)` (0.75rem / 12px), matching the Figma design spec.
- The fix is in the two consumer components, not the Popover itself — the Popover component correctly applies whatever value it receives and defaults to `var(--goa-border-radius-m)` when no override is passed. Other popover consumers (Dropdown, DatePicker, MenuButton) inherit the default and are unaffected.

## Files changed

| File | Change |
|------|--------|
| `libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte` | `borderradius="8"` → `var(--goa-border-radius-xl)` for V2 nav |
| `libs/web-components/src/components/app-header/AppHeader.svelte` | `borderradius="4"` → `var(--goa-border-radius-xl)` for tablet menu |

## Test plan

- [x] Unit tests pass (`vitest --run --project=*-unit` — 1271 passed)
- [ ] Visual check: run `npm run serve:prs:react`, open V2 app header with dropdown menu, confirm rounded corners on popover
- [ ] Visual check: resize to tablet, confirm "Menu" popover also has rounded corners

https://claude.ai/code/session_01WQuFT7xSApArMp8Y6WgssR