### PR TITLE
feat(docs): add inline search with slash commands to grid pages

### DIFF
--- a/docs/src/components/ComponentsGrid.tsx
+++ b/docs/src/components/ComponentsGrid.tsx
@@ -23,13 +23,14 @@ import {
   GoabFormItem,
   GoabIcon,
   GoabIconButton,
-  GoabInput,
   GoabPushDrawer,
 } from "@abgov/react-components";
 
 import { useTwoLevelSort } from "../hooks/useTwoLevelSort";
 import { useContainerNarrow } from "../hooks/useContainerWidth";
 import { useViewSettings } from "../hooks/useViewSettings";
+import { InlineSearch, type SlashCommand } from "./search/InlineSearch";
+import { useSearch } from "./search/useSearch";
 
 // Type for component data (matches Astro content collection)
 export interface Component {
@@ -102,10 +103,8 @@ function getCategoryBadgeType(
 
 // Format category for display
 function formatCategory(category: string): string {
-  return category
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
+  const words = category.replace(/-/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
 // Format status for display
@@ -137,10 +136,9 @@ function getThumbnailPath(slug: string): string {
 
 export function ComponentsGrid({ components }: ComponentsGridProps) {
   // State
-  const [searchValue, setSearchValue] = useState("");
-  const [searchChips, setSearchChips] = useState<string[]>([]);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [isSticky, setIsSticky] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
 
   // Ref for grid container (used by ResizeObserver for container-aware breakpoints)
   const gridRef = useRef<HTMLDivElement>(null);
@@ -182,6 +180,7 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
   const { sortConfig, setSortConfig, sortByKey, clearSort, handleTableSort } =
     useTwoLevelSort();
   const isContainerNarrow = useContainerNarrow(gridRef, 624);
+  const { search, isLoading, error } = useSearch();
   const { viewSettings, setLayout } = useViewSettings({
     pageKey: "components",
     defaultLayout: "card", // 'card' = grid view
@@ -244,6 +243,45 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
     return { categories, statuses };
   }, [components]);
 
+  // Slash commands derived from available filter values
+  const slashCommands = useMemo((): SlashCommand[] => {
+    const cmds: SlashCommand[] = [];
+    filterOptions.categories.forEach((cat) => {
+      cmds.push({
+        id: `category:${cat}`,
+        label: formatCategory(cat),
+        group: "Category",
+        filterType: "category",
+        filterValue: cat,
+        active: appliedFilters.category.includes(cat),
+      });
+    });
+    filterOptions.statuses.forEach((status) => {
+      cmds.push({
+        id: `status:${status}`,
+        label: formatStatus(status),
+        group: "Status",
+        filterType: "status",
+        filterValue: status,
+        active: appliedFilters.status.includes(status),
+      });
+    });
+    return cmds;
+  }, [filterOptions, appliedFilters]);
+
+  const handleSlashCommand = useCallback((cmd: SlashCommand) => {
+    const filterType = cmd.filterType as "category" | "status";
+    setAppliedFilters((prev) => {
+      const current = prev[filterType];
+      return {
+        ...prev,
+        [filterType]: current.includes(cmd.filterValue)
+          ? current.filter((v) => v !== cmd.filterValue)
+          : [...current, cmd.filterValue],
+      };
+    });
+  }, []);
+
   // View mode: 'card' = grid view, 'list' = list view (table)
   const viewMode = useMemo(
     (): "card" | "list" => (viewSettings.layout === "list" ? "list" : "card"),
@@ -267,24 +305,15 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
   const filteredComponents = useMemo(() => {
     let result = components;
 
-    // Apply search chips
-    if (searchChips.length > 0) {
-      result = result.filter((component) =>
-        searchChips.every(
-          (chip) =>
-            component.data.name.toLowerCase().includes(chip.toLowerCase()) ||
-            (component.data.description || "")
-              .toLowerCase()
-              .includes(chip.toLowerCase()) ||
-            component.data.category.toLowerCase().includes(chip.toLowerCase()) ||
-            (component.data.tags || []).some((tag) =>
-              tag.toLowerCase().includes(chip.toLowerCase()),
-            ) ||
-            (component.data.webComponentTag || "")
-              .toLowerCase()
-              .includes(chip.toLowerCase()),
-        ),
-      );
+    // Apply search filter
+    if (searchQuery.trim()) {
+      const searchResults = search(searchQuery, "component");
+      const matchingSlugs = new Set(searchResults.map((r) => r.slug));
+      // Preserve search relevance order by sorting to match searchResults order
+      const slugOrder = new Map(searchResults.map((r, i) => [r.slug, i]));
+      result = result
+        .filter((c) => matchingSlugs.has(c.slug))
+        .sort((a, b) => (slugOrder.get(a.slug) ?? 0) - (slugOrder.get(b.slug) ?? 0));
     }
 
     // Apply category filters
@@ -363,7 +392,7 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
     }
 
     return result;
-  }, [components, searchChips, appliedFilters, sortConfig]);
+  }, [components, appliedFilters, sortConfig, searchQuery, search]);
 
   // Group components by category
   const groupedComponents = useMemo(() => {
@@ -429,19 +458,6 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
     });
   }, []);
 
-  // Search handlers
-  const applySearch = useCallback(() => {
-    const trimmed = searchValue.trim();
-    if (trimmed && !searchChips.includes(trimmed)) {
-      setSearchChips((prev) => [...prev, trimmed]);
-      setSearchValue("");
-    }
-  }, [searchValue, searchChips]);
-
-  const removeSearchChip = useCallback((chip: string) => {
-    setSearchChips((prev) => prev.filter((c) => c !== chip));
-  }, []);
-
   // Filter handlers
   const togglePendingFilter = useCallback(
     (filterType: "category" | "status", value: string) => {
@@ -476,9 +492,9 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
     [],
   );
 
-  // Clear all filters, search, and sort
+  // Clear all filters, sort, and search
   const clearAll = useCallback(() => {
-    setSearchChips([]);
+    setSearchQuery("");
     clearAllFilters();
     clearSort();
   }, [clearAllFilters, clearSort]);
@@ -605,9 +621,7 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
   );
 
   const hasActiveFilters =
-    searchChips.length > 0 ||
-    appliedFilters.category.length > 0 ||
-    appliedFilters.status.length > 0;
+    appliedFilters.category.length > 0 || appliedFilters.status.length > 0;
 
   return (
     <div className="components-grid" ref={gridRef}>
@@ -618,21 +632,18 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
       <div
         className={`components-toolbar ${isSticky ? "components-toolbar--sticky" : ""}`}
       >
-        {/* Search input */}
+        {/* Search input - filters the grid directly */}
         <div className="components-search-section">
-          <GoabFormItem
-            helpText={!isSticky ? "Search by name, category, or tag" : undefined}
-          >
-            <GoabInput
-              name="componentSearch"
-              value={searchValue}
-              leadingIcon="search"
-              width="100%"
-              size="compact"
-              onChange={(e) => setSearchValue(e.value)}
-              onKeyPress={(e) => e.key === "Enter" && applySearch()}
-            />
-          </GoabFormItem>
+          <InlineSearch
+            value={searchQuery}
+            onChange={setSearchQuery}
+            onClear={() => setSearchQuery("")}
+            placeholder="Search or type / to filter..."
+            commands={slashCommands}
+            onCommandSelect={handleSlashCommand}
+            isLoading={isLoading}
+            error={error}
+          />
         </div>
 
         {/* View toggle + Filters */}
@@ -707,14 +718,29 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
             fillColor="var(--goa-color-text-secondary)"
           />
 
-          {/* Search chips */}
-          {searchChips.map((chip) => (
+          {/* Sort chips */}
+          {sortConfig.primary && (
             <GoabFilterChip
-              key={chip}
-              content={chip}
-              onClick={() => removeSearchChip(chip)}
+              content={sortConfig.primary.key}
+              leadingIcon={
+                sortConfig.primary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
+              secondaryText={sortConfig.secondary ? "1st" : undefined}
+              onClick={() =>
+                setSortConfig({ primary: sortConfig.secondary, secondary: null })
+              }
             />
-          ))}
+          )}
+          {sortConfig.secondary && (
+            <GoabFilterChip
+              content={sortConfig.secondary.key}
+              leadingIcon={
+                sortConfig.secondary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
+              secondaryText="2nd"
+              onClick={() => setSortConfig((prev) => ({ ...prev, secondary: null }))}
+            />
+          )}
 
           {/* Category filter chips */}
           {appliedFilters.category.map((cat) => (
@@ -1018,14 +1044,13 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
           flex-direction: row;
           align-items: flex-start;
           gap: var(--goa-space-m);
-          padding: var(--goa-space-m) 0;
-          margin-bottom: 12px;
+          padding: var(--goa-space-m) 0 var(--goa-space-xs);
           transition: padding 0.15s ease;
         }
 
         /* When sticky - add shadow */
         .components-toolbar--sticky {
-          padding: var(--goa-space-s) 0;
+          padding: var(--goa-space-s) 0 var(--goa-space-xs);
           background: transparent;
           margin-bottom: 0;
         }
@@ -1052,6 +1077,7 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
           display: flex;
           align-items: flex-start;
           gap: var(--goa-space-m);
+          min-height: 40px;
         }
 
         /* Narrow container: stack toolbar vertically */
@@ -1100,12 +1126,14 @@ export function ComponentsGrid({ components }: ComponentsGridProps) {
           align-items: center;
           gap: var(--goa-space-s);
           flex-wrap: wrap;
-          margin-bottom: var(--goa-space-m);
+          padding-top: var(--goa-space-2xs);
+          margin-bottom: var(--goa-space-l);
         }
 
         .components-count {
           color: var(--goa-color-text-secondary);
           font: var(--goa-typography-body-s);
+          margin-top: var(--goa-space-m);
           margin-bottom: var(--goa-space-m);
         }
 

--- a/docs/src/components/ExamplesGrid.tsx
+++ b/docs/src/components/ExamplesGrid.tsx
@@ -24,13 +24,14 @@ import {
   GoabFormItem,
   GoabIcon,
   GoabIconButton,
-  GoabInput,
   GoabPushDrawer,
 } from "@abgov/react-components";
 
 import { useTwoLevelSort } from "../hooks/useTwoLevelSort";
 import { useContainerNarrow } from "../hooks/useContainerWidth";
 import { useViewSettings, type LayoutType } from "../hooks/useViewSettings";
+import { InlineSearch, type SlashCommand } from "./search/InlineSearch";
+import { useSearch } from "./search/useSearch";
 
 // Type for example data (matches Astro content collection)
 export interface Example {
@@ -106,27 +107,28 @@ function getCategoryBadgeType(
   }
 }
 
-// Format category for display
+// Format category for display (sentence case)
 function formatCategory(category: string): string {
-  return category.replace(/-/g, " ");
+  const words = category.replace(/-/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
 // Format scale for display
 function formatScale(scale: string): string {
-  return scale;
+  return scale.charAt(0).toUpperCase() + scale.slice(1);
 }
 
 // Format user type for display
 function formatUserType(userType: string): string {
-  return userType;
+  if (userType === "both") return "Citizen and worker";
+  return userType.charAt(0).toUpperCase() + userType.slice(1);
 }
 
 export function ExamplesGrid({ examples }: ExamplesGridProps) {
   // State
-  const [searchValue, setSearchValue] = useState("");
-  const [searchChips, setSearchChips] = useState<string[]>([]);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [isSticky, setIsSticky] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
 
   // Ref for sticky detection sentinel
   const gridRef = useRef<HTMLDivElement>(null);
@@ -183,6 +185,7 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
   const { sortConfig, setSortConfig, sortByKey, clearSort, handleTableSort } =
     useTwoLevelSort();
   const isContainerNarrow = useContainerNarrow(gridRef, 780);
+  const { search, isLoading, error } = useSearch();
   const { viewSettings, setLayout } = useViewSettings({
     pageKey: "examples",
     defaultLayout: "card", // 'card' = grid view
@@ -241,11 +244,85 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
 
   // Extract unique filter values
   const filterOptions = useMemo(() => {
-    const categories = [...new Set(examples.flatMap((e) => e.data.categories))].sort();
-    const scales = [...new Set(examples.map((e) => e.data.scale))].sort();
-    const userTypes = [...new Set(examples.map((e) => e.data.userType))].sort();
-    return { categories, scales, userTypes };
+    const categories = [...new Set(examples.flatMap((e) => e.data.categories))].sort(
+      (a, b) => (a === "forms" ? -1 : b === "forms" ? 1 : a.localeCompare(b)),
+    );
+    const scales = [...new Set(examples.map((e) => e.data.scale))].sort((a, b) =>
+      a === "product" ? 1 : b === "product" ? -1 : a.localeCompare(b),
+    );
+    const allUserTypes = [...new Set(examples.map((e) => e.data.userType))].sort(
+      (a, b) => (a === "both" ? 1 : b === "both" ? -1 : a.localeCompare(b)),
+    );
+    const userTypes = allUserTypes.filter((ut) => ut !== "both");
+    return { categories, scales, userTypes, allUserTypes };
   }, [examples]);
+
+  // Slash commands derived from available filter values
+  const slashCommands = useMemo((): SlashCommand[] => {
+    const cmds: SlashCommand[] = [];
+    filterOptions.scales.forEach((scale) => {
+      cmds.push({
+        id: `scale:${scale}`,
+        label: formatScale(scale),
+        group: "Scale",
+        filterType: "scale",
+        filterValue: scale,
+        active: appliedFilters.scale.includes(scale),
+      });
+    });
+    filterOptions.categories.forEach((cat) => {
+      cmds.push({
+        id: `category:${cat}`,
+        label: formatCategory(cat),
+        group: "Category",
+        filterType: "category",
+        filterValue: cat,
+        active: appliedFilters.category.includes(cat),
+      });
+    });
+    filterOptions.allUserTypes.forEach((ut) => {
+      cmds.push({
+        id: `userType:${ut}`,
+        label: formatUserType(ut),
+        group: "User Type",
+        filterType: "userType",
+        filterValue: ut,
+        active:
+          ut === "both"
+            ? appliedFilters.userType.includes("citizen") &&
+              appliedFilters.userType.includes("worker")
+            : appliedFilters.userType.includes(ut),
+      });
+    });
+    return cmds;
+  }, [filterOptions, appliedFilters]);
+
+  const handleSlashCommand = useCallback((cmd: SlashCommand) => {
+    const filterType = cmd.filterType as "category" | "scale" | "userType";
+    // "both" expands to citizen + worker
+    if (filterType === "userType" && cmd.filterValue === "both") {
+      setAppliedFilters((prev) => {
+        const hasBoth =
+          prev.userType.includes("citizen") && prev.userType.includes("worker");
+        return {
+          ...prev,
+          userType: hasBoth
+            ? prev.userType.filter((v) => v !== "citizen" && v !== "worker")
+            : [...new Set([...prev.userType, "citizen", "worker"])],
+        };
+      });
+      return;
+    }
+    setAppliedFilters((prev) => {
+      const current = prev[filterType];
+      return {
+        ...prev,
+        [filterType]: current.includes(cmd.filterValue)
+          ? current.filter((v) => v !== cmd.filterValue)
+          : [...current, cmd.filterValue],
+      };
+    });
+  }, []);
 
   // View mode: 'card' = grid view, 'list' = list view
   // On mobile, always use grid view (cards)
@@ -271,24 +348,14 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
   const filteredExamples = useMemo(() => {
     let result = examples;
 
-    // Apply search chips
-    if (searchChips.length > 0) {
-      result = result.filter((example) =>
-        searchChips.every(
-          (chip) =>
-            example.data.title.toLowerCase().includes(chip.toLowerCase()) ||
-            example.data.categories.some((cat) =>
-              cat.toLowerCase().includes(chip.toLowerCase()),
-            ) ||
-            example.data.scale.toLowerCase().includes(chip.toLowerCase()) ||
-            (example.data.tags || []).some((tag) =>
-              tag.toLowerCase().includes(chip.toLowerCase()),
-            ) ||
-            example.data.components.some((comp) =>
-              comp.toLowerCase().includes(chip.toLowerCase()),
-            ),
-        ),
-      );
+    // Apply search filter
+    if (searchQuery.trim()) {
+      const searchResults = search(searchQuery, "example");
+      const matchingSlugs = new Set(searchResults.map((r) => r.slug));
+      const slugOrder = new Map(searchResults.map((r, i) => [r.slug, i]));
+      result = result
+        .filter((e) => matchingSlugs.has(e.slug))
+        .sort((a, b) => (slugOrder.get(a.slug) ?? 0) - (slugOrder.get(b.slug) ?? 0));
     }
 
     // Apply category filters (OR logic - show if example has ANY of the selected categories)
@@ -305,10 +372,13 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
       );
     }
 
-    // Apply userType filters
+    // Apply userType filters ("both" examples match either citizen or worker)
     if (appliedFilters.userType.length > 0) {
       result = result.filter((example) =>
-        appliedFilters.userType.includes(example.data.userType),
+        example.data.userType === "both"
+          ? appliedFilters.userType.includes("citizen") ||
+            appliedFilters.userType.includes("worker")
+          : appliedFilters.userType.includes(example.data.userType),
       );
     }
 
@@ -383,7 +453,7 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
     }
 
     return result;
-  }, [examples, searchChips, appliedFilters, sortConfig]);
+  }, [examples, appliedFilters, sortConfig, searchQuery, search]);
 
   // Group examples
   const groupedExamples = useMemo(() => {
@@ -455,19 +525,6 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
     });
   }, []);
 
-  // Search handlers
-  const applySearch = useCallback(() => {
-    const trimmed = searchValue.trim();
-    if (trimmed && !searchChips.includes(trimmed)) {
-      setSearchChips((prev) => [...prev, trimmed]);
-      setSearchValue("");
-    }
-  }, [searchValue, searchChips]);
-
-  const removeSearchChip = useCallback((chip: string) => {
-    setSearchChips((prev) => prev.filter((c) => c !== chip));
-  }, []);
-
   // Filter handlers
   const togglePendingFilter = useCallback(
     (filterType: "category" | "scale" | "userType", value: string) => {
@@ -502,9 +559,9 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
     [],
   );
 
-  // Clear all filters and search
+  // Clear all filters, sort, and search
   const clearAll = useCallback(() => {
-    setSearchChips([]);
+    setSearchQuery("");
     clearAllFilters();
     clearSort();
   }, [clearAllFilters, clearSort]);
@@ -678,7 +735,6 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
   );
 
   const hasActiveFilters =
-    searchChips.length > 0 ||
     appliedFilters.category.length > 0 ||
     appliedFilters.scale.length > 0 ||
     appliedFilters.userType.length > 0;
@@ -690,21 +746,18 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
 
       {/* Toolbar */}
       <div className={`examples-toolbar ${isSticky ? "examples-toolbar--sticky" : ""}`}>
-        {/* Search input */}
+        {/* Search input - filters the grid directly */}
         <div className="examples-search-section">
-          <GoabFormItem
-            helpText={!isSticky ? "Search by keyword, category, or name" : undefined}
-          >
-            <GoabInput
-              name="exampleSearch"
-              value={searchValue}
-              leadingIcon="search"
-              width="100%"
-              size="compact"
-              onChange={(e) => setSearchValue(e.value)}
-              onKeyPress={(e) => e.key === "Enter" && applySearch()}
-            />
-          </GoabFormItem>
+          <InlineSearch
+            value={searchQuery}
+            onChange={setSearchQuery}
+            onClear={() => setSearchQuery("")}
+            placeholder="Search or type / to filter..."
+            commands={slashCommands}
+            onCommandSelect={handleSlashCommand}
+            isLoading={isLoading}
+            error={error}
+          />
         </div>
 
         {/* View toggle + Filters */}
@@ -779,14 +832,29 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
             fillColor="var(--goa-color-text-secondary)"
           />
 
-          {/* Search chips */}
-          {searchChips.map((chip) => (
+          {/* Sort chips */}
+          {sortConfig.primary && (
             <GoabFilterChip
-              key={chip}
-              content={chip}
-              onClick={() => removeSearchChip(chip)}
+              content={sortConfig.primary.key}
+              leadingIcon={
+                sortConfig.primary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
+              secondaryText={sortConfig.secondary ? "1st" : undefined}
+              onClick={() =>
+                setSortConfig({ primary: sortConfig.secondary, secondary: null })
+              }
             />
-          ))}
+          )}
+          {sortConfig.secondary && (
+            <GoabFilterChip
+              content={sortConfig.secondary.key}
+              leadingIcon={
+                sortConfig.secondary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
+              secondaryText="2nd"
+              onClick={() => setSortConfig((prev) => ({ ...prev, secondary: null }))}
+            />
+          )}
 
           {/* Category filter chips */}
           {appliedFilters.category.map((cat) => (
@@ -1156,14 +1224,13 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
           flex-direction: row;
           align-items: flex-start;
           gap: var(--goa-space-m);
-          padding: var(--goa-space-m) 0;
-          margin-bottom: 12px;
+          padding: var(--goa-space-m) 0 var(--goa-space-xs);
           transition: padding 0.15s ease;
         }
 
         /* When sticky - add shadow */
         .examples-toolbar--sticky {
-          padding: var(--goa-space-s) 0;
+          padding: var(--goa-space-s) 0 var(--goa-space-xs);
           margin-bottom: 0;
           background: transparent;
         }
@@ -1190,6 +1257,7 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
           display: flex;
           align-items: flex-start;
           gap: var(--goa-space-m);
+          min-height: 40px;
         }
 
         /* Narrow container: stack toolbar vertically */
@@ -1237,12 +1305,14 @@ export function ExamplesGrid({ examples }: ExamplesGridProps) {
           align-items: center;
           gap: var(--goa-space-s);
           flex-wrap: wrap;
-          margin-bottom: var(--goa-space-m);
+          padding-top: var(--goa-space-2xs);
+          margin-bottom: var(--goa-space-l);
         }
 
         .examples-count {
           color: var(--goa-color-text-secondary);
           font: var(--goa-typography-body-s);
+          margin-top: var(--goa-space-m);
           margin-bottom: var(--goa-space-m);
         }
 

--- a/docs/src/components/TokensGrid.tsx
+++ b/docs/src/components/TokensGrid.tsx
@@ -25,13 +25,13 @@ import {
   GoabFormItem,
   GoabIcon,
   GoabIconButton,
-  GoabInput,
   GoabPushDrawer,
 } from "@abgov/react-components";
 
 import { useTwoLevelSort } from "../hooks/useTwoLevelSort";
 import { useContainerNarrow } from "../hooks/useContainerWidth";
 import type { FlatToken } from "../lib/tokens";
+import { InlineSearch, type SlashCommand } from "./search/InlineSearch";
 
 interface FilterGroup {
   name: string;
@@ -102,12 +102,11 @@ function toScssSyntax(cssName: string): string {
 
 export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
   // State
-  const [searchValue, setSearchValue] = useState("");
-  const [searchChips, setSearchChips] = useState<string[]>([]);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [isSticky, setIsSticky] = useState(false);
   const [copiedToken, setCopiedToken] = useState<string | null>(null);
   const [tokenSyntax, setTokenSyntax] = useState<TokenSyntax>("css");
+  const [searchQuery, setSearchQuery] = useState("");
 
   // Ref for sticky detection sentinel
   const gridRef = useRef<HTMLDivElement>(null);
@@ -133,15 +132,6 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
     observer.observe(sentinel);
     return () => observer.disconnect();
   }, []);
-
-  // Read URL search parameter on mount (e.g., /tokens?search=color)
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const searchParam = params.get("search");
-    if (searchParam && !searchChips.includes(searchParam)) {
-      setSearchChips([searchParam]);
-    }
-  }, []); // Only run on mount
 
   // Filter state
   const [pendingFilters, setPendingFilters] = useState<string[]>([]);
@@ -195,6 +185,26 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
     return () => tabs.removeEventListener("_change", handleChange);
   }, []);
 
+  // Slash commands derived from filter groups
+  const slashCommands = useMemo((): SlashCommand[] => {
+    return filterGroups.map((group) => ({
+      id: `category:${group.name}`,
+      label: group.name,
+      group: "Category",
+      filterType: "category",
+      filterValue: group.name,
+      active: appliedFilters.includes(group.name),
+    }));
+  }, [filterGroups, appliedFilters]);
+
+  const handleSlashCommand = useCallback((cmd: SlashCommand) => {
+    setAppliedFilters((prev) =>
+      prev.includes(cmd.filterValue)
+        ? prev.filter((v) => v !== cmd.filterValue)
+        : [...prev, cmd.filterValue],
+    );
+  }, []);
+
   // View mode: 'list' (table) on desktop, 'card' on mobile
   // No user toggle - automatically switches based on viewport
   const viewMode = useMemo((): "card" | "list" => {
@@ -205,15 +215,11 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
   const filteredTokens = useMemo(() => {
     let result = tokens;
 
-    // Apply search chips
-    if (searchChips.length > 0) {
-      result = result.filter((token) =>
-        searchChips.every(
-          (chip) =>
-            token.name.toLowerCase().includes(chip.toLowerCase()) ||
-            token.value.toLowerCase().includes(chip.toLowerCase()) ||
-            token.category.toLowerCase().includes(chip.toLowerCase()),
-        ),
+    // Apply search filter (substring match on token name since search index groups tokens by category)
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(
+        (t) => t.name.toLowerCase().includes(q) || t.category.toLowerCase().includes(q),
       );
     }
 
@@ -250,20 +256,7 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
     }
 
     return result;
-  }, [tokens, searchChips, appliedFilters, sortConfig, filterGroups]);
-
-  // Search handlers
-  const applySearch = useCallback(() => {
-    const trimmed = searchValue.trim();
-    if (trimmed && !searchChips.includes(trimmed)) {
-      setSearchChips((prev) => [...prev, trimmed]);
-      setSearchValue("");
-    }
-  }, [searchValue, searchChips]);
-
-  const removeSearchChip = useCallback((chip: string) => {
-    setSearchChips((prev) => prev.filter((c) => c !== chip));
-  }, []);
+  }, [tokens, appliedFilters, sortConfig, filterGroups, searchQuery]);
 
   // Filter handlers
   const togglePendingFilter = useCallback((category: string) => {
@@ -309,9 +302,9 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
     [getFormattedTokenName],
   );
 
-  // Clear all filters, search, and sort
+  // Clear all filters, sort, and search
   const clearAll = useCallback(() => {
-    setSearchChips([]);
+    setSearchQuery("");
     clearAllFilters();
     clearSort();
   }, [clearAllFilters, clearSort]);
@@ -796,7 +789,7 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
     [copiedToken, copyToClipboard, getFormattedTokenName],
   );
 
-  const hasActiveFilters = searchChips.length > 0 || appliedFilters.length > 0;
+  const hasActiveFilters = appliedFilters.length > 0 || sortConfig.primary;
 
   return (
     <div className="tokens-grid" ref={gridRef}>
@@ -805,21 +798,16 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
 
       {/* Toolbar */}
       <div className={`tokens-toolbar ${isSticky ? "tokens-toolbar--sticky" : ""}`}>
-        {/* Search input */}
+        {/* Search input - filters the grid directly */}
         <div className="tokens-search-section">
-          <GoabFormItem
-            helpText={!isSticky ? "Search by name, value, or category" : undefined}
-          >
-            <GoabInput
-              name="tokenSearch"
-              value={searchValue}
-              leadingIcon="search"
-              width="100%"
-              size="compact"
-              onChange={(e) => setSearchValue(e.value)}
-              onKeyPress={(e) => e.key === "Enter" && applySearch()}
-            />
-          </GoabFormItem>
+          <InlineSearch
+            value={searchQuery}
+            onChange={setSearchQuery}
+            onClear={() => setSearchQuery("")}
+            placeholder="Search or type / to filter..."
+            commands={slashCommands}
+            onCommandSelect={handleSlashCommand}
+          />
         </div>
 
         {/* Syntax toggle + Filters */}
@@ -894,14 +882,29 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
             fillColor="var(--goa-color-text-secondary)"
           />
 
-          {/* Search chips */}
-          {searchChips.map((chip) => (
+          {/* Sort chips */}
+          {sortConfig.primary && (
             <GoabFilterChip
-              key={chip}
-              content={chip}
-              onClick={() => removeSearchChip(chip)}
+              content={sortConfig.primary.key}
+              leadingIcon={
+                sortConfig.primary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
+              secondaryText={sortConfig.secondary ? "1st" : undefined}
+              onClick={() =>
+                setSortConfig({ primary: sortConfig.secondary, secondary: null })
+              }
             />
-          ))}
+          )}
+          {sortConfig.secondary && (
+            <GoabFilterChip
+              content={sortConfig.secondary.key}
+              leadingIcon={
+                sortConfig.secondary.direction === "asc" ? "arrow-up" : "arrow-down"
+              }
+              secondaryText="2nd"
+              onClick={() => setSortConfig((prev) => ({ ...prev, secondary: null }))}
+            />
+          )}
 
           {/* Filter group chips */}
           {appliedFilters.map((filterName) => (
@@ -1100,14 +1103,13 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
           flex-direction: row;
           align-items: flex-start;
           gap: var(--goa-space-m);
-          padding: var(--goa-space-m) 0;
-          margin-bottom: 12px;
+          padding: var(--goa-space-m) 0 var(--goa-space-xs);
           transition: padding 0.15s ease;
         }
 
         /* When sticky - add shadow */
         .tokens-toolbar--sticky {
-          padding: var(--goa-space-s) 0;
+          padding: var(--goa-space-s) 0 var(--goa-space-xs);
           background: transparent;
           margin-bottom: 0;
         }
@@ -1134,6 +1136,7 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
           display: flex;
           align-items: flex-start;
           gap: var(--goa-space-m);
+          min-height: 40px;
         }
 
         /* Filter button: desktop shows text, mobile shows icon-only */
@@ -1182,12 +1185,14 @@ export function TokensGrid({ tokens, filterGroups }: TokensGridProps) {
           align-items: center;
           gap: var(--goa-space-s);
           flex-wrap: wrap;
-          margin-bottom: var(--goa-space-m);
+          padding-top: var(--goa-space-2xs);
+          margin-bottom: var(--goa-space-l);
         }
 
         .tokens-count {
           color: var(--goa-color-text-secondary);
           font: var(--goa-typography-body-s);
+          margin-top: var(--goa-space-m);
           margin-bottom: var(--goa-space-m);
         }
 

--- a/docs/src/components/search/InlineSearch.tsx
+++ b/docs/src/components/search/InlineSearch.tsx
@@ -1,0 +1,393 @@
+/**
+ * InlineSearch.tsx
+ *
+ * Controlled search input for grid pages (Components, Examples, Tokens).
+ * - Regular text filters the grid directly (parent controls value/onChange)
+ * - Typing "/" enters command mode with stepped navigation:
+ *   - Multi-dimension pages (Components, Examples): first pick a dimension
+ *     (e.g., "Category", "Scale"), then see its values
+ *   - Single-dimension pages (Tokens): skip straight to values
+ */
+
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { SearchInput } from "./SearchInput";
+
+export interface SlashCommand {
+  id: string;
+  /** Display label, e.g., "Interaction" */
+  label: string;
+  /** Group header, e.g., "Scale" */
+  group: string;
+  /** Filter dimension key, e.g., "scale" */
+  filterType: string;
+  /** Filter value, e.g., "interaction" */
+  filterValue: string;
+  /** Whether this filter is currently active */
+  active?: boolean;
+}
+
+interface InlineSearchProps {
+  value: string;
+  onChange: (value: string) => void;
+  onClear: () => void;
+  placeholder?: string;
+  commands?: SlashCommand[];
+  onCommandSelect?: (command: SlashCommand) => void;
+  /** Whether the search index is still loading */
+  isLoading?: boolean;
+  /** Error message if search index failed to load */
+  error?: string | null;
+}
+
+export function InlineSearch({
+  value,
+  onChange,
+  onClear,
+  placeholder,
+  commands = [],
+  onCommandSelect,
+  isLoading,
+  error,
+}: InlineSearchProps) {
+  const [commandMode, setCommandMode] = useState(false);
+  const [commandInput, setCommandInput] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedDimension, setSelectedDimension] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Derive unique filter dimensions from commands (with counts)
+  const dimensions = useMemo(() => {
+    const groupMap = new Map<string, { count: number; activeCount: number }>();
+    for (const cmd of commands) {
+      const existing = groupMap.get(cmd.group) || { count: 0, activeCount: 0 };
+      existing.count++;
+      if (cmd.active) existing.activeCount++;
+      groupMap.set(cmd.group, existing);
+    }
+    return Array.from(groupMap.entries()).map(([name, { count, activeCount }]) => ({
+      name,
+      count,
+      activeCount,
+    }));
+  }, [commands]);
+
+  const hasMultipleDimensions = dimensions.length > 1;
+
+  // Show dimension picker when multiple dimensions exist and none is selected yet
+  const showDimensions =
+    commandMode && hasMultipleDimensions && selectedDimension === null;
+
+  // Filter dimensions by typed input (e.g., "/s" narrows to "Scale")
+  const filteredDimensions = useMemo(() => {
+    if (!showDimensions) return [];
+    if (commandInput === "/") return dimensions;
+    const query = commandInput.slice(1).toLowerCase();
+    return dimensions.filter((dim) => dim.name.toLowerCase().includes(query));
+  }, [showDimensions, dimensions, commandInput]);
+
+  // Filter commands to selected dimension (or all if single-dimension page)
+  const filteredCommands = useMemo(() => {
+    if (!commandMode || showDimensions) return [];
+
+    let cmds = selectedDimension
+      ? commands.filter((cmd) => cmd.group === selectedDimension)
+      : commands;
+
+    if (commandInput === "/") return cmds;
+    const query = commandInput.slice(1).toLowerCase();
+    return cmds.filter((cmd) => cmd.label.toLowerCase().includes(query));
+  }, [commandMode, showDimensions, commands, commandInput, selectedDimension]);
+
+  // Group commands for display (used on single-dimension pages like Tokens)
+  const groupedCommands = useMemo(() => {
+    const groups: { group: string; items: { cmd: SlashCommand; index: number }[] }[] = [];
+    let currentGroup: string | null = null;
+    let index = 0;
+
+    for (const cmd of filteredCommands) {
+      if (cmd.group !== currentGroup) {
+        currentGroup = cmd.group;
+        groups.push({ group: cmd.group, items: [] });
+      }
+      groups[groups.length - 1].items.push({ cmd, index: index++ });
+    }
+
+    return groups;
+  }, [filteredCommands]);
+
+  // Click outside closes command mode
+  useEffect(() => {
+    if (!commandMode) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setCommandMode(false);
+        setCommandInput("");
+        setSelectedDimension(null);
+      }
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [commandMode]);
+
+  const handleDimensionSelect = useCallback((dimensionName: string) => {
+    setSelectedDimension(dimensionName);
+    setCommandInput("/");
+    setSelectedIndex(0);
+  }, []);
+
+  const handleChange = useCallback(
+    (newValue: string) => {
+      // Backspace from "/" in value mode -> go back to dimensions
+      if (newValue === "" && commandMode && selectedDimension !== null) {
+        setSelectedDimension(null);
+        setCommandInput("/");
+        setSelectedIndex(0);
+        return;
+      }
+
+      if (newValue.startsWith("/") && commands.length > 0) {
+        setCommandMode(true);
+        setCommandInput(newValue);
+        setSelectedIndex(0);
+      } else if (commandMode) {
+        setCommandMode(false);
+        setCommandInput("");
+        setSelectedDimension(null);
+        onChange(newValue);
+      } else {
+        onChange(newValue);
+      }
+    },
+    [commandMode, commands.length, onChange, selectedDimension],
+  );
+
+  const handleCommandSelect = useCallback(
+    (cmd: SlashCommand) => {
+      setCommandMode(false);
+      setCommandInput("");
+      setSelectedDimension(null);
+      onCommandSelect?.(cmd);
+    },
+    [onCommandSelect],
+  );
+
+  const handleClose = useCallback(() => {
+    if (commandMode && selectedDimension !== null) {
+      // Escape from value mode -> back to dimensions
+      setSelectedDimension(null);
+      setCommandInput("/");
+      setSelectedIndex(0);
+    } else if (commandMode) {
+      setCommandMode(false);
+      setCommandInput("");
+      setSelectedDimension(null);
+    } else if (value) {
+      onClear();
+    }
+  }, [commandMode, selectedDimension, value, onClear]);
+
+  // Keyboard navigation for both dimensions and commands
+  const handleCommandNav = useCallback(
+    (key: string) => {
+      if (showDimensions) {
+        if (key === "ArrowDown") {
+          setSelectedIndex((prev) =>
+            prev < filteredDimensions.length - 1 ? prev + 1 : prev,
+          );
+        } else if (key === "ArrowUp") {
+          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+        } else if (key === "Enter" || key === "ArrowRight") {
+          const dim = filteredDimensions[selectedIndex];
+          if (dim) handleDimensionSelect(dim.name);
+        }
+      } else {
+        if (key === "ArrowDown") {
+          setSelectedIndex((prev) =>
+            prev < filteredCommands.length - 1 ? prev + 1 : prev,
+          );
+        } else if (key === "ArrowUp") {
+          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+        } else if (key === "Enter") {
+          const selected = filteredCommands[selectedIndex];
+          if (selected) handleCommandSelect(selected);
+        } else if (key === "ArrowLeft" && selectedDimension !== null) {
+          setSelectedDimension(null);
+          setCommandInput("/");
+          setSelectedIndex(0);
+        }
+      }
+    },
+    [
+      showDimensions,
+      filteredDimensions,
+      filteredCommands,
+      selectedIndex,
+      handleCommandSelect,
+      handleDimensionSelect,
+    ],
+  );
+
+  const displayValue = commandMode ? commandInput : value;
+  const showClose = commandMode || !!value;
+  const hasDropdownItems = showDimensions
+    ? filteredDimensions.length > 0
+    : filteredCommands.length > 0;
+
+  return (
+    <div className="inline-search" ref={containerRef}>
+      <SearchInput
+        value={displayValue}
+        onChange={handleChange}
+        onClose={showClose ? handleClose : undefined}
+        autoFocus={false}
+        placeholder={placeholder}
+        onResultNav={commandMode && hasDropdownItems ? handleCommandNav : undefined}
+      />
+
+      {/* Loading state (only shown while user is actively typing) */}
+      {isLoading && value && !error && (
+        <div className="inline-search-commands" role="status" aria-live="polite">
+          <div className="inline-search-loading">Loading search...</div>
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <div className="inline-search-commands" role="alert">
+          <div className="inline-search-error">
+            <strong>Unable to load search</strong>
+            <p>Try refreshing the page.</p>
+          </div>
+        </div>
+      )}
+
+      {/* Step 1: Dimension picker (multi-dimension pages) */}
+      {showDimensions && filteredDimensions.length > 0 && (
+        <div className="inline-search-commands" role="listbox">
+          <ul className="inline-commands-list">
+            {filteredDimensions.map((dim, index) => (
+              <li
+                key={dim.name}
+                className="inline-commands-item inline-commands-dimension"
+                data-selected={index === selectedIndex}
+                role="option"
+                aria-selected={index === selectedIndex}
+                onClick={() => handleDimensionSelect(dim.name)}
+                onMouseEnter={() => setSelectedIndex(index)}
+              >
+                <span className="inline-commands-command">{dim.name}</span>
+                <span className="inline-commands-meta">
+                  {dim.activeCount > 0 && (
+                    <span className="inline-commands-active-count">
+                      {dim.activeCount} active
+                    </span>
+                  )}
+                  <span className="inline-commands-shortcut">
+                    /{dim.name.charAt(0).toLowerCase()}
+                  </span>
+                  <span className="inline-commands-chevron" aria-hidden="true">
+                    ›
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ul>
+          <div className="inline-commands-footer">
+            <kbd>▲▼</kbd> navigate <kbd>→</kbd> open <kbd>Esc</kbd> cancel
+          </div>
+        </div>
+      )}
+
+      {/* Step 2: Filter values (after dimension selected, or single-dimension pages) */}
+      {commandMode && !showDimensions && filteredCommands.length > 0 && (
+        <div className="inline-search-commands" role="listbox">
+          {/* Back button when inside a dimension */}
+          {selectedDimension && (
+            <button
+              className="inline-commands-back"
+              onClick={() => {
+                setSelectedDimension(null);
+                setCommandInput("/");
+                setSelectedIndex(0);
+              }}
+            >
+              <span className="inline-commands-back-arrow" aria-hidden="true">
+                ‹
+              </span>
+              {selectedDimension}
+            </button>
+          )}
+
+          {selectedDimension ? (
+            // Stepped mode: flat list for the selected dimension
+            <ul className="inline-commands-list">
+              {filteredCommands.map((cmd, index) => (
+                <li
+                  key={cmd.id}
+                  className={`inline-commands-item ${cmd.active ? "inline-commands-item--active" : ""}`}
+                  data-selected={index === selectedIndex}
+                  role="option"
+                  aria-selected={index === selectedIndex}
+                  onClick={() => handleCommandSelect(cmd)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                >
+                  <span className="inline-commands-command">{cmd.label}</span>
+                  {cmd.active && (
+                    <span className="inline-commands-check" aria-label="Active">
+                      ✓
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            // Single-dimension page (e.g., Tokens): grouped with headers
+            groupedCommands.map(({ group, items }) => (
+              <div key={group} className="inline-commands-group">
+                <div className="inline-commands-group-header">{group}</div>
+                <ul className="inline-commands-list">
+                  {items.map(({ cmd, index }) => (
+                    <li
+                      key={cmd.id}
+                      className={`inline-commands-item ${cmd.active ? "inline-commands-item--active" : ""}`}
+                      data-selected={index === selectedIndex}
+                      role="option"
+                      aria-selected={index === selectedIndex}
+                      onClick={() => handleCommandSelect(cmd)}
+                      onMouseEnter={() => setSelectedIndex(index)}
+                    >
+                      <span className="inline-commands-command">{cmd.label}</span>
+                      <span className="inline-commands-shortcut">
+                        /{cmd.label.charAt(0).toLowerCase()}
+                      </span>
+                      {cmd.active && (
+                        <span className="inline-commands-check" aria-label="Active">
+                          ✓
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))
+          )}
+
+          <div className="inline-commands-footer">
+            <kbd>▲▼</kbd> navigate <kbd>Enter</kbd> toggle{" "}
+            {selectedDimension ? (
+              <>
+                <kbd>←</kbd> back <kbd>Esc</kbd> back
+              </>
+            ) : (
+              <>
+                <kbd>Esc</kbd> cancel
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default InlineSearch;

--- a/docs/src/components/search/SearchFilterHints.tsx
+++ b/docs/src/components/search/SearchFilterHints.tsx
@@ -11,8 +11,8 @@
  * Supports keyboard navigation (↑↓) and selection (Enter/click).
  */
 
-import { useEffect, useState } from 'react';
-import type { SearchFilter } from './useSearch';
+import { useEffect, useState } from "react";
+import type { SearchFilter } from "./useSearch";
 
 export interface FilterOption {
   /** Command to type (e.g., "/component") */
@@ -32,32 +32,32 @@ export interface FilterOption {
 /** Available filter commands */
 export const FILTER_OPTIONS: FilterOption[] = [
   {
-    command: '/get-started',
-    alias: '/g',
-    label: 'Get started',
-    description: 'Search only get started pages',
-    filter: 'page',
+    command: "/get-started",
+    alias: "/g",
+    label: "Get started",
+    description: "Search only get started pages",
+    filter: "page",
   },
   {
-    command: '/component',
-    alias: '/c',
-    label: 'Components',
-    description: 'Search only components',
-    filter: 'component',
+    command: "/component",
+    alias: "/c",
+    label: "Components",
+    description: "Search only components",
+    filter: "component",
   },
   {
-    command: '/example',
-    alias: '/e',
-    label: 'Examples',
-    description: 'Search only examples',
-    filter: 'example',
+    command: "/example",
+    alias: "/e",
+    label: "Examples",
+    description: "Search only examples",
+    filter: "example",
   },
   {
-    command: '/token',
-    alias: '/t',
-    label: 'Tokens',
-    description: 'Search only design tokens',
-    filter: 'token',
+    command: "/token",
+    alias: "/t",
+    label: "Tokens",
+    description: "Search only design tokens",
+    filter: "token",
   },
 ];
 
@@ -79,20 +79,20 @@ interface SearchFilterHintsProps {
  * - Input starts with "/" and partially matches a command or alias
  */
 export function shouldShowFilterHints(inputValue: string): boolean {
-  if (!inputValue.startsWith('/')) return false;
+  if (!inputValue.startsWith("/")) return false;
 
   // Exact "/" shows all hints
-  if (inputValue === '/') return true;
+  if (inputValue === "/") return true;
 
   // Check if input matches any command prefix (but not a complete command with space)
-  const hasSpace = inputValue.includes(' ');
+  const hasSpace = inputValue.includes(" ");
   if (hasSpace) return false;
 
   const lower = inputValue.toLowerCase();
   return FILTER_OPTIONS.some(
-    opt =>
+    (opt) =>
       opt.command.toLowerCase().startsWith(lower) ||
-      opt.alias.toLowerCase().startsWith(lower)
+      opt.alias.toLowerCase().startsWith(lower),
   );
 }
 
@@ -110,14 +110,14 @@ export function parseFilterCommand(input: string): {
   query: string;
   command: string | null;
 } {
-  if (!input.startsWith('/')) {
+  if (!input.startsWith("/")) {
     return { filter: null, query: input, command: null };
   }
 
-  const spaceIndex = input.indexOf(' ');
+  const spaceIndex = input.indexOf(" ");
   if (spaceIndex === -1) {
     // No space yet - could be typing a command
-    return { filter: null, query: '', command: null };
+    return { filter: null, query: "", command: null };
   }
 
   const commandPart = input.slice(0, spaceIndex).toLowerCase();
@@ -142,15 +142,15 @@ export function parseFilterCommand(input: string): {
  * Get filtered options based on current input.
  */
 export function getFilteredOptions(inputValue: string): FilterOption[] {
-  if (inputValue === '/') {
+  if (inputValue === "/") {
     return FILTER_OPTIONS;
   }
 
   const lower = inputValue.toLowerCase();
   return FILTER_OPTIONS.filter(
-    opt =>
+    (opt) =>
       opt.command.toLowerCase().startsWith(lower) ||
-      opt.alias.toLowerCase().startsWith(lower)
+      opt.alias.toLowerCase().startsWith(lower),
   );
 }
 
@@ -181,7 +181,7 @@ export function SearchFilterHints({
         {options.map((option, index) => (
           <li
             key={option.command}
-            className={`search-filter-hints-item ${option.disabled ? 'search-filter-hints-item--disabled' : ''}`}
+            className={`search-filter-hints-item ${option.disabled ? "search-filter-hints-item--disabled" : ""}`}
             data-selected={index === selectedIndex}
             role="option"
             aria-selected={index === selectedIndex}
@@ -201,9 +201,7 @@ export function SearchFilterHints({
               <span className="search-filter-hints-command">{option.command}</span>
               <span className="search-filter-hints-alias">({option.alias})</span>
             </div>
-            <div className="search-filter-hints-description">
-              {option.description}
-            </div>
+            <div className="search-filter-hints-description">{option.description}</div>
           </li>
         ))}
       </ul>

--- a/docs/src/components/search/SearchInput.tsx
+++ b/docs/src/components/search/SearchInput.tsx
@@ -15,7 +15,7 @@ import { getFilterLabel } from "./search-utils";
 interface SearchInputProps {
   value: string;
   onChange: (value: string) => void;
-  onClose: () => void;
+  onClose?: () => void;
   /** Currently active filter (if any) */
   activeFilter?: SearchFilter;
   /** The command that activated the filter (e.g., "/component") */
@@ -24,6 +24,10 @@ interface SearchInputProps {
   onClearFilter?: () => void;
   /** Forward arrow/enter keys to results navigation */
   onResultNav?: (key: string) => void;
+  /** Whether to auto-focus the input on mount (default: true) */
+  autoFocus?: boolean;
+  /** Override the default placeholder text */
+  placeholder?: string;
 }
 
 /**
@@ -36,6 +40,8 @@ function SearchIcon() {
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
+      width={20}
+      height={20}
       strokeWidth={2}
       stroke="currentColor"
     >
@@ -57,6 +63,8 @@ function CloseIcon() {
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
+      width={18}
+      height={18}
       strokeWidth={2}
       stroke="currentColor"
     >
@@ -81,27 +89,30 @@ export function SearchInput({
   activeCommand,
   onClearFilter,
   onResultNav,
+  autoFocus = true,
+  placeholder: placeholderOverride,
 }: SearchInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Auto-focus the input when mounted
+  // Auto-focus the input when mounted (can be disabled for inline usage)
   useEffect(() => {
+    if (!autoFocus) return;
     // Small delay to ensure modal animation completes
     const timer = setTimeout(() => {
       inputRef.current?.focus();
     }, 50);
     return () => clearTimeout(timer);
-  }, []);
+  }, [autoFocus]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(e.target.value);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    // Escape closes the modal
+    // Escape closes the modal/dropdown
     if (e.key === "Escape") {
       e.preventDefault();
-      onClose();
+      onClose?.();
     }
     // Backspace on empty input clears the active filter
     if (e.key === "Backspace" && value === "" && activeFilter) {
@@ -109,16 +120,21 @@ export function SearchInput({
       onClearFilter?.();
     }
     // Forward arrow/enter to results navigation
-    if (onResultNav && ["ArrowUp", "ArrowDown", "Enter"].includes(e.key)) {
+    if (
+      onResultNav &&
+      ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Enter"].includes(e.key)
+    ) {
       e.preventDefault();
       onResultNav(e.key);
     }
   };
 
   // Determine the placeholder text based on filter
-  const placeholder = activeFilter
-    ? `Search ${getFilterLabel(activeFilter)}...`
-    : "Search components and examples... (type / to filter)";
+  const placeholder = placeholderOverride
+    ? placeholderOverride
+    : activeFilter
+      ? `Search ${getFilterLabel(activeFilter)}...`
+      : "Search components and examples... (type / to filter)";
 
   return (
     <div className="search-input-container">
@@ -160,21 +176,25 @@ export function SearchInput({
         spellCheck="false"
       />
 
-      {/* Keyboard hint (desktop only, hidden via CSS on mobile) */}
-      <span className="search-input-hint" aria-hidden="true">
-        <kbd className="search-input-kbd">{isMac() ? "⌘" : "Ctrl"}</kbd>
-        <kbd className="search-input-kbd">K</kbd>
-      </span>
+      {/* Keyboard hint (desktop only, hidden via CSS on mobile, only in modal) */}
+      {autoFocus && (
+        <span className="search-input-hint" aria-hidden="true">
+          <kbd className="search-input-kbd">{isMac() ? "⌘" : "Ctrl"}</kbd>
+          <kbd className="search-input-kbd">K</kbd>
+        </span>
+      )}
 
-      {/* Close button */}
-      <button
-        type="button"
-        className="search-input-close"
-        onClick={onClose}
-        aria-label="Close search"
-      >
-        <CloseIcon />
-      </button>
+      {/* Close button (hidden when onClose is not provided) */}
+      {onClose && (
+        <button
+          type="button"
+          className="search-input-close"
+          onClick={onClose}
+          aria-label="Close search"
+        >
+          <CloseIcon />
+        </button>
+      )}
     </div>
   );
 }

--- a/docs/src/components/search/SearchModal.tsx
+++ b/docs/src/components/search/SearchModal.tsx
@@ -25,6 +25,7 @@ import { SearchInput } from "./SearchInput";
 import { SearchResults, type SearchResultsHandle } from "./SearchResults";
 import {
   SearchFilterHints,
+  FILTER_OPTIONS,
   shouldShowFilterHints,
   parseFilterCommand,
   getFilteredOptions,
@@ -40,12 +41,21 @@ import "./search.css";
 interface SearchModalContentProps {
   onClose: () => void;
   previousFocusRef: React.RefObject<HTMLElement | null>;
+  initialFilter?: SearchFilter;
 }
 
-function SearchModalContent({ onClose, previousFocusRef }: SearchModalContentProps) {
+function SearchModalContent({
+  onClose,
+  previousFocusRef,
+  initialFilter,
+}: SearchModalContentProps) {
   const [query, setQuery] = useState("");
-  const [activeFilter, setActiveFilter] = useState<SearchFilter>(null);
-  const [activeCommand, setActiveCommand] = useState<string | null>(null);
+  const [activeFilter, setActiveFilter] = useState<SearchFilter>(initialFilter ?? null);
+  const [activeCommand, setActiveCommand] = useState<string | null>(() => {
+    if (!initialFilter) return null;
+    const option = FILTER_OPTIONS.find((opt) => opt.filter === initialFilter);
+    return option?.command ?? null;
+  });
   const [hintSelectedIndex, setHintSelectedIndex] = useState(0);
   const modalRef = useRef<HTMLDivElement>(null);
   const searchResultsRef = useRef<SearchResultsHandle>(null);
@@ -293,13 +303,15 @@ function SearchModalContent({ onClose, previousFocusRef }: SearchModalContentPro
 
 export function SearchModal() {
   const [isOpen, setIsOpen] = useState(false);
+  const [pendingFilter, setPendingFilter] = useState<SearchFilter>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   /**
    * Open the search modal.
    */
-  const openModal = useCallback(() => {
+  const openModal = useCallback((filter?: SearchFilter) => {
     previousFocusRef.current = document.activeElement as HTMLElement;
+    setPendingFilter(filter ?? null);
     setIsOpen(true);
     document.body.style.overflow = "hidden";
   }, []);
@@ -309,6 +321,7 @@ export function SearchModal() {
    */
   const closeModal = useCallback(() => {
     setIsOpen(false);
+    setPendingFilter(null);
     document.body.style.overflow = "";
   }, []);
 
@@ -332,11 +345,12 @@ export function SearchModal() {
   }, [isOpen, openModal, closeModal]);
 
   /**
-   * Listen for goa-search-open custom event (from MobileHeader).
+   * Listen for goa-search-open custom event (from MobileHeader and SearchTrigger).
    */
   useEffect(() => {
-    const handleSearchOpen = () => {
-      openModal();
+    const handleSearchOpen = (e: Event) => {
+      const filter = (e as CustomEvent).detail?.filter as SearchFilter | undefined;
+      openModal(filter);
     };
 
     window.addEventListener("goa-search-open", handleSearchOpen);
@@ -348,7 +362,13 @@ export function SearchModal() {
     return null;
   }
 
-  return <SearchModalContent onClose={closeModal} previousFocusRef={previousFocusRef} />;
+  return (
+    <SearchModalContent
+      onClose={closeModal}
+      previousFocusRef={previousFocusRef}
+      initialFilter={pendingFilter}
+    />
+  );
 }
 
 export default SearchModal;

--- a/docs/src/components/search/SearchNoResults.tsx
+++ b/docs/src/components/search/SearchNoResults.tsx
@@ -7,7 +7,7 @@
  * - Suggestions section with popular search terms
  */
 
-import { popularSearches } from './quick-links';
+import { popularSearches } from "./quick-links";
 
 interface SearchNoResultsProps {
   /** The search query that had no results */
@@ -26,11 +26,9 @@ export function SearchNoResults({ query, onSuggestionClick }: SearchNoResultsPro
 
       {/* Suggestions */}
       <section className="search-no-results-suggestions">
-        <div className="search-no-results-suggestions-header">
-          Try searching for
-        </div>
+        <div className="search-no-results-suggestions-header">Try searching for</div>
         <ul className="search-no-results-suggestions-list">
-          {popularSearches.map(term => (
+          {popularSearches.map((term) => (
             <li key={term}>
               <button
                 type="button"

--- a/docs/src/components/search/index.ts
+++ b/docs/src/components/search/index.ts
@@ -12,21 +12,18 @@ export {
   type ExampleEntry,
   type SearchEntry,
   type SearchResult,
-} from './useSearch';
+} from "./useSearch";
 
-export {
-  useSearchHistory,
-  type HistoryItem,
-} from './useSearchHistory';
+export { useSearchHistory, type HistoryItem } from "./useSearchHistory";
 
 // Components
-export { SearchModal, default as SearchModalDefault } from './SearchModal';
-export { SearchPage, default as SearchPageDefault } from './SearchPage';
-export { SearchInput } from './SearchInput';
-export { SearchResults } from './SearchResults';
-export { SearchResultItem } from './SearchResultItem';
-export { SearchEmptyState } from './SearchEmptyState';
-export { SearchNoResults } from './SearchNoResults';
+export { SearchModal, default as SearchModalDefault } from "./SearchModal";
+export { SearchPage, default as SearchPageDefault } from "./SearchPage";
+export { SearchInput } from "./SearchInput";
+export { SearchResults } from "./SearchResults";
+export { SearchResultItem } from "./SearchResultItem";
+export { SearchEmptyState } from "./SearchEmptyState";
+export { SearchNoResults } from "./SearchNoResults";
 
 // Config
-export { quickLinks, popularSearches, type QuickLink } from './quick-links';
+export { quickLinks, popularSearches, type QuickLink } from "./quick-links";

--- a/docs/src/components/search/search.css
+++ b/docs/src/components/search/search.css
@@ -114,6 +114,11 @@
   background: transparent;
 }
 
+.search-input-field:focus,
+.search-input-field:focus-visible {
+  outline: none;
+}
+
 .search-input-field::placeholder {
   color: var(--goa-color-greyscale-500, #666);
 }
@@ -747,6 +752,232 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+/* ==========================================================================
+   Inline Search (grid pages)
+   ========================================================================== */
+
+.inline-search {
+  position: relative;
+}
+
+/* Give the input a full border and compact padding when used inline */
+.inline-search .search-input-container {
+  border: 1px solid var(--goa-color-greyscale-300, #ccc);
+  border-radius: var(--goa-border-radius-m);
+  border-bottom: 1px solid var(--goa-color-greyscale-300, #ccc);
+  padding: var(--goa-space-xs) var(--goa-space-m);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.inline-search:focus-within .search-input-container {
+  border-color: var(--goa-color-greyscale-black);
+  box-shadow: inset 0 0 0 1px var(--goa-color-greyscale-black);
+}
+
+/* Suppress browser/global focus outline on the input itself —
+   the container's :focus-within border is the visual indicator */
+.inline-search .search-input-field:focus,
+.inline-search .search-input-field:focus-visible {
+  outline: none;
+}
+
+/* ==========================================================================
+   Inline Slash Commands Dropdown
+   ========================================================================== */
+
+.inline-search-commands {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: white;
+  border: 1px solid var(--goa-color-greyscale-200, #e0e0e0);
+  border-radius: var(--goa-border-radius-m);
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  max-height: 50vh;
+  overflow-y: auto;
+  margin-top: var(--goa-space-2xs);
+  animation: inlineCommandsIn 100ms ease-out;
+}
+
+@keyframes inlineCommandsIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.inline-commands-group-header {
+  padding: var(--goa-space-xs) var(--goa-space-l);
+  font: var(--goa-typography-body-xs);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--goa-color-greyscale-500, #666);
+}
+
+.inline-commands-group:not(:first-child) .inline-commands-group-header {
+  border-top: 1px solid var(--goa-color-greyscale-200, #e0e0e0);
+  padding-top: var(--goa-space-s);
+}
+
+.inline-commands-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.inline-commands-item {
+  display: flex;
+  align-items: center;
+  gap: var(--goa-space-s);
+  padding: var(--goa-space-s) var(--goa-space-l);
+  cursor: pointer;
+  transition: background-color 100ms ease;
+}
+
+.inline-commands-item:hover,
+.inline-commands-item[data-selected="true"] {
+  background: var(--goa-color-greyscale-100, #f5f5f5);
+}
+
+.inline-commands-command {
+  font: var(--goa-typography-body-m);
+  font-weight: 600;
+  color: var(--goa-color-interactive-default, #0070c4);
+  min-width: 0;
+}
+
+.inline-commands-shortcut {
+  font: var(--goa-typography-body-s);
+  color: var(--goa-color-greyscale-500, #666);
+}
+
+.inline-commands-label {
+  font: var(--goa-typography-body-s);
+  color: var(--goa-color-greyscale-600, #555);
+}
+
+.inline-commands-check {
+  margin-left: auto;
+  color: var(--goa-color-interactive-default, #0070c4);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.inline-commands-item--active {
+  background: var(--goa-color-greyscale-50, #fafafa);
+}
+
+/* Dimension picker items (stepped slash commands) */
+
+.inline-commands-meta {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--goa-space-s);
+  flex-shrink: 0;
+}
+
+.inline-commands-active-count {
+  font: var(--goa-typography-body-xs);
+  color: var(--goa-color-interactive-default, #0070c4);
+  font-weight: 600;
+}
+
+.inline-commands-chevron {
+  color: var(--goa-color-greyscale-400, #999);
+  font-size: 18px;
+  line-height: 1;
+}
+
+/* Back button at top of value list (stepped mode) */
+
+.inline-commands-back {
+  display: flex;
+  align-items: center;
+  gap: var(--goa-space-xs);
+  width: 100%;
+  padding: var(--goa-space-xs) var(--goa-space-l);
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--goa-color-greyscale-200, #e0e0e0);
+  cursor: pointer;
+  font: var(--goa-typography-body-s);
+  font-weight: 600;
+  color: var(--goa-color-greyscale-600, #555);
+  text-align: left;
+}
+
+.inline-commands-back:hover {
+  background: var(--goa-color-greyscale-100, #f5f5f5);
+}
+
+.inline-commands-back-arrow {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.inline-commands-footer {
+  padding: var(--goa-space-xs) var(--goa-space-l);
+  border-top: 1px solid var(--goa-color-greyscale-200, #e0e0e0);
+  font: var(--goa-typography-body-xs);
+  color: var(--goa-color-greyscale-500, #666);
+}
+
+.inline-commands-footer kbd {
+  display: inline-block;
+  padding: 0 var(--goa-space-2xs);
+  font-family: var(--goa-font-family-mono, monospace);
+  font-size: 11px;
+  background: var(--goa-color-greyscale-100, #f5f5f5);
+  border: 1px solid var(--goa-color-greyscale-200, #e0e0e0);
+  border-radius: 3px;
+}
+
+/* Inline search error state */
+.inline-search-error {
+  padding: var(--goa-space-m) var(--goa-space-l);
+  text-align: center;
+}
+
+.inline-search-error strong {
+  display: block;
+  color: var(--goa-color-status-emergency, #d32f2f);
+  font: var(--goa-typography-body-s);
+  font-weight: var(--goa-font-weight-semi-bold);
+  margin-bottom: var(--goa-space-2xs);
+}
+
+.inline-search-error p {
+  margin: 0;
+  font: var(--goa-typography-body-xs);
+  color: var(--goa-color-greyscale-600, #555);
+}
+
+/* Inline search loading state */
+.inline-search-loading {
+  padding: var(--goa-space-m) var(--goa-space-l);
+  text-align: center;
+  font: var(--goa-typography-body-s);
+  color: var(--goa-color-greyscale-600, #555);
+}
+
+@media (max-width: 640px) {
+  .inline-commands-item {
+    min-height: 44px;
+  }
 }
 
 /* Mobile adjustments for search page */

--- a/docs/src/components/search/useSearch.ts
+++ b/docs/src/components/search/useSearch.ts
@@ -354,100 +354,103 @@ export function useSearch(): UseSearchReturn {
    * @param query - Search query string
    * @param filter - Optional filter to limit results to 'component' or 'example'
    */
-  const search = useCallback((query: string, filter?: SearchFilter): SearchResult[] => {
-    if (!indexRef.current || !query.trim()) {
-      return [];
-    }
-
-    // Search across all indexed fields
-    // FlexSearch returns results per field, we need to merge them
-    const searchResults = indexRef.current.search(query, {
-      limit: 50,
-      enrich: true,
-    });
-
-    // Collect unique results with scores
-    const scoreMap = new Map<string, number>();
-
-    // FlexSearch returns array of field results
-    for (const fieldResult of searchResults) {
-      // Each field result has a `result` array
-      const results = fieldResult.result;
-      for (let i = 0; i < results.length; i++) {
-        const result = results[i];
-        // Result can be string, number, or object with id property
-        const id =
-          typeof result === "string" || typeof result === "number"
-            ? String(result)
-            : (result as { id: string }).id;
-        // Score based on position (earlier = higher score) and field
-        // Field importance is already handled by resolution
-        const positionScore = 1 - (i / results.length) * 0.5;
-        const currentScore = scoreMap.get(id) || 0;
-        scoreMap.set(id, currentScore + positionScore);
+  const search = useCallback(
+    (query: string, filter?: SearchFilter, limit: number = 500): SearchResult[] => {
+      if (!indexRef.current || !query.trim()) {
+        return [];
       }
-    }
 
-    // Convert to results array with scoring boosts
-    const queryLower = query.toLowerCase().trim();
+      // Search across all indexed fields
+      // FlexSearch returns results per field, we need to merge them
+      const searchResults = indexRef.current.search(query, {
+        limit,
+        enrich: true,
+      });
 
-    const results: SearchResult[] = [];
-    for (const [id, score] of scoreMap) {
-      const entry = entryMapRef.current.get(id);
-      if (entry) {
-        let finalScore = score;
+      // Collect unique results with scores
+      const scoreMap = new Map<string, number>();
 
-        // Exact name match boost: if query matches component/example/token name exactly
-        // "button" query + "Button" component = exact match = big boost
-        const entryName =
-          entry.type === "component"
-            ? (entry as ComponentEntry).name
-            : entry.type === "token"
-              ? (entry as TokenEntry).title
-              : (entry as ExampleEntry).title;
+      // FlexSearch returns array of field results
+      for (const fieldResult of searchResults) {
+        // Each field result has a `result` array
+        const results = fieldResult.result;
+        for (let i = 0; i < results.length; i++) {
+          const result = results[i];
+          // Result can be string, number, or object with id property
+          const id =
+            typeof result === "string" || typeof result === "number"
+              ? String(result)
+              : (result as { id: string }).id;
+          // Score based on position (earlier = higher score) and field
+          // Field importance is already handled by resolution
+          const positionScore = 1 - (i / results.length) * 0.5;
+          const currentScore = scoreMap.get(id) || 0;
+          scoreMap.set(id, currentScore + positionScore);
+        }
+      }
 
-        if (entryName.toLowerCase() === queryLower) {
-          // Exact match - this is almost certainly what they want
-          finalScore += 10;
-        } else if (entryName.toLowerCase().startsWith(queryLower)) {
-          // Name starts with query - also a strong signal
-          // "but" query + "Button" component = starts with = medium boost
-          finalScore += 3;
+      // Convert to results array with scoring boosts
+      const queryLower = query.toLowerCase().trim();
+
+      const results: SearchResult[] = [];
+      for (const [id, score] of scoreMap) {
+        const entry = entryMapRef.current.get(id);
+        if (entry) {
+          let finalScore = score;
+
+          // Exact name match boost: if query matches component/example/token name exactly
+          // "button" query + "Button" component = exact match = big boost
+          const entryName =
+            entry.type === "component"
+              ? (entry as ComponentEntry).name
+              : entry.type === "token"
+                ? (entry as TokenEntry).title
+                : (entry as ExampleEntry).title;
+
+          if (entryName.toLowerCase() === queryLower) {
+            // Exact match - this is almost certainly what they want
+            finalScore += 10;
+          } else if (entryName.toLowerCase().startsWith(queryLower)) {
+            // Name starts with query - also a strong signal
+            // "but" query + "Button" component = starts with = medium boost
+            finalScore += 3;
+          }
+
+          // Small boost for components over examples (tiebreaker)
+          if (entry.type === "component") {
+            finalScore += 0.5;
+          }
+
+          results.push({
+            ...entry,
+            score: finalScore,
+          });
+        }
+      }
+
+      // Sort by: score (includes type boost) → status
+      results.sort((a, b) => {
+        // First by score (component boost already included)
+        const scoreDiff = b.score - a.score;
+        if (Math.abs(scoreDiff) > 0.05) {
+          return scoreDiff;
         }
 
-        // Small boost for components over examples (tiebreaker)
-        if (entry.type === "component") {
-          finalScore += 0.5;
-        }
+        // Then by status priority (stable/published first)
+        const aPriority = getStatusPriority(a.status);
+        const bPriority = getStatusPriority(b.status);
+        return aPriority - bPriority;
+      });
 
-        results.push({
-          ...entry,
-          score: finalScore,
-        });
-      }
-    }
-
-    // Sort by: score (includes type boost) → status
-    results.sort((a, b) => {
-      // First by score (component boost already included)
-      const scoreDiff = b.score - a.score;
-      if (Math.abs(scoreDiff) > 0.05) {
-        return scoreDiff;
+      // Apply filter if specified
+      if (filter) {
+        return results.filter((result) => result.type === filter);
       }
 
-      // Then by status priority (stable/published first)
-      const aPriority = getStatusPriority(a.status);
-      const bPriority = getStatusPriority(b.status);
-      return aPriority - bPriority;
-    });
-
-    // Apply filter if specified
-    if (filter) {
-      return results.filter((result) => result.type === filter);
-    }
-
-    return results;
-  }, []);
+      return results;
+    },
+    [],
+  );
 
   return {
     search,

--- a/docs/src/components/search/useSearchHistory.ts
+++ b/docs/src/components/search/useSearchHistory.ts
@@ -9,7 +9,7 @@
  *   const { history, addToHistory, clearHistory } = useSearchHistory();
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect } from "react";
 
 // ============================================================================
 // Types
@@ -18,7 +18,7 @@ import { useState, useCallback, useEffect } from 'react';
 export interface HistoryItem {
   /** The result that was clicked */
   id: string;
-  type: 'component' | 'example' | 'token' | 'page';
+  type: "component" | "example" | "token" | "page";
   title: string;
   slug: string;
   /** Category slug for components (e.g., 'inputs-and-actions') */
@@ -33,7 +33,7 @@ interface UseSearchHistoryReturn {
   /** Recent search history, most recent first */
   history: HistoryItem[];
   /** Add a result to history */
-  addToHistory: (item: Omit<HistoryItem, 'timestamp'>) => void;
+  addToHistory: (item: Omit<HistoryItem, "timestamp">) => void;
   /** Clear all history */
   clearHistory: () => void;
 }
@@ -42,7 +42,7 @@ interface UseSearchHistoryReturn {
 // Constants
 // ============================================================================
 
-const STORAGE_KEY = 'goa-ds-recent-searches';
+const STORAGE_KEY = "goa-ds-recent-searches";
 const MAX_HISTORY_ITEMS = 5;
 
 // ============================================================================
@@ -53,7 +53,7 @@ const MAX_HISTORY_ITEMS = 5;
  * Safely read history from localStorage.
  */
 function readHistory(): HistoryItem[] {
-  if (typeof window === 'undefined') return [];
+  if (typeof window === "undefined") return [];
 
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -65,13 +65,13 @@ function readHistory(): HistoryItem[] {
     // Validate each item has required fields
     return parsed.filter(
       (item): item is HistoryItem =>
-        typeof item === 'object' &&
+        typeof item === "object" &&
         item !== null &&
-        typeof item.id === 'string' &&
-        typeof item.type === 'string' &&
-        typeof item.title === 'string' &&
-        typeof item.slug === 'string' &&
-        typeof item.timestamp === 'number'
+        typeof item.id === "string" &&
+        typeof item.type === "string" &&
+        typeof item.title === "string" &&
+        typeof item.slug === "string" &&
+        typeof item.timestamp === "number",
     );
   } catch {
     return [];
@@ -82,13 +82,13 @@ function readHistory(): HistoryItem[] {
  * Safely write history to localStorage.
  */
 function writeHistory(history: HistoryItem[]): void {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
   } catch (error) {
     // localStorage might be full or disabled
-    console.warn('Failed to save search history:', error);
+    console.warn("Failed to save search history:", error);
   }
 }
 
@@ -109,8 +109,8 @@ export function useSearchHistory(): UseSearchHistoryReturn {
    * Deduplicates by id+type, moves existing items to top.
    * Limits to MAX_HISTORY_ITEMS.
    */
-  const addToHistory = useCallback((item: Omit<HistoryItem, 'timestamp'>) => {
-    setHistory(prev => {
+  const addToHistory = useCallback((item: Omit<HistoryItem, "timestamp">) => {
+    setHistory((prev) => {
       // Create the new item with timestamp
       const newItem: HistoryItem = {
         ...item,
@@ -118,9 +118,7 @@ export function useSearchHistory(): UseSearchHistoryReturn {
       };
 
       // Remove any existing item with same id+type (dedup)
-      const filtered = prev.filter(
-        h => !(h.id === item.id && h.type === item.type)
-      );
+      const filtered = prev.filter((h) => !(h.id === item.id && h.type === item.type));
 
       // Add new item at the start, limit to max items
       const updated = [newItem, ...filtered].slice(0, MAX_HISTORY_ITEMS);
@@ -137,7 +135,7 @@ export function useSearchHistory(): UseSearchHistoryReturn {
    */
   const clearHistory = useCallback(() => {
     setHistory([]);
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       localStorage.removeItem(STORAGE_KEY);
     }
   }, []);

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -3,6 +3,9 @@
 import '@abgov/web-components/index.css';
 import '@design-tokens/tokens.css';
 
+// Import search styles eagerly so inline search inputs don't flash unstyled
+import '../components/search/search.css';
+
 // Global search modal (available on all pages)
 import { SearchModal } from '../components/search';
 


### PR DESCRIPTION
## Summary

- Replace basic string-match search inputs on Components, Examples, and Tokens grids with FlexSearch-powered inline search
- Add contextual slash commands (type `/`) that toggle grid filters with a stepped dimension picker
- Consistent search UX across all three grid pages

## What it does
https://github.com/user-attachments/assets/40a80315-808b-48d1-958c-e193b429f576


Type in the search input to filter the grid by relevance. Type `/` to open a slash command menu that lets you quickly apply filters (category, status, scale, user type) without opening the filter drawer. Multi-dimension pages (Components, Examples) show a dimension picker first, single-dimension pages (Tokens) go straight to values.

Keyboard navigation: arrow keys to navigate, right arrow to drill into a dimension, left/backspace to go back, escape to close, enter to toggle a filter.

## Test plan

- [ ] `/components` - search narrows grid, `/` shows Category + Status dimensions
- [ ] `/examples` - search narrows grid, `/` shows Scale, Category, User Type dimensions
- [ ] `/tokens` - search narrows grid, `/` shows category values directly
- [ ] Arrow key navigation works (up/down, right to drill in, left to go back)
- [ ] Slash command filters stay in sync with filter drawer checkboxes
- [ ] Clear all resets search + filters + sort
- [ ] Cmd+K global search modal still works independently
- [ ] No flash of unstyled content on page load