### PR TITLE
chore: Updating our astro default site URL

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -10,7 +10,7 @@ const workspaceRoot = path.resolve(__dirname, "..");
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://goa-design-2.netlify.app",
+  site: "https://design.alberta.ca",
   root: ".",
   outDir: "../dist/docs",
   build: {


### PR DESCRIPTION
# Before (the change)

Our default astro URL referenced our Netlify deployment.

# After (the change)

Our new default astro URL references our actual deployed URL

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
