### PR TITLE
fix(#3548): pin secondary menu at bottom of Work Side Menu during scroll

### DIFF
--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -108,10 +108,7 @@ export function App() {
                   url="/bugs/2720"
                 />
                 <GoabWorkSideMenuItem label="2721 Text Tag Margin" url="/bugs/2721" />
-                <GoabWorkSideMenuItem
-                  label="2750 Year Select Sorting"
-                  url="/bugs/2750"
-                />
+                <GoabWorkSideMenuItem label="2750 Year Select Sorting" url="/bugs/2750" />
                 <GoabWorkSideMenuItem
                   label="2768 Enable/Disable Components"
                   url="/bugs/2768"
@@ -225,14 +222,9 @@ export function App() {
                   label="3607 Radio and Checkbox Interaction Area"
                   url="/bugs/3607"
                 />
-                <GoabWorkSideMenuItem
-                  label="3505 Link Icon Click"
-                  url="/bugs/3505"
-                />
-                <GoabWorkSideMenuItem
-                  label="3614 IconButton Hitboxes"
-                  url="/bugs/3614"
-                />
+                <GoabWorkSideMenuItem label="3505 Link Icon Click" url="/bugs/3505" />
+                <GoabWorkSideMenuItem label="3548 Side Menu Scroll" url="/bugs/3548" />
+                <GoabWorkSideMenuItem label="3614 IconButton Hitboxes" url="/bugs/3614" />
                 <GoabWorkSideMenuItem
                   label="3685 Checkbox & Radio: Reveal width not aligned with item"
                   url="/bugs/3685"
@@ -260,10 +252,7 @@ export function App() {
                   label="1813 DatePicker Width Properties"
                   url="/features/1813"
                 />
-                <GoabWorkSideMenuItem
-                  label="1908 Linear Progress"
-                  url="/features/1908"
-                />
+                <GoabWorkSideMenuItem label="1908 Linear Progress" url="/features/1908" />
                 <GoabWorkSideMenuItem
                   label="2054 MaxWidth Support"
                   url="/features/2054"
@@ -277,15 +266,12 @@ export function App() {
                   label="2361 Radio/Checkbox Clickable Area"
                   url="/features/2361"
                 />
+                <GoabWorkSideMenuItem label="2440 MenuButton Icon" url="/features/2440" />
                 <GoabWorkSideMenuItem
-                  label="2440 MenuButton Icon"
-                  url="/features/2440"
+                  label="2469/3580 Push Drawer"
+                  url="/features/2469"
                 />
-                <GoabWorkSideMenuItem label="2469/3580 Push Drawer" url="/features/2469" />
-                <GoabWorkSideMenuItem
-                  label="2492 TextArea onBlur"
-                  url="/features/2492"
-                />
+                <GoabWorkSideMenuItem label="2492 TextArea onBlur" url="/features/2492" />
                 <GoabWorkSideMenuItem
                   label="2609 Data Table Base Component"
                   url="/features/2609"
@@ -360,10 +346,7 @@ export function App() {
                   label="3407 Tabs Orientation"
                   url="/features/3407-stack-on-mobile"
                 />
-                <GoabWorkSideMenuItem
-                  label="3398 Group open prop"
-                  url="/features/3398"
-                />
+                <GoabWorkSideMenuItem label="3398 Group open prop" url="/features/3398" />
                 <GoabWorkSideMenuItem
                   label="3478 Popover API Rewrite"
                   url="/features/3478"

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -50,12 +50,13 @@ import { Bug3384Route } from "./routes/bugs/bug3384";
 import { Bug3450Route } from "./routes/bugs/bug3450";
 import { Bug3497Route } from "./routes/bugs/bug3497";
 import { Bug3498Route } from "./routes/bugs/bug3498";
+import { Bug3548Route } from "./routes/bugs/bug3548";
 import { Bug3607Route } from "./routes/bugs/bug3607";
 import { Bug3505Route } from "./routes/bugs/bug3505";
 import { Bug3614Route } from "./routes/bugs/bug3614";
-import { Bug3685Route } from "./routes/bugs/bug3685";
 import { Bug3635Route } from "./routes/bugs/bug3635";
 import { Bug3637Route } from "./routes/bugs/bug3637";
+import { Bug3685Route } from "./routes/bugs/bug3685";
 
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
@@ -155,10 +156,11 @@ root.render(
           <Route path="bugs/3498" element={<Bug3498Route />} />
           <Route path="bugs/3607" element={<Bug3607Route />} />
           <Route path="bugs/3505" element={<Bug3505Route />} />
+          <Route path="bugs/3548" element={<Bug3548Route />} />
           <Route path="bugs/3614" element={<Bug3614Route />} />
-          <Route path="bugs/3685" element={<Bug3685Route />} />
           <Route path="bugs/3635" element={<Bug3635Route />} />
           <Route path="bugs/3637" element={<Bug3637Route />} />
+          <Route path="bugs/3685" element={<Bug3685Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />
           <Route path="features/1547" element={<Feat1547Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3548.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3548.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect } from "react";
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabDetails,
+  GoabLink,
+  GoabWorkSideMenu,
+  GoabWorkSideMenuGroup,
+  GoabWorkSideMenuItem,
+} from "@abgov/react-components";
+
+import v2TokensUrl from "@abgov/design-tokens-v2/dist/tokens.css?url";
+
+export function Bug3548Route() {
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = v2TokensUrl;
+    document.head.appendChild(link);
+    return () => {
+      document.head.removeChild(link);
+    };
+  }, []);
+
+  function onToggle() {
+    setOpen((prev) => !prev);
+  }
+
+  return (
+    <div style={{ display: "flex" }}>
+      <GoabWorkSideMenu
+        heading="Bug 3548"
+        url="#"
+        userName="Jane Doe"
+        userSecondaryText="jane.doe@gov.ab.ca"
+        open={open}
+        onToggle={onToggle}
+        primaryContent={
+          <>
+            <GoabWorkSideMenuItem url="#dashboard" label="Dashboard" icon="home" />
+            <GoabWorkSideMenuItem url="#inbox" label="Inbox" icon="mail" badge="12" />
+            <GoabWorkSideMenuGroup heading="Applications" icon="folder">
+              <GoabWorkSideMenuItem
+                url="#app-1"
+                label="New applications"
+                icon="document"
+              />
+              <GoabWorkSideMenuItem url="#app-2" label="In progress" icon="time" />
+              <GoabWorkSideMenuItem url="#app-3" label="Under review" icon="eye" />
+              <GoabWorkSideMenuItem
+                url="#app-4"
+                label="Approved"
+                icon="checkmark-circle"
+              />
+              <GoabWorkSideMenuItem url="#app-5" label="Denied" icon="close-circle" />
+            </GoabWorkSideMenuGroup>
+            <GoabWorkSideMenuGroup heading="Reports" icon="bar-chart">
+              <GoabWorkSideMenuItem
+                url="#report-1"
+                label="Monthly summary"
+                icon="document-text"
+              />
+              <GoabWorkSideMenuItem
+                url="#report-2"
+                label="Quarterly audit"
+                icon="document-text"
+              />
+              <GoabWorkSideMenuItem
+                url="#report-3"
+                label="Annual review"
+                icon="document-text"
+              />
+            </GoabWorkSideMenuGroup>
+            <GoabWorkSideMenuItem url="#users" label="User management" icon="people" />
+            <GoabWorkSideMenuItem
+              url="#permissions"
+              label="Permissions"
+              icon="lock-closed"
+            />
+            <GoabWorkSideMenuItem
+              url="#notifications"
+              label="Notifications"
+              icon="notifications"
+            />
+            <GoabWorkSideMenuItem url="#calendar" label="Calendar" icon="calendar" />
+            <GoabWorkSideMenuItem url="#tasks" label="Tasks" icon="list" />
+            <GoabWorkSideMenuItem url="#bookmarks" label="Bookmarks" icon="bookmark" />
+            <GoabWorkSideMenuItem url="#history" label="History" icon="time" />
+            <GoabWorkSideMenuItem url="#archive" label="Archive" icon="archive" />
+            <GoabWorkSideMenuItem url="#settings" label="Settings" icon="settings" />
+          </>
+        }
+        secondaryContent={
+          <>
+            <GoabWorkSideMenuItem url="#search" label="Search" icon="search" />
+            <GoabWorkSideMenuItem url="#support" label="Get support" icon="help-circle" />
+            <GoabWorkSideMenuItem
+              url="#releases"
+              label="Release notes"
+              icon="information-circle"
+            />
+          </>
+        }
+        accountContent={
+          <>
+            <GoabWorkSideMenuItem url="#profile" label="My profile" icon="person" />
+            <GoabWorkSideMenuItem
+              url="#signout"
+              label="Sign out"
+              type="emergency"
+              icon="log-out"
+            />
+          </>
+        }
+      />
+      <div style={{ flex: 1, padding: "2rem" }}>
+        <GoabText tag="h1" mt="m">
+          Bug #3548: Work Side Menu scroll fix
+        </GoabText>
+
+        <GoabBlock>
+          <GoabLink trailingIcon="open">
+            <a
+              href="https://github.com/GovAlta/ui-components/issues/3548"
+              target="_blank"
+              rel="noopener"
+            >
+              View on GitHub
+            </a>
+          </GoabLink>
+
+          <GoabDetails heading="Issue Description">
+            <GoabText tag="p">
+              The secondary menu (Search, Get support, Release notes, Collapse menu)
+              should stay pinned at the bottom while only the primary nav area scrolls.
+              Currently the entire area below the logo scrolls, including the secondary
+              menu items.
+            </GoabText>
+          </GoabDetails>
+        </GoabBlock>
+
+        <GoabDivider mt="l" mb="l" />
+
+        <GoabText tag="h2">Test Cases</GoabText>
+
+        <GoabText tag="h3">Test 1: Primary nav scrolls independently</GoabText>
+        <GoabText tag="p">
+          The primary nav on the left has enough items to overflow. Scroll the primary nav
+          area and verify the secondary menu items (Search, Get support, Release notes)
+          and the collapse toggle stay pinned at the bottom.
+        </GoabText>
+
+        <GoabText tag="h3">Test 2: Header stays fixed at top</GoabText>
+        <GoabText tag="p">
+          While scrolling the primary nav, the logo and heading should remain fixed at the
+          top. Primary nav items should not scroll behind the header.
+        </GoabText>
+
+        <GoabText tag="h3">Test 3: Collapsed menu</GoabText>
+        <GoabText tag="p">
+          Click the collapse toggle. The menu should collapse to icon-only mode. The
+          bottom section should still be visible and pinned.
+        </GoabText>
+
+        <GoabText tag="h3">Test 4: Resize viewport</GoabText>
+        <GoabText tag="p">
+          Resize the browser window height. The scroll area should adapt, and the bottom
+          section should always stay visible.
+        </GoabText>
+      </div>
+    </div>
+  );
+}
+
+export default Bug3548Route;

--- a/libs/react-components/specs/work-side-menu.browser.spec.tsx
+++ b/libs/react-components/specs/work-side-menu.browser.spec.tsx
@@ -1,11 +1,7 @@
 import { render } from "vitest-browser-react";
 import { useState } from "react";
 import { GoabButton } from "../src";
-import {
-  GoabWorkSideMenu,
-  GoabWorkSideMenuItem,
-  GoabWorkSideMenuGroup,
-} from "../src";
+import { GoabWorkSideMenu, GoabWorkSideMenuItem, GoabWorkSideMenuGroup } from "../src";
 import { expect, describe, it, vi } from "vitest";
 import { page } from "@vitest/browser/context";
 
@@ -236,6 +232,116 @@ describe("WorkSideMenu", () => {
       await button.click();
       await vi.waitFor(() => {
         expect(menu.element().classList.contains("closed")).toBeFalsy();
+      });
+    });
+  });
+
+  describe("Scroll pinning (#3548)", () => {
+    it("should keep secondary menu visible when primary nav overflows", async () => {
+      await page.viewport(1024, 400);
+
+      const Component = () => {
+        return (
+          <GoabWorkSideMenu
+            heading="Test App"
+            url="https://example.com/"
+            testId="scroll-menu"
+            open={true}
+            primaryContent={
+              <>
+                {Array.from({ length: 15 }, (_, i) => (
+                  <GoabWorkSideMenuItem
+                    key={i}
+                    url={`#item-${i}`}
+                    label={`Primary item ${i + 1}`}
+                    icon="document"
+                  />
+                ))}
+              </>
+            }
+            secondaryContent={
+              <GoabWorkSideMenuItem
+                url="#secondary"
+                label="Secondary item"
+                icon="search"
+                testId="pinned-secondary"
+              />
+            }
+          />
+        );
+      };
+
+      const result = render(<Component />);
+      const menu = result.getByTestId("scroll-menu");
+      const secondary = result.getByTestId("pinned-secondary");
+
+      await vi.waitFor(() => {
+        expect(menu.element().classList.contains("scrolling")).toBe(true);
+        expect(secondary).toBeVisible();
+      });
+    });
+
+    it("should show scroll indicators when overflow is triggered by expanding a group", async () => {
+      await page.viewport(1024, 500);
+
+      const Component = () => {
+        return (
+          <GoabWorkSideMenu
+            heading="Test App"
+            url="https://example.com/"
+            testId="scroll-menu-dynamic"
+            open={true}
+            primaryContent={
+              <>
+                <GoabWorkSideMenuItem url="#item-1" label="Item 1" icon="home" />
+                <GoabWorkSideMenuItem url="#item-2" label="Item 2" icon="mail" />
+                <GoabWorkSideMenuGroup
+                  heading="Expandable group"
+                  icon="folder"
+                  testId="expand-group"
+                >
+                  {Array.from({ length: 10 }, (_, i) => (
+                    <GoabWorkSideMenuItem
+                      key={i}
+                      url={`#group-item-${i}`}
+                      label={`Group item ${i + 1}`}
+                      icon="document"
+                    />
+                  ))}
+                </GoabWorkSideMenuGroup>
+                <GoabWorkSideMenuItem url="#item-3" label="Item 3" icon="list" />
+              </>
+            }
+            secondaryContent={
+              <GoabWorkSideMenuItem
+                url="#secondary"
+                label="Secondary item"
+                icon="search"
+                testId="pinned-secondary-dynamic"
+              />
+            }
+          />
+        );
+      };
+
+      const result = render(<Component />);
+      const menu = result.getByTestId("scroll-menu-dynamic");
+      const group = result.getByTestId("expand-group");
+
+      // Initially no overflow — group is collapsed
+      await vi.waitFor(() => {
+        expect(menu.element().classList.contains("scrolling")).toBe(false);
+      });
+
+      // Expand the group to trigger overflow
+      const summary = group.element().querySelector("summary");
+      await summary?.click();
+
+      // Scroll indicators should appear dynamically
+      await vi.waitFor(() => {
+        expect(menu.element().classList.contains("scrolling")).toBe(true);
+        const secondary = result.getByTestId("pinned-secondary-dynamic");
+        expect(secondary).toBeVisible();
       });
     });
   });

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
@@ -45,6 +45,9 @@
   // *******
 
   let _isScrolling = false;
+  let _atTop = true;
+  let _atBottom = false;
+  let _scrollTop = 0;
   let _showAccountMenu = false;
   let _showTooltip = false;
   let _menuItemWithOpenPopover: HTMLElement | null = null;
@@ -58,10 +61,12 @@
   let _tooltipLabel: string = "";
 
   let _bindTimeoutId: any;
+  let _resizeTimeoutId: any;
   let _mouseEnterTimeoutId: any;
   let _mouseLeaveTimeoutId: any;
 
   let observer: MutationObserver | null = null;
+  let _resizeObserver: ResizeObserver | null = null;
 
   const _logo =
     "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' fill='none'%3E%3Crect width='31.695' height='31.688' x='.028' fill='%2300B6ED' rx='4'/%3E%3Cg clip-path='url(%23a)'%3E%3Cmask id='b' width='47' height='39' x='-11' y='-2' maskUnits='userSpaceOnUse' style='mask-type:alpha'%3E%3Cpath fill='%23545860' d='M22.017 31.103a63.47 63.47 0 0 1-7.22-3.164 52.41 52.41 0 0 0 6.195-2.724 43.148 43.148 0 0 0 1.023 5.89m13.27-24.392c-1.034-.13-.497.348-.785 1.7-1.246 5.832-6.05 10.035-10.873 12.855-.506-6.678-.3-14.093.967-18.636 1.069-3.836 2.34-3.132.763-3.938-1.66-.848-3.44.273-4.882 3.13C19.033 4.68 12.393 20.19 1.78 30.664c-5.43 5.36-10.34 2.6-11.323 1.775-.8-.67-1.096.365-.103 1.426 4.39 4.7 10.805 2.003 13.141-.314 6.455-6.405 13.96-20.193 16.996-26.044a89.89 89.89 0 0 0 .243 15.294 44.69 44.69 0 0 1-7.619 2.885c-1.504.391-2.435 1-2.462 1.691-.03.758.98 1.397 2.44 2.085 2.6 1.226 10.216 4.798 12.093 5.878 1.606.925 2.39.204 2.866-.796.622-1.302-1.083-2.054-2.735-2.545a50.47 50.47 0 0 1-1.48-8.385c3.87-2.365 7.682-5.52 9.88-9.452a18.004 18.004 0 0 0 1.568-4.365c.23-.934.293-1.9.186-2.855 0 0-.03-.209-.186-.229'/%3E%3C/mask%3E%3Cg mask='url(%23b)'%3E%3Crect width='31.695' height='31.695' x='.028' fill='%23fff' rx='3.048'/%3E%3C/g%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='a'%3E%3Crect width='32' height='31.992' y='.008' fill='%23fff' rx='4'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E";
@@ -74,11 +79,23 @@
     await tick();
     addEventListeners();
     observer = watchPathChanges(setCurrentUrl);
+
+    if (typeof ResizeObserver !== "undefined") {
+      _resizeObserver = new ResizeObserver(() => {
+        _resizeTimeoutId = performOnce(_resizeTimeoutId, setMenuScrolling, 1);
+      });
+      if (_menuEl) _resizeObserver.observe(_menuEl);
+    }
   });
 
   onDestroy(() => {
     removeEventListeners();
     observer?.disconnect();
+    _resizeObserver?.disconnect();
+    clearTimeout(_bindTimeoutId);
+    clearTimeout(_resizeTimeoutId);
+    clearTimeout(_mouseEnterTimeoutId);
+    clearTimeout(_mouseLeaveTimeoutId);
   });
 
   // *********
@@ -86,9 +103,29 @@
   // *********
 
   // Menu
+  function updateScrollPosition() {
+    const offsetHeight = _scrollEl?.clientHeight || 0;
+    const scrollHeight = _menuEl?.scrollHeight || 0;
+    _atTop = _scrollTop <= 1;
+    _atBottom = _scrollTop + offsetHeight >= scrollHeight - 1;
+  }
+
   function setMenuScrolling() {
     _isScrolling =
       (_menuEl?.scrollHeight || 0) > (_scrollEl?.clientHeight || 0);
+    if (!_isScrolling) {
+      _atTop = true;
+      _atBottom = true;
+    } else {
+      updateScrollPosition();
+    }
+  }
+
+  function handleMenuScroll(e: Event) {
+    const detail = (e as CustomEvent).detail;
+    if (!detail) return;
+    _scrollTop = detail.scrollTop;
+    updateScrollPosition();
   }
 
   function toggleMenu() {
@@ -298,6 +335,7 @@
     window.addEventListener("resize", handleWindowResize);
     _rootEl.addEventListener("_mobilePopoverOpen", onMobilePopoverOpen);
     _rootEl.addEventListener("_mobilePopoverClose", onMobilePopoverClose);
+    _scrollEl.addEventListener("_scroll", handleMenuScroll);
   }
 
   function removeEventListeners() {
@@ -305,6 +343,7 @@
     window.removeEventListener("keydown", handleWindowKeyDown);
     window.removeEventListener("resize", handleWindowResize);
     document.body.removeEventListener("click", closeAccountMenu);
+    _scrollEl?.removeEventListener("_scroll", handleMenuScroll);
   }
 </script>
 
@@ -312,6 +351,8 @@
   class="root"
   class:closed={!open}
   class:scrolling={_isScrolling}
+  class:at-top={_atTop}
+  class:at-bottom={_atBottom}
   class:drawer-open={_mobilePopoverOpen}
   data-testid={testid}
   role="presentation"
@@ -324,7 +365,7 @@
     on:click={handleToggleClick}
   />
   <div class="container">
-    <header>
+    <header class="top-section">
       {#if url}
         <a href={url} class="header" role="menuitem" data-testid="url">
           <img alt="GoA Logo" class="logo" src={_logo} />
@@ -337,86 +378,88 @@
         </div>
       {/if}
     </header>
-    <goa-scrollable
-      vpadding="0"
-      hpadding="0"
-      maxheight="calc(100vh - 137px)"
-      bind:this={_scrollEl}
-    >
-      <nav class="menu" role="presentation" bind:this={_menuEl}>
+    <div class="scroll-area">
+      <goa-scrollable
+        vpadding="0"
+        hpadding="0"
+        maxheight="100%"
+        bind:this={_scrollEl}
+      >
         <div
           class="primary-menu"
           role="presentation"
+          bind:this={_menuEl}
           on:mouseleave={handleMouseLeave}
         >
           <slot name="primary"></slot>
         </div>
-
-        {#if $$slots.secondary}
-          <div
-            class="secondary-menu"
-            role="presentation"
-            on:mouseleave={handleMouseLeave}
-          >
-            <slot name="secondary"></slot>
-          </div>
-        {/if}
-
-        {#if $$slots.account}
-          <div
-            class="account-menu"
-            role="presentation"
-            class:show={_showAccountMenu}
-            on:mouseleave={handleMouseLeave}
-            on:focusout={handleAccountFocusOut}
-          >
-            <slot name="account"></slot>
-          </div>
-
-          <button
-            class="profile"
-            on:click={handleProfileClick}
-            on:focusout={handleAccountFocusOut}
-            aria-haspopup="true"
-            aria-expanded={_showAccountMenu}
-          >
-            <div class="profile-image">
-              <goa-icon
-                size="large"
-                type="person-circle"
-                fillcolor="var(--goa-color-greyscale-400)"
-                arialabel={userName}
-              />
-            </div>
-
-            <div class="profile-details">
-              <div class="profile-name">{userName}</div>
-              <div class="profile-secondary">{userSecondaryText}</div>
-            </div>
-            <div class="profile-chevron">
-              <goa-icon size="small" type="chevron-down" />
-            </div>
-          </button>
-        {/if}
-        <div class="toggle-menu">
-          <button
-            class="toggle-button"
-            data-testid="toggle-menu"
-            on:click={handleToggleClick}
-            aria-label={open ? "Collapse menu" : "Expand menu"}
-          >
-            <goa-icon
-              size="small"
-              theme="outline"
-              type={open ? "arrow-start" : "arrow-end"}
-            />
-            <span class="toggle-button-label"
-              >{open ? "Collapse menu" : "Expand menu"}</span
-            >
-          </button>
+      </goa-scrollable>
+    </div>
+    <div class="bottom-section">
+      {#if $$slots.secondary}
+        <div
+          class="secondary-menu"
+          role="presentation"
+          on:mouseleave={handleMouseLeave}
+        >
+          <slot name="secondary"></slot>
         </div>
-      </nav>
-    </goa-scrollable>
+      {/if}
+
+      {#if $$slots.account}
+        <div
+          class="account-menu"
+          role="presentation"
+          class:show={_showAccountMenu}
+          on:mouseleave={handleMouseLeave}
+          on:focusout={handleAccountFocusOut}
+        >
+          <slot name="account"></slot>
+        </div>
+
+        <button
+          class="profile"
+          on:click={handleProfileClick}
+          on:focusout={handleAccountFocusOut}
+          aria-haspopup="true"
+          aria-expanded={_showAccountMenu}
+        >
+          <div class="profile-image">
+            <goa-icon
+              size="large"
+              type="person-circle"
+              fillcolor="var(--goa-color-greyscale-400)"
+              arialabel={userName}
+            />
+          </div>
+
+          <div class="profile-details">
+            <div class="profile-name">{userName}</div>
+            <div class="profile-secondary">{userSecondaryText}</div>
+          </div>
+          <div class="profile-chevron">
+            <goa-icon size="small" type="chevron-down" />
+          </div>
+        </button>
+      {/if}
+      <div class="toggle-menu">
+        <button
+          class="toggle-button"
+          data-testid="toggle-menu"
+          on:click={handleToggleClick}
+          aria-label={open ? "Collapse menu" : "Expand menu"}
+        >
+          <goa-icon
+            size="small"
+            theme="outline"
+            type={open ? "arrow-start" : "arrow-end"}
+          />
+          <span class="toggle-button-label"
+            >{open ? "Collapse menu" : "Expand menu"}</span
+          >
+        </button>
+      </div>
+    </div>
     <div class="tooltip" bind:this={_tooltipEl} class:show={_showTooltip}>
       {_tooltipLabel}
     </div>
@@ -535,7 +578,6 @@
 
     gap: var(--goa-space-s);
     align-items: center;
-    border-bottom: 1px solid transparent;
     text-decoration: none;
     transition: margin 100ms ease-out;
   }
@@ -545,11 +587,18 @@
     outline-offset: 2px;
   }
 
-  .scrolling header {
-    border-bottom: var(
-      --goa-work-side-menu-border,
-      var(--goa-border-width-s) solid var(--goa-color-greyscale-200)
-    );
+  .top-section {
+    border-bottom: var(--goa-work-side-menu-top-section-border);
+    box-shadow: var(--goa-work-side-menu-top-section-shadow);
+    transition:
+      border-bottom-color var(--goa-work-side-menu-transition-duration-medium)
+        ease,
+      box-shadow var(--goa-work-side-menu-transition-duration-medium) ease;
+  }
+
+  .scrolling:not(.at-top) .top-section {
+    border-bottom: var(--goa-work-side-menu-top-section-border-scrolled);
+    box-shadow: var(--goa-work-side-menu-top-section-shadow-scrolled);
   }
 
   .heading {
@@ -570,23 +619,41 @@
     animation: none;
   }
 
-  .menu {
-    display: flex;
-    position: relative;
-    flex-grow: 1;
-    min-height: calc(100vh - 137px);
-    flex-direction: column;
-    align-items: stretch;
-    transition: padding 100ms ease-out;
+  .scroll-area {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .scroll-area goa-scrollable {
+    display: block;
+    /* 3px offsets goa-scrollable's internal bottom padding */
+    height: calc(100% - 3px);
   }
 
   .primary-menu {
-    flex: 1 0 min-content;
     padding: var(--goa-space-m) var(--goa-space-m) 0;
   }
+
+  .bottom-section {
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    border-top: var(--goa-work-side-menu-bottom-section-border);
+    box-shadow: var(--goa-work-side-menu-bottom-section-shadow);
+    transition:
+      border-top-color var(--goa-work-side-menu-transition-duration-medium) ease,
+      box-shadow var(--goa-work-side-menu-transition-duration-medium) ease;
+  }
+
+  .scrolling:not(.at-bottom) .bottom-section {
+    border-top: var(--goa-work-side-menu-bottom-section-border-scrolled);
+    box-shadow: var(--goa-work-side-menu-bottom-section-shadow-scrolled);
+  }
+
   .secondary-menu {
-    margin: var(--goa-space-xs) 0 0;
-    padding: var(--goa-space-m) var(--goa-space-m) 0;
+    padding: var(--goa-space-xs) var(--goa-space-m) 0;
   }
 
   .account-menu {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       },
       "devDependencies": {
         "@abgov/design-tokens": "1.10.0",
-        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.2.1",
+        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.2.2",
         "@abgov/nx-release": "12.0.0",
         "@angular-devkit/build-angular": "21.2.6",
         "@angular-devkit/core": "21.2.6",
@@ -132,9 +132,9 @@
     },
     "node_modules/@abgov/design-tokens-v2": {
       "name": "@abgov/design-tokens",
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.2.1.tgz",
-      "integrity": "sha512-1L11cx9GOnA3HWr10CShiPYp0pqXVt7v0v2a/ptfSdju5qNwWMrlrcJ6/fPNHAV+7a/blbMjFXn9Yk0lZz0Syg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.2.2.tgz",
+      "integrity": "sha512-z98ET4AF2Hx4iVSr1fZF82p+N0a+Fs2Wii4twVL2GdCL/nETzg0W5wcTAGvAXZoJ3GSlTEVT8pyO2prm2uqNBw==",
       "dev": true
     },
     "node_modules/@abgov/nx-release": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@abgov/design-tokens": "1.10.0",
-    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.2.1",
+    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.2.2",
     "@abgov/nx-release": "12.0.0",
     "@angular-devkit/build-angular": "21.2.6",
     "@angular-devkit/core": "21.2.6",


### PR DESCRIPTION
## Summary

- Restructures the Work Side Menu so only the primary nav area scrolls, while the secondary menu (Search, Get support, Release notes), account section, and collapse toggle stay pinned at the bottom
- Adds scroll-aware border and shadow indicators that fade in/out (300ms) based on scroll position, only showing when there is hidden content in that direction
- Adds browser test verifying secondary menu remains visible when primary nav overflows


https://github.com/user-attachments/assets/98aa5743-a78f-479f-9f52-000c4d284d02

### Top of scroll
<img width="996" height="927" alt="image" src="https://github.com/user-attachments/assets/2e89d6eb-7c24-4eb2-8789-e331efee5efd" />
### Middle of scroll
<img width="996" height="927" alt="image" src="https://github.com/user-attachments/assets/703084ad-3975-47c9-9880-37c93d55f695" />
### Bottom of scroll
<img width="996" height="927" alt="image" src="https://github.com/user-attachments/assets/057c4efb-55cb-44eb-ac32-f6c374a37b93" />
### No scroll
<img width="996" height="1072" alt="image" src="https://github.com/user-attachments/assets/1cd65718-e58f-4e9c-a623-c373445db15d" />

Closes #3548

## Test plan

- [ ] Open the PR playground at `/bugs/3548` which has enough primary items to overflow
- [ ] Verify primary nav scrolls independently while secondary menu stays pinned at bottom
- [ ] Verify header stays fixed at top, items don't scroll behind it
- [ ] Verify border and shadow appear/fade when scrolled away from top or bottom
- [ ] Verify border and shadow disappear when scrolled fully to either end
- [ ] Collapse the menu and verify layout still works at 72px width
- [ ] Resize the viewport height and confirm the layout adapts
- [ ] Test on mobile viewport (menu opens as full-screen modal)