### PR TITLE
feat(#3361): add JSDocs comments to wrappers and common types

### DIFF
--- a/apps/prs/angular/src/app/everything.component.html
+++ b/apps/prs/angular/src/app/everything.component.html
@@ -754,7 +754,7 @@
           <goab-form-item label="Upload card" helpText="Cancel and delete emit events.">
             <goab-file-upload-card
               filename="budget.xlsx"
-              filesize="1.2 MB"
+              size="1.2 MB"
               (onCancel)="onFileUploadCardCancel($event)"
               (onDelete)="onFileUploadCardDelete($event)"
             ></goab-file-upload-card>

--- a/libs/angular-components/src/lib/components/accordion/accordion.ts
+++ b/libs/angular-components/src/lib/components/accordion/accordion.ts
@@ -46,17 +46,26 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Let users show and hide sections of related content on a page. */
 export class GoabAccordion extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Sets the heading text. */
   @Input() heading?: string;
+  /** Sets secondary text. */
   @Input() secondaryText?: string;
+  /** Sets the state of the accordion container open or closed. */
   @Input({ transform: booleanAttribute }) open?: boolean;
+  /** Sets the heading size of the accordion container heading. */
   @Input() headingSize?: GoabAccordionHeadingSize;
+  /** Sets the heading content template reference. */
   @Input() headingContent!: TemplateRef<any>;
+  /** Sets the maximum width of the accordion. */
   @Input() maxWidth?: string;
+  /** Sets the position of the expand/collapse icon. */
   @Input() iconPosition?: GoabAccordionIconPosition;
 
+  /** Emits when the accordion opens or closes. Emits the new open state as a boolean. */
   @Output() onChange = new EventEmitter<boolean>();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/badge/badge.ts
+++ b/libs/angular-components/src/lib/components/badge/badge.ts
@@ -49,16 +49,24 @@ import { GoabBaseComponent } from "../base.component";
     `,
   ],
 })
+/** Small labels which hold small amounts of information, system feedback, or states. */
 export class GoabBadge extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Sets the context and colour of the badge. */
   @Input() type?: GoabBadgeType;
+  /** Sets the text label of the badge. */
   @Input() content?: string;
   // Ensure boolean input; attribute only set when true so default behaviour is false
+  /** @deprecated Use icontype instead. Includes an icon in the badge. */
   @Input({ transform: booleanAttribute }) icon?: boolean;
+  /** Sets the icon type to display in the badge. */
   @Input() iconType?: GoabIconType;
+  /** Sets the size of the badge. @default "medium" */
   @Input() size?: GoabBadgeSize = "medium";
+  /** Sets the visual emphasis. 'subtle' for less prominent, 'strong' for more emphasis. @default "strong" */
   @Input() emphasis?: GoabBadgeEmphasis = "strong";
+  /** Sets the accessible label for screen readers. */
   @Input() ariaLabel?: string;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/base.component.ts
+++ b/libs/angular-components/src/lib/components/base.component.ts
@@ -15,11 +15,17 @@ import { ControlValueAccessor } from "@angular/forms";
   standalone: true,
   template: ``, //** IMPLEMENT IN SUBCLASS
 })
+/** Provides shared margin and test id inputs for Angular GoA wrapper components. */
 export abstract class GoabBaseComponent {
+  /** Sets the top margin spacing token. */
   @Input() mt?: Spacing;
+  /** Sets the bottom margin spacing token. */
   @Input() mb?: Spacing;
+  /** Sets the left margin spacing token. */
   @Input() ml?: Spacing;
+  /** Sets the right margin spacing token. */
   @Input() mr?: Spacing;
+  /** Sets the data-testid attribute for automated testing. */
   @Input() testId?: string;
 }
 
@@ -78,12 +84,16 @@ export abstract class GoabControlValueAccessor
   extends GoabBaseComponent
   implements ControlValueAccessor
 {
+  /** Sets the id attribute of the underlying web component. */
   @Input() id?: string;
   // supports disabled="true" instead of [disabled]="true"
+  /** Sets the disabled state for the control. */
   @Input({ transform: booleanAttribute }) public disabled?: boolean;
   // supports error="true" instead of [error]="true"
+  /** Sets the error state for the control. */
   @Input({ transform: booleanAttribute }) public error?: boolean;
   // this should be unknown (not string) as it might be an integer or a date or a boolean
+  /** Sets the control value used by Angular forms and one-way binding. */
   @Input() value?: unknown | null | undefined;
 
   // implement ControlValueAccessor

--- a/libs/angular-components/src/lib/components/block/block.ts
+++ b/libs/angular-components/src/lib/components/block/block.ts
@@ -39,14 +39,21 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Group components into a block with consistent space between. */
 export class GoabBlock extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Sets the spacing between items. Uses design system spacing tokens. */
   @Input() gap?: Spacing;
+  /** Sets the stacking direction of child components. */
   @Input() direction?: GoabBlockDirection;
+  /** Sets the primary axis alignment of child components. */
   @Input() alignment?: GoabBlockAlignment;
+  /** Sets the width of the block container. Defaults to max-content. */
   @Input() width?: string;
+  /** Sets the minimum width of the block container. */
   @Input() minWidth?: string;
+  /** Sets the maximum width of the block container. */
   @Input() maxWidth?: string;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/button-group/button-group.ts
+++ b/libs/angular-components/src/lib/components/button-group/button-group.ts
@@ -34,10 +34,13 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Display multiple related actions stacked or in a horizontal row to help with arrangement and spacing. */
 export class GoabButtonGroup extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Positions the button group in the page layout. */
   @Input() alignment?: GoabButtonGroupAlignment;
+  /** Sets the spacing between buttons in the button group. */
   @Input() gap?: GoabButtonGroupGap;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/button/button.ts
+++ b/libs/angular-components/src/lib/components/button/button.ts
@@ -49,20 +49,32 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Carry out an important action or navigate to another page. */
 export class GoabButton extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Sets the visual style of the button. Use "primary" for main actions, "secondary" for alternative actions, "tertiary" for low-emphasis actions, and "start" for prominent call-to-action buttons. @default "primary" */
   @Input() type?: GoabButtonType = "primary";
+  /** Sets the size of the button. Use "compact" for inline actions or space-constrained layouts. @default "normal" */
   @Input() size?: GoabButtonSize;
+  /** Sets the color variant for semantic meaning. Use "destructive" for delete or irreversible actions, "inverse" for dark backgrounds. @default "normal" */
   @Input() variant?: GoabButtonVariant;
+  /** Sets the disabled state. When true, prevents user interaction and applies disabled styling. */
   @Input({ transform: booleanAttribute }) disabled?: boolean;
+  /** Sets the icon displayed before the button text. */
   @Input() leadingIcon?: GoabIconType;
+  /** Icon displayed after the button text. */
   @Input() trailingIcon?: GoabIconType;
+  /** Sets a custom width for the button (e.g., "200px" or "100%"). */
   @Input() width?: string;
+  /** Action identifier passed in click events for event delegation patterns. */
   @Input() action?: string;
+  /** Single argument value passed with the action in click events. */
   @Input() actionArg?: string;
+  /** Multiple argument values passed with the action in click events. */
   @Input() actionArgs?: Record<string, unknown>;
 
+  /** Emits when the button is clicked. */
   @Output() onClick = new EventEmitter();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/calendar/calendar.ts
+++ b/libs/angular-components/src/lib/components/calendar/calendar.ts
@@ -40,16 +40,22 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Visual calendar for date selection. */
 export class GoabCalendar extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   version = "2";
 
+  /** Name identifier for the calendar, included in change events. */
   @Input() name?: string;
+  /** The currently selected date value in YYYY-MM-DD format. */
   @Input() value?: Date | string;
+  /** The minimum selectable date in YYYY-MM-DD format. Defaults to 5 years in the past. */
   @Input() min?: Date | string | undefined;
+  /** The maximum selectable date in YYYY-MM-DD format. Defaults to 5 years in the future. */
   @Input() max?: Date | string | undefined;
 
+  /** Emits when the selected date changes. Emits the selected date details as GoabCalendarOnChangeDetail. */
   @Output() onChange = new EventEmitter<GoabCalendarOnChangeDetail>();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/callout/callout.ts
+++ b/libs/angular-components/src/lib/components/callout/callout.ts
@@ -43,6 +43,7 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Communicate important information through a strong visual emphasis. */
 export class GoabCallout extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
@@ -58,11 +59,18 @@ export class GoabCallout extends GoabBaseComponent implements OnInit {
     }, 0);
   }
 
+  /** Define the context and colour of the callout. @default "information" */
   @Input() type?: GoabCalloutType = "information";
+  /** Callout heading text. */
   @Input() heading?: string = "";
+  /** Sets the size of the callout. 'medium' has reduced padding and type size for compact areas. @default "large" */
   @Input() size?: GoabCalloutSize = "large";
+  /** Sets the maximum width of the callout. */
   @Input() maxWidth?: string;
+  /** Indicates how assistive technology should handle updates to the live region. @default "off" */
   @Input() ariaLive?: GoabCalloutAriaLive = "off";
+  /** Sets the icon theme. 'outline' for stroked icons, 'filled' for solid icons. @default "outline" */
   @Input() iconTheme?: GoabCalloutIconTheme = "outline";
+  /** Sets the visual prominence. 'high' for full background, 'medium' for subtle, 'low' for minimal. @default "medium" */
   @Input() emphasis?: GoabCalloutEmphasis = "medium";
 }

--- a/libs/angular-components/src/lib/components/card-actions/card-actions.ts
+++ b/libs/angular-components/src/lib/components/card-actions/card-actions.ts
@@ -18,6 +18,7 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A container that groups related content and actions. */
 export class GoabCardActions implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 

--- a/libs/angular-components/src/lib/components/card-content/card-content.ts
+++ b/libs/angular-components/src/lib/components/card-content/card-content.ts
@@ -18,6 +18,7 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A container that groups related content and actions. */
 export class GoabCardContent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 

--- a/libs/angular-components/src/lib/components/card-image/card-image.ts
+++ b/libs/angular-components/src/lib/components/card-image/card-image.ts
@@ -19,10 +19,13 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A container that groups related content and actions. */
 export class GoabCardImage implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** @required The URL of the image to display. */
   @Input({ required: true }) src!: string;
+  /** @required Height of the image container. Accepts CSS values like "200px" or "100%". */
   @Input({ required: true }) height!: string;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/card/card.ts
+++ b/libs/angular-components/src/lib/components/card/card.ts
@@ -31,6 +31,7 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A container that groups related content and actions. */
 export class GoabCard extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
@@ -45,6 +46,8 @@ export class GoabCard extends GoabBaseComponent implements OnInit {
     }, 0);
   }
 
+  /** Adds a shadow to the card. 0 shows a border, 1-3 increase shadow intensity. */
   @Input({ transform: numberAttribute }) elevation?: number;
+  /** Sets the width of the card. */
   @Input() width?: string;
 }

--- a/libs/angular-components/src/lib/components/checkbox-list/checkbox-list.ts
+++ b/libs/angular-components/src/lib/components/checkbox-list/checkbox-list.ts
@@ -1,4 +1,7 @@
-import { GoabCheckboxListOnChangeDetail, GoabCheckboxSize } from "@abgov/ui-components-common";
+import {
+  GoabCheckboxListOnChangeDetail,
+  GoabCheckboxSize,
+} from "@abgov/ui-components-common";
 import {
   CUSTOM_ELEMENTS_SCHEMA,
   Component,
@@ -47,16 +50,21 @@ import { GoabControlValueAccessor } from "../base.component";
     },
   ],
 })
+/** A multiple selection input. */
 export class GoabCheckboxList extends GoabControlValueAccessor implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
   version = "2";
+  /** @required The name for the checkbox list group. Used as group identifier in change events. */
   @Input() name!: string;
+  /** Sets the maximum width of the checkbox list container. */
   @Input() maxWidth?: string;
+  /** Sets the size of the checkbox list. 'compact' reduces spacing between items. @default "default" */
   @Input() size?: GoabCheckboxSize = "default";
 
   // Override value to handle string arrays consistently
+  /** Array of currently selected checkbox values. */
   @Input() override value?: string[];
 
 
@@ -67,6 +75,7 @@ export class GoabCheckboxList extends GoabControlValueAccessor implements OnInit
     });
   }
 
+  /** Emits when a checkbox selection changes. Emits the change detail including name, value array, and event. */
   @Output() onChange = new EventEmitter<GoabCheckboxListOnChangeDetail>();
 
   _onChange(e: Event) {

--- a/libs/angular-components/src/lib/components/checkbox/checkbox.ts
+++ b/libs/angular-components/src/lib/components/checkbox/checkbox.ts
@@ -67,6 +67,7 @@ import { GoabControlValueAccessor } from "../base.component";
   ],
   imports: [NgTemplateOutlet],
 })
+/** Let the user select one or more options. */
 export class GoabCheckbox extends GoabControlValueAccessor implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
@@ -83,19 +84,31 @@ export class GoabCheckbox extends GoabControlValueAccessor implements OnInit {
     }, 0);
   }
 
+  /** Sets the name of the checkbox input for form submission. */
   @Input() name?: string;
+  /** Marks the checkbox item as selected. */
   @Input({ transform: booleanAttribute }) checked?: boolean;
+  /** Shows a mixed/partial selection state. Used for 'Select All' checkboxes when some items are selected. */
   @Input({ transform: booleanAttribute }) indeterminate?: boolean;
+  /** Label shown beside the checkbox. */
   @Input() text?: string;
   // ** NOTE: can we just use the base component for this?
+  /** The value binding. */
   @Input() override value?: string | number | boolean | null;
+  /** Defines how the text will be translated for the screen reader. If not specified it will fall back to the name. */
   @Input() ariaLabel?: string;
+  /** Sets additional description content displayed below the checkbox label. Accepts plain text or a template. */
   @Input() description!: string | TemplateRef<any>;
+  /** Sets the template for the expandable reveal slot content. */
   @Input() reveal?: TemplateRef<any>;
+  /** Text announced by screen readers when the reveal slot content is displayed. */
   @Input() revealArialLabel?: string;
+  /** Sets the maximum width of the checkbox. */
   @Input() maxWidth?: string;
+  /** Sets the size of the checkbox. 'compact' reduces spacing for dense layouts. @default "default" */
   @Input() size?: GoabCheckboxSize = "default";
 
+  /** Emits when the checkbox value changes. Emits the new checkbox state as a GoabCheckboxOnChangeDetail object. */
   @Output() onChange = new EventEmitter<GoabCheckboxOnChangeDetail>();
 
   getDescriptionAsString(): string {

--- a/libs/angular-components/src/lib/components/chip/chip.ts
+++ b/libs/angular-components/src/lib/components/chip/chip.ts
@@ -41,6 +41,7 @@ import { GoabBaseComponent } from "../base.component";
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Compact element for labels, tags, or selections. */
 export class GoabChip extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
@@ -55,13 +56,20 @@ export class GoabChip extends GoabBaseComponent implements OnInit {
     }, 0);
   }
 
+  /** @deprecated Use GoAFilterChip instead. Icon displayed at the start of the chip. */
   @Input() leadingIcon?: GoabIconType | null;
+  /** @deprecated Use GoAFilterChip instead. Shows an error state on the chip. */
   @Input({ transform: booleanAttribute }) error?: boolean;
+  /** @deprecated Use GoAFilterChip instead. When true, shows a delete icon and makes chip clickable. */
   @Input({ transform: booleanAttribute }) deletable?: boolean;
+  /** @deprecated Use GoAFilterChip instead. The text content displayed in the chip. */
   @Input() content?: string = "";
+  /** @deprecated Use GoAFilterChip instead. The chip variant style. */
   @Input() variant?: GoabChipVariant;
+  /** @deprecated Use GoAFilterChip instead. The icon theme - outline or filled. */
   @Input() iconTheme?: GoabChipTheme;
 
+  /** Emits when the chip is clicked. */
   @Output() onClick = new EventEmitter();
 
   _onClick() {

--- a/libs/angular-components/src/lib/components/circular-progress/circular-progress.ts
+++ b/libs/angular-components/src/lib/components/circular-progress/circular-progress.ts
@@ -32,14 +32,21 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Provide feedback of progress to users while loading. */
 export class GoabCircularProgress implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Stretch across the full screen or use it inline. */
   @Input() variant?: GoabCircularProgressVariant;
+  /** Size of the progress indicator. */
   @Input() size?: GoabCircularProgressSize;
+  /** Loading message displayed under the progress indicator. */
   @Input() message?: string;
+  /** Show/hide the page loader. This allows for fade transition to be applied in each transition. */
   @Input({ transform: booleanAttribute }) visible?: boolean;
+  /** Set the progress value. Setting this value will change the type from infinite to progress. */
   @Input({ transform: numberAttribute }) progress?: number;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/column-layout/column-layout.ts
+++ b/libs/angular-components/src/lib/components/column-layout/column-layout.ts
@@ -18,6 +18,7 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Organizes page content in one, two, or three responsive columns. */
 export class GoabColumnLayout implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 

--- a/libs/angular-components/src/lib/components/container/container.ts
+++ b/libs/angular-components/src/lib/components/container/container.ts
@@ -50,17 +50,27 @@ import { GoabBaseComponent } from "../base.component";
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Group information, create hierarchy, and show related information. */
 export class GoabContainer extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Sets the container and accent bar styling. @default "interactive" */
   @Input() type?: GoabContainerType = "interactive";
+  /** Sets the style of accent on the container. @default "filled" */
   @Input() accent?: GoabContainerAccent = "filled";
+  /** Sets the amount of white space in the container. @default "relaxed" */
   @Input() padding?: GoabContainerPadding = "relaxed";
+  /** Sets the width of the container. @default "full" */
   @Input() width?: GoabContainerWidth = "full";
+  /** Sets the maximum width of the container. */
   @Input() maxWidth?: string;
+  /** Sets the minimum height of the container. */
   @Input() minHeight?: string;
+  /** Sets the maximum height of the container. */
   @Input() maxHeight?: string;
+  /** Sets the template for the title slot content. */
   @Input() title!: TemplateRef<any>;
+  /** Sets the template for the actions slot content. */
   @Input() actions!: TemplateRef<any>;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/data-grid/data-grid.ts
+++ b/libs/angular-components/src/lib/components/data-grid/data-grid.ts
@@ -24,11 +24,15 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Advanced table with sorting and selection. */
 export class GoabDataGrid implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Controls visibility of the keyboard navigation indicator icon. Use "visible" to show or "hidden" to hide. @default "visible" */
   @Input() keyboardIconVisibility: "visible" | "hidden" = "visible";
+  /** Position of the keyboard navigation indicator icon. @default "left" */
   @Input() keyboardIconPosition: "left" | "right" = "left";
+  /** @required Navigation mode. "table" navigates like a table (up/down between rows), "layout" allows wrapping between rows with left/right arrows. */
   @Input({ required: true }) keyboardNav!: "layout" | "table";
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/date-picker/date-picker.ts
+++ b/libs/angular-components/src/lib/components/date-picker/date-picker.ts
@@ -55,6 +55,7 @@ import { GoabControlValueAccessor } from "../base.component";
     },
   ],
 })
+/** Lets users select a date through a calendar without the need to manually type it in a field. */
 export class GoabDatePicker extends GoabControlValueAccessor implements OnInit {
   protected elementRef = inject(ElementRef);
   private cdr = inject(ChangeDetectorRef);
@@ -62,17 +63,22 @@ export class GoabDatePicker extends GoabControlValueAccessor implements OnInit {
   isReady = false;
   version = "2";
 
+  /** Sets the name of the date field. */
   @Input() name?: string;
+  /** Sets the value of the calendar date. */
   @Input() override value?: Date | string | null | undefined;
+  /** Sets the minimum date value allowed. */
   @Input() min?: Date | string;
+  /** Sets the maximum date value allowed. */
   @Input() max?: Date | string;
+  /** Sets the date picker type. 'calendar' shows a calendar popup, 'input' shows just a date input. @default "calendar" */
   @Input() type?: GoabDatePickerInputType;
-  /***
-   * @deprecated This property has no effect and will be removed in a future version
-   */
+  /** @deprecated This property has no effect and will be removed in a future version. */
   @Input() relative?: boolean;
+  /** Sets the width of the date picker input. */
   @Input() width?: string;
 
+  /** Emits when the selected date changes. Emits the date picker change detail including name and value. */
   @Output() onChange = new EventEmitter<GoabDatePickerOnChangeDetail>();
 
   private once: Once = new Once();

--- a/libs/angular-components/src/lib/components/details/details.ts
+++ b/libs/angular-components/src/lib/components/details/details.ts
@@ -32,11 +32,15 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Let users reveal more detailed information when they need it. */
 export class GoabDetails extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** @required The title heading. */
   @Input({ required: true }) heading!: string;
+  /** Controls if details is expanded or not. */
   @Input({ transform: booleanAttribute }) open?: boolean;
+  /** Sets the maximum width of the details. */
   @Input() maxWidth?: string;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/divider/divider.ts
+++ b/libs/angular-components/src/lib/components/divider/divider.ts
@@ -26,6 +26,7 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Indicate a separation of layout, or to distinguish large chunks of information on a page. */
 export class GoabDivider extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 

--- a/libs/angular-components/src/lib/components/drawer/drawer.ts
+++ b/libs/angular-components/src/lib/components/drawer/drawer.ts
@@ -38,17 +38,25 @@ import { GoabDrawerPosition, GoabDrawerSize } from "@abgov/ui-components-common"
   } `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A panel that slides in from the side of the screen to display additional content or actions without navigating away from the current view. */
 export class GoabDrawer implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   version = "2";
 
+  /** @required Whether the drawer is open. */
   @Input({ required: true, transform: booleanAttribute }) open!: boolean;
+  /** @required The position of the drawer. */
   @Input({ required: true }) position!: GoabDrawerPosition;
+  /** The heading text displayed at the top of the drawer. */
   @Input() heading!: string | TemplateRef<any>;
+  /** Sets max height on bottom position, sets width on left and right position. */
   @Input() maxSize?: GoabDrawerSize;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Sets the actions area content using an Angular template reference. */
   @Input() actions!: TemplateRef<any>;
+  /** Emits when the drawer is closed. */
   @Output() onClose = new EventEmitter();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/dropdown-item/dropdown-item.ts
+++ b/libs/angular-components/src/lib/components/dropdown-item/dropdown-item.ts
@@ -24,13 +24,19 @@ import { GoabDropdownItemMountType } from "@abgov/ui-components-common";
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Present a list of options to the user to select from. */
 export class GoabDropdownItem implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** The value submitted when this item is selected. */
   @Input() value?: string;
+  /** Text used to filter and match this item in typeahead search. */
   @Input() filter?: string;
+  /** Display label for the dropdown item. */
   @Input() label?: string;
+  /** Sets the name attribute of the dropdown item. */
   @Input() name?: string;
+  /** Controls how the item is registered with the parent dropdown. */
   @Input() mountType?: GoabDropdownItemMountType;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/dropdown/dropdown.ts
+++ b/libs/angular-components/src/lib/components/dropdown/dropdown.ts
@@ -13,7 +13,7 @@ import {
   forwardRef,
   OnInit,
   ChangeDetectorRef,
-    inject,
+  inject,
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 
@@ -67,31 +67,43 @@ import { GoabControlValueAccessor } from "../base.component";
     },
   ],
 })
+/** Present a list of options to the user to select from. */
 export class GoabDropdown extends GoabControlValueAccessor implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Identifier for the dropdown. Should be unique. */
   @Input() name?: string;
+  /** Defines how the selected value will be translated for the screen reader. If not specified it will fall back to the name. */
   @Input() ariaLabel?: string;
+  /** The aria-labelledby attribute identifies the element(or elements) that labels the dropdown it is applied to. Normally it is the id of the label. */
   @Input() ariaLabelledBy?: string;
+  /** When true the dropdown will have the ability to filter options by typing into the input field. */
   @Input({ transform: booleanAttribute }) filterable?: boolean;
+  /** Icon shown to the left of the dropdown input. */
   @Input() leadingIcon?: GoabIconType;
+  /** Maximum height of the dropdown menu. Non-native only. */
   @Input() maxHeight?: string;
+  /** When true, allows multiple items to be selected. Not currently exposed. */
   @Input({ transform: booleanAttribute }) multiselect?: boolean;
+  /** When true will render the native select HTML element. */
   @Input({ transform: booleanAttribute }) native?: boolean;
+  /** The text displayed for the dropdown before a selection is made. Non-native only. */
   @Input() placeholder?: string;
+  /** Overrides the autosized menu width. Non-native only. */
   @Input() width?: string;
+  /** Sets the maximum width of the dropdown. Use a CSS unit (px, %, ch, rem, em). */
   @Input() maxWidth?: string;
+  /** Specifies the autocomplete attribute for the dropdown input. Native only. */
   @Input() autoComplete?: string;
+  /** Sets the size of the dropdown. Compact reduces height for dense layouts. @default "default" */
   @Input() size?: GoabDropdownSize = "default";
-  /***
-   * @deprecated This property has no effect and will be removed in a future version
-   */
+  /** @deprecated This property has no effect and will be removed in a future version. */
   @Input() relative?: boolean;
+  /** Emits when the user selects a value from the dropdown. Emits a GoabDropdownOnChangeDetail object with the new value. */
   @Output() onChange = new EventEmitter<GoabDropdownOnChangeDetail>();
 
   isReady = false;
   version = "2";
-
 
   ngOnInit(): void {
     // For Angular 20, we need to delay rendering the web component

--- a/libs/angular-components/src/lib/components/file-upload-card/file-upload-card.ts
+++ b/libs/angular-components/src/lib/components/file-upload-card/file-upload-card.ts
@@ -33,17 +33,26 @@ import {
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Display uploaded file with actions. */
 export class GoabFileUploadCard implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** @required The name of the uploaded file to display. */
   @Input({ required: true }) filename!: string;
-  @Input({ transform: numberAttribute }) size?: number;
+  /** @required The file size in bytes. Displayed in a human-readable format (KB, MB). */
+  @Input({ required: true, transform: numberAttribute }) size!: number;
+  /** The MIME type of the file. Used to determine the file type icon. */
   @Input() type?: string;
+  /** Upload progress percentage from 0-100. Use -1 to indicate upload is complete. */
   @Input({ transform: numberAttribute }) progress?: number;
+  /** Error message to display. When set, the card shows an error state with a cancel button. */
   @Input() error?: string;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
+  /** Emits when the user cancels a file upload. Emits a GoabFileUploadOnCancelDetail object with the filename. */
   @Output() onCancel = new EventEmitter<GoabFileUploadOnCancelDetail>();
+  /** Emits when the user removes an uploaded file. Emits a GoabFileUploadOnDeleteDetail object with the filename. */
   @Output() onDelete = new EventEmitter<GoabFileUploadOnDeleteDetail>();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/file-upload-input/file-upload-input.ts
+++ b/libs/angular-components/src/lib/components/file-upload-input/file-upload-input.ts
@@ -36,14 +36,20 @@ import { GoabBaseComponent } from "../base.component";
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Help users select and upload a file. */
 export class GoabFileUploadInput extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Sets the id attribute on the file upload input element. */
   @Input() id?: string = "";
-  @Input({ required: true }) variant!: GoabFileUploadInputVariant;
+  /** The input display variant. "dragdrop" shows a drag-and-drop area, "button" shows a simple button. @default "dragdrop" */
+  @Input() variant?: GoabFileUploadInputVariant;
+  /** Maximum file size with unit (e.g., "5MB", "100KB", "1GB"). Files exceeding this will be rejected. @default "5MB" */
   @Input() maxFileSize?: string = "5MB";
+  /** Accepted file types as a comma-separated list of MIME types or file extensions (e.g., "image/*,.pdf"). */
   @Input() accept?: string;
 
+  /** Emits when a file is selected. Emits the selected file details. */
   @Output() onSelectFile = new EventEmitter<GoabFileUploadInputOnSelectFileDetail>();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/filter-chip/filter-chip.ts
+++ b/libs/angular-components/src/lib/components/filter-chip/filter-chip.ts
@@ -36,16 +36,24 @@ import { GoabBaseComponent } from "../base.component";
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Allow the user to enter information, filter content, and make selections. */
 export class GoabFilterChip extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Shows an error state. */
   @Input({ transform: booleanAttribute }) error?: boolean;
+  /** Marks the chip as deletable. */
   @Input({ transform: booleanAttribute }) deletable?: boolean;
+  /** Text label of the chip. */
   @Input() content?: string = "";
+  /** Sets the icon theme style for the filter chip. */
   @Input() iconTheme?: GoabChipTheme;
+  /** Secondary text displayed in a smaller size before the main content. */
   @Input() secondaryText?: string = "";
+  /** Icon displayed at the start of the chip. */
   @Input() leadingIcon?: GoabIconType | null = null;
 
+  /** Emits when the filter chip delete button is clicked. */
   @Output() onClick = new EventEmitter();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/footer-meta-section/footer-meta-section.ts
+++ b/libs/angular-components/src/lib/components/footer-meta-section/footer-meta-section.ts
@@ -18,11 +18,13 @@ import {
   styles: [":host { width: 100%; }"],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Copyright and legal links in footer. */
 export class GoabAppFooterMetaSection implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
-  /** "slot" is required and must equal to "meta" so it can be rendered in the correct position **/
+  /** @required Sets the slot to "meta" to render the section in the correct footer position. */
   @Input({ required: true }) slot!: "meta";
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/footer-nav-section/footer-nav-section.ts
+++ b/libs/angular-components/src/lib/components/footer-nav-section/footer-nav-section.ts
@@ -22,13 +22,17 @@ import {
   styles: [":host { width: 100%; }"],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Navigation links section in footer. */
 export class GoabAppFooterNavSection implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** The section heading displayed above the navigation links. */
   @Input() heading?: string;
+  /** Maximum number of columns to display links in on larger screens. @default 1 */
   @Input() maxColumnCount? = 1;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
-  /** "slot" is required and must equal to "nav" so it can be rendered in the correct position **/
+  /** @required Sets the slot to "nav" to render the section in the correct footer position. */
   @Input({ required: true }) slot!: "nav";
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/footer/footer.ts
+++ b/libs/angular-components/src/lib/components/footer/footer.ts
@@ -24,11 +24,15 @@ import {
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Provides information related your service at the bottom of every page. */
 export class GoabAppFooter implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** The maximum width of the main content area. */
   @Input() maxContentWidth?: string;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** URL for the Government of Alberta logo link. Set to empty string to disable the link. */
   @Input() url?: string;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/form-item/form-item-slot.ts
+++ b/libs/angular-components/src/lib/components/form-item/form-item-slot.ts
@@ -12,5 +12,6 @@ import { Component, Input } from "@angular/core";
  * // similar to app-footer-meta-section & app-footer-nav-section
  */
 export class GoabFormItemSlot {
+  /** @required Sets which form-item slot this content should render into. */
   @Input({ required: true }) slot!: "helptext" | "error";
 }

--- a/libs/angular-components/src/lib/components/form-item/form-item.ts
+++ b/libs/angular-components/src/lib/components/form-item/form-item.ts
@@ -42,24 +42,29 @@ import { GoabFormItemType } from "@abgov/ui-components-common";
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Wraps an input control with a text label, requirement label, helper text, and error text. */
 export class GoabFormItem extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Creates a label for the form item. */
   @Input() label?: string;
+  /** Sets the label size. 'regular' for standard, 'large' for emphasis. */
   @Input() labelSize?: GoabFormItemLabelSize;
+  /** Help text displayed under the form field to provide additional explanation. */
   @Input() helpText?: string;
+  /** Error text displayed under the form field. Leave blank to indicate a valid field. */
   @Input() error?: string;
+  /** Marks the field with an optional or required label indicator. */
   @Input() requirement?: GoabFormItemRequirement;
+  /** Sets the maximum width of the form item. */
   @Input() maxWidth?: string;
+  /** Sets the id attribute on the form item element. */
   @Input() id?: string;
+  /** Specifies the input type for appropriate message spacing. Used with checkbox-list or radio-group. */
   @Input() type?: GoabFormItemType = "";
-  /**
-   * Public form: to arrange fields in the summary
-   */
+  /** Sets the display order within the form summary. For public-form use only. */
   @Input() publicFormSummaryOrder?: number;
-  /**
-   * Public form: allow to override the label value within the form-summary to provide a shorter description of the value
-   */
+  /** Overrides the label value within the form-summary to provide a shorter description. For public-form use only. */
   @Input() name?: string;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/form-step/form-step.ts
+++ b/libs/angular-components/src/lib/components/form-step/form-step.ts
@@ -19,10 +19,13 @@ import {
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Individual step in a multi-step form. */
 export class GoabFormStep implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** The step label text displayed to users. */
   @Input() text?: string;
+  /** The completion status of the step. Affects visual styling and icons. */
   @Input() status?: GoabFormStepStatus;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/form-stepper/form-stepper.ts
+++ b/libs/angular-components/src/lib/components/form-stepper/form-stepper.ts
@@ -32,10 +32,13 @@ import { GoabBaseComponent } from "../base.component";
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Provides a visual representation of a form through a series of steps. */
 export class GoabFormStepper extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** The current step state value (1-based index). Leaving it blank (-1) will allow any step to be accessed. @default -1 */
   @Input() step?: number = -1;
+  /** Emits when the form stepper step changes. Emits the new step as GoabFormStepperOnChangeDetail. */
   @Output() onChange = new EventEmitter<GoabFormStepperOnChangeDetail>();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/form/fieldset.ts
+++ b/libs/angular-components/src/lib/components/form/fieldset.ts
@@ -23,11 +23,16 @@ import {
   standalone: true,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Container for form inputs and validation. */
 export class GoabFieldset {
+  /** Sets the id of the fieldset. */
   @Input() id?: string;
+  /** Sets the section title displayed above the fieldset content. */
   @Input() sectionTitle?: string;
+  /** Sets when changes will be dispatched to the form. @default "continue" */
   @Input() dispatchOn: GoabFormDispatchOn = "continue";
 
+  /** Emits when the fieldset continues to the next step. Emits the continue detail. */
   @Output() onContinue = new EventEmitter<GoabFieldsetOnContinueDetail>();
 
   _onContinue(event: Event) {

--- a/libs/angular-components/src/lib/components/form/public-form-page.ts
+++ b/libs/angular-components/src/lib/components/form/public-form-page.ts
@@ -36,20 +36,28 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Container for form inputs and validation. */
 export class GoabPublicFormPage extends GoabBaseComponent {
+  /** Sets the id of the form page. */
   @Input() id = "";
+  /** Sets the main heading text of the form page. */
   @Input() heading = "";
+  /** Sets the sub-heading text displayed below the main heading. */
   @Input() subHeading = "";
+  /** Sets the heading used in the summary view for this page. */
   @Input() summaryHeading = "";
+  /** Sets the section title displayed above the heading. */
   @Input() sectionTitle = "";
+  /** Sets the URL for the back navigation link. */
   @Input() backUrl = "";
+  /** Sets the type of the form page step. @default "step" */
   @Input() type: GoabPublicFormPageStep = "step";
+  /** Sets the text for the continue or confirm button. */
   @Input() buttonText = "";
+  /** Sets the visibility of the continue button. @default "visible" */
   @Input() buttonVisibility: GoabPublicFormPageButtonVisibility = "visible";
 
-  /**
-   * triggers when the form page continues to the next step
-   */
+  /** Emits when the form page continues to the next step. */
   @Output() onContinue = new EventEmitter<Event>();
 
   _onContinue(event: Event) {

--- a/libs/angular-components/src/lib/components/form/public-form-summary.ts
+++ b/libs/angular-components/src/lib/components/form/public-form-summary.ts
@@ -10,6 +10,8 @@ import { Component, CUSTOM_ELEMENTS_SCHEMA, Input } from "@angular/core";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Container for form inputs and validation. */
 export class GoabPublicFormSummary {
+  /** Sets the heading text displayed above the form summary. */
   @Input() heading?: string;
 }

--- a/libs/angular-components/src/lib/components/form/public-form.ts
+++ b/libs/angular-components/src/lib/components/form/public-form.ts
@@ -23,12 +23,18 @@ import { GoabFormState, GoabPublicFormStatus } from "@abgov/ui-components-common
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Container for form inputs and validation. */
 export class GoabPublicForm {
+  /** The initialization status of the form. Set to "initializing" while loading external state, then "complete" when ready. @default "complete" */
   @Input() status?: GoabPublicFormStatus = "complete";
+  /** A name identifier for the form. Useful for debugging complex forms with multiple nested forms. */
   @Input() name?: string;
 
+  /** Emits when the form is initialized. */
   @Output() onInit = new EventEmitter<Event>();
+  /** Emits when the form is complete. Emits the form state. */
   @Output() onComplete = new EventEmitter<GoabFormState>();
+  /** Emits when the form state changes. Emits the updated form state. */
   @Output() onStateChange = new EventEmitter<GoabFormState>();
 
   _onInit(e: Event) {

--- a/libs/angular-components/src/lib/components/form/public-subform-index.ts
+++ b/libs/angular-components/src/lib/components/form/public-subform-index.ts
@@ -23,9 +23,14 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Container for form inputs and validation. */
 export class GoabPublicSubformIndex extends GoabBaseComponent {
+  /** Sets the heading text of the subform index page. */
   @Input() heading?: string = "";
+  /** Sets the section title displayed above the heading. */
   @Input() sectionTitle?: string = "";
+  /** Sets the text for the action button that navigates to the subform. */
   @Input() actionButtonText?: string = "";
+  /** Sets the visibility of the continue button. @default "hidden" */
   @Input() buttonVisibility?: "visible" | "hidden" = "hidden";
 }

--- a/libs/angular-components/src/lib/components/form/public-subform.ts
+++ b/libs/angular-components/src/lib/components/form/public-subform.ts
@@ -27,12 +27,18 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Container for form inputs and validation. */
 export class GoabPublicSubform extends GoabBaseComponent {
+  /** Sets the id of the subform. */
   @Input() id?: string = "";
+  /** Sets the name identifier for the subform. */
   @Input() name?: string = "";
+  /** Sets the text for the continue button. */
   @Input() continueMsg?: string = "";
 
+  /** Emits when the subform is initialized. */
   @Output() onInit = new EventEmitter<Event>();
+  /** Emits when the subform state changes. */
   @Output() onStateChange = new EventEmitter<Event>();
 
   _onInit(e: Event) {

--- a/libs/angular-components/src/lib/components/form/task-list.ts
+++ b/libs/angular-components/src/lib/components/form/task-list.ts
@@ -17,6 +17,8 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Container for form inputs and validation. */
 export class GoabPublicFormTaskList extends GoabBaseComponent {
+  /** Sets the heading text displayed above the task list. */
   @Input() heading?: string;
 }

--- a/libs/angular-components/src/lib/components/form/task.ts
+++ b/libs/angular-components/src/lib/components/form/task.ts
@@ -11,6 +11,8 @@ import { GoabPublicFormTaskStatus } from "@abgov/ui-components-common";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Container for form inputs and validation. */
 export class GoabPublicFormTask {
+  /** Sets the status of the task, which determines its badge display. */
   @Input() status?: GoabPublicFormTaskStatus;
 }

--- a/libs/angular-components/src/lib/components/grid/grid.ts
+++ b/libs/angular-components/src/lib/components/grid/grid.ts
@@ -31,11 +31,14 @@ import { GoabBaseComponent } from "../base.component";
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Arrange a number of components into a responsive grid pattern. */
 export class GoabGrid extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** @required Minimum width of the child elements. */
   @Input({ required: true }) minChildWidth!: string;
+  /** Gap between child items. */
   @Input() gap?: Spacing;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/header-menu/header-menu.ts
+++ b/libs/angular-components/src/lib/components/header-menu/header-menu.ts
@@ -25,11 +25,15 @@ import { GoabBaseComponent } from "../base.component";
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Menu items within the app header. */
 export class GoabAppHeaderMenu extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Icon displayed before the heading text. */
   @Input() leadingIcon?: GoabIconType;
+  /** The menu heading text displayed as the dropdown trigger. */
   @Input() heading?: string;
+  /** Sets the slot name for the component. */
   @Input() slotName?: string;
 
   @HostBinding("attr.slot")

--- a/libs/angular-components/src/lib/components/header/header.ts
+++ b/libs/angular-components/src/lib/components/header/header.ts
@@ -32,13 +32,19 @@ import { GoabBaseComponent } from "../base.component";
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Provide structure to help users find their way around the service. */
 export class GoabAppHeader extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Sets the URL to link from the alberta.ca logo. A full url is required. */
   @Input() url?: string;
+  /** Sets the service name to display in the app header. */
   @Input() heading?: string;
+  /** V2 only: Secondary text displayed under the service name. */
   @Input() secondaryText?: string;
+  /** Maximum width of the content area. */
   @Input() maxContentWidth?: string;
+  /** Sets the breakpoint in px for the full menu to display. */
   @Input({ transform: numberAttribute }) fullMenuBreakpoint?: number;
 
   isReady = false;
@@ -51,6 +57,7 @@ export class GoabAppHeader extends GoabBaseComponent implements OnInit {
     }, 0);
   }
 
+  /** Emits when the menu button is clicked. Used for custom menu handling. */
   @Output() onMenuClick = new EventEmitter();
 
   _onMenuClick() {

--- a/libs/angular-components/src/lib/components/hero-banner/hero-banner.ts
+++ b/libs/angular-components/src/lib/components/hero-banner/hero-banner.ts
@@ -33,17 +33,26 @@ import { NgTemplateOutlet } from "@angular/common";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A visual band of text, including an image and a call to action. */
 export class GoabHeroBanner implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** Main heading text. */
   @Input() heading?: string;
+  /** Background image url. */
   @Input() backgroundUrl?: string;
+  /** Minimum height of the hero banner. Defaults to 600px when a background image is provided. */
   @Input() minHeight?: string;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Maximum width of the content area. */
   @Input() maxContentWidth?: string;
+  /** Hero Banner background color when no background image is provided. */
   @Input() backgroundColor?: string;
+  /** Text color within the hero banner. */
   @Input() textColor?: string;
+  /** Angular template reference for the actions slot content. */
   @Input() actions!: TemplateRef<any>;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/icon-button/icon-button.ts
+++ b/libs/angular-components/src/lib/components/icon-button/icon-button.ts
@@ -45,20 +45,31 @@ import { GoabBaseComponent } from "../base.component";
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A compact button with an icon and no text. */
 export class GoabIconButton extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
   protected readonly JSON = JSON;
+  /** @required Sets the icon. */
   @Input({ required: true }) icon!: GoabIconType;
+  /** Sets the size of button. @default "medium" */
   @Input() size?: GoabIconSize = "medium";
+  /** Styles the button to show color, light, dark or destructive action. */
   @Input() variant?: GoabIconButtonVariant;
+  /** Sets the title of the button. */
   @Input() title?: string;
+  /** Disables the button. */
   @Input({ transform: booleanAttribute }) disabled?: boolean;
+  /** Sets the aria-label of the button. */
   @Input() ariaLabel?: string;
+  /** Action identifier passed in click events for event delegation patterns. */
   @Input() action?: string;
+  /** Single argument value passed with the action in click events. */
   @Input() actionArg?: string;
+  /** Multiple argument values passed with the action in click events. */
   @Input() actionArgs?: Record<string, unknown>;
+  /** Emits when the icon button is clicked. */
   @Output() onClick = new EventEmitter();
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/icon/icon.ts
+++ b/libs/angular-components/src/lib/components/icon/icon.ts
@@ -43,16 +43,25 @@ import { GoabBaseComponent } from "../base.component";
   styles: [":host { display: inline-flex; align-items: center; }"],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A simple and universal graphic symbol representing an action, object, or concept to help guide the user. */
 export class GoabIcon extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** @required The icon type to display. See GoabIconType for available icons. */
   @Input({ required: true }) type!: GoabIconType | GoabIconOverridesType;
+  /** Sets the size of the icon. Accepts numeric (1-6) or named sizes. @default "medium" */
   @Input() size?: GoabIconSize;
+  /** Sets the icon theme. 'outline' shows stroked icons, 'filled' shows solid icons. */
   @Input() theme?: GoabIconTheme;
+  /** When true, inverts the icon colors for use on dark backgrounds. */
   @Input({ transform: booleanAttribute }) inverted?: boolean;
+  /** Sets a custom fill color for the icon. Accepts any valid CSS color value. */
   @Input() fillColor?: string;
+  /** Sets the opacity of the icon from 0 (transparent) to 1 (opaque). */
   @Input({ transform: numberAttribute }) opacity?: number;
+  /** Adds an accessible title to the icon SVG. Used by screen readers. */
   @Input() title?: string;
+  /** Defines how the icon will be announced by screen readers. */
   @Input() ariaLabel?: string;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/input-number/input-number.ts
+++ b/libs/angular-components/src/lib/components/input-number/input-number.ts
@@ -107,48 +107,86 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
     },
   ],
 })
+/** A single-line field where users can input and edit numeric values. */
 export class GoabInputNumber implements ControlValueAccessor, OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** Sets the type of the input field. @default "number" */
   @Input() type: GoabInputType = "number";
+  /** Name of input value that is received in the onChange event. */
   @Input() name?: string;
+  /** Unique identifier for the input element. Used for label associations and accessibility. */
   @Input() id?: string;
+  /** Debounce delay in milliseconds before firing the change event. 0 means no debounce. */
   @Input({ transform: numberAttribute }) debounce?: number;
+  /** Disables this input. The input will not receive focus or events. */
   @Input({ transform: booleanAttribute }) disabled?: boolean;
+  /** Controls whether and how text input is automatically capitalized as it is entered/edited by the user. This only works on mobile devices. */
   @Input() autoCapitalize?: GoabInputAutoCapitalize;
+  /** Text displayed within the input when no value is set. */
   @Input() placeholder?: string;
+  /** Icon shown to the left of the text. */
   @Input() leadingIcon?: GoabIconType;
+  /** Icon shown to the right of the text. */
   @Input() trailingIcon?: GoabIconType;
+  /** Sets the visual style variant. 'goa' for standard GoA styling, 'bare' for minimal styling. */
   @Input() variant?: string;
+  /** Sets the cursor focus to the input. */
   @Input({ transform: booleanAttribute }) focused?: boolean;
+  /** Makes the input readonly. */
   @Input({ transform: booleanAttribute }) readonly?: boolean;
+  /** Sets the input to an error state. */
   @Input({ transform: booleanAttribute }) error?: boolean;
+  /** Sets the width of the text input area. */
   @Input() width?: string;
+  /** @deprecated Use leadingContent slot instead. */
   @Input() prefix?: string;
+  /** @deprecated Use trailingContent slot instead. */
   @Input() suffix?: string;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Defines how the input will be translated for the screen reader. If not specified it will fall back to the name. */
   @Input() ariaLabel?: string;
+  /** Sets the maximum number of characters (as UTF-16 code units) the user can enter into the input. */
   @Input({ transform: numberAttribute }) maxLength?: number;
+  /** A string value that supports any number, or an ISO 8601 format if using the date or datetime type. */
   @Input() min?: string | number;
+  /** A string value that supports any number, or an ISO 8601 format if using the date or datetime type. */
   @Input() max?: string | number;
+  /** How much a number or date should change by. */
   @Input({ transform: numberAttribute }) step?: number;
+  /** The aria-labelledby attribute identifies the element (or elements) that labels the input. */
   @Input() ariaLabelledBy?: string;
+  /** Top margin. */
   @Input() mt?: Spacing;
+  /** Right margin. */
   @Input() mr?: Spacing;
+  /** Bottom margin. */
   @Input() mb?: Spacing;
+  /** Left margin. */
   @Input() ml?: Spacing;
+  /** Aria label for the trailing icon. Use only when the trailing icon is interactive. */
   @Input() trailingIconAriaLabel?: string;
+  /** Sets the text alignment within the input field. @default "right" */
   @Input() textAlign?: "left" | "right" = "right"; // Default to right for numbers
 
+  /** Bound to value. */
   @Input() value: number | null = null;
+  /** Sets the leading content slot, accepting a string or template reference. */
   @Input() leadingContent!: string | TemplateRef<any>;
+  /** Sets the trailing content slot, accepting a string or template reference. */
   @Input() trailingContent!: string | TemplateRef<any>;
 
+  /** Emits when the trailing icon is clicked. */
   @Output() onTrailingIconClick = new EventEmitter<void>(); // Keep void type
+  /** Emits when the input receives focus. Emits focus detail including the current value. */
   @Output() onFocus = new EventEmitter<GoabInputOnFocusDetail>();
+  /** Emits when the input loses focus. Emits blur detail including the current value. */
   @Output() onBlur = new EventEmitter<GoabInputOnBlurDetail>();
+  /** Emits when a key is pressed in the input. Emits key press detail including the value and key pressed. */
   @Output() onKeyPress = new EventEmitter<GoabInputOnKeyPressDetail>();
+  /** Emits when the input value changes. Emits change detail including the new value. */
   @Output() onChange = new EventEmitter<GoabInputOnChangeDetail>();
 
   handleTrailingIconClick = false;

--- a/libs/angular-components/src/lib/components/input/input.ts
+++ b/libs/angular-components/src/lib/components/input/input.ts
@@ -20,7 +20,7 @@ import {
   numberAttribute,
   TemplateRef,
   ChangeDetectorRef,
-    inject,
+  inject,
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 import { GoabControlValueAccessor } from "../base.component";
@@ -108,39 +108,70 @@ import { NgTemplateOutlet } from "@angular/common";
     },
   ],
 })
+/** A single-line field where users can input and edit text. */
 export class GoabInput extends GoabControlValueAccessor implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Sets the type of the input field. @default "text" */
   @Input() type?: GoabInputType = "text";
+  /** Name of input value that is received in the onChange event. */
   @Input() name?: string;
+  /** Debounce delay in milliseconds before firing the change event. 0 means no debounce. */
   @Input({ transform: numberAttribute }) debounce?: number;
+  /** Controls whether and how text input is automatically capitalized as it is entered/edited by the user. This only works on mobile devices. */
   @Input() autoCapitalize?: GoabInputAutoCapitalize;
+  /** Specifies the autocomplete attribute for the input field. */
   @Input() autoComplete?: string;
+  /** Text displayed within the input when no value is set. */
   @Input() placeholder?: string;
+  /** Icon shown to the left of the text. */
   @Input() leadingIcon?: GoabIconType;
+  /** Icon shown to the right of the text. */
   @Input() trailingIcon?: GoabIconType;
+  /** Sets the visual style variant. 'goa' for standard GoA styling, 'bare' for minimal styling. */
   @Input() variant?: string;
+  /** Sets the cursor focus to the input. */
   @Input({ transform: booleanAttribute }) focused?: boolean;
+  /** Makes the input readonly. */
   @Input({ transform: booleanAttribute }) readonly?: boolean;
+  /** Sets the width of the text input area. */
   @Input() width?: string;
+  /** @deprecated Use leadingContent slot instead. */
   @Input() prefix?: string;
+  /** @deprecated Use trailingContent slot instead. */
   @Input() suffix?: string;
+  /** Defines how the input will be translated for the screen reader. If not specified it will fall back to the name. */
   @Input() ariaLabel?: string;
+  /** Sets the maximum number of characters (as UTF-16 code units) the user can enter into the input. */
   @Input({ transform: numberAttribute }) maxLength?: number;
+  /** A string value that supports any number, or an ISO 8601 format if using the date or datetime type. */
   @Input() min?: string | number;
+  /** A string value that supports any number, or an ISO 8601 format if using the date or datetime type. */
   @Input() max?: string | number;
+  /** How much a number or date should change by. */
   @Input({ transform: numberAttribute }) step?: number;
+  /** The aria-labelledby attribute identifies the element (or elements) that labels the input. */
   @Input() ariaLabelledBy?: string;
+  /** Aria label for the trailing icon. Use only when the trailing icon is interactive. */
   @Input() trailingIconAriaLabel?: string;
+  /** Sets the text alignment within the input field. @default "left" */
   @Input() textAlign?: "left" | "right" = "left";
+  /** Sets the leading content slot, accepting a string or template reference. */
   @Input() leadingContent!: string | TemplateRef<any>;
+  /** Sets the trailing content slot, accepting a string or template reference. */
   @Input() trailingContent!: string | TemplateRef<any>;
+  /** Sets the size of the input. 'compact' reduces height for dense layouts. @default "default" */
   @Input() size?: GoabInputSize = "default";
 
+  /** Emits when the trailing icon is clicked. */
   @Output() onTrailingIconClick = new EventEmitter();
+  /** Emits when the input receives focus. Emits focus detail including the current value. */
   @Output() onFocus = new EventEmitter<GoabInputOnFocusDetail>();
+  /** Emits when the input loses focus. Emits blur detail including the current value. */
   @Output() onBlur = new EventEmitter<GoabInputOnBlurDetail>();
+  /** Emits when a key is pressed in the input. Emits key press detail including the value and key pressed. */
   @Output() onKeyPress = new EventEmitter<GoabInputOnKeyPressDetail>();
+  /** Emits when the input value changes. Emits change detail including the new value. */
   @Output() onChange = new EventEmitter<GoabInputOnChangeDetail>();
 
   version = "2";

--- a/libs/angular-components/src/lib/components/linear-progress/linear-progress.ts
+++ b/libs/angular-components/src/lib/components/linear-progress/linear-progress.ts
@@ -23,13 +23,19 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Provide visual feedback to users while loading. */
 export class GoabLinearProgress implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Progress value (0-100). When undefined, shows an indeterminate loading animation. */
   @Input() progress?: number | null | undefined;
+  /** Controls visibility of the percentage text. */
   @Input() percentVisibility?: "visible" | "hidden" | undefined;
+  /** Accessible label for the progress bar. */
   @Input() ariaLabel?: string;
+  /** ID of the element that labels this progress bar. */
   @Input() ariaLabelledBy?: string;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testid?: string;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/link/link.ts
+++ b/libs/angular-components/src/lib/components/link/link.ts
@@ -39,21 +39,34 @@ import {
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Wraps an anchor element to add icons or margins. */
 export class GoabLink implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** Icon displayed before the link text. */
   @Input() leadingIcon?: GoabIconType;
+  /** Icon displayed after the link text. */
   @Input() trailingIcon?: GoabIconType;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Custom action event name to dispatch when the link is clicked. */
   @Input() action?: string;
+  /** Sets the color theme. 'interactive' for blue, 'dark' for black, 'light' for white text. @default "interactive" */
   @Input() color?: GoabLinkColor = "interactive";
+  /** Sets the text size and corresponding icon size. @default "medium" */
   @Input() size?: GoabLinkSize = "medium";
+  /** Single argument to pass with the action event (deprecated, use actionArgs). */
   @Input() actionArg?: string;
+  /** Object of arguments to pass with the action event. */
   @Input() actionArgs?: Record<string, unknown>;
+  /** Top margin. */
   @Input() mt?: Spacing;
+  /** Bottom margin. */
   @Input() mb?: Spacing;
+  /** Left margin. */
   @Input() ml?: Spacing;
+  /** Right margin. */
   @Input() mr?: Spacing;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/menu-button/menu-action.ts
+++ b/libs/angular-components/src/lib/components/menu-button/menu-action.ts
@@ -16,9 +16,14 @@ import { CUSTOM_ELEMENTS_SCHEMA, Component, Input } from "@angular/core";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Individual action item within a menu button. */
 export class GoabMenuAction {
-  @Input({required: true}) text!: string;
-  @Input({required: true}) action!: string;
+  /** @required Display text for the menu action. */
+  @Input({ required: true }) text!: string;
+  /** @required Action identifier included in the click event. */
+  @Input({ required: true }) action!: string;
+  /** Icon displayed before the text. */
   @Input() icon?: GoabIconType;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 }

--- a/libs/angular-components/src/lib/components/menu-button/menu-button.ts
+++ b/libs/angular-components/src/lib/components/menu-button/menu-button.ts
@@ -34,15 +34,25 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A button with more than one action. */
 export class GoabMenuButton {
+  /** The button label text. When provided, displays as a text button with a dropdown icon. */
   @Input() text?: string;
+  /** The button style variant. */
   @Input() type?: GoabButtonType;
+  /** Sets the size of the button. */
   @Input() size?: GoabButtonSize;
+  /** Sets the color variant for semantic meaning. */
   @Input() variant?: GoabButtonVariant;
+  /** Maximum width of the dropdown menu. */
   @Input() maxWidth?: string;
+  /** Icon displayed before the button text. When no text is provided, displays as an icon button. */
   @Input() leadingIcon?: GoabIconType;
+  /** Sets the aria-label for the icon button in icon-only mode. */
   @Input() ariaLabel?: string;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Emits when a menu action is clicked. Emits the action detail. */
   @Output() onAction = new EventEmitter<GoabMenuButtonOnActionDetail>();
 
   _onAction(e: Event) {

--- a/libs/angular-components/src/lib/components/microsite-header/microsite-header.ts
+++ b/libs/angular-components/src/lib/components/microsite-header/microsite-header.ts
@@ -37,16 +37,24 @@ import { NgTemplateOutlet } from "@angular/common";
   imports: [NgTemplateOutlet],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Communicate what stage the service is at, connect to Alberta.ca, and gather feedback on your service. */
 export class GoabMicrositeHeader implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** @required The service type which determines the badge style. "live" shows official government site text, "alpha" and "beta" show development stage badges. */
   @Input({ required: true }) type!: GoabServiceLevel;
+  /** @required App or service version displayed on the right side of the header. */
   @Input() version!: string | TemplateRef<any>;
+  /** Url to feedback page that will be displayed when provided. */
   @Input() feedbackUrl?: string;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Maximum width of the content area. */
   @Input() maxContentWidth?: string;
+  /** For internal feedback urls sets target. */
   @Input() feedbackUrlTarget?: GoabLinkTarget;
+  /** Sets the target attribute for the header link. */
   @Input() headerUrlTarget?: GoabLinkTarget;
 
   ngOnInit(): void {
@@ -56,6 +64,7 @@ export class GoabMicrositeHeader implements OnInit {
     });
   }
 
+  /** Emits when the feedback link is clicked. */
   @Output() onFeedbackClick = new EventEmitter();
 
   getVersionAsString(): string {

--- a/libs/angular-components/src/lib/components/modal/modal.ts
+++ b/libs/angular-components/src/lib/components/modal/modal.ts
@@ -52,6 +52,7 @@ import { NgTemplateOutlet } from "@angular/common";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** An overlay that appears in front of all other content, and requires a user to take an action before continuing. */
 export class GoabModal implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
@@ -67,20 +68,29 @@ export class GoabModal implements OnInit {
     }, 0);
   }
 
+  /** Define the context and colour of the callout modal. It is required when type is set to callout. */
   @Input() calloutVariant?: GoabModalCalloutVariant;
+  /** Controls if modal is visible or not. */
   @Input({ transform: booleanAttribute }) open?: boolean;
+  /** Set the max allowed width of the modal. */
   @Input() maxWidth?: string;
+  /** Show close icon and allow clicking the background to close the modal. */
   @Input() closable = false;
+  /** Sets the animation transition when opening/closing. 'fast' or 'slow' for animated, 'none' for instant. */
   @Input() transition?: GoabModalTransition;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
   /**
    * @deprecated The role property is deprecated and will be removed in a future version.
    * The modal will always use role="dialog".
    */
   @Input() role?: string;
+  /** The heading text displayed at the top of the modal. */
   @Input() heading!: string | TemplateRef<any>;
+  /** Sets the template reference for the modal action buttons. */
   @Input() actions!: TemplateRef<any>;
 
+  /** Emits when the modal is closed. */
   @Output() onClose = new EventEmitter();
 
   getHeadingAsString(): string {

--- a/libs/angular-components/src/lib/components/notification/notification.ts
+++ b/libs/angular-components/src/lib/components/notification/notification.ts
@@ -37,16 +37,23 @@ import {
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Display important page level information or notifications. */
 export class GoabNotification implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
   version = "2";
+  /** Define the context and colour of the notification. @default "information" */
   @Input() type?: GoabNotificationType = "information";
+  /** Indicates how assistive technology should handle updates to the live region. */
   @Input() ariaLive?: GoabAriaLiveType;
+  /** Maximum width of the content area. */
   @Input() maxContentWidth?: string;
+  /** Sets the visual prominence. 'high' for full background, 'low' for medium. @default "high" */
   @Input() emphasis?: GoabNotificationEmphasis = "high";
+  /** When true, reduces padding for a more compact notification. */
   @Input({ transform: booleanAttribute }) compact?: boolean;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
   ngOnInit(): void {
@@ -56,6 +63,7 @@ export class GoabNotification implements OnInit {
     });
   }
 
+  /** Emits when the notification is dismissed. */
   @Output() onDismiss = new EventEmitter();
 
   _onDismiss() {

--- a/libs/angular-components/src/lib/components/page-block/page-block.ts
+++ b/libs/angular-components/src/lib/components/page-block/page-block.ts
@@ -21,11 +21,14 @@ import {
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Full-width section with optional background. */
 export class GoabPageBlock implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** Maximum width of the content area. Use "full" for 100% width or a CSS dimension like "1200px". */
   @Input() width?: GoabPageBlockSize;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/pages/pages.ts
+++ b/libs/angular-components/src/lib/components/pages/pages.ts
@@ -30,10 +30,12 @@ import { GoabBaseComponent } from "../base.component";
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Container for paginated content views. */
 export class GoabPages extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** The currently visible page (1-based index). */
   @Input({ transform: numberAttribute }) current?: number;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/pagination/pagination.ts
+++ b/libs/angular-components/src/lib/components/pagination/pagination.ts
@@ -40,14 +40,19 @@ import { GoabBaseComponent } from "../base.component";
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Help users navigation between multiple pages or screens as part of a set. */
 export class GoabPagination extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
   version = "2";
+  /** @required Total number of data items within all pages. */
   @Input({ required: true }) itemCount!: number;
+  /** @required The current page being viewed (non-zero based). */
   @Input({ required: true }) pageNumber!: number;
+  /** Number of data items shown per page. @default 10 */
   @Input() perPageCount?: number = 10;
+  /** Controls which nav controls are visible. @default "all" */
   @Input() variant?: GoabPaginationVariant = "all";
 
   ngOnInit(): void {
@@ -57,6 +62,7 @@ export class GoabPagination extends GoabBaseComponent implements OnInit {
     });
   }
 
+  /** Emits when the page changes. Emits the new page number as part of the change detail. */
   @Output() onChange = new EventEmitter<GoabPaginationOnChangeDetail>();
 
   _onChange(e: Event) {

--- a/libs/angular-components/src/lib/components/popover/popover.ts
+++ b/libs/angular-components/src/lib/components/popover/popover.ts
@@ -38,18 +38,22 @@ import { GoabBaseComponent } from "../base.component";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A small overlay that opens on demand, used in other components. */
 export class GoabPopover extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** Sets the maximum width of the popover container. @default "320px" */
   @Input() maxWidth = "320px";
+  /** Sets the minimum width of the popover container. */
   @Input() minWidth?: string;
+  /** Sets if the popover has padding. Use false when content needs to be flush with boundaries. @default true */
   @Input() padded = true;
+  /** Provides control to where the popover content is positioned. */
   @Input() position?: GoabPopoverPosition;
-  /***
-   * @deprecated This property has no effect and will be removed in a future version
-   */
+  /** @deprecated This property has no effect and will be removed in a future version. */
   @Input() relative?: boolean;
+  /** @required Sets the target template reference for the popover trigger. */
   @Input({ required: true }) target!: TemplateRef<any>;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/push-drawer/push-drawer.ts
+++ b/libs/angular-components/src/lib/components/push-drawer/push-drawer.ts
@@ -38,16 +38,23 @@ import {
   } `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A panel that pushes the main page content aside on desktop, falling back to an overlay drawer on smaller screens. */
 export class GoabPushDrawer implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   version = "2";
 
+  /** Sets the open state of the push drawer. */
   @Input({ transform: booleanAttribute }) open?: boolean;
+  /** Sets the heading text or template for the push drawer. */
   @Input() heading!: string | TemplateRef<any>;
+  /** Sets the width of the push drawer panel. */
   @Input() width?: string;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Sets the template reference for the actions slot content. */
   @Input() actions!: TemplateRef<any>;
+  /** Emits when the push drawer closes. */
   @Output() onClose = new EventEmitter();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/radio-group/radio-group.ts
+++ b/libs/angular-components/src/lib/components/radio-group/radio-group.ts
@@ -55,14 +55,19 @@ import { GoabControlValueAccessor } from "../base.component";
     },
   ],
 })
+/** Allow users to select one option from a set. */
 export class GoabRadioGroup extends GoabControlValueAccessor implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
   version = "2";
+  /** The name for the radio group. Used for accessibility and change events. */
   @Input() name?: string;
+  /** Sets the layout direction. 'vertical' stacks items, 'horizontal' places them in a row. */
   @Input() orientation?: GoabRadioGroupOrientation;
+  /** Defines how the radio group will be announced by screen readers. */
   @Input() ariaLabel?: string;
+  /** Sets the size of all radio items. 'compact' reduces spacing for dense layouts (V2 only). @default "default" */
   @Input() size?: GoabRadioGroupSize = "default";
 
 
@@ -73,6 +78,7 @@ export class GoabRadioGroup extends GoabControlValueAccessor implements OnInit {
     });
   }
 
+  /** Emits when the selected radio item changes. Emits the name, value, and event of the selected item. */
   @Output() onChange = new EventEmitter<GoabRadioGroupOnChangeDetail>();
 
   _onChange(e: Event) {

--- a/libs/angular-components/src/lib/components/radio-item/radio-item.ts
+++ b/libs/angular-components/src/lib/components/radio-item/radio-item.ts
@@ -49,20 +49,33 @@ import { GoabBaseComponent } from "../base.component";
   imports: [NgTemplateOutlet],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Individual radio option within a group. */
 export class GoabRadioItem extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** The value of this radio option. Will be emitted when selected. */
   @Input() value?: string;
+  /** The display label for this radio option. Falls back to value if not provided. */
   @Input() label?: string;
+  /** The name of the radio group. Inherited from the parent RadioGroup if not set. */
   @Input() name?: string;
+  /** Additional description text displayed below the label. */
   @Input() description!: string | TemplateRef<any>;
+  /** Sets the template reference for the reveal slot content. */
   @Input() reveal?: TemplateRef<any>;
+  /** Defines how this option will be announced by screen readers. */
   @Input() ariaLabel?: string;
+  /** Text announced by screen readers when the reveal slot content is displayed. */
   @Input() revealAriaLabel?: string;
+  /** Disables this radio option. Also disabled if the parent RadioGroup is disabled. */
   @Input({ transform: booleanAttribute }) disabled?: boolean;
+  /** Sets this radio option as checked/selected. */
   @Input({ transform: booleanAttribute }) checked?: boolean;
+  /** Shows an error state on this radio option. */
   @Input({ transform: booleanAttribute }) error?: boolean;
+  /** Sets the maximum width of this radio item. */
   @Input() maxWidth?: string;
+  /** Enables compact layout for the radio item, reducing spacing for dense layouts. */
   @Input({ transform: booleanAttribute }) compact?: boolean;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/side-menu-group/side-menu-group.ts
+++ b/libs/angular-components/src/lib/components/side-menu-group/side-menu-group.ts
@@ -32,12 +32,15 @@ import { GoabBaseComponent } from "../base.component";
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Group of related side menu items. */
 export class GoabSideMenuGroup extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
   version = "2";
+  /** @required The heading text for the menu group. */
   @Input({ required: true }) heading!: string;
+  /** Icon displayed alongside the heading. */
   @Input() icon?: GoabIconType;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/side-menu-heading/side-menu-heading.ts
+++ b/libs/angular-components/src/lib/components/side-menu-heading/side-menu-heading.ts
@@ -30,13 +30,17 @@ import { NgTemplateOutlet } from "@angular/common";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Section heading in side menu. */
 export class GoabSideMenuHeading implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
   version = "2";
+  /** @required Icon displayed before the heading text. */
   @Input() icon!: GoabIconType;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Sets the template for the meta slot content. */
   @Input() meta!: TemplateRef<any>;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/side-menu/side-menu.ts
+++ b/libs/angular-components/src/lib/components/side-menu/side-menu.ts
@@ -20,11 +20,13 @@ import {
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A side navigation that helps the user navigate between pages. */
 export class GoabSideMenu implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
   version = "2";
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/skeleton/skeleton.ts
+++ b/libs/angular-components/src/lib/components/skeleton/skeleton.ts
@@ -33,13 +33,18 @@ import { GoabBaseComponent } from "../base.component";
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Provide visual feedback to users while loading a content heavy page or page element. */
 export class GoabSkeleton extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** @required Sets the skeleton shape to represent your content. */
   @Input({ required: true }) type!: GoabSkeletonType;
+  /** Sets the maximum width. Currently only used in card skeleton type. @default "300px" */
   @Input() maxWidth = "300px";
+  /** Size can affect either the height, width or both for different skeleton types. */
   @Input() size?: GoabSkeletonSize;
+  /** Used within components that contain multiple lines. Currently only used in card skeleton type. */
   @Input({ transform: numberAttribute }) lineCount?: number;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/spacer/spacer.ts
+++ b/libs/angular-components/src/lib/components/spacer/spacer.ts
@@ -27,12 +27,16 @@ import {
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Negative area between the components and the interface. */
 export class GoabSpacer implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** Horizontal spacing. */
   @Input() hSpacing?: GoabSpacerHorizontalSpacing;
+  /** Vertical spacing. */
   @Input() vSpacing?: GoabSpacerVerticalSpacing;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/spinner/spinner.ts
+++ b/libs/angular-components/src/lib/components/spinner/spinner.ts
@@ -28,14 +28,20 @@ import {
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Loading indicator for async operations. */
 export class GoabSpinner implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** Sets the spinner type. */
   @Input() type?: GoabSpinnerType;
+  /** Sets the size of the spinner. */
   @Input() size?: GoabSpinnerSize;
+  /** When true, inverts colors for use on dark backgrounds. */
   @Input({ transform: booleanAttribute }) invert?: boolean;
+  /** Progress value (0-100). When >= 0, shows a progress spinner instead of infinite. */
   @Input({ transform: numberAttribute }) progress?: number;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/tab/tab.ts
+++ b/libs/angular-components/src/lib/components/tab/tab.ts
@@ -32,12 +32,16 @@ import { NgTemplateOutlet } from "@angular/common";
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   imports: [NgTemplateOutlet],
 })
+/** Individual tab within a tabs component. */
 export class GoabTab implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** The text label for this tab. Can also use the heading slot for custom content. */
   @Input() heading!: string | TemplateRef<any>;
+  /** When true, disables the tab. */
   @Input({ transform: booleanAttribute }) disabled?: boolean;
+  /** Sets the URL slug for the tab. */
   @Input() slug?: string;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/table-sort-header/table-sort-header.ts
+++ b/libs/angular-components/src/lib/components/table-sort-header/table-sort-header.ts
@@ -25,12 +25,16 @@ import {
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A set of structured data that is easy for a user to scan, examine, and compare. */
 export class GoabTableSortHeader implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** Column name identifier for sorting. */
   @Input() name?: string;
+  /** Sets the sort direction indicator. @default "none" */
   @Input() direction?: GoabTableSortDirection = "none";
+  /** Sort order number for multi-column sort display ("1", "2", etc). */
   @Input() sortOrder?: GoabTableSortOrder;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/table/table.ts
+++ b/libs/angular-components/src/lib/components/table/table.ts
@@ -46,14 +46,19 @@ import { GoabBaseComponent } from "../base.component";
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A set of structured data that is easy for a user to scan, examine, and compare. */
 export class GoabTable extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
   version = "2";
+  /** Width of the table. By default it will fit the enclosed content. */
   @Input() width?: string;
+  /** Sets a relaxed variant of the table with more vertical padding for the cells. */
   @Input() variant?: GoabTableVariant;
+  /** Sets sort mode: "single" allows one column, "multi" allows up to 2 columns. */
   @Input() sortMode?: GoabTableSortMode;
+  /** When true, alternates row background colors for improved readability. */
   @Input({ transform: booleanAttribute }) striped?: boolean;
 
   ngOnInit(): void {
@@ -63,7 +68,9 @@ export class GoabTable extends GoabBaseComponent implements OnInit {
     });
   }
 
+  /** Emits when a table column is sorted. Emits the sort column and direction as GoabTableOnSortDetail. */
   @Output() onSort = new EventEmitter<GoabTableOnSortDetail>();
+  /** Emits when multi-column sorting changes. Emits an array of sort entries as GoabTableOnMultiSortDetail. */
   @Output() onMultiSort = new EventEmitter<GoabTableOnMultiSortDetail>();
 
   _onSort(e: Event) {

--- a/libs/angular-components/src/lib/components/tabs/tabs.ts
+++ b/libs/angular-components/src/lib/components/tabs/tabs.ts
@@ -37,16 +37,21 @@ import {
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Let users navigate between related sections of content, displaying one section at a time. */
 export class GoabTabs implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
   version = "2";
+  /** The initially active tab (1-based index). If not set, the first tab is active. */
   @Input({ transform: numberAttribute }) initialTab?: number;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Visual style variant. "segmented" shows pill-style tabs with animation. */
   @Input() variant?: GoabTabsVariant;
   /** Tab layout orientation. "auto" stacks vertically on mobile (default), "horizontal" keeps horizontal on all screen sizes. */
   @Input() orientation?: GoabTabsOrientation;
+  /** Sets the navigation mode for tab switching. "hash" updates the URL hash when switching tabs. */
   @Input() navigation?: GoabTabsNavigation;
 
   ngOnInit(): void {
@@ -56,6 +61,7 @@ export class GoabTabs implements OnInit {
     });
   }
 
+  /** Emits when the active tab changes. Emits the new tab index as GoabTabsOnChangeDetail. */
   @Output() onChange = new EventEmitter<GoabTabsOnChangeDetail>();
 
   _onChange(e: Event) {

--- a/libs/angular-components/src/lib/components/temporary-notification-ctrl/temporary-notification-ctrl.ts
+++ b/libs/angular-components/src/lib/components/temporary-notification-ctrl/temporary-notification-ctrl.ts
@@ -26,12 +26,16 @@ type SnackbarHorizontalPosition = "left" | "center" | "right";
 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** A notification that appears at the bottom of the screen. */
 export class GoabTemporaryNotificationCtrl implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** Vertical position of the notification container. @default "bottom" */
   @Input() verticalPosition: SnackbarVerticalPosition = "bottom";
+  /** Horizontal position of the notification container. @default "center" */
   @Input() horizontalPosition: SnackbarHorizontalPosition = "center";
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/text/text.ts
+++ b/libs/angular-components/src/lib/components/text/text.ts
@@ -39,13 +39,19 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Provides consistent sizing, spacing, and colour to written content. */
 export class GoabText implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** The HTML element to render. Use semantic elements like 'h1'-'h6' for headings. */
   @Input() tag?: GoabTextTextElement | GoabTextHeadingElement;
+  /** Overrides the text size. */
   @Input() size?: GoabTextSize;
+  /** Sets the max width. */
   @Input() maxWidth?: GoabTextMaxWidth;
+  /** Sets the text colour. */
   @Input() color?: GoabTextColor;
+  /** Sets the id attribute on the host element. */
   @Input() id?: string;
   /*
     This is necessary because angular outputs two elements, <goab-text> and <goa-text>
@@ -54,9 +60,13 @@ export class GoabText implements OnInit {
   @HostBinding("attr.id") get hostId() {
     return this.id;
   }
+  /** Top margin. */
   @Input() mt?: Spacing;
+  /** Bottom margin. */
   @Input() mb?: Spacing;
+  /** Left margin. */
   @Input() ml?: Spacing;
+  /** Right margin. */
   @Input() mr?: Spacing;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/textarea/textarea.ts
+++ b/libs/angular-components/src/lib/components/textarea/textarea.ts
@@ -16,7 +16,7 @@ import {
   numberAttribute,
   OnInit,
   ChangeDetectorRef,
-    inject,
+  inject,
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 
@@ -66,28 +66,42 @@ import { GoabControlValueAccessor } from "../base.component";
     },
   ],
 })
+/** A multi-line field where users can input and edit text. */
 export class GoabTextArea extends GoabControlValueAccessor implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Name of the input value that is received in the _change event. */
   @Input() name?: string;
+  /** Text displayed within the input when no value is set. */
   @Input() placeholder?: string;
+  /** Set the number of rows. @default 3 */
   @Input({ transform: numberAttribute }) rows?: number;
+  /** Sets the input to a read only state. */
   @Input({ transform: booleanAttribute }) readOnly?: boolean;
+  /** Width of the text area. */
   @Input() width?: string;
+  /** Defines how the text will be translated for the screen reader. If not specified it will fall back to the name. */
   @Input() ariaLabel?: string;
+  /** Counting interval for characters or words, specifying whether to count every character or word. @default "" */
   @Input() countBy?: GoabTextAreaCountBy = "";
+  /** Maximum number of characters or words allowed. @default -1 */
   @Input() maxCount?: number = -1;
+  /** Maximum width of the text area. */
   @Input() maxWidth?: string;
+  /** Specifies the autocomplete attribute for the textarea input. @default "on" */
   @Input() autoComplete?: string = "on";
+  /** Sets the size variant of the textarea. @default "default" */
   @Input() size?: GoabTextAreaSize = "default";
 
+  /** Emits when the textarea value changes. Emits the name and new value. */
   @Output() onChange = new EventEmitter<GoabTextAreaOnChangeDetail>();
+  /** Emits when a key is pressed in the textarea. Emits the name, value, and key. */
   @Output() onKeyPress = new EventEmitter<GoabTextAreaOnKeyPressDetail>();
+  /** Emits when the textarea loses focus. Emits the name and current value. */
   @Output() onBlur = new EventEmitter<GoabTextAreaOnBlurDetail>();
 
   isReady = false;
   version = "2";
-
 
   ngOnInit(): void {
     // For Angular 20, we need to delay rendering the web component

--- a/libs/angular-components/src/lib/components/tooltip/tooltip.ts
+++ b/libs/angular-components/src/lib/components/tooltip/tooltip.ts
@@ -43,13 +43,18 @@ import { GoabBaseComponent } from "../base.component";
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   imports: [NgTemplateOutlet],
 })
+/** A small popover that displays more information about an item. */
 export class GoabTooltip extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  /** Position with respect to the child element. @default "top" */
   @Input() position?: GoabTooltipPosition;
+  /** The content of the tooltip. */
   @Input() content?: string | TemplateRef<unknown>;
+  /** Horizontal alignment to the child element. @default "center" */
   @Input() hAlign?: GoabTooltipHorizontalAlignment;
+  /** Sets the maximum width of the tooltip. Must use 'px' unit. */
   @Input() maxWidth?: string;
 
   ngOnInit(): void {

--- a/libs/angular-components/src/lib/components/work-side-menu-group/work-side-menu-group.ts
+++ b/libs/angular-components/src/lib/components/work-side-menu-group/work-side-menu-group.ts
@@ -27,12 +27,17 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Collapsible group of items within the work side menu. */
 export class GoabWorkSideMenuGroup implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** @required The text displayed in the group heading. */
   @Input({ required: true }) heading!: string;
+  /** Icon displayed before the group label. When omitted, no icon is rendered and no space is reserved. */
   @Input() icon?: GoabIconType;
+  /** Whether the group is open. */
   @Input({ transform: booleanAttribute }) open?: boolean;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/work-side-menu-item/work-side-menu-item.ts
+++ b/libs/angular-components/src/lib/components/work-side-menu-item/work-side-menu-item.ts
@@ -37,17 +37,27 @@ import { NgTemplateOutlet } from "@angular/common";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Individual menu item within the work side menu. */
 export class GoabWorkSideMenuItem implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** @required The text label displayed for the menu item. */
   @Input({ required: true }) label!: string;
+  /** The URL the menu item links to. Optional — when absent, renders as a button instead of a link. */
   @Input() url?: string;
+  /** Badge text displayed alongside the menu item (e.g., notification count). */
   @Input() badge?: string;
+  /** When true, indicates this is the currently active menu item. */
   @Input() current?: boolean;
+  /** When true, displays a divider line above this menu item. */
   @Input() divider?: boolean;
+  /** Icon displayed before the menu item label. */
   @Input() icon?: string;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Sets the visual style of the badge. Use "emergency" for urgent items, "success" for positive status. @default "normal" */
   @Input() type?: GoabWorkSideMenuItemType = "normal";
+  /** Template reference for the popover content slot. */
   @Input() popoverContent!: TemplateRef<any>;
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/work-side-menu/work-side-menu.ts
+++ b/libs/angular-components/src/lib/components/work-side-menu/work-side-menu.ts
@@ -41,19 +41,31 @@ import { NgTemplateOutlet } from "@angular/common";
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Side menu variant for worker applications. */
 export class GoabWorkSideMenu implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** @required The application name displayed in the header. */
   @Input({ required: true }) heading!: string;
+  /** @required URL for the header link. Clicking the logo/heading navigates to this URL. */
   @Input({ required: true }) url!: string;
+  /** User's name displayed in the profile section. */
   @Input() userName?: string;
+  /** Secondary text displayed below the user's name, such as role or email. */
   @Input() userSecondaryText?: string;
+  /** Controls whether the side menu is expanded or collapsed. */
   @Input({ transform: booleanAttribute }) open?: boolean;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
+  /** Template reference for the primary navigation slot content. */
   @Input() primaryContent!: TemplateRef<any>;
+  /** Template reference for the secondary navigation slot content. */
   @Input() secondaryContent!: TemplateRef<any>;
+  /** Template reference for the account slot content. */
   @Input() accountContent!: TemplateRef<any>;
+  /** Emits when the side menu is toggled open or closed. */
   @Output() onToggle = new EventEmitter();
+  /** Emits when a navigation link is clicked. Emits the URL as a string. */
   @Output() onNavigate = new EventEmitter<string>();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/work-side-notification-item/work-side-notification-item.ts
+++ b/libs/angular-components/src/lib/components/work-side-notification-item/work-side-notification-item.ts
@@ -33,17 +33,26 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Displays an individual notification item in the work-side notification panel. */
 export class GoabWorkSideNotificationItem implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** Sets the visual style of the notification item. */
   @Input() type?: GoabWorkSideNotificationItemType;
+  /** The timestamp for when the notification was created. */
   @Input() timestamp?: string;
+  /** The title text of the notification item. */
   @Input() title?: string;
+  /** @required The description text of the notification item. */
   @Input({ required: true }) description!: string;
+  /** Indicates whether the notification is read or unread. */
   @Input() readStatus?: GoabWorkSideNotificationReadStatus;
+  /** Sets the priority level of the notification. */
   @Input() priority?: GoabWorkSideNotificationPriority;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
+  /** Emits when the notification item is clicked. */
   @Output() onClick = new EventEmitter<void>();
 
   isReady = false;

--- a/libs/angular-components/src/lib/components/work-side-notification-panel/work-side-notification-panel.ts
+++ b/libs/angular-components/src/lib/components/work-side-notification-panel/work-side-notification-panel.ts
@@ -28,14 +28,20 @@ import {
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
+/** Displays a panel of work-side notifications. */
 export class GoabWorkSideNotificationPanel implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
+  /** The heading text displayed at the top of the notification panel. */
   @Input() heading?: string;
+  /** Sets the initially active tab in the notification panel. */
   @Input() activeTab?: GoabWorkSideNotificationActiveTabType;
+  /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
 
+  /** Emits when the user clicks "Mark all as read". */
   @Output() onMarkAllRead = new EventEmitter<void>();
+  /** Emits when the user clicks "View all". */
   @Output() onViewAll = new EventEmitter<void>();
 
   isReady = false;

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -2,35 +2,66 @@ export type GoabSpinnerType = "infinite" | "progress";
 
 export type GoabSpinnerSize = "small" | "medium" | "large" | "xlarge";
 
+/**
+ * Provides details when a radio group's selected value changes.
+ */
 export type GoabRadioGroupOnChangeDetail = {
+  /** The radio group name. */
   name: string;
+  /** The selected value. */
   value: string;
+  /** The originating DOM event. */
   event: Event;
 };
 
+/**
+ * Provides details when a checkbox list value changes.
+ */
 export type GoabCheckboxListOnChangeDetail = {
+  /** The checkbox list name. */
   name: string;
+  /** The selected values. */
   value: string[];
+  /** The originating DOM event. */
   event: Event;
 };
 
+/**
+ * Provides details when an input value changes.
+ */
 export type GoabInputOnChangeDetail<T = string> = {
+  /** The input name. */
   name: string;
+  /** The updated value. */
   value: T;
+  /** The originating DOM event. */
   event: Event;
 };
 
 // @deprecated GoaInputOnBlurDetail has been deprecated. Use GoabInputOnBlurDetail instead.
 export type GoaInputOnBlurDetail = GoabInputOnBlurDetail;
+/**
+ * Provides details when an input loses focus.
+ */
 export type GoabInputOnBlurDetail<T = string> = {
+  /** The input name. */
   name: string;
+  /** The input value at blur time. */
   value: T;
+  /** The originating DOM event. */
   event: Event;
 };
 
+/**
+ * Provides details when an input receives focus.
+ */
 export type GoabInputOnFocusDetail<T = string> = GoabInputOnChangeDetail<T>;
 
+/**
+ * Provides details when a menu button action is selected.
+ */
 export type GoabMenuButtonOnActionDetail = {
+  /** The selected action identifier. */
   action: string;
 };
 
@@ -42,48 +73,87 @@ export type GoabInputAutoCapitalize =
   | "words"
   | "characters";
 
+/**
+ * Provides details when a key is pressed in an input.
+ */
 export type GoabInputOnKeyPressDetail<T = string> = {
+  /** The input name. */
   name: string;
+  /** The current input value. */
   value: T;
+  /** The pressed key. */
   key: T;
+  /** The originating DOM event. */
   event: Event;
 };
 
+/**
+ * Provides details when the active step changes in a form stepper.
+ */
 export type GoabFormStepperOnChangeDetail = {
+  /** The 1-based step value. */
   step: number;
 };
 
+/**
+ * Provides details when a file is selected in file upload input.
+ */
 export type GoabFileUploadInputOnSelectFileDetail = {
+  /** The selected file. */
   file: File;
+  /** The originating DOM event. */
   event: Event;
 };
 
+/**
+ * Provides details when a file upload item is canceled.
+ */
 export type GoabFileUploadOnCancelDetail = {
+  /** The file name being canceled. */
   filename: string;
+  /** The originating DOM event. */
   event: Event;
 };
 
+/**
+ * Provides details when a file upload item is deleted.
+ */
 export type GoabFileUploadOnDeleteDetail = {
+  /** The file name being deleted. */
   filename: string;
+  /** The originating DOM event. */
   event: Event;
 };
 
 export type GoabDropdownItemMountType = "append" | "prepend" | "reset";
 
+/**
+ * Provides details when a dropdown selection changes.
+ */
 export type GoabDropdownOnChangeDetail = {
+  /** The dropdown name, when provided. */
   name?: string;
+  /** The selected value for single-select dropdowns. */
   value?: string;
+  /** The selected values for multi-select dropdowns. */
   values?: string[];
+  /** The originating DOM event. */
   event: Event;
 };
 
+/**
+ * Provides details when a date picker value changes.
+ */
 export type GoabDatePickerOnChangeDetail = {
+  /** The date picker name, when provided. */
   name?: string;
+  /** The selected date as a string. */
   valueStr: string;
   /**
    * @deprecated Use `valueStr` instead
    */
   value: Date;
+  /** The originating DOM event. */
   event: Event;
 };
 export type GoabDatePickerInputType = "calendar" | "input";
@@ -93,16 +163,29 @@ export type GoabChipVariant = "filter";
 export type GoabChipTheme = "outline" | "filled";
 export type GoabFilterChipTheme = "outline" | "filled";
 
+/**
+ * Provides details when a checkbox value or checked state changes.
+ */
 export type GoabCheckboxOnChangeDetail = {
+  /** The checkbox name, when provided. */
   name?: string;
+  /** The checkbox value, when provided. */
   value?: string;
+  /** The updated checked state. */
   checked: boolean;
+  /** Indicates whether the change came from value or checked binding. */
   binding: "value" | "check";
+  /** The originating DOM event. */
   event: Event;
 };
 
+/**
+ * Provides details when a calendar value changes.
+ */
 export type GoabCalendarOnChangeDetail = {
+  /** The calendar name, when provided. */
   name?: string;
+  /** The selected date value. */
   value: string;
 };
 
@@ -122,7 +205,11 @@ export type GoabBadgeType =
 
 export type GoabPaginationVariant = "all" | "links-only";
 
+/**
+ * Provides details when pagination changes pages.
+ */
 export type GoabPaginationOnChangeDetail = {
+  /** The selected page number. */
   page: number;
 };
 
@@ -182,22 +269,41 @@ export type GoabTooltipHorizontalAlignment = "left" | "right" | "center";
 
 export type GoabTextAreaCountBy = "character" | "word" | "";
 
+/**
+ * Provides details when a textarea value changes.
+ */
 export type GoabTextAreaOnChangeDetail = {
+  /** The textarea name. */
   name: string;
+  /** The updated value. */
   value: string;
+  /** The originating DOM event. */
   event: Event;
 };
 
+/**
+ * Provides details when a key is pressed in a textarea.
+ */
 export type GoabTextAreaOnKeyPressDetail = {
+  /** The textarea name. */
   name: string;
+  /** The current value. */
   value: string;
+  /** The pressed key. */
   key: string;
+  /** The originating DOM event. */
   event: Event;
 };
 
+/**
+ * Provides details when a textarea loses focus.
+ */
 export type GoabTextAreaOnBlurDetail = {
+  /** The textarea name. */
   name: string;
+  /** The value at blur time. */
   value: string;
+  /** The originating DOM event. */
   event: Event;
 };
 
@@ -213,7 +319,11 @@ export interface GoabTabsProps {
   orientation?: GoabTabsOrientation;
 }
 
+/**
+ * Provides details when the active tab changes.
+ */
 export type GoabTabsOnChangeDetail = {
+  /** The selected tab index. */
   tab: number;
 };
 // Table
@@ -236,12 +346,21 @@ export type GoabTableSortEntry = {
   direction: "asc" | "desc";
 };
 
+/**
+ * Provides details when a single table sort changes.
+ */
 export type GoabTableOnSortDetail = {
+  /** The sorted column key. */
   sortBy: string;
+  /** The sort direction as a numeric value. */
   sortDir: number;
 };
 
+/**
+ * Provides details when multi-sort values change.
+ */
 export type GoabTableOnMultiSortDetail = {
+  /** The collection of active sort entries. */
   sorts: GoabTableSortEntry[];
 };
 
@@ -1110,7 +1229,7 @@ export interface Margins {
 }
 
 export type GoabBlockDirection = "row" | "column";
-export type GoabBlockAlignment = "center" | "start" | "end";
+export type GoabBlockAlignment = "center" | "start" | "end" | "normal";
 
 export type GoabPageBlockSize = "full" | string;
 
@@ -1137,7 +1256,11 @@ export type GoabFormField = {
 };
 
 export type GoabFormStorageType = "none" | "local" | "session";
+/**
+ * Provides details used to register a callback at form mount time.
+ */
 export type GoabFormOnMountDetail = {
+  /** Callback used to set the next route or step. */
   fn: (next: string) => void;
 };
 export type GoabFormOnStateChange = {
@@ -1181,9 +1304,15 @@ export type GoabFieldsetSchema = {
   data?: GoabFieldsetData;
 };
 
+/**
+ * Provides details when a fieldset continue action is triggered.
+ */
 export interface GoabFieldsetOnContinueDetail {
+  /** The fieldset element that triggered continue. */
   el: HTMLElement;
+  /** The fieldset state at trigger time. */
   state: Record<string, GoabFieldsetItemState>;
+  /** Indicates whether the action was canceled. */
   cancelled: boolean;
 }
 

--- a/libs/react-components/src/lib/accordion/accordion.tsx
+++ b/libs/react-components/src/lib/accordion/accordion.tsx
@@ -3,14 +3,15 @@ import { ReactNode, useEffect, useRef, type JSX } from "react";
 import type {
   GoabAccordionHeadingSize,
   GoabAccordionIconPosition,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 import { transformProps, lowercase } from "../common/extract-props";
 
 interface WCProps extends Margins {
   open?: string;
   headingsize?: GoabAccordionHeadingSize;
-  heading: string;
+  heading?: string;
   secondarytext?: string;
   headingContent?: ReactNode;
   maxwidth?: string;
@@ -31,18 +32,29 @@ declare module "react" {
 }
 
 export interface GoabAccordionProps extends Margins, DataAttributes {
+  /** Sets the heading text. */
+  heading?: string;
+  /** Sets the state of the accordion container open or closed. */
   open?: boolean;
+  /** Sets the heading size of the accordion container heading. @default "small" */
   headingSize?: GoabAccordionHeadingSize;
+  /** Sets secondary text displayed alongside the heading. */
   secondaryText?: string;
-  heading: string;
+  /** Sets content rendered within the accordion heading, alongside the heading text. */
   headingContent?: ReactNode;
+  /** Sets the maximum width of the accordion. @default "none" */
   maxWidth?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Sets the position of the expand/collapse icon. @default "left" */
   iconPosition?: GoabAccordionIconPosition;
+  /** Callback fired when the accordion is opened or closed. Receives the new open state as a boolean. */
   onChange?: (open: boolean) => void;
+  /** Content rendered inside the accordion body. */
   children?: ReactNode;
 }
 
+/** Let users show and hide sections of related content on a page. */
 export function GoabAccordion({
   open,
   onChange,
@@ -69,11 +81,7 @@ export function GoabAccordion({
   }, [onChange]);
 
   return (
-    <goa-accordion
-      ref={ref}
-      open={open ? "true" : undefined}
-      {..._props}
-    >
+    <goa-accordion ref={ref} open={open ? "true" : undefined} {..._props}>
       {headingContent && <div slot="headingcontent">{headingContent}</div>}
       {children}
     </goa-accordion>

--- a/libs/react-components/src/lib/app-header-menu/app-header-menu.tsx
+++ b/libs/react-components/src/lib/app-header-menu/app-header-menu.tsx
@@ -18,13 +18,19 @@ declare module "react" {
 }
 
 export interface GoabAppHeaderMenuProps extends DataAttributes {
+  /** @required The menu heading text displayed as the dropdown trigger. */
   heading: string;
+  /** Icon displayed before the heading text. */
   leadingIcon?: GoabIconType;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Slot name used to place this menu in the correct slot of the parent component. */
   slotName?: string;
+  /** Content rendered inside the menu dropdown, typically navigation links. */
   children?: ReactNode;
 }
 
+/** Menu items within the app header. */
 export function GoabAppHeaderMenu({
   children,
   slotName,

--- a/libs/react-components/src/lib/app-header/app-header.tsx
+++ b/libs/react-components/src/lib/app-header/app-header.tsx
@@ -26,16 +26,25 @@ declare module "react" {
 }
 
 export interface GoabAppHeaderProps extends DataAttributes {
+  /** Set the service name to display in the app header. */
   heading?: string;
+  /** V2 only: Secondary text displayed under the service name. */
   secondaryText?: string;
+  /** Set the URL to link from the alberta.ca logo. A full url is required. */
   url?: string;
+  /** Maximum width of the content area. */
   maxContentWidth?: string;
+  /** Sets the breakpoint in px for the full menu to display. */
   fullMenuBreakpoint?: number;
+  /** Content rendered inside the app header, typically navigation links. */
   children?: React.ReactNode;
+  /** Callback fired when the menu button is clicked. When provided, clicking the menu button dispatches a custom event instead of toggling the menu. */
   onMenuClick?: () => void;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
+/** Provide structure to help users find their way around the service. */
 export function GoabAppHeader({
   onMenuClick,
   children,

--- a/libs/react-components/src/lib/badge/badge.tsx
+++ b/libs/react-components/src/lib/badge/badge.tsx
@@ -31,13 +31,21 @@ declare module "react" {
 }
 
 export interface GoabBadgeProps extends Margins, DataAttributes {
+  /** @required Sets the context and colour of the badge. */
   type: GoabBadgeType;
+  /** @deprecated Use iconType instead. When true, displays an icon in the badge. */
   icon?: boolean;
+  /** Text label of the badge. */
   content?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Accessible label for screen readers. */
   ariaLabel?: string;
+  /** Icon type to display in the badge. */
   iconType?: GoabIconType;
+  /** Sets the size of the badge. @default "medium" */
   size?: GoabBadgeSize;
+  /** Sets the visual emphasis. 'subtle' for less prominent, 'strong' for more emphasis. @default "strong" */
   emphasis?: GoabBadgeEmphasis;
 }
 
@@ -59,6 +67,7 @@ function getIconValue(icon?: boolean, iconType?: GoabIconType): "true" | "false"
   return iconType ? "true" : "false";
 }
 
+/** Small labels which hold small amounts of information, system feedback, or states. */
 export function GoabBadge({
   icon,
   iconType,

--- a/libs/react-components/src/lib/block/block.tsx
+++ b/libs/react-components/src/lib/block/block.tsx
@@ -1,7 +1,8 @@
 import {
   GoabBlockAlignment,
   GoabBlockDirection,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
   Spacing,
 } from "@abgov/ui-components-common";
 import { ReactNode } from "react";
@@ -28,29 +29,27 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabBlockProps extends Margins, DataAttributes {
+  /** Spacing between items. Uses design system spacing tokens. @default "m" */
   gap?: Spacing;
+  /** Stacking direction of child components. @default "row" */
   direction?: GoabBlockDirection;
+  /** Primary axis alignment of child components. @default "normal" */
   alignment?: GoabBlockAlignment;
+  /** Sets the minimum width of the block container. */
   minWidth?: string;
+  /** Sets the maximum width of the block container. */
   maxWidth?: string;
+  /** Sets the width of the block container. */
   width?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Content rendered inside the block container. */
   children?: ReactNode;
 }
 
-export function GoabBlock({
-  testId,
-  children,
-  ...rest
-}: GoabBlockProps) {
-  const _props = transformProps<WCProps>(
-    { testid: testId, ...rest },
-    kebab
-  );
+/** Group components into a block with consistent space between. */
+export function GoabBlock({ testId, children, ...rest }: GoabBlockProps) {
+  const _props = transformProps<WCProps>({ testid: testId, ...rest }, kebab);
 
-  return (
-    <goa-block {..._props}>
-      {children}
-    </goa-block>
-  );
+  return <goa-block {..._props}>{children}</goa-block>;
 }

--- a/libs/react-components/src/lib/button-group/button-group.tsx
+++ b/libs/react-components/src/lib/button-group/button-group.tsx
@@ -1,7 +1,8 @@
 import {
   GoabButtonGroupAlignment,
   GoabButtonGroupGap,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 
 import type { JSX } from "react";
@@ -23,23 +24,24 @@ declare module "react" {
 }
 
 export interface GoabButtonGroupProps extends Margins, DataAttributes {
+  /** @required Positions the button group in the page layout. */
   alignment: GoabButtonGroupAlignment;
+  /** Sets the spacing between buttons in the button group. @default "relaxed" */
   gap?: GoabButtonGroupGap;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Button components to render inside the group. */
   children?: React.ReactNode;
 }
 
+/** Display multiple related actions stacked or in a horizontal row to help with arrangement and spacing. */
 export function GoabButtonGroup({
   children,
   ...rest
 }: GoabButtonGroupProps): JSX.Element {
   const _props = transformProps<WCProps>(rest, lowercase);
 
-  return (
-    <goa-button-group {..._props}>
-      {children}
-    </goa-button-group>
-  );
+  return <goa-button-group {..._props}>{children}</goa-button-group>;
 }
 
 export default GoabButtonGroup;

--- a/libs/react-components/src/lib/button/button.tsx
+++ b/libs/react-components/src/lib/button/button.tsx
@@ -37,21 +37,35 @@ declare module "react" {
 }
 
 export interface GoabButtonProps extends Margins, DataAttributes {
+  /** Sets the visual style of the button. Use "primary" for main actions, "secondary" for alternative actions, "tertiary" for low-emphasis actions, and "start" for prominent call-to-action buttons. @default "primary" */
   type?: GoabButtonType;
+  /** Controls the size of the button. Use "compact" for inline actions or space-constrained layouts. @default "normal" */
   size?: GoabButtonSize;
+  /** Sets the color variant for semantic meaning. Use "destructive" for delete or irreversible actions, "inverse" for dark backgrounds. @default "normal" */
   variant?: GoabButtonVariant;
+  /** When true, prevents user interaction and applies disabled styling. */
   disabled?: boolean;
+  /** Icon displayed before the button text. */
   leadingIcon?: GoabIconType;
+  /** Icon displayed after the button text. */
   trailingIcon?: GoabIconType;
+  /** Sets a custom width for the button (e.g., "200px" or "100%"). */
   width?: string;
+  /** Callback fired when the button is clicked. */
   onClick?: () => void;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Action identifier passed in click events for event delegation patterns. */
   action?: string;
+  /** Multiple argument values passed with the action in click events. */
   actionArgs?: Record<string, unknown>;
+  /** Single argument value passed with the action in click events. */
   actionArg?: string;
+  /** Content rendered inside the button. */
   children?: ReactNode;
 }
 
+/** Carry out an important action or navigate to another page. */
 export function GoabButton({
   disabled,
   onClick,

--- a/libs/react-components/src/lib/calendar/calendar.tsx
+++ b/libs/react-components/src/lib/calendar/calendar.tsx
@@ -27,14 +27,21 @@ declare module "react" {
   }
 }
 export interface GoabCalendarProps extends Margins, DataAttributes {
-  name?: string;
-  value?: string;
-  min?: string;
-  max?: string;
-  testId?: string;
+  /** @required Callback fired when the selected date changes. */
   onChange: (details: GoabCalendarOnChangeDetail) => void;
+  /** Name identifier for the calendar, included in change events. */
+  name?: string;
+  /** The currently selected date value in YYYY-MM-DD format. */
+  value?: string;
+  /** The minimum selectable date in YYYY-MM-DD format. Defaults to 5 years in the past. */
+  min?: string;
+  /** The maximum selectable date in YYYY-MM-DD format. Defaults to 5 years in the future. */
+  max?: string;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
 }
 
+/** Visual calendar for date selection. */
 export function GoabCalendar({
   min,
   max,

--- a/libs/react-components/src/lib/callout/callout.tsx
+++ b/libs/react-components/src/lib/callout/callout.tsx
@@ -4,7 +4,8 @@ import {
   GoabCalloutSize,
   GoabCalloutType,
   GoabCalloutIconTheme,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 import { transformProps, lowercase } from "../common/extract-props";
 
@@ -30,17 +31,27 @@ declare module "react" {
 }
 
 export interface GoabCalloutProps extends Margins, DataAttributes {
+  /** Callout heading text. */
   heading?: string;
+  /** Sets the context and colour of the callout. @default "information" */
   type?: GoabCalloutType;
+  /** Sets the size of the callout. 'medium' has reduced padding and type size for compact areas. @default "large" */
   size?: GoabCalloutSize;
+  /** Sets the icon theme. 'outline' for stroked icons, 'filled' for solid icons. @default "outline" */
   iconTheme?: GoabCalloutIconTheme;
+  /** Sets the visual prominence. 'high' for full background, 'medium' for subtle, 'low' for minimal. @default "medium" */
   emphasis?: GoabCalloutEmphasis;
+  /** Sets the maximum width of the callout. */
   maxWidth?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Indicates how assistive technology should handle updates to the live region. @default "off" */
   ariaLive?: GoabCalloutAriaLive;
+  /** Content rendered inside the callout body. */
   children?: React.ReactNode;
 }
 
+/** Communicate important information through a strong visual emphasis. */
 export const GoabCallout = ({
   type = "information",
   iconTheme = "outline",

--- a/libs/react-components/src/lib/card/card-actions.tsx
+++ b/libs/react-components/src/lib/card/card-actions.tsx
@@ -11,9 +11,11 @@ declare module "react" {
 }
 
 export interface GoabCardActionsProps extends DataAttributes {
+  /** Content rendered inside the card actions area, typically action buttons. */
   children?: React.ReactNode;
 }
 
+/** A container that groups related content and actions. */
 export function GoabCardActions({
   children,
   ...rest

--- a/libs/react-components/src/lib/card/card-content.tsx
+++ b/libs/react-components/src/lib/card/card-content.tsx
@@ -11,9 +11,11 @@ declare module "react" {
 }
 
 export interface GoabCardContentProps extends DataAttributes {
+  /** Content rendered inside the card content area. */
   children?: React.ReactNode;
 }
 
+/** A container that groups related content and actions. */
 export function GoabCardContent({
   children,
   ...rest

--- a/libs/react-components/src/lib/card/card-group.tsx
+++ b/libs/react-components/src/lib/card/card-group.tsx
@@ -11,13 +11,12 @@ declare module "react" {
 }
 
 export interface GoabCardGroupProps extends DataAttributes {
+  /** Content rendered inside the card group, typically multiple Card components. */
   children?: React.ReactNode;
 }
 
-export function GoabCardGroup({
-  children,
-  ...rest
-}: GoabCardGroupProps): JSX.Element {
+/** A container that groups related content and actions. */
+export function GoabCardGroup({ children, ...rest }: GoabCardGroupProps): JSX.Element {
   const _props = transformProps(rest, lowercase);
 
   return <goa-card-group {..._props}>{children}</goa-card-group>;

--- a/libs/react-components/src/lib/card/card-image.tsx
+++ b/libs/react-components/src/lib/card/card-image.tsx
@@ -16,10 +16,13 @@ declare module "react" {
 }
 
 export interface GoabCardImageProps extends DataAttributes {
+  /** @required The URL of the image to display. */
   src: string;
+  /** @required Height of the image container. Accepts CSS values like "200px" or "100%". */
   height: string;
 }
 
+/** A container that groups related content and actions. */
 export function GoabCardImage(props: GoabCardImageProps): JSX.Element {
   const _props = transformProps<WCProps>(props, lowercase);
 

--- a/libs/react-components/src/lib/card/card.tsx
+++ b/libs/react-components/src/lib/card/card.tsx
@@ -20,23 +20,21 @@ declare module "react" {
 }
 
 export interface GoabCardProps extends Margins, DataAttributes {
+  /** Adds a shadow to the card. 0 shows a border, 1-3 increase shadow intensity. */
   elevation?: number;
+  /** Sets the width of the card. @default "100%" */
   width?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Content rendered inside the card. */
   children?: React.ReactNode;
 }
 
-export function GoabCard({
-  children,
-  ...rest
-}: GoabCardProps): JSX.Element {
+/** A container that groups related content and actions. */
+export function GoabCard({ children, ...rest }: GoabCardProps): JSX.Element {
   const _props = transformProps<WCProps>(rest, lowercase);
 
-  return (
-    <goa-card {..._props}>
-      {children}
-    </goa-card>
-  );
+  return <goa-card {..._props}>{children}</goa-card>;
 }
 
 export default GoabCard;

--- a/libs/react-components/src/lib/checkbox-list/checkbox-list.tsx
+++ b/libs/react-components/src/lib/checkbox-list/checkbox-list.tsx
@@ -1,7 +1,4 @@
-import {
-  GoabCheckboxListOnChangeDetail,
-  Margins,
-} from "@abgov/ui-components-common";
+import { GoabCheckboxListOnChangeDetail, Margins } from "@abgov/ui-components-common";
 import { useEffect, useRef, type JSX } from "react";
 
 interface WCProps extends Margins {
@@ -26,17 +23,27 @@ declare module "react" {
 }
 
 export interface GoabCheckboxListProps extends Margins {
+  /** @required The name for the checkbox list group. Used as group identifier in change events. */
   name: string;
+  /** Array of currently selected checkbox values. */
   value?: string[];
+  /** Disables all checkboxes in the list. */
   disabled?: boolean;
+  /** Shows an error state on all checkboxes in the list. */
   error?: boolean;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Sets the maximum width of the checkbox list container. */
   maxWidth?: string;
+  /** Sets the size of the checkbox list. 'compact' reduces spacing between items. @default "default" */
   size?: "default" | "compact";
+  /** Content rendered inside the checkbox list. */
   children?: React.ReactNode;
+  /** Callback fired when the selected values change. */
   onChange?: (detail: GoabCheckboxListOnChangeDetail) => void;
 }
 
+/** A multiple selection input. */
 export function GoabCheckboxList({
   name,
   value = [],

--- a/libs/react-components/src/lib/checkbox/checkbox.tsx
+++ b/libs/react-components/src/lib/checkbox/checkbox.tsx
@@ -11,9 +11,10 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-checkbox": WCProps & React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-checkbox": WCProps &
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
@@ -39,28 +40,46 @@ interface WCProps extends Margins {
 
 /* eslint-disable-next-line */
 export interface GoabCheckboxProps extends Margins, DataAttributes {
-  id?: string;
+  /** @required Unique name to identify the checkbox. */
   name: string;
+  /** Sets a unique id for the checkbox element. */
+  id?: string;
+  /** Marks the checkbox item as selected. */
   checked?: boolean;
+  /** Shows a mixed/partial selection state. Used for 'Select All' checkboxes when some items are selected. */
   indeterminate?: boolean;
+  /** Disable this control. It will not receive focus or events. */
   disabled?: boolean;
+  /** Shows an error on the checkbox item. */
   error?: boolean;
+  /** Label shown beside the checkbox. */
   text?: string;
+  /** The value binding. */
   value?: string | number | boolean;
+  /** Content rendered inside the checkbox label slot. */
   children?: React.ReactNode;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Defines how the text will be translated for the screen reader. If not specified it will fall back to the name. */
   ariaLabel?: string;
+  /** Additional description text displayed below the checkbox label. */
   description?: string | React.ReactNode;
+  /** Content revealed when the checkbox is checked. */
   reveal?: React.ReactNode;
+  /** Text announced by screen readers when the reveal slot content is displayed. */
   revealAriaLabel?: string;
+  /** Sets the maximum width of the checkbox. */
   maxWidth?: string;
+  /** Sets the size of the checkbox. 'compact' reduces spacing for dense layouts. @default "default" */
   size?: GoabCheckboxSize;
+  /** Callback fired when the checkbox selection changes. */
   onChange?: (detail: GoabCheckboxOnChangeDetail) => void;
 }
 
 // legacy
 export type Props = GoabCheckboxProps;
 
+/** Let the user select one or more options. */
 export function GoabCheckbox({
   error,
   checked,

--- a/libs/react-components/src/lib/chip/chip.tsx
+++ b/libs/react-components/src/lib/chip/chip.tsx
@@ -1,4 +1,9 @@
-import { DataAttributes, GoabChipTheme, GoabChipVariant, Margins } from "@abgov/ui-components-common";
+import {
+  DataAttributes,
+  GoabChipTheme,
+  GoabChipVariant,
+  Margins,
+} from "@abgov/ui-components-common";
 import { useEffect, useRef } from "react";
 import { transformProps, lowercase } from "../common/extract-props";
 
@@ -16,30 +21,35 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-chip": WCProps & React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-chip": WCProps &
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
 
 export interface GoabChipProps extends Margins, DataAttributes {
-  onClick?: () => void;
-  deletable?: boolean;
-  leadingIcon?: string;
-  iconTheme?: GoabChipTheme;
-  error?: boolean;
+  /** @required @deprecated Use GoAFilterChip instead. The text content displayed in the chip. */
   content: string;
+  /** @deprecated Use GoAFilterChip instead. When true, shows a delete icon and makes chip clickable. */
+  deletable?: boolean;
+  /** @deprecated Use GoAFilterChip instead. Icon displayed at the start of the chip. */
+  leadingIcon?: string;
+  /** @deprecated Use GoAFilterChip instead. The icon theme - outline or filled. */
+  iconTheme?: GoabChipTheme;
+  /** @deprecated Use GoAFilterChip instead. Shows an error state on the chip. */
+  error?: boolean;
+  /** @deprecated Use GoAFilterChip instead. The chip variant style. */
   variant?: GoabChipVariant;
+  /** @deprecated Use GoAFilterChip instead. Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Callback fired when the chip is clicked or deleted. */
+  onClick?: () => void;
 }
 
-export const GoabChip = ({
-  error,
-  deletable,
-  onClick,
-  ...rest
-}: GoabChipProps) => {
+/** Compact element for labels, tags, or selections. */
+export const GoabChip = ({ error, deletable, onClick, ...rest }: GoabChipProps) => {
   const el = useRef<HTMLElement>(null);
 
   const _props = transformProps<WCProps>(rest, lowercase);

--- a/libs/react-components/src/lib/circular-progress/circular-progress.tsx
+++ b/libs/react-components/src/lib/circular-progress/circular-progress.tsx
@@ -22,14 +22,21 @@ declare module "react" {
 }
 
 export interface GoabCircularProgressProps {
+  /** Controls the display mode. 'fullscreen' stretches across the full screen; 'inline' is used within content. @default "inline" */
   variant?: GoabCircularProgressVariant;
+  /** Sets the size of the progress indicator. @default "large" */
   size?: GoabCircularProgressSize;
+  /** Loading message displayed below the progress indicator. */
   message?: string;
+  /** Controls visibility of the progress indicator, allowing a fade transition to be applied. */
   visible?: boolean;
+  /** Sets the progress value (0–100). When omitted, an infinite spinner is shown. */
   progress?: number;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
+/** Provide feedback of progress to users while loading. */
 export const GoabCircularProgress = ({
   visible,
   message,

--- a/libs/react-components/src/lib/container/container.tsx
+++ b/libs/react-components/src/lib/container/container.tsx
@@ -3,7 +3,8 @@ import {
   GoabContainerPadding,
   GoabContainerType,
   GoabContainerWidth,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 import { ReactNode, type JSX } from "react";
 import { transformProps, lowercase } from "../common/extract-props";
@@ -29,20 +30,33 @@ declare module "react" {
 }
 
 export interface GoabContainerProps extends Margins, DataAttributes {
-  accent?: GoabContainerAccent;
+  /** Sets the container and accent bar styling. @default "interactive" */
   type?: GoabContainerType;
-  heading?: ReactNode;
-  title?: ReactNode;
+  /** Sets the style of accent on the container. @default "filled" */
+  accent?: GoabContainerAccent;
+  /** Sets the amount of white space in the container. @default "relaxed" */
   padding?: GoabContainerPadding;
-  actions?: ReactNode;
-  children?: ReactNode;
+  /** Sets the width of the container. @default "full" */
   width?: GoabContainerWidth;
+  /** Sets the maximum width of the container. */
   maxWidth?: string;
+  /** Sets the minimum height of the container. */
   minHeight?: string;
+  /** Sets the maximum height of the container. */
   maxHeight?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Content rendered in the container's title/heading area. */
+  heading?: ReactNode;
+  /** @deprecated Use heading instead. Alias for the heading prop. */
+  title?: ReactNode;
+  /** Content rendered in the container's actions area, typically buttons or controls. */
+  actions?: ReactNode;
+  /** Content rendered inside the container body. */
+  children?: ReactNode;
 }
 
+/** Group information, create hierarchy, and show related information. */
 export function GoabContainer({
   heading,
   title,

--- a/libs/react-components/src/lib/data-grid/data-grid.tsx
+++ b/libs/react-components/src/lib/data-grid/data-grid.tsx
@@ -16,12 +16,17 @@ declare module "react" {
 }
 
 export interface GoabDataGridProps {
-  keyboardIconVisibility?: "visible" | "hidden";
-  keyboardIconPosition?: "left" | "right";
+  /** @required Navigation mode. 'table' navigates like a table (up/down between rows), 'layout' allows wrapping between rows with left/right arrows. */
   keyboardNav: "layout" | "table";
+  /** Controls visibility of the keyboard navigation indicator icon. @default "visible" */
+  keyboardIconVisibility?: "visible" | "hidden";
+  /** Position of the keyboard navigation indicator icon. @default "left" */
+  keyboardIconPosition?: "left" | "right";
+  /** Content rendered inside the data grid, typically rows and cells. */
   children?: React.ReactNode;
 }
 
+/** Advanced table with sorting and selection. */
 export function GoabDataGrid({
   keyboardIconVisibility = "visible",
   keyboardIconPosition = "left",

--- a/libs/react-components/src/lib/date-picker/date-picker.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.tsx
@@ -35,22 +35,31 @@ declare module "react" {
 }
 
 export interface GoabDatePickerProps extends Margins, DataAttributes {
-  name?: string;
-  value?: Date | string | undefined;
-  error?: boolean;
-  min?: Date | string;
-  max?: Date | string;
+  /** Sets the date picker type. 'calendar' shows a calendar popup, 'input' shows just a date input. @default "calendar" */
   type?: GoabDatePickerInputType;
+  /** Name of the date field. */
+  name?: string;
+  /** Value of the calendar date, as a Date object or an ISO date string (yyyy-mm-dd). */
+  value?: Date | string | undefined;
+  /** Sets the input to an error state. */
+  error?: boolean;
+  /** Minimum date value allowed. */
+  min?: Date | string;
+  /** Maximum date value allowed. */
+  max?: Date | string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
-  /***
-   * @deprecated This property has no effect and will be removed in a future version
-   */
+  /** @deprecated This property has no effect and will be removed in a future version. */
   relative?: boolean;
+  /** Disables the date picker. */
   disabled?: boolean;
+  /** Sets the width of the date picker input. */
   width?: string;
+  /** Callback fired when the selected date changes. */
   onChange?: (detail: GoabDatePickerOnChangeDetail) => void;
 }
 
+/** Lets users select a date through a calendar without the need to manually type it in a field. */
 export function GoabDatePicker({
   value,
   error,

--- a/libs/react-components/src/lib/details/details.tsx
+++ b/libs/react-components/src/lib/details/details.tsx
@@ -20,25 +20,24 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabDetailsProps extends Margins, DataAttributes {
+  /** @required The title heading. */
   heading: string;
-  open?: boolean;
-  maxWidth?: string;
-  testId?: string;
+  /** @required Content rendered inside the details body. */
   children: ReactNode;
+  /** Controls if details is expanded or not. */
+  open?: boolean;
+  /** Sets the maximum width of the details. @default "75ch" */
+  maxWidth?: string;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
 }
 
-export function GoabDetails({
-  open,
-  children,
-  ...rest
-}: GoabDetailsProps) {
+/** Let users reveal more detailed information when they need it. */
+export function GoabDetails({ open, children, ...rest }: GoabDetailsProps) {
   const _props = transformProps<WCProps>(rest, lowercase);
 
   return (
-    <goa-details
-      open={open ? "true" : undefined}
-      {..._props}
-    >
+    <goa-details open={open ? "true" : undefined} {..._props}>
       {children}
     </goa-details>
   );

--- a/libs/react-components/src/lib/divider/divider.tsx
+++ b/libs/react-components/src/lib/divider/divider.tsx
@@ -13,9 +13,11 @@ declare module "react" {
 }
 
 export interface GoabDividerProps extends Margins {
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
+/** Indicate a separation of layout, or to distinguish large chunks of information on a page. */
 export function GoabDivider(props: GoabDividerProps) {
   return (
     <goa-divider

--- a/libs/react-components/src/lib/drawer/drawer.tsx
+++ b/libs/react-components/src/lib/drawer/drawer.tsx
@@ -21,16 +21,25 @@ declare module "react" {
 }
 
 export interface GoabDrawerProps {
+  /** @required The position of the drawer. */
   position: GoabDrawerPosition;
-  open?: boolean;
-  heading?: string | ReactNode;
-  maxSize?: GoabDrawerSize;
-  testId?: string;
-  actions?: ReactNode;
+  /** @required Content rendered inside the drawer body. */
   children: ReactNode;
+  /** @required Callback fired when the drawer requests to be closed. */
   onClose: () => void;
+  /** Whether the drawer is open. */
+  open?: boolean;
+  /** The heading text displayed at the top of the drawer. Accepts a string or a ReactNode for custom heading content. */
+  heading?: string | ReactNode;
+  /** Sets max height on bottom position, sets width on left and right position. */
+  maxSize?: GoabDrawerSize;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
+  /** Action elements rendered in the drawer footer slot. */
+  actions?: ReactNode;
 }
 
+/** A panel that slides in from the side of the screen to display additional content or actions without navigating away from the current view. */
 export function GoabDrawer({
   position,
   open,

--- a/libs/react-components/src/lib/dropdown/dropdown-item.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown-item.tsx
@@ -21,16 +21,21 @@ declare module "react" {
 }
 
 export interface GoabDropdownItemProps {
+  /** @required The value submitted when this item is selected. */
   value: string;
+  /** Display label for the dropdown item. */
   label?: string;
+  /** Text used to filter and match this item in typeahead search. */
   filter?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Controls how the item is registered with the parent dropdown. */
   mountType?: GoabDropdownItemMountType;
-
-  // @deprecated
+  /** @deprecated */
   name?: string;
 }
 
+/** Present a list of options to the user to select from. */
 export function GoabDropdownOption(props: GoabDropdownItemProps) {
   useEffect(() => {
     console.warn("GoabDropdownOption is deprecated. Please use GoabDropdownItem");
@@ -39,6 +44,7 @@ export function GoabDropdownOption(props: GoabDropdownItemProps) {
   return <GoabDropdownItem {...props} />;
 }
 
+/** Present a list of options to the user to select from. */
 export function GoabDropdownItem({
   value,
   label,

--- a/libs/react-components/src/lib/dropdown/dropdown.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown.tsx
@@ -2,7 +2,8 @@ import {
   GoabDropdownOnChangeDetail,
   GoabDropdownSize,
   GoabIconType,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 import { useEffect, useRef, type JSX } from "react";
 import { transformProps, lowercase } from "../common/extract-props";
@@ -35,39 +36,56 @@ declare module "react" {
   namespace JSX {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface IntrinsicElements {
-      "goa-dropdown": WCProps & React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-dropdown": WCProps &
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
 
 export interface GoabDropdownProps extends Margins, DataAttributes {
+  /** Identifier for the dropdown. Should be unique. */
   name?: string;
+  /** The currently selected value(s) of the dropdown. */
   value?: string[] | string;
+  /** Callback fired when the selected value changes. */
   onChange?: (detail: GoabDropdownOnChangeDetail) => void;
-
-  // optional
+  /** Defines how the selected value will be translated for the screen reader. If not specified it will fall back to the name. */
   ariaLabel?: string;
+  /** The aria-labelledby attribute identifies the element that labels the dropdown. Normally it is the id of the label. */
   ariaLabelledBy?: string;
+  /** The id attribute for the dropdown element. */
   id?: string;
+  /** Dropdown items rendered inside the dropdown. */
   children?: React.ReactNode;
+  /** Disables the dropdown control. */
   disabled?: boolean;
+  /** Shows an error state on the dropdown. */
   error?: boolean;
+  /** When true, allows filtering options by typing into the input field. */
   filterable?: boolean;
+  /** Icon shown to the left of the dropdown input. */
   leadingIcon?: GoabIconType;
+  /** Maximum height of the dropdown menu. Non-native only. @default "276px" */
   maxHeight?: string;
+  /** When true, allows multiple items to be selected. */
   multiselect?: boolean;
+  /** When true, renders the native select HTML element. */
   native?: boolean;
+  /** The text displayed in the dropdown before a selection is made. Non-native only. */
   placeholder?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Overrides the autosized menu width. Non-native only. */
   width?: string;
+  /** Sets the maximum width of the dropdown. Use a CSS unit (px, %, ch, rem, em). */
   maxWidth?: string;
+  /** Specifies the autocomplete attribute for the dropdown input. Native only. */
   autoComplete?: string;
+  /** Sets the size of the dropdown. Compact reduces height for dense layouts. */
   size?: GoabDropdownSize;
-  /***
-   * @deprecated This property has no effect and will be removed in a future version
-   */
+  /** @deprecated This property has no effect and will be removed in a future version. */
   relative?: boolean;
 }
 
@@ -81,6 +99,7 @@ function stringify(value: string | string[] | undefined): string {
   return JSON.stringify(value);
 }
 
+/** Present a list of options to the user to select from. */
 export function GoabDropdown({
   value,
   onChange,

--- a/libs/react-components/src/lib/file-upload-card/file-upload-card.tsx
+++ b/libs/react-components/src/lib/file-upload-card/file-upload-card.tsx
@@ -30,16 +30,25 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabFileUploadCardProps extends DataAttributes {
+  /** @required The name of the uploaded file to display. */
   filename: string;
+  /** @required The file size in bytes. Displayed in a human-readable format (KB, MB). */
   size: number;
+  /** The MIME type of the file. Used to determine the file type icon. */
   type?: string;
+  /** Upload progress percentage from 0-100. Use -1 to indicate upload is complete. @default -1 */
   progress?: number;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Error message to display. When set, the card shows an error state with a cancel button. */
   error?: string;
+  /** Callback fired when the user clicks the remove button on an uploaded file. */
   onDelete?: (detail: GoabFileUploadOnDeleteDetail) => void;
+  /** Callback fired when the user clicks the cancel button during file upload. */
   onCancel?: (detail: GoabFileUploadOnCancelDetail) => void;
 }
 
+/** Display uploaded file with actions. */
 export function GoabFileUploadCard({
   onDelete,
   onCancel,

--- a/libs/react-components/src/lib/file-upload-input/file-upload-input.tsx
+++ b/libs/react-components/src/lib/file-upload-input/file-upload-input.tsx
@@ -18,22 +18,29 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-file-upload-input": WCProps & React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-file-upload-input": WCProps &
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
 
 /* eslint-disable-next-line */
 export interface GoabFileUploadInputProps extends DataAttributes {
-  variant?: GoabFileUploadInputVariant;
-  accept?: string;
-  maxFileSize?: string;
-  testId?: string;
+  /** @required Callback fired when a valid file is selected or dropped. */
   onSelectFile: (detail: GoabFileUploadInputOnSelectFileDetail) => void;
+  /** The input display variant. "dragdrop" shows a drag-and-drop area, "button" shows a simple button. @default "dragdrop" */
+  variant?: GoabFileUploadInputVariant;
+  /** Accepted file types as a comma-separated list of MIME types or file extensions (e.g., "image/*,.pdf"). */
+  accept?: string;
+  /** Maximum file size with unit (e.g., "5MB", "100KB", "1GB"). Files exceeding this will be rejected. @default "5MB" */
+  maxFileSize?: string;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
 }
 
+/** Help users select and upload a file. */
 export function GoabFileUploadInput({ onSelectFile, ...rest }: GoabFileUploadInputProps) {
   const el = useRef<HTMLElement>(null);
 

--- a/libs/react-components/src/lib/filter-chip/filter-chip.tsx
+++ b/libs/react-components/src/lib/filter-chip/filter-chip.tsx
@@ -21,23 +21,32 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-filter-chip": WCProps & React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-filter-chip": WCProps &
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
 
 export interface GoabFilterChipProps extends Margins, DataAttributes {
-  onClick?: () => void;
-  iconTheme?: GoabFilterChipTheme;
-  error?: boolean;
+  /** @required Text label of the chip. */
   content: string;
+  /** Theme style of the leading icon. @default "outline" */
+  iconTheme?: GoabFilterChipTheme;
+  /** Shows an error state. */
+  error?: boolean;
+  /** Secondary text displayed in a smaller size before the main content. */
   secondaryText?: string;
+  /** Icon displayed at the start of the chip. */
   leadingIcon?: GoabIconType;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Callback fired when the filter chip is clicked to remove it. */
+  onClick?: () => void;
 }
 
+/** Allow the user to enter information, filter content, and make selections. */
 export const GoabFilterChip = ({
   iconTheme = "outline",
   error,

--- a/libs/react-components/src/lib/footer-meta-section/footer-meta-section.tsx
+++ b/libs/react-components/src/lib/footer-meta-section/footer-meta-section.tsx
@@ -17,10 +17,13 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabAppFooterMetaSectionProps extends DataAttributes {
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Anchor link elements rendered as footer meta navigation links. */
   children?: ReactNode;
 }
 
+/** Copyright and legal links in footer. */
 export function GoabAppFooterMetaSection({
   children,
   ...rest

--- a/libs/react-components/src/lib/footer-nav-section/footer-nav-section.tsx
+++ b/libs/react-components/src/lib/footer-nav-section/footer-nav-section.tsx
@@ -19,12 +19,17 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabFooterNavSectionProps extends DataAttributes {
-  maxColumnCount?: number;
+  /** The section heading displayed above the navigation links. */
   heading?: string;
+  /** Maximum number of columns to display links in on larger screens. @default 1 */
+  maxColumnCount?: number;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Anchor link elements rendered as footer navigation links. */
   children?: ReactNode;
 }
 
+/** Navigation links section in footer. */
 export function GoabAppFooterNavSection({
   children,
   ...rest

--- a/libs/react-components/src/lib/footer/footer.tsx
+++ b/libs/react-components/src/lib/footer/footer.tsx
@@ -20,12 +20,17 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabAppFooterProps extends DataAttributes {
+  /** The maximum width of the main content area. */
   maxContentWidth?: string;
-  children?: ReactNode;
-  testId?: string;
+  /** URL for the Government of Alberta logo link. Set to empty string to disable the link. @default "https://alberta.ca" */
   url?: string;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
+  /** Content rendered inside the footer, typically navigation and meta sections. */
+  children?: ReactNode;
 }
 
+/** Provides information related your service at the bottom of every page. */
 export function GoabAppFooter({ children, ...rest }: GoabAppFooterProps): JSX.Element {
   const _props = transformProps<WCProps>(rest, lowercase);
 

--- a/libs/react-components/src/lib/form-item/form-item.tsx
+++ b/libs/react-components/src/lib/form-item/form-item.tsx
@@ -2,7 +2,8 @@ import {
   GoabFormItemLabelSize,
   GoabFormItemRequirement,
   GoabFormItemType,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 
 import type { JSX } from "react";
@@ -33,26 +34,33 @@ declare module "react" {
 }
 
 export interface GoabFormItemProps extends Margins, DataAttributes {
+  /** Creates a label for the form item. */
   label?: string;
+  /** Sets the label size. 'regular' for standard, 'large' for emphasis. @default "regular" */
   labelSize?: GoabFormItemLabelSize;
+  /** Marks the field with an optional or required label indicator. */
   requirement?: GoabFormItemRequirement;
+  /** Error text displayed under the form field. Leave blank to indicate a valid field. Accepts a string or ReactNode for custom error content. */
   error?: string | React.ReactNode;
+  /** Help text displayed under the form field to provide additional explanation. Accepts a string or ReactNode for custom help content. */
   helpText?: string | React.ReactNode;
+  /** Sets the maximum width of the form item. @default "none" */
   maxWidth?: string;
+  /** Specifies the input type for appropriate message spacing. Used with checkbox-list or radio-group. */
   type?: GoabFormItemType;
-  /**
-   * Public form: to arrange fields in the summary
-   */
+  /** Sets the display order within the form summary. For public-form use only. */
   publicFormSummaryOrder?: number;
-  /**
-   * Public form: allow to override the label value within the form-summary to provide a shorter description of the value
-   */
+  /** Overrides the label value within the form-summary to provide a shorter description. For public-form use only. */
   name?: string;
+  /** Content rendered inside the form item, typically an input component. */
   children?: React.ReactNode;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Sets the id attribute on the form item element. */
   id?: string;
 }
 
+/** Wraps an input control with a text label, requirement label, helper text, and error text. */
 export function GoabFormItem({
   error,
   helpText,

--- a/libs/react-components/src/lib/form-step/form-step.tsx
+++ b/libs/react-components/src/lib/form-step/form-step.tsx
@@ -15,10 +15,13 @@ declare module "react" {
 }
 
 export interface GoabFormStepProps {
+  /** @required The step label text displayed to users. */
   text: string;
+  /** The completion status of the step. Affects visual styling and icons. */
   status?: GoabFormStepStatus;
 }
 
+/** Individual step in a multi-step form. */
 export function GoabFormStep(props: GoabFormStepProps) {
   return <goa-form-step text={props.text} status={props.status} />;
 }

--- a/libs/react-components/src/lib/form-stepper/form-stepper.tsx
+++ b/libs/react-components/src/lib/form-stepper/form-stepper.tsx
@@ -17,12 +17,17 @@ declare module "react" {
 }
 
 export interface GoabFormStepperProps extends Margins {
+  /** The current step state value (1-based index). Leaving it blank (-1) will allow any step to be accessed. */
   step?: number;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Content rendered inside the form stepper, typically GoabFormStep components. */
   children?: ReactNode;
+  /** Callback fired when the active step changes. */
   onChange?: (detail: GoabFormStepperOnChangeDetail) => void;
 }
 
+/** Provides a visual representation of a form through a series of steps. */
 export function GoabFormStepper({
   testId,
   step,

--- a/libs/react-components/src/lib/form/fieldset.tsx
+++ b/libs/react-components/src/lib/form/fieldset.tsx
@@ -16,21 +16,28 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-fieldset": WCProps & React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-fieldset": WCProps &
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
 
 interface GoabFieldsetProps extends DataAttributes {
-  id?: string;
-  sectionTitle?: string;
-  dispatchOn?: GoabFormDispatchOn;
-  onContinue?: (event: GoabFieldsetOnContinueDetail) => void;
+  /** Content rendered inside the fieldset. */
   children: ReactNode;
+  /** Sets the unique identifier for the fieldset. */
+  id?: string;
+  /** Sets the section title of the fieldset. */
+  sectionTitle?: string;
+  /** Sets when form field changes are dispatched to the form. @default "continue" */
+  dispatchOn?: GoabFormDispatchOn;
+  /** Callback fired when the fieldset continue action is triggered. */
+  onContinue?: (event: GoabFieldsetOnContinueDetail) => void;
 }
 
+/** Container for form inputs and validation. */
 export function GoabFieldset({
   onContinue,
   children,

--- a/libs/react-components/src/lib/form/public-form-page.tsx
+++ b/libs/react-components/src/lib/form/public-form-page.tsx
@@ -2,7 +2,8 @@ import { ReactNode, useEffect, useRef } from "react";
 import {
   GoabPublicFormPageButtonVisibility,
   GoabPublicFormPageStep,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 import { transformProps, kebab } from "../common/extract-props";
 
@@ -22,31 +23,40 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-public-form-page": WCProps & React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-public-form-page": WCProps &
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
 
 interface GoabPublicFormPageProps extends Margins, DataAttributes {
-  id?: string;
-  heading?: string;
-  subHeading?: string;
-  summaryHeading?: string;
-  sectionTitle?: string;
-  backUrl?: string;
-  type?: GoabPublicFormPageStep;
-  buttonText?: string;
-  buttonVisibility?: GoabPublicFormPageButtonVisibility;
-  /**
-   * Triggered when the form page continues to the next step
-   * @param event - The continue event details
-   */
-  onContinue?: (event: Event) => void;
+  /** Content rendered inside the form page. */
   children: ReactNode;
+  /** Sets the unique identifier for the form page. */
+  id?: string;
+  /** Sets the heading text displayed at the top of the form page. */
+  heading?: string;
+  /** Sets the subheading text displayed below the main heading. */
+  subHeading?: string;
+  /** Sets the heading text used when this page appears in the form summary. */
+  summaryHeading?: string;
+  /** Sets the section title displayed above the heading. */
+  sectionTitle?: string;
+  /** Sets the URL for the back navigation link. */
+  backUrl?: string;
+  /** Sets the type of the form page. @default "step" */
+  type?: GoabPublicFormPageStep;
+  /** Sets the text label for the continue or confirm button. */
+  buttonText?: string;
+  /** Sets the visibility of the continue button. @default "visible" */
+  buttonVisibility?: GoabPublicFormPageButtonVisibility;
+  /** Callback fired when the form page continues to the next step. */
+  onContinue?: (event: Event) => void;
 }
 
+/** Container for form inputs and validation. */
 export function GoabPublicFormPage({
   onContinue,
   children,

--- a/libs/react-components/src/lib/form/public-form-summary.tsx
+++ b/libs/react-components/src/lib/form/public-form-summary.tsx
@@ -15,21 +15,18 @@ declare module "react" {
 }
 
 interface GoabPublicFormSummaryProps extends DataAttributes {
+  /** Sets the heading text displayed above the form summary content. */
   heading?: string;
 }
 
+/** Container for form inputs and validation. */
 export function GoabPublicFormSummary({
   heading = "",
   ...rest
 }: GoabPublicFormSummaryProps) {
-  const _props = transformProps<WCProps>(
-    { heading, ...rest },
-    lowercase
-  );
+  const _props = transformProps<WCProps>({ heading, ...rest }, lowercase);
 
-  return (
-    <goa-public-form-summary {..._props} />
-  );
+  return <goa-public-form-summary {..._props} />;
 }
 
 export default GoabPublicFormSummary;

--- a/libs/react-components/src/lib/form/public-form.tsx
+++ b/libs/react-components/src/lib/form/public-form.tsx
@@ -16,22 +16,30 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-public-form": WCProps & React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-public-form": WCProps &
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
 
 interface GoabPublicFormProps extends DataAttributes {
-  status?: GoabPublicFormStatus;
-  name?: string;
-  onInit?: (event: Event) => void;
-  onComplete?: (event: GoabFormState) => void;
-  onStateChange?: (event: GoabFormState) => void;
+  /** Content rendered inside the public form. */
   children: ReactNode;
+  /** The initialization status of the form. Set to "initializing" while loading external state, then "complete" when ready. @default "complete" */
+  status?: GoabPublicFormStatus;
+  /** A name identifier for the form. Useful for debugging complex forms with multiple nested forms. */
+  name?: string;
+  /** Callback fired when the form is initialized. */
+  onInit?: (event: Event) => void;
+  /** Callback fired when the form is completed. */
+  onComplete?: (event: GoabFormState) => void;
+  /** Callback fired when the form state changes. */
+  onStateChange?: (event: GoabFormState) => void;
 }
 
+/** Container for form inputs and validation. */
 export function GoabPublicForm({
   onInit,
   onComplete,

--- a/libs/react-components/src/lib/form/public-subform-index.tsx
+++ b/libs/react-components/src/lib/form/public-subform-index.tsx
@@ -19,13 +19,19 @@ declare module "react" {
 }
 
 interface GoabPublicSubformIndexProps extends Margins, DataAttributes {
-  heading?: string;
-  sectionTitle?: string;
-  actionButtonText?: string;
-  buttonVisibility?: "visible" | "hidden";
+  /** Content rendered inside the subform index. */
   children: ReactNode;
+  /** Sets the heading text displayed at the top of the subform index page. */
+  heading?: string;
+  /** Sets the section title displayed above the heading. */
+  sectionTitle?: string;
+  /** Sets the text label for the action button that adds a new subform entry. */
+  actionButtonText?: string;
+  /** Sets the visibility of the action button. @default "hidden" */
+  buttonVisibility?: "visible" | "hidden";
 }
 
+/** Container for form inputs and validation. */
 export function GoabPublicSubformIndex({
   heading = "",
   sectionTitle = "",
@@ -35,8 +41,14 @@ export function GoabPublicSubformIndex({
   ...rest
 }: GoabPublicSubformIndexProps) {
   const _props = transformProps<WCProps>(
-    { heading, "section-title": sectionTitle, "action-button-text": actionButtonText, "button-visibility": buttonVisibility, ...rest },
-    kebab
+    {
+      heading,
+      "section-title": sectionTitle,
+      "action-button-text": actionButtonText,
+      "button-visibility": buttonVisibility,
+      ...rest,
+    },
+    kebab,
   );
 
   return (

--- a/libs/react-components/src/lib/form/public-subform.tsx
+++ b/libs/react-components/src/lib/form/public-subform.tsx
@@ -12,22 +12,30 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-public-subform": WCProps & React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-public-subform": WCProps &
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
 
 interface GoabPublicSubformProps extends Margins, DataAttributes {
-  id?: string;
-  name?: string;
-  continueMsg?: string;
-  onInit?: (event: Event) => void;
-  onStateChange?: (event: Event) => void;
+  /** Content rendered inside the subform. */
   children: ReactNode;
+  /** Sets the unique identifier for the subform. */
+  id?: string;
+  /** Sets the name identifier for the subform. */
+  name?: string;
+  /** Sets the message displayed on the continue button. */
+  continueMsg?: string;
+  /** Callback fired when the subform is initialized. */
+  onInit?: (event: Event) => void;
+  /** Callback fired when the subform state changes. */
+  onStateChange?: (event: Event) => void;
 }
 
+/** Container for form inputs and validation. */
 export function GoabPublicSubform({
   id = "",
   name = "",
@@ -41,7 +49,7 @@ export function GoabPublicSubform({
 
   const _props = transformProps<WCProps>(
     { id, name, "continue-msg": continueMsg, ...rest },
-    kebab
+    kebab,
   );
 
   useEffect(() => {

--- a/libs/react-components/src/lib/form/task-list.tsx
+++ b/libs/react-components/src/lib/form/task-list.tsx
@@ -16,21 +16,20 @@ declare module "react" {
 }
 
 interface GoabPublicFormTaskListProps extends Margins, DataAttributes {
-  heading?: string;
+  /** Content rendered inside the task list, typically GoabPublicFormTask items. */
   children: ReactNode;
+  /** Sets the heading text displayed above the task list. */
+  heading?: string;
 }
 
+/** Container for form inputs and validation. */
 export function GoabPublicFormTaskList({
   children,
   ...rest
 }: GoabPublicFormTaskListProps) {
   const _props = transformProps<WCProps>(rest, lowercase);
 
-  return (
-    <goa-public-form-task-list {..._props}>
-      {children}
-    </goa-public-form-task-list>
-  );
+  return <goa-public-form-task-list {..._props}>{children}</goa-public-form-task-list>;
 }
 
 export default GoabPublicFormTaskList;

--- a/libs/react-components/src/lib/form/task.tsx
+++ b/libs/react-components/src/lib/form/task.tsx
@@ -16,19 +16,19 @@ declare module "react" {
 }
 
 interface GoabPublicFormTaskProps extends DataAttributes {
-  status?: GoabPublicFormTaskStatus;
+  /** Content rendered inside the task item, typically the task name or description. */
   children: ReactNode;
+  /** Sets the status of the task, which determines the badge displayed. @default "cannot-start" */
+  status?: GoabPublicFormTaskStatus;
 }
 
+/** Container for form inputs and validation. */
 export function GoabPublicFormTask({
   status = "cannot-start",
   children,
   ...rest
 }: GoabPublicFormTaskProps) {
-  const _props = transformProps<WCProps>(
-    { status, ...rest },
-    lowercase
-  );
+  const _props = transformProps<WCProps>({ status, ...rest }, lowercase);
 
   return <goa-public-form-task {..._props}>{children}</goa-public-form-task>;
 }

--- a/libs/react-components/src/lib/grid/grid.tsx
+++ b/libs/react-components/src/lib/grid/grid.tsx
@@ -18,12 +18,17 @@ declare module "react" {
 }
 
 export interface GoabGridProps extends Margins {
-  gap?: Spacing;
+  /** @required Minimum width of the child elements. */
   minChildWidth: string;
+  /** Gap between child items. @default "m" */
+  gap?: Spacing;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Content rendered inside the grid layout. */
   children?: React.ReactNode;
 }
 
+/** Arrange a number of components into a responsive grid pattern. */
 export function GoabGrid({
   gap,
   minChildWidth,

--- a/libs/react-components/src/lib/hero-banner/hero-banner-actions.tsx
+++ b/libs/react-components/src/lib/hero-banner/hero-banner-actions.tsx
@@ -1,8 +1,10 @@
 import type { JSX } from "react";
 export type GoabHeroBannerActionsType = {
+  /** Content rendered inside the hero banner actions slot, typically buttons or links. */
   children?: React.ReactNode;
 };
 
+/** Displays action content in the hero banner actions area. */
 export function GoabHeroBannerActions({
   children,
 }: GoabHeroBannerActionsType): JSX.Element {

--- a/libs/react-components/src/lib/hero-banner/hero-banner.tsx
+++ b/libs/react-components/src/lib/hero-banner/hero-banner.tsx
@@ -19,16 +19,25 @@ declare module "react" {
 }
 
 export interface GoabHeroBannerProps {
+  /** @required Main heading text. */
   heading: string;
+  /** Background image url. */
   backgroundUrl?: string;
+  /** Minimum height of the hero banner. Defaults to 600px when a background image is provided. */
   minHeight?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Content rendered inside the hero banner body. */
   children?: React.ReactNode;
+  /** Maximum width of the content area. @default "100%" */
   maxContentWidth?: string;
+  /** Hero Banner background color when no background image is provided. @default "#f8f8f8" */
   backgroundColor?: string;
+  /** Text color within the hero banner. */
   textColor?: string;
 }
 
+/** A visual band of text, including an image and a call to action. */
 export function GoabHeroBanner({
   heading,
   backgroundUrl,

--- a/libs/react-components/src/lib/icon-button/icon-button.tsx
+++ b/libs/react-components/src/lib/icon-button/icon-button.tsx
@@ -2,7 +2,8 @@ import {
   GoabIconButtonVariant,
   GoabIconSize,
   GoabIconType,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 import { useEffect, useRef, type JSX, ReactNode } from "react";
 import { transformProps, lowercase } from "../common/extract-props";
@@ -24,28 +25,42 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-icon-button": WCProps & React.HTMLAttributes<HTMLButtonElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-icon-button": WCProps &
+        React.HTMLAttributes<HTMLButtonElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
 
 export interface GoabIconButtonProps extends Margins, DataAttributes {
+  /** @required Sets the icon. */
   icon: GoabIconType;
+  /** Sets the size of button. @default "medium" */
   size?: GoabIconSize;
+  /** Styles the button to show color, light, dark or destructive action. @default "color" */
   variant?: GoabIconButtonVariant;
+  /** Sets the title of the button. */
   title?: string;
+  /** Disables the button. */
   disabled?: boolean;
+  /** Callback fired when the icon button is clicked. */
   onClick?: () => void;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Sets the aria-label of the button. */
   ariaLabel?: string;
+  /** Action identifier passed in click events for event delegation patterns. */
   action?: string;
+  /** Multiple argument values passed with the action in click events. */
   actionArgs?: Record<string, unknown>;
+  /** Single argument value passed with the action in click events. */
   actionArg?: string;
+  /** Content rendered inside the icon button. */
   children?: ReactNode;
 }
 
+/** A compact button with an icon and no text. */
 export function GoabIconButton({
   variant = "color",
   size = "medium",
@@ -58,10 +73,7 @@ export function GoabIconButton({
 }: GoabIconButtonProps): JSX.Element {
   const ref = useRef<HTMLElement>(null);
 
-  const _props = transformProps<WCProps>(
-    { variant, size, ...rest },
-    lowercase
-  );
+  const _props = transformProps<WCProps>({ variant, size, ...rest }, lowercase);
 
   useEffect(() => {
     if (!ref.current) {

--- a/libs/react-components/src/lib/icon/icon.tsx
+++ b/libs/react-components/src/lib/icon/icon.tsx
@@ -3,7 +3,8 @@ import {
   GoabIconSize,
   GoabIconTheme,
   GoabIconType,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 
 import type { JSX } from "react";
@@ -22,14 +23,23 @@ declare module "react" {
 }
 
 export interface GoabIconProps extends Margins, DataAttributes {
+  /** @required The icon type to display. See GoabIconType for available icons. */
   type: GoabIconType | GoabIconOverridesType;
+  /** Sets the size of the icon. Accepts numeric (1-6) or named sizes. @default "medium" */
   size?: GoabIconSize;
+  /** Sets the icon theme. 'outline' shows stroked icons, 'filled' shows solid icons. @default "outline" */
   theme?: GoabIconTheme;
+  /** When true, inverts the icon colors for use on dark backgrounds. */
   inverted?: string | boolean; // TODO: Change type to only boolean
+  /** Sets a custom fill color for the icon. Accepts any valid CSS color value. */
   fillColor?: string;
+  /** Sets the opacity of the icon from 0 (transparent) to 1 (opaque). @default 1 */
   opacity?: number;
+  /** Adds an accessible title to the icon SVG. Used by screen readers. */
   title?: string;
+  /** Defines how the icon will be announced by screen readers. */
   ariaLabel?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
@@ -45,10 +55,8 @@ interface WCProps extends Margins {
   testid?: string;
 }
 
-export function GoabIcon({
-  inverted,
-  ...rest
-}: GoabIconProps): JSX.Element {
+/** A simple and universal graphic symbol representing an action, object, or concept to help guide the user. */
+export function GoabIcon({ inverted, ...rest }: GoabIconProps): JSX.Element {
   const _props = transformProps<WCProps>(rest, lowercase);
 
   return (

--- a/libs/react-components/src/lib/input/input.tsx
+++ b/libs/react-components/src/lib/input/input.tsx
@@ -10,13 +10,10 @@ import {
   GoabInputOnKeyPressDetail,
   GoabInputSize,
   GoabInputType,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 import { transformProps, lowercase } from "../common/extract-props";
-
-export interface IgnoreMe {
-  ignore: string;
-}
 
 interface WCProps extends Margins {
   type?: GoabInputType;
@@ -57,41 +54,65 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-input": WCProps & React.HTMLAttributes<HTMLInputElement> & {
-        ref?: React.RefObject<HTMLInputElement | null>;
-      };
+      "goa-input": WCProps &
+        React.HTMLAttributes<HTMLInputElement> & {
+          ref?: React.RefObject<HTMLInputElement | null>;
+        };
     }
   }
 }
 
 interface BaseProps extends Margins, DataAttributes {
-  // required
+  /** Name of input value that is received in event detail payloads. */
   name: string;
 
-  // optional
+  /** Sets the id attribute of the input element. */
   id?: string;
+  /** Debounce delay in milliseconds before firing the change event. 0 means no debounce. */
   debounce?: number;
+  /** Sets the input disabled state. */
   disabled?: boolean;
+  /** Controls automatic capitalization behavior on supported mobile browsers. */
   autoCapitalize?: GoabAutoCapitalize;
+  /** Sets the autocomplete attribute for the input element. */
   autoComplete?: string;
+  /** Sets placeholder text when the input is empty. */
   placeholder?: string;
+  /** Sets the icon shown before the value. */
   leadingIcon?: GoabIconType;
+  /** Sets the icon shown after the value. */
   trailingIcon?: GoabIconType;
+  /** Callback fired when the trailing icon is clicked. */
   onTrailingIconClick?: () => void;
+  /** Sets the visual style variant. @default "goa" */
   variant?: "goa" | "bare";
+  /** Sets focus on initial render or controlled updates. */
   focused?: boolean;
+  /** Sets the readonly state. */
   readonly?: boolean;
+  /** Sets the error state styling. */
   error?: boolean;
+  /** Sets the width of the input field. */
   width?: string;
+  /** @deprecated Use leadingContent instead. */
   prefix?: string;
+  /** @deprecated Use trailingContent instead. */
   suffix?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Sets the aria-label used by assistive technologies. */
   ariaLabel?: string;
+  /** Sets content in the leading slot. */
   leadingContent?: React.ReactNode;
+  /** Sets content in the trailing slot. */
   trailingContent?: React.ReactNode;
+  /** Sets the maximum number of characters. */
   maxLength?: number;
+  /** Sets the aria-label for an interactive trailing icon. */
   trailingIconAriaLabel?: string;
+  /** Sets text alignment. @default "left" */
   textAlign?: "left" | "right";
+  /** Sets the input size. @default "default" */
   size?: GoabInputSize;
 }
 
@@ -101,13 +122,21 @@ type OnBlur<T = string> = (detail: GoabInputOnBlurDetail<T>) => void;
 type OnKeyPress<T = string> = (detail: GoabInputOnKeyPressDetail<T>) => void;
 
 export interface GoabInputProps extends BaseProps {
+  /** Callback fired when the input value changes. Receives GoabInputOnChangeDetail. */
   onChange?: OnChange<string>;
+  /** Bound to the current value of the input field. */
   value?: string;
+  /** Minimum value. Supports any number, or ISO 8601 format for date/datetime types. */
   min?: number | string;
+  /** Maximum value. Supports any number, or ISO 8601 format for date/datetime types. */
   max?: number | string;
+  /** How much a number or date value should change by. @default 1 */
   step?: number;
+  /** Callback fired when the input receives focus. Receives GoabInputOnFocusDetail. */
   onFocus?: OnFocus<string>;
+  /** Callback fired when the input loses focus. Receives GoabInputOnBlurDetail. */
   onBlur?: OnBlur<string>;
+  /** Callback fired when a key is pressed in the input. Receives GoabInputOnKeyPressDetail. */
   onKeyPress?: OnKeyPress<string>;
 }
 
@@ -133,6 +162,7 @@ interface GoabDateInputProps extends BaseProps {
   onKeyPress?: OnKeyPress<GoabDate>;
 }
 
+/** A single-line field where users can input and edit text. */
 export function GoabInput({
   variant = "goa",
   textAlign = "left",
@@ -259,14 +289,17 @@ function toString(value: GoabDate | null | undefined, tmpl = "yyyy-MM-dd"): stri
   return format(value, tmpl);
 }
 
+/** A single-line field where users can input and edit text. */
 export function GoabInputText(props: GoabInputProps): JSX.Element {
   return <GoabInput {...props} type="text" />;
 }
 
+/** A single-line field where users can enter masked password text. */
 export function GoabInputPassword(props: GoabInputProps): JSX.Element {
   return <GoabInput {...props} type="password" />;
 }
 
+/** A single-line field where users can enter or select a date. */
 export function GoabInputDate({
   value,
   min = "",
@@ -285,6 +318,7 @@ export function GoabInputDate({
   );
 }
 
+/** A single-line field where users can enter or select a time. */
 export function GoabInputTime({
   value,
   min = "",
@@ -301,6 +335,7 @@ export function GoabInputTime({
   );
 }
 
+/** A single-line field where users can enter a date and time. */
 export function GoabInputDateTime({
   value,
   min = "",
@@ -317,22 +352,27 @@ export function GoabInputDateTime({
   );
 }
 
+/** A single-line field where users can enter an email address. */
 export function GoabInputEmail(props: GoabInputProps): JSX.Element {
   return <GoabInput {...props} type="email" />;
 }
 
+/** A single-line field where users can enter search terms. */
 export function GoabInputSearch(props: GoabInputProps): JSX.Element {
   return <GoabInput {...props} type="search" trailingIcon="search" />;
 }
 
+/** A single-line field where users can enter a URL. */
 export function GoabInputUrl(props: GoabInputProps): JSX.Element {
   return <GoabInput {...props} type="url" />;
 }
 
+/** A single-line field where users can enter a phone number. */
 export function GoabInputTel(props: GoabInputProps): JSX.Element {
   return <GoabInput {...props} type="tel" />;
 }
 
+/** A control that allows users to select a file for upload. */
 export function GoabInputFile(props: GoabInputProps): JSX.Element {
   return (
     <input
@@ -351,10 +391,12 @@ export function GoabInputFile(props: GoabInputProps): JSX.Element {
   );
 }
 
+/** A single-line field where users can enter or select a month. */
 export function GoabInputMonth(props: GoabInputProps): JSX.Element {
   return <GoabInput {...props} type="month" />;
 }
 
+/** A single-line field where users can input and edit numeric values. */
 export function GoabInputNumber({
   min = Number.MIN_VALUE,
   max = Number.MAX_VALUE,
@@ -390,6 +432,7 @@ export function GoabInputNumber({
   );
 }
 
+/** A range input where users can choose a numeric value within minimum and maximum limits. */
 export function GoabInputRange(props: GoabInputProps): JSX.Element {
   return <GoabInput {...props} type="range" />;
 }

--- a/libs/react-components/src/lib/linear-progress/linear-progress.tsx
+++ b/libs/react-components/src/lib/linear-progress/linear-progress.tsx
@@ -16,13 +16,19 @@ declare module "react" {
 }
 
 export interface GoabLinearProgressProps {
+  /** Progress value (0-100). When undefined, shows an indeterminate loading animation. */
   progress?: number | null;
+  /** Controls visibility of the percentage text. @default "visible" */
   percentVisibility?: "visible" | "hidden" | undefined;
+  /** Accessible label for the progress bar. */
   ariaLabel?: string;
+  /** ID of the element that labels this progress bar. */
   ariaLabelledBy?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
+/** Provide visual feedback to users while loading. */
 export const GoabLinearProgress = ({
   progress,
   percentVisibility,

--- a/libs/react-components/src/lib/link/link.tsx
+++ b/libs/react-components/src/lib/link/link.tsx
@@ -29,17 +29,27 @@ declare module "react" {
 }
 
 export interface GoabLinkProps extends Margins, DataAttributes {
-  leadingIcon?: GoabIconType;
-  trailingIcon?: GoabIconType;
-  action?: string;
-  actionArgs?: Record<string, unknown>;
-  actionArg?: string;
-  color?: GoabLinkColor;
-  size?: GoabLinkSize;
-  testId?: string;
+  /** @required Content rendered inside the link. */
   children: ReactNode;
+  /** Icon displayed before the link text. */
+  leadingIcon?: GoabIconType;
+  /** Icon displayed after the link text. */
+  trailingIcon?: GoabIconType;
+  /** Custom action event name to dispatch when the link is clicked. */
+  action?: string;
+  /** Object of arguments to pass with the action event. */
+  actionArgs?: Record<string, unknown>;
+  /** Single argument to pass with the action event. Deprecated, use actionArgs instead. */
+  actionArg?: string;
+  /** Sets the color theme. 'interactive' for blue, 'dark' for black, 'light' for white text. @default "interactive" */
+  color?: GoabLinkColor;
+  /** Sets the text size and corresponding icon size. @default "medium" */
+  size?: GoabLinkSize;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
 }
 
+/** Wraps an anchor element to add icons or margins. */
 export function GoabLink({
   actionArgs,
   actionArg,
@@ -51,11 +61,7 @@ export function GoabLink({
   const _props = transformProps<WCProps>({ color, size, ...rest }, lowercase);
 
   return (
-    <goa-link
-      action-arg={actionArg}
-      action-args={JSON.stringify(actionArgs)}
-      {..._props}
-    >
+    <goa-link action-arg={actionArg} action-args={JSON.stringify(actionArgs)} {..._props}>
       {children}
     </goa-link>
   );

--- a/libs/react-components/src/lib/menu-button/menu-action.tsx
+++ b/libs/react-components/src/lib/menu-button/menu-action.tsx
@@ -18,20 +18,22 @@ declare module "react" {
   }
 }
 
-
 export interface GoabMenuActionProps extends DataAttributes {
+  /** @required Display text for the menu action. */
   text: string;
+  /** @required Action identifier included in the click event. */
   action: string;
+  /** Icon displayed before the text. */
   icon?: GoabIconType;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
+/** Individual action item within a menu button. */
 export function GoabMenuAction(props: GoabMenuActionProps): JSX.Element {
   const _props = transformProps<WCProps>(props, lowercase);
 
-  return (
-    <goa-menu-action {..._props}></goa-menu-action>
-  );
+  return <goa-menu-action {..._props}></goa-menu-action>;
 }
 
 export default GoabMenuAction;

--- a/libs/react-components/src/lib/menu-button/menu-button.tsx
+++ b/libs/react-components/src/lib/menu-button/menu-button.tsx
@@ -1,4 +1,11 @@
-import { DataAttributes, GoabButtonSize, GoabButtonType, GoabButtonVariant, GoabIconType, GoabMenuButtonOnActionDetail } from "@abgov/ui-components-common";
+import {
+  DataAttributes,
+  GoabButtonSize,
+  GoabButtonType,
+  GoabButtonVariant,
+  GoabIconType,
+  GoabMenuButtonOnActionDetail,
+} from "@abgov/ui-components-common";
 import { ReactNode, type JSX, useRef, useEffect } from "react";
 import { transformProps, kebab } from "../common/extract-props";
 
@@ -24,18 +31,29 @@ declare module "react" {
 }
 
 export interface GoabMenuButtonProps extends DataAttributes {
+  /** The button label text. When provided, displays as a text button with a dropdown icon. */
   text?: string;
+  /** The button style variant. @default "primary" */
   type?: GoabButtonType;
+  /** Sets the size of the button. @default "normal" */
   size?: GoabButtonSize;
+  /** Sets the color variant for semantic meaning. @default "normal" */
   variant?: GoabButtonVariant;
+  /** Maximum width of the dropdown menu. */
   maxWidth?: string;
+  /** Icon displayed before the button text. When no text is provided, displays as an icon button. */
   leadingIcon?: GoabIconType;
+  /** Sets the aria-label for the icon button in icon-only mode. @default "Open menu" */
   ariaLabel?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Callback fired when a menu action is selected. */
   onAction?: (detail: GoabMenuButtonOnActionDetail) => void;
+  /** Content rendered inside the menu button, typically GoabMenuAction items. */
   children?: ReactNode;
 }
 
+/** A button with more than one action. */
 export function GoabMenuButton({
   type = "primary",
   testId,
@@ -45,10 +63,7 @@ export function GoabMenuButton({
 }: GoabMenuButtonProps): JSX.Element {
   const el = useRef<HTMLElement>(null);
 
-  const _props = transformProps<WCProps>(
-    { type, testid: testId, ...rest },
-    kebab
-  );
+  const _props = transformProps<WCProps>({ type, testid: testId, ...rest }, kebab);
 
   useEffect(() => {
     if (!el.current) {

--- a/libs/react-components/src/lib/microsite-header/microsite-header.tsx
+++ b/libs/react-components/src/lib/microsite-header/microsite-header.tsx
@@ -24,16 +24,25 @@ interface WCProps {
 }
 
 export interface GoabHeaderProps {
+  /** @required The service type which determines the badge style. "live" shows official government site text, "alpha" and "beta" show development stage badges. */
   type: GoabServiceLevel;
+  /** App or service version displayed on the right side of the header. Accepts a string or custom ReactNode for rich content. */
   version?: string | React.ReactNode;
+  /** URL to a feedback page displayed when provided. */
   feedbackUrl?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Maximum width of the content area. @default "100%" */
   maxContentWidth?: string;
+  /** Sets the target attribute for the feedback URL link. @default "blank" */
   feedbackUrlTarget?: GoabLinkTarget;
+  /** Sets the target attribute for the header link. @default "blank" */
   headerUrlTarget?: GoabLinkTarget;
+  /** Callback fired when the feedback link is clicked, enables custom feedback handling. */
   onFeedbackClick?: () => void;
 }
 
+/** Communicate what stage the service is at, connect to Alberta.ca, and gather feedback on your service. */
 export function GoabMicrositeHeader({
   type,
   version,

--- a/libs/react-components/src/lib/modal/modal.tsx
+++ b/libs/react-components/src/lib/modal/modal.tsx
@@ -32,14 +32,23 @@ declare module "react" {
 }
 
 export interface GoabModalProps {
+  /** The heading text displayed at the top of the modal. */
   heading?: ReactNode;
+  /** Set the max allowed width of the modal. @default "60ch" */
   maxWidth?: string;
+  /** Content rendered in the modal's actions slot, typically action buttons. */
   actions?: ReactElement<any>;
+  /** Callback fired when the modal is closed. When provided, enables the close button and backdrop click-to-close behavior. */
   onClose?: () => void;
+  /** Sets the animation transition when opening/closing. 'fast' or 'slow' for animated, 'none' for instant. */
   transition?: GoabModalTransition;
+  /** Content rendered inside the modal body. */
   children?: ReactNode;
+  /** Controls if the modal is visible or not. */
   open?: boolean;
+  /** Sets the context and colour of the callout modal. Required when used as a callout type. */
   calloutVariant?: GoabModalCalloutVariant;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
   /**
    * @deprecated The role property is deprecated and will be removed in a future version.
@@ -48,6 +57,7 @@ export interface GoabModalProps {
   role?: GoabModalRole;
 }
 
+/** An overlay that appears in front of all other content, and requires a user to take an action before continuing. */
 export function GoabModal({
   heading,
   children,

--- a/libs/react-components/src/lib/notification/notification.tsx
+++ b/libs/react-components/src/lib/notification/notification.tsx
@@ -26,16 +26,25 @@ declare module "react" {
 }
 
 export interface GoabNotificationProps {
+  /** Define the context and colour of the notification. */
   type?: GoabNotificationType;
+  /** Indicates how assistive technology should handle updates to the live region. @default "polite" */
   ariaLive?: GoabAriaLiveType;
+  /** Maximum width of the content area. @default "100%" */
   maxContentWidth?: string;
+  /** Sets the visual prominence. 'high' for full background, 'low' for a bordered style. @default "high" */
   emphasis?: GoabNotificationEmphasis;
+  /** When true, reduces padding for a more compact notification. */
   compact?: boolean;
+  /** Content rendered inside the notification. */
   children?: React.ReactNode;
+  /** Callback fired when the notification is dismissed. */
   onDismiss?: () => void;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
+/** Display important page level information or notifications. */
 export const GoabNotification = ({
   type = "information",
   emphasis = "high",

--- a/libs/react-components/src/lib/one-column-layout/one-column-layout.tsx
+++ b/libs/react-components/src/lib/one-column-layout/one-column-layout.tsx
@@ -10,11 +10,13 @@ declare module "react" {
 }
 
 export interface GoabPageProps {
+  /** Content rendered inside the one-column layout. */
   children?: ReactNode;
 }
 
 export type PageProps = GoabPageProps;
 
+/** Organizes page content in a single responsive column. */
 export function GoabOneColumnLayout(props: GoabPageProps): JSX.Element {
   return <goa-one-column-layout>{props.children}</goa-one-column-layout>;
 }

--- a/libs/react-components/src/lib/page-block/page-block.tsx
+++ b/libs/react-components/src/lib/page-block/page-block.tsx
@@ -16,14 +16,18 @@ declare module "react" {
 }
 
 export interface GoabPageBlockProps {
+  /** Maximum width of the content area. Use "full" for 100% width or a CSS dimension like "1200px". @default "full" */
   width?: GoabPageBlockSize;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Content rendered inside the page block. */
   children?: ReactNode;
 }
 
 // legacy name
 export type PageBlockProps = GoabPageBlockProps;
 
+/** Full-width section with optional background. */
 export function GoabPageBlock(props: PageBlockProps): JSX.Element {
   return (
     <goa-page-block width={props.width} testid={props.testId}>

--- a/libs/react-components/src/lib/pages/pages.tsx
+++ b/libs/react-components/src/lib/pages/pages.tsx
@@ -16,10 +16,13 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabPagesProps extends Margins {
+  /** The currently visible page (1-based index). @default 1 */
   current?: number;
+  /** Page content to show or hide based on the current page index. */
   children?: ReactNode;
 }
 
+/** Container for paginated content views. */
 export function GoabPages(props: GoabPagesProps): JSX.Element {
   return (
     <goa-pages

--- a/libs/react-components/src/lib/pagination/pagination.tsx
+++ b/libs/react-components/src/lib/pagination/pagination.tsx
@@ -22,17 +22,24 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabPaginationProps extends Margins {
+  /** @required Total number of data items within all pages. */
   itemCount: number;
-  perPageCount?: number;
+  /** @required The current page being viewed (non-zero based). */
   pageNumber: number;
-  variant?: "all" | "links-only";
+  /** @required Callback fired when the user navigates to a different page. */
   onChange: (detail: GoabPaginationOnChangeDetail) => void;
+  /** Number of data items shown per page. @default 10 */
+  perPageCount?: number;
+  /** Controls which nav controls are visible. @default "all" */
+  variant?: "all" | "links-only";
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
 // legacy
 export type PaginationProps = GoabPaginationProps;
 
+/** Help users navigation between multiple pages or screens as part of a set. */
 export function GoabPagination({ onChange, ...props }: GoabPaginationProps) {
   const ref = useRef<HTMLElement>(null);
 

--- a/libs/react-components/src/lib/popover/popover.tsx
+++ b/libs/react-components/src/lib/popover/popover.tsx
@@ -1,4 +1,8 @@
-import { DataAttributes, GoabPopoverPosition, Margins } from "@abgov/ui-components-common";
+import {
+  DataAttributes,
+  GoabPopoverPosition,
+  Margins,
+} from "@abgov/ui-components-common";
 import { ReactNode, type JSX } from "react";
 import { transformProps, lowercase } from "../common/extract-props";
 
@@ -21,19 +25,25 @@ declare module "react" {
 }
 
 export interface GoabPopoverProps extends Margins, DataAttributes {
-  target?: ReactNode;
-  testId?: string;
-  maxWidth?: string;
-  minWidth?: string;
-  padded?: boolean;
-  position?: GoabPopoverPosition;
+  /** Content rendered inside the popover body. */
   children: ReactNode;
-  /***
-   * @deprecated This property has no effect and will be removed in a future version
-   */
+  /** @required Sets the element used as the popover trigger. */
+  target: ReactNode;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
+  /** Sets the maximum width of the popover container. @default "320px" */
+  maxWidth?: string;
+  /** Sets the minimum width of the popover container. */
+  minWidth?: string;
+  /** Sets if the popover has padding. Use false when content needs to be flush with boundaries. @default true */
+  padded?: boolean;
+  /** Provides control to where the popover content is positioned. @default "auto" */
+  position?: GoabPopoverPosition;
+  /** @deprecated This property has no effect and will be removed in a future version. */
   relative?: boolean;
 }
 
+/** A small overlay that opens on demand, used in other components. */
 export function GoabPopover({
   target,
   padded,

--- a/libs/react-components/src/lib/push-drawer/push-drawer.tsx
+++ b/libs/react-components/src/lib/push-drawer/push-drawer.tsx
@@ -19,15 +19,23 @@ declare module "react" {
 }
 
 export interface GoabPushDrawerProps {
-  open?: boolean;
-  heading?: string | ReactNode;
-  width?: string;
-  testId?: string;
-  actions?: ReactNode;
+  /** @required Content rendered inside the push drawer body. */
   children: ReactNode;
+  /** @required Callback fired when the push drawer is closed. */
   onClose: () => void;
+  /** Controls the open/closed state of the push drawer. */
+  open?: boolean;
+  /** Sets the heading text or custom heading content. */
+  heading?: string | ReactNode;
+  /** Sets the width of the push drawer panel. @default "492px" */
+  width?: string;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
+  /** Content rendered in the actions slot, typically action buttons. */
+  actions?: ReactNode;
 }
 
+/** A panel that pushes the main page content aside on desktop, falling back to an overlay drawer on smaller screens. */
 export function GoabPushDrawer({
   open,
   heading,

--- a/libs/react-components/src/lib/radio-group/radio-group.tsx
+++ b/libs/react-components/src/lib/radio-group/radio-group.tsx
@@ -3,7 +3,8 @@ import {
   GoabRadioGroupOnChangeDetail,
   GoabRadioGroupOrientation,
   GoabRadioGroupSize,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 import { transformProps, lowercase } from "../common/extract-props";
 
@@ -26,27 +27,40 @@ declare module "react" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
     interface IntrinsicElements {
-      "goa-radio-group": WCProps & React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+      "goa-radio-group": WCProps &
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
 
 export interface GoabRadioGroupProps extends Margins, DataAttributes {
+  /** @required The name for the radio group. Used for accessibility and change events. */
   name: string;
+  /** The currently selected value in the radio group. */
   value?: string;
+  /** The identifier for the radio group element. */
   id?: string;
+  /** Disables all radio items in the group. */
   disabled?: boolean;
+  /** Sets the layout direction. 'vertical' stacks items, 'horizontal' places them in a row. @default "vertical" */
   orientation?: GoabRadioGroupOrientation;
+  /** Sets the size of all radio items. 'compact' reduces spacing for dense layouts. @default "default" */
   size?: GoabRadioGroupSize;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Shows an error state on all radio items in the group. */
   error?: boolean;
+  /** Defines how the radio group will be announced by screen readers. */
   ariaLabel?: string;
+  /** Radio items to render inside the group. */
   children?: React.ReactNode;
+  /** Callback fired when the selected radio item changes. */
   onChange?: (detail: GoabRadioGroupOnChangeDetail) => void;
 }
 
+/** Allow users to select one option from a set. */
 export function GoabRadioGroup({
   disabled,
   error,

--- a/libs/react-components/src/lib/radio-group/radio.tsx
+++ b/libs/react-components/src/lib/radio-group/radio.tsx
@@ -28,21 +28,35 @@ declare module "react" {
 }
 
 export interface GoabRadioItemProps extends Margins {
+  /** The value of this radio option. Will be emitted when selected. */
   value?: string;
+  /** The display label for this radio option. Falls back to value if not provided. */
   label?: string;
+  /** The name of the radio group. Inherited from the parent RadioGroup if not set. */
   name?: string;
+  /** Additional description text displayed below the label. */
   description?: string | React.ReactNode;
+  /** Content revealed below the radio option when it is selected. */
   reveal?: React.ReactNode;
+  /** Text announced by screen readers when the reveal content is displayed. */
   revealAriaLabel?: string;
+  /** Sets the maximum width of this radio item. */
   maxWidth?: string;
+  /** Disables this radio option. Also disabled if the parent RadioGroup is disabled. */
   disabled?: boolean;
+  /** Sets this radio option as checked/selected. */
   checked?: boolean;
+  /** Shows an error state on this radio option. */
   error?: boolean;
+  /** Reduces spacing for dense layouts. */
   compact?: boolean;
+  /** Additional content rendered inside the radio item. */
   children?: React.ReactNode;
+  /** Defines how this option will be announced by screen readers. */
   ariaLabel?: string;
 }
 
+/** Individual radio option within a group. */
 export function GoabRadioItem({
   name,
   label,

--- a/libs/react-components/src/lib/side-menu-group/side-menu-group.tsx
+++ b/libs/react-components/src/lib/side-menu-group/side-menu-group.tsx
@@ -19,12 +19,17 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabSideMenuGroupProps extends Margins {
+  /** @required The heading text for the menu group. */
   heading: string;
+  /** Icon displayed alongside the heading. */
   icon?: GoabIconType;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Navigation links rendered inside the menu group. */
   children?: ReactNode;
 }
 
+/** Group of related side menu items. */
 export function GoabSideMenuGroup({
   heading,
   icon,

--- a/libs/react-components/src/lib/side-menu-heading/side-menu-heading.tsx
+++ b/libs/react-components/src/lib/side-menu-heading/side-menu-heading.tsx
@@ -18,13 +18,23 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabSideMenuHeadingProps {
-  meta?: ReactNode;
-  testId?: string;
+  /** Icon displayed before the heading text. */
   icon?: GoabIconType;
+  /** Content rendered in the meta slot, displayed alongside the heading. */
+  meta?: ReactNode;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
+  /** The heading text or content rendered inside the side menu heading. */
   children?: ReactNode;
 }
 
-export function GoabSideMenuHeading({ meta, testId, icon, children }: GoabSideMenuHeadingProps) {
+/** Section heading in side menu. */
+export function GoabSideMenuHeading({
+  meta,
+  testId,
+  icon,
+  children,
+}: GoabSideMenuHeadingProps) {
   return (
     <goa-side-menu-heading icon={icon} testid={testId} version="2">
       {children}

--- a/libs/react-components/src/lib/side-menu/side-menu.tsx
+++ b/libs/react-components/src/lib/side-menu/side-menu.tsx
@@ -16,10 +16,13 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabSideMenuProps {
-  testId?: string;
+  /** @required Navigation links and groups rendered inside the side menu. */
   children: ReactNode;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
 }
 
+/** A side navigation that helps the user navigate between pages. */
 export function GoabSideMenu({ testId, children }: GoabSideMenuProps): JSX.Element {
   return (
     <goa-side-menu testid={testId} version="2">

--- a/libs/react-components/src/lib/skeleton/skeleton.tsx
+++ b/libs/react-components/src/lib/skeleton/skeleton.tsx
@@ -18,16 +18,22 @@ declare module "react" {
 }
 
 export interface GoabSkeletonProps extends Margins {
-  maxWidth?: string;
-  size?: GoabSkeletonSize;
-  lineCount?: number;
+  /** @required Sets the skeleton shape to represent your content. */
   type: GoabSkeletonType;
+  /** Sets the maximum width. Currently only used in card skeleton type. @default "300px" */
+  maxWidth?: string;
+  /** Size can affect either the height, width or both for different skeleton types. @default "1" */
+  size?: GoabSkeletonSize;
+  /** Used within components that contain multiple lines. Currently only used in card skeleton type. @default 3 */
+  lineCount?: number;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
 // legacy name
 export type SkeletonProps = GoabSkeletonProps;
 
+/** Provide visual feedback to users while loading a content heavy page or page element. */
 export const GoabSkeleton = ({
   maxWidth,
   size,

--- a/libs/react-components/src/lib/spacer/spacer.tsx
+++ b/libs/react-components/src/lib/spacer/spacer.tsx
@@ -21,11 +21,15 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabSpacerProps {
+  /** Horizontal spacing. @default "none" */
   hSpacing?: GoabSpacerHorizontalSpacing;
+  /** Vertical spacing. @default "none" */
   vSpacing?: GoabSpacerVerticalSpacing;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
+/** Negative area between the components and the interface. */
 export function GoabSpacer(props: GoabSpacerProps) {
   return (
     <goa-spacer

--- a/libs/react-components/src/lib/spinner/spinner.tsx
+++ b/libs/react-components/src/lib/spinner/spinner.tsx
@@ -20,15 +20,21 @@ declare module "react" {
 }
 
 export interface GoabSpinnerProps {
+  /** @required Sets the spinner animation type. */
   type: GoabSpinnerType;
+  /** @required Sets the size of the spinner. */
   size: GoabSpinnerSize;
+  /** When true, inverts colors for use on dark backgrounds. */
   invert?: boolean;
+  /** Progress value (0-100). When set to 0 or greater, shows a progress spinner instead of infinite. */
   progress?: number;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
 export type SpinnerProps = GoabSpinnerProps;
 
+/** Loading indicator for async operations. */
 export function GoabSpinner({
   type,
   size,

--- a/libs/react-components/src/lib/tab/tab.tsx
+++ b/libs/react-components/src/lib/tab/tab.tsx
@@ -16,13 +16,23 @@ declare module "react" {
 }
 
 export interface GoabTabItemProps {
+  /** The text label for this tab. Can also pass React nodes for custom heading content. */
   heading?: React.ReactNode;
+  /** When true, disables the tab so it cannot be selected. */
   disabled?: boolean;
+  /** Content rendered inside the tab panel. */
   children?: React.ReactNode;
+  /** URL-friendly identifier for the tab, used for hash-based navigation. */
   slug?: string;
 }
 
-export function GoabTab({ heading, disabled, slug, children }: GoabTabItemProps): JSX.Element {
+/** Individual tab within a tabs component. */
+export function GoabTab({
+  heading,
+  disabled,
+  slug,
+  children,
+}: GoabTabItemProps): JSX.Element {
   return (
     <goa-tab
       slug={slug}

--- a/libs/react-components/src/lib/table/table-sort-header.tsx
+++ b/libs/react-components/src/lib/table/table-sort-header.tsx
@@ -1,4 +1,8 @@
-import { DataAttributes, GoabTableSortDirection, GoabTableSortOrder } from "@abgov/ui-components-common";
+import {
+  DataAttributes,
+  GoabTableSortDirection,
+  GoabTableSortOrder,
+} from "@abgov/ui-components-common";
 
 import type { JSX } from "react";
 
@@ -19,12 +23,17 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabTableSortProps extends DataAttributes {
+  /** Column name identifier for sorting. */
   name?: string;
+  /** Sets the sort direction indicator. @default "none" */
   direction?: GoabTableSortDirection;
+  /** Sort order number for multi-column sort display. Used for displaying priority numbers when multiple columns are sorted. */
   sortOrder?: GoabTableSortOrder;
+  /** Content rendered inside the sort header button (typically the column heading text). */
   children?: React.ReactNode;
 }
 
+/** A set of structured data that is easy for a user to scan, examine, and compare. */
 export function GoabTableSortHeader({
   name,
   direction = "none",
@@ -33,7 +42,12 @@ export function GoabTableSortHeader({
   ...rest
 }: GoabTableSortProps): JSX.Element {
   return (
-    <goa-table-sort-header name={name} direction={direction} sort-order={sortOrder} {...rest}>
+    <goa-table-sort-header
+      name={name}
+      direction={direction}
+      sort-order={sortOrder}
+      {...rest}
+    >
       {children}
     </goa-table-sort-header>
   );

--- a/libs/react-components/src/lib/table/table.tsx
+++ b/libs/react-components/src/lib/table/table.tsx
@@ -29,20 +29,29 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabTableProps extends Margins {
+  /** Width of the table. By default it will fit the enclosed content. */
   width?: string;
+  /** Callback fired when a single-column sort header is clicked. */
   onSort?: (detail: GoabTableOnSortDetail) => void;
+  /** Callback fired when multi-column sorting changes. */
   onMultiSort?: (detail: GoabTableOnMultiSortDetail) => void;
+  /** Sort mode: "single" allows one column, "multi" allows up to 2 columns. @default "single" */
   sortMode?: GoabTableSortMode;
   // stickyHeader?: boolean; TODO: enable this later
+  /** A relaxed variant of the table with more vertical padding for the cells. @default "normal" */
   variant?: GoabTableVariant;
+  /** When true, alternates row background colors for improved readability. */
   striped?: boolean;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Content rendered inside the table (table rows, headers, etc.). */
   children?: ReactNode;
 }
 
 // legacy name
 export type TableProps = GoabTableProps;
 
+/** A set of structured data that is easy for a user to scan, examine, and compare. */
 export function GoabTable({ onSort, onMultiSort, sortMode, ...props }: GoabTableProps) {
   const ref = useRef<HTMLTableElement>(null);
   useEffect(() => {

--- a/libs/react-components/src/lib/tabs/tabs.tsx
+++ b/libs/react-components/src/lib/tabs/tabs.tsx
@@ -27,16 +27,23 @@ declare module "react" {
 }
 
 export interface GoabTabsProps {
+  /** The initially active tab (1-based index). If not set, the first tab is active. */
   initialTab?: number;
+  /** Content rendered inside the tabs container, typically GoabTab components. */
   children?: React.ReactNode;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Visual style variant. "segmented" shows pill-style tabs with animation. @default "default" */
   variant?: GoabTabsVariant;
-  /** Tab layout orientation. "auto" stacks vertically on mobile (default), "horizontal" keeps horizontal on all screen sizes. */
+  /** Tab layout orientation. "auto" stacks vertically on mobile, "horizontal" keeps horizontal on all screen sizes. @default "auto" */
   orientation?: GoabTabsOrientation;
+  /** Controls URL navigation mode on tab change. @default "hash" */
   navigation?: GoabTabsNavigation;
+  /** Callback fired when the active tab changes. */
   onChange?: (detail: GoabTabsOnChangeDetail) => void;
 }
 
+/** Let users navigate between related sections of content, displaying one section at a time. */
 export function GoabTabs({
   initialTab,
   children,

--- a/libs/react-components/src/lib/temporary-notification-ctrl/temporary-notification-ctrl.tsx
+++ b/libs/react-components/src/lib/temporary-notification-ctrl/temporary-notification-ctrl.tsx
@@ -23,11 +23,15 @@ declare module "react" {
 }
 
 export interface GoabTemporaryNotificationCtrlProps {
+  /** Vertical position of the notification container. @default "bottom" */
   verticalPosition?: SnackbarVerticalPosition;
+  /** Horizontal position of the notification container. @default "center" */
   horizontalPosition?: SnackbarHorizontalPosition;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
 
+/** A notification that appears at the bottom of the screen. */
 export const GoabTemporaryNotificationCtrl = ({
   verticalPosition = "bottom",
   horizontalPosition = "center",
@@ -37,17 +41,15 @@ export const GoabTemporaryNotificationCtrl = ({
   const el = useRef<HTMLElement>(null);
 
   const _props = transformProps<WCProps>(
-    { "vertical-position": verticalPosition, "horizontal-position": horizontalPosition, ...rest },
-    kebab
+    {
+      "vertical-position": verticalPosition,
+      "horizontal-position": horizontalPosition,
+      ...rest,
+    },
+    kebab,
   );
 
-  return (
-    <goa-temp-notification-ctrl
-      ref={el}
-      {..._props}
-      testid={testId}
-    />
-  );
+  return <goa-temp-notification-ctrl ref={el} {..._props} testid={testId} />;
 };
 
 export default GoabTemporaryNotificationCtrl;

--- a/libs/react-components/src/lib/text/text.tsx
+++ b/libs/react-components/src/lib/text/text.tsx
@@ -5,7 +5,8 @@ import {
   GoabTextTextElement,
   GoabTextSize,
   GoabTextColor,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 import { transformProps, lowercase } from "../common/extract-props";
 
@@ -27,29 +28,28 @@ declare module "react" {
 }
 
 interface GoATextProps extends Margins, DataAttributes {
+  /** Content rendered inside the text element. */
+  children: ReactNode;
   /** @deprecated Please use 'tag' property instead */
   as?: GoabTextTextElement | GoabTextHeadingElement;
+  /** The HTML element to render. Use semantic elements like 'h1'-'h6' for headings. */
   tag?: GoabTextTextElement | GoabTextHeadingElement;
+  /** Overrides the text size. */
   size?: GoabTextSize;
+  /** Sets the max width. @default "65ch" */
   maxWidth?: GoabTextMaxWidth;
+  /** Sets the text colour. @default "primary" */
   color?: GoabTextColor;
+  /** Sets the id attribute on the element. */
   id?: string;
-  children: ReactNode;
 }
 
-export function GoabText({
-  as,
-  tag,
-  children,
-  ...rest
-}: GoATextProps): JSX.Element {
+/** Provides consistent sizing, spacing, and colour to written content. */
+export function GoabText({ as, tag, children, ...rest }: GoATextProps): JSX.Element {
   const _props = transformProps<WCProps>(rest, lowercase);
 
   return (
-    <goa-text
-      as={tag || as}
-      {..._props}
-    >
+    <goa-text as={tag || as} {..._props}>
       {children}
     </goa-text>
   );

--- a/libs/react-components/src/lib/textarea/textarea.tsx
+++ b/libs/react-components/src/lib/textarea/textarea.tsx
@@ -42,28 +42,47 @@ declare module "react" {
 }
 
 export interface GoabTextAreaProps extends Margins, DataAttributes {
+  /** @required Name of the input value that is received in the change event. */
   name: string;
+  /** Bound to the current value of the textarea. */
   value?: string;
+  /** Sets the id attribute on the textarea element. */
   id?: string;
+  /** Text displayed within the textarea when no value is set. */
   placeholder?: string;
+  /** Sets the number of visible text rows. @default 3 */
   rows?: number;
+  /** Sets the input to an error state. */
   error?: boolean;
+  /** Sets the input to a read only state. */
   readOnly?: boolean;
+  /** Sets the input to a disabled state. */
   disabled?: boolean;
+  /** Sets the width of the text area. @default "100%" */
   width?: string;
+  /** Sets the maximum width of the text area. @default "60ch" */
   maxWidth?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Defines how the text will be translated for the screen reader. If not specified it will fall back to the name. */
   ariaLabel?: string;
+  /** Counting interval for characters or words, specifying whether to count every character or word. */
   countBy?: GoabTextAreaCountBy;
+  /** Maximum number of characters or words allowed. */
   maxCount?: number;
+  /** Specifies the autocomplete attribute for the textarea input. */
   autoComplete?: string;
+  /** Sets the visual size variant of the text area. */
   size?: GoabTextAreaSize;
-
+  /** Callback fired when the value of the textarea changes. */
   onChange?: (event: GoabTextAreaOnChangeDetail) => void;
+  /** Callback fired when a key is pressed within the textarea. */
   onKeyPress?: (event: GoabTextAreaOnKeyPressDetail) => void;
+  /** Callback fired when the textarea loses focus. */
   onBlur?: (event: GoabTextAreaOnBlurDetail) => void;
 }
 
+/** A multi-line field where users can input and edit text. */
 export function GoabTextArea({
   readOnly,
   disabled,

--- a/libs/react-components/src/lib/three-column-layout/three-column-layout.tsx
+++ b/libs/react-components/src/lib/three-column-layout/three-column-layout.tsx
@@ -16,17 +16,27 @@ declare module "react" {
 }
 
 export interface GoabThreeColumnLayoutProps {
-  leftColumnWidth?: string;
-  rightColumnWidth?: string;
-  maxContentWidth?: string;
-  header?: ReactNode;
-  footer?: ReactNode;
-  nav?: ReactNode;
-  sidebar?: ReactNode; // DEPRECATED
-  sideMenu?: ReactNode;
+  /** Main content rendered in the center column. */
   children: ReactNode;
+  /** Sets the width of the left column. */
+  leftColumnWidth?: string;
+  /** Sets the width of the right column. */
+  rightColumnWidth?: string;
+  /** Sets the maximum width of the content area. */
+  maxContentWidth?: string;
+  /** Content rendered in the page header slot. */
+  header?: ReactNode;
+  /** Content rendered in the page footer slot. */
+  footer?: ReactNode;
+  /** Content rendered in the navigation slot. */
+  nav?: ReactNode;
+  /** @deprecated Use sideMenu instead. Content rendered in the side menu slot. */
+  sidebar?: ReactNode;
+  /** Content rendered in the side menu slot. */
+  sideMenu?: ReactNode;
 }
 
+/** Organizes page content in three responsive columns. */
 export function GoabThreeColumnLayout(props: GoabThreeColumnLayoutProps) {
   return (
     <goa-three-column-layout

--- a/libs/react-components/src/lib/tooltip/tooltip.tsx
+++ b/libs/react-components/src/lib/tooltip/tooltip.tsx
@@ -1,7 +1,8 @@
 import {
   GoabTooltipHorizontalAlignment,
   GoabTooltipPosition,
-  Margins, DataAttributes,
+  Margins,
+  DataAttributes,
 } from "@abgov/ui-components-common";
 import { ReactNode, type JSX } from "react";
 import { transformProps, lowercase } from "../common/extract-props";
@@ -26,14 +27,21 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabTooltipProps extends Margins, DataAttributes {
+  /** Position of the tooltip with respect to the child element. @default "top" */
   position?: GoabTooltipPosition;
+  /** The content of the tooltip. Accepts a string or a ReactNode. */
   content?: string | ReactNode;
+  /** Horizontal alignment of the tooltip relative to the child element. @default "center" */
   hAlign?: GoabTooltipHorizontalAlignment;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Sets the maximum width of the tooltip. Must use 'px' unit. */
   maxWidth?: string;
+  /** The element that triggers the tooltip on hover or focus. */
   children?: ReactNode;
 }
 
+/** A small popover that displays more information about an item. */
 export function GoabTooltip({
   content,
   children,
@@ -44,10 +52,7 @@ export function GoabTooltip({
   const isStringContent = typeof content === "string";
 
   return (
-    <goa-tooltip
-      content={isStringContent ? (content as string) : undefined}
-      {..._props}
-    >
+    <goa-tooltip content={isStringContent ? (content as string) : undefined} {..._props}>
       {!isStringContent && content && <div slot="content">{content}</div>}
       {children}
     </goa-tooltip>

--- a/libs/react-components/src/lib/two-column-layout/two-column-layout.tsx
+++ b/libs/react-components/src/lib/two-column-layout/two-column-layout.tsx
@@ -15,14 +15,21 @@ declare module "react" {
 }
 
 export interface GoabTwoColumnLayoutProps {
-  navColumnWidth?: string;
-  maxContentWidth?: string;
+  /** Content rendered in the page header slot. */
   header: ReactNode;
+  /** Content rendered in the page footer slot. */
   footer: ReactNode;
+  /** Content rendered in the navigation column slot. */
   nav: ReactNode;
+  /** @required Main content rendered in the body of the layout. */
   children: ReactNode;
+  /** Sets the width of the navigation column. */
+  navColumnWidth?: string;
+  /** Sets the maximum width of the content area. */
+  maxContentWidth?: string;
 }
 
+/** Organizes page content in two responsive columns. */
 export function GoabTwoColumnLayout(props: GoabTwoColumnLayoutProps) {
   return (
     <goa-two-column-layout

--- a/libs/react-components/src/lib/work-side-menu-group/work-side-menu-group.tsx
+++ b/libs/react-components/src/lib/work-side-menu-group/work-side-menu-group.tsx
@@ -18,13 +18,19 @@ declare module "react" {
 }
 
 export interface GoabWorkSideMenuGroupProps {
+  /** @required The text displayed in the group heading. */
   heading: string;
+  /** Icon displayed before the group label. When omitted, no icon is rendered and no space is reserved. */
   icon?: GoabIconType;
+  /** Whether the group is open. */
   open?: boolean;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Content rendered inside the group, typically WorkSideMenuItem components. */
   children?: React.ReactNode;
 }
 
+/** Collapsible group of items within the work side menu. */
 export function GoabWorkSideMenuGroup(props: GoabWorkSideMenuGroupProps): JSX.Element {
   return (
     <goa-work-side-menu-group

--- a/libs/react-components/src/lib/work-side-menu-item/work-side-menu-item.tsx
+++ b/libs/react-components/src/lib/work-side-menu-item/work-side-menu-item.tsx
@@ -21,18 +21,29 @@ declare module "react" {
 }
 
 export interface GoabWorkSideMenuItemProps {
+  /** @required The text label displayed for the menu item. */
   label: string;
+  /** The URL the menu item links to. When absent, renders as a button instead of a link. */
   url?: string;
+  /** Badge text displayed alongside the menu item (e.g., notification count). */
   badge?: string;
+  /** When true, indicates this is the currently active menu item. */
   current?: boolean;
+  /** When true, displays a divider line above this menu item. */
   divider?: boolean;
+  /** Icon displayed before the menu item label. */
   icon?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Sets the visual style of the badge. Use "emergency" for urgent items, "success" for positive status. @default "normal" */
   type?: GoabWorkSideMenuItemType;
+  /** Content rendered inside the menu item. */
   children?: React.ReactNode;
+  /** Content rendered inside the popover panel attached to this menu item. */
   popoverContent?: React.ReactNode;
 }
 
+/** Individual menu item within the work side menu. */
 export function GoabWorkSideMenuItem(props: GoabWorkSideMenuItemProps): JSX.Element {
   return (
     <goa-work-side-menu-item

--- a/libs/react-components/src/lib/work-side-menu/work-side-menu.tsx
+++ b/libs/react-components/src/lib/work-side-menu/work-side-menu.tsx
@@ -23,19 +23,31 @@ declare module "react" {
 
 /* eslint-disable-next-line */
 export interface GoabWorkSideMenuProps {
+  /** @required The application name displayed in the header. */
   heading: string;
+  /** @required URL for the header link. Clicking the logo/heading navigates to this URL. */
   url: string;
+  /** User's name displayed in the profile section. */
   userName?: string;
+  /** Secondary text displayed below the user's name, such as role or email. */
   userSecondaryText?: string;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Content rendered in the primary navigation slot. */
   primaryContent?: ReactNode;
+  /** Content rendered in the secondary navigation slot. */
   secondaryContent?: ReactNode;
+  /** Content rendered in the account/profile slot. */
   accountContent?: ReactNode;
+  /** Controls whether the side menu is expanded or collapsed. */
   open?: boolean;
+  /** Callback fired when the side menu is toggled open or closed. */
   onToggle?: () => void;
+  /** Callback fired when a menu item is navigated, providing the target URL path. */
   onNavigate?: (path: string) => void;
 }
 
+/** Side menu variant for worker applications. */
 export function GoabWorkSideMenu({
   heading,
   url,

--- a/libs/react-components/src/lib/work-side-notification-item/work-side-notification-item.tsx
+++ b/libs/react-components/src/lib/work-side-notification-item/work-side-notification-item.tsx
@@ -26,16 +26,25 @@ declare module "react" {
 }
 
 export interface GoabWorkSideNotificationItemProps {
-  type?: GoabWorkSideNotificationItemType;
-  timestamp?: string;
-  title?: string;
+  /** @required The body text content of the notification card. */
   description: string;
+  /** Sets the visual type/style of the notification item. @default "default" */
+  type?: GoabWorkSideNotificationItemType;
+  /** ISO timestamp string representing when the notification occurred. */
+  timestamp?: string;
+  /** Title text displayed in the notification card header. */
+  title?: string;
+  /** Indicates whether the notification has been read or is unread. @default "unread" */
   readStatus?: GoabWorkSideNotificationReadStatus;
+  /** Sets the urgency level of the notification. @default "normal" */
   priority?: GoabWorkSideNotificationPriority;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Callback fired when the notification item is clicked. */
   onClick?: () => void;
 }
 
+/** Displays an individual notification item in the work-side notification panel. */
 export function GoabWorkSideNotificationItem({
   type,
   timestamp,

--- a/libs/react-components/src/lib/work-side-notification-panel/work-side-notification-panel.tsx
+++ b/libs/react-components/src/lib/work-side-notification-panel/work-side-notification-panel.tsx
@@ -18,14 +18,21 @@ declare module "react" {
 }
 
 export interface GoabWorkSideNotificationPanelProps {
+  /** Sets the panel heading text. @default "Notifications" */
   heading?: string;
+  /** Sets the initially active tab. @default "unread" */
   activeTab?: GoabWorkSideNotificationActiveTabType;
+  /** Sets a data-testid attribute for automated testing. */
   testId?: string;
+  /** Notification item content rendered inside the panel. */
   children?: ReactNode;
+  /** Callback fired when the "Mark all as read" button is clicked. */
   onMarkAllRead?: () => void;
+  /** Callback fired when the "View all" button is clicked. */
   onViewAll?: () => void;
 }
 
+/** Displays a panel of work-side notifications. */
 export function GoabWorkSideNotificationPanel({
   heading,
   activeTab,


### PR DESCRIPTION
React and Angular wrappers lacked JSDoc comments, giving consumers no inline documentation in their IDE when using components or inspecting props.

## JSDoc added across all wrappers

- **Component-level** descriptions on every exported class/function
- **Prop-level** descriptions using consistent `Sets the...` phrasing, with `@default`, `@required`, and `@deprecated` tags where applicable
- **Common types** (`GoabInputOnChangeDetail`, etc.) documented for IDE hover tooltips

## Required/optional corrections (found during audit)

| File | Change |
|---|---|
| `file-upload-card.ts` | `size` → `@Input({ required: true })`, aligned with React + Svelte |
| `file-upload-input.ts` | `variant` → optional with `@default "dragdrop"`, aligned with React + Svelte |
| `accordion.tsx` | `heading` → optional, aligned with Angular |
| `popover.tsx` | `target` → required, aligned with Angular |
| `drawer.ts`, `modal.ts`, `radio-item.ts` | Removed incorrect `@required` JSDoc tags from optional fields |

# Before (the change)

No inline documentation when consuming React/Angular wrapper components — no component descriptions, no prop hints, no type documentation visible in IDEs.

# After (the change)

Hovering a component or prop in any IDE shows descriptions, defaults, deprecation notices, and required flags sourced directly from the wrapper source.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Open a project consuming `@abgov/react-components` or `@abgov/angular-components` and hover over any component or prop to verify JSDoc descriptions appear. Check `@required`, `@default`, and `@deprecated` tags render correctly in the IDE tooltip.