### PR TITLE
fix(#3716): move Foundations to last position in main nav

### DIFF
--- a/docs/src/components/nav/ParentMenu.tsx
+++ b/docs/src/components/nav/ParentMenu.tsx
@@ -45,10 +45,10 @@ const SUBMENU_SECTIONS = ["components", "get-started", "foundations"] as const;
 // Main navigation sections
 const SECTIONS: TopLevelSection[] = [
   { id: "get-started", label: "Get started", icon: "document-text" },
-  { id: "foundations", label: "Foundations", icon: "list" },
   { id: "examples", label: "Examples", icon: "browsers" },
   { id: "components", label: "Components", icon: "shapes" },
   { id: "tokens", label: "Tokens", icon: "code-slash" },
+  { id: "foundations", label: "Foundations", icon: "list" },
 ];
 
 export function ParentMenu({


### PR DESCRIPTION
## Summary

- Moves Foundations from second to last position in the main navigation sidebar

<img width="331" height="528" alt="image" src="https://github.com/user-attachments/assets/12ea8bd9-406f-41b9-b02a-23f5390788af" />

## Test plan

- [ ] Check main nav order: Get started, Examples, Components, Tokens, Foundations