### PR TITLE
chore: Updating web-components from 1.x to 2.x

### DIFF
--- a/docs/src/pages/get-started/migration-guide.astro
+++ b/docs/src/pages/get-started/migration-guide.astro
@@ -189,7 +189,10 @@ import DocumentationPageLayout from "../../layouts/DocumentationPageLayout.astro
     <ul>
       <li>New products should use DS 2.0</li>
       <li>Active products should aim to migrate by September 2026</li>
-      <li>Web components 1.x receive limited fixes from March to September</li>
+      <li>
+        After launch, web components will move to version 2.x. Although this is a major
+        version update, it does not include breaking changes.
+      </li>
       <li>
         Angular 4.x and React 6.x receive limited fixes or features from March to
         September


### PR DESCRIPTION
# Before (the change)

We referenced web-components 1.x in the migration guide. This will not actually be factual in our current release, as our web-components will be upgrading to 2.x

# After (the change)

The references was changed to reference 2.x instead.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
