### PR TITLE
docs: add workspace template links and Get Started section

### DIFF
--- a/docs/src/components/LinkCard.astro
+++ b/docs/src/components/LinkCard.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * LinkCard.astro
+ *
+ * A compact card linking to an external resource.
+ * Supports an optional ionicon icon.
+ *
+ * Usage in MDX:
+ * ```mdx
+ * import LinkCard from '../../components/LinkCard.astro';
+ * <div style="display:flex;gap:1rem;flex-wrap:wrap;">
+ *   <LinkCard href="https://example.com" icon="logo-react" title="React template" description="Start building with React" />
+ * </div>
+ * ```
+ */
+
+interface Props {
+  href: string;
+  title: string;
+  description?: string;
+  icon?: string;
+}
+
+const { href, title, description, icon } = Astro.props;
+---
+
+<a href={href} target="_blank" rel="noopener noreferrer" class="link-card">
+  {icon && <ion-icon name={icon} class="link-card-icon"></ion-icon>}
+  <span class="link-card-text">
+    <goa-text version="2" size="body-m" mt="none" mb="none"><strong class="link-card-title">{title}</strong></goa-text>
+    {description && <goa-text version="2" size="body-xs" mt="none" mb="none"><span class="link-card-description">{description}</span></goa-text>}
+  </span>
+</a>
+
+<style>
+  .link-card {
+    flex: 1;
+    min-width: 14rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--goa-color-greyscale-200, #dcdcdc);
+    border-radius: 8px;
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .link-card:hover {
+    border-color: var(--goa-color-interactive-default, #0070c4);
+  }
+
+  .link-card-icon {
+    font-size: 1.25rem;
+    color: var(--goa-color-greyscale-800, #333);
+    margin-top: 0.125rem;
+    flex-shrink: 0;
+  }
+
+  .link-card-text {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .link-card-title {
+    color: var(--goa-color-interactive-default, #0070c4);
+  }
+
+  .link-card-description {
+    font-size: 0.875rem;
+    color: var(--goa-color-text-secondary, #666);
+  }
+</style>

--- a/docs/src/content/examples/workspace/index.mdx
+++ b/docs/src/content/examples/workspace/index.mdx
@@ -2,8 +2,7 @@
 id: workspace
 title: Workspace
 description: The workspace is for productivity-focused services used by service delivery staff as a daily tool to review information, manage records, and complete tasks. The design prioritizes productivity, efficiency, and accuracy so staff can move through their work quickly while ensuring the best outcome for citizens and government.<br><span style="display:block;height:0.5rem"></span>Workspaces should be adapted to fit each service's context and user needs. The reference example is a starting point to expand on, not a rigid template.
-categories:
-  - structure-and-navigation
+categories: []
 scale: product
 userType: worker
 tags:
@@ -27,7 +26,24 @@ previewImage: /thumbnails/workspace-preview.png
 status: published
 ---
 
-<goa-button version="2" type="tertiary" mt="s" mb="xl" onclick="window.open('https://digital-service-demo-v2.netlify.app/workspace', '_blank')">View demo</goa-button>
+<goa-button version="2" type="tertiary" mt="s" mb="l" onclick="window.open('https://digital-service-demo-v2.netlify.app/workspace', '_blank')">View demo</goa-button>
+
+import LinkCard from "../../../components/LinkCard.astro";
+
+<div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem;">
+  <LinkCard
+    href="https://github.com/GovAlta/goa-workspace-playground"
+    icon="logo-react"
+    title="React template"
+    description="GitHub template for building a workspace with React"
+  />
+  <LinkCard
+    href="https://github.com/GovAlta/goa-workspace-angular"
+    icon="logo-angular"
+    title="Angular template"
+    description="GitHub template for building a workspace with Angular"
+  />
+</div>
 
 **Primary user:** Service delivery staff
 
@@ -215,6 +231,27 @@ Workspace patterns are supported by component features designed for denser, more
 - **Data grid** — The [data grid](/components/data-grid) works with the table component to support accessible, keyboard-navigable data views. Use them together when the user needs to move through records efficiently without relying on a mouse.
 - **Segmented tabs** — A new [tab](/components/tab) variant that works as a segmented toggle for switching between views or modes within a workspace, rather than navigating between pages.
 - **Enhanced filter chips** — [Filter chips](/components/filter-chip) now support secondary text and secondary icons, making them more useful for richer filtering in workspace data views.
+
+---
+
+## Get started
+
+Use one of the workspace templates as a starting point for your service. Each template includes the sidebar navigation, dashboard, data views, and case detail patterns described above.
+
+<div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:1.5rem;">
+  <LinkCard
+    href="https://github.com/GovAlta/goa-workspace-playground"
+    icon="logo-react"
+    title="React template"
+    description="GitHub template for building a workspace with React"
+  />
+  <LinkCard
+    href="https://github.com/GovAlta/goa-workspace-angular"
+    icon="logo-angular"
+    title="Angular template"
+    description="GitHub template for building a workspace with Angular"
+  />
+</div>
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds React and Angular GitHub template cards to the workspace example page (top and bottom)
- New reusable `LinkCard.astro` component for linking to external resources
- New "Get Started" section before Considerations with both template links
- Removes single-category classification (workspace spans all categories)

<img width="1253" height="976" alt="image" src="https://github.com/user-attachments/assets/9d44b99e-bb68-46f1-a851-15f69f8ed407" />
<img width="1253" height="976" alt="image" src="https://github.com/user-attachments/assets/b7d01ab4-4929-42b0-af00-70252fdb6750" />


## Test plan

- [ ] Check workspace page at /examples/workspace
- [ ] Verify template cards link to GitHub repos (not GitHub Pages demos)
- [ ] Verify "View demo" button still links to the Netlify demo
- [ ] Check "Get Started" section at the bottom has both template cards