### PR TITLE
fix(#3726): highlight last TOC heading when scrolled to bottom

### DIFF
--- a/docs/src/components/TableOfContents.tsx
+++ b/docs/src/components/TableOfContents.tsx
@@ -82,12 +82,21 @@ export function TableOfContents({ cssQuery }: TOCProps) {
     // Update active heading on scroll - only check visible headings
     function handleScroll() {
       const headings = document.querySelectorAll<HTMLHeadingElement>(cssQuery);
+      const visibleHeadings = Array.from(headings).filter(isVisible);
+
+      if (visibleHeadings.length === 0) return;
+
+      // When scrolled to the bottom, activate the last visible heading
+      const atBottom =
+        window.innerHeight + window.scrollY >= document.body.scrollHeight - 10;
+      if (atBottom) {
+        const id = visibleHeadings[visibleHeadings.length - 1].getAttribute("id");
+        if (id) setActiveId(id);
+        return;
+      }
+
       let activeHeading: HTMLHeadingElement | null = null;
-
-      for (const heading of headings) {
-        // Only consider visible headings
-        if (!isVisible(heading)) continue;
-
+      for (const heading of visibleHeadings) {
         const rect = heading.getBoundingClientRect();
         if (rect.top < 120) {
           activeHeading = heading;
@@ -95,7 +104,7 @@ export function TableOfContents({ cssQuery }: TOCProps) {
       }
 
       if (activeHeading) {
-        const id = (activeHeading as HTMLHeadingElement).getAttribute("id");
+        const id = activeHeading.getAttribute("id");
         if (id) setActiveId(id);
       }
     }


### PR DESCRIPTION
## Summary

- Fixes the sticky TOC highlighting the wrong section for short sections near the bottom of the page (e.g. "Get started" on the workspace page)
- Adds a bottom-of-page check in `handleScroll`: when `window.innerHeight + window.scrollY >= document.body.scrollHeight - 10`, the last visible heading is set as active instead of relying on the 120px threshold

https://github.com/user-attachments/assets/dc976102-18f6-454a-97ce-a15f1ac5bb8f

Closes #3726

## Test plan

- [ ] Navigate to a docs page with a short final section (e.g. workspace example page)
- [ ] Scroll to the very bottom of the page — the last TOC item should be highlighted
- [ ] Click the last TOC item — it should become active
- [ ] Scroll back up — TOC highlighting should still work normally for all other sections

https://claude.ai/code/session_01Rcc9hcmnjnE8vdXhiz7VMM