### PR TITLE
fix(#3744): Update Figma links to new component library

### DIFF
--- a/docs/src/content/components/accordion.mdx
+++ b/docs/src/content/components/accordion.mdx
@@ -11,7 +11,7 @@ tags:
   - expandable panel
 relatedComponents:
   - details
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=15931-553576
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=15932-570754
 githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aopen%20label%3AAccordion
 webComponentTag: goa-accordion
 reactClassName: GoabAccordion

--- a/docs/src/content/components/app-header.mdx
+++ b/docs/src/content/components/app-header.mdx
@@ -18,7 +18,7 @@ tags:
 relatedComponents:
   - app-header-menu
   - microsite-header
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=4576-224884
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=58757-186832
 githubUrl: https://github.com/GovAlta/ui-components/labels/Header
 webComponentTag: goa-app-header
 reactClassName: GoabAppHeader

--- a/docs/src/content/components/badge.mdx
+++ b/docs/src/content/components/badge.mdx
@@ -13,7 +13,7 @@ tags:
 relatedComponents:
   - chip
   - callout
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=458-16984
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-153280
 githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22Badge%22
 webComponentTag: goa-badge
 reactClassName: GoabBadge

--- a/docs/src/content/components/button-group.mdx
+++ b/docs/src/content/components/button-group.mdx
@@ -9,7 +9,7 @@ tags:
   - submit
 relatedComponents:
   - button
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-302108
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=13541-388737
 githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22Button%20group%22
 webComponentTag: goa-button-group
 reactClassName: GoabButtonGroup

--- a/docs/src/content/components/button.mdx
+++ b/docs/src/content/components/button.mdx
@@ -11,7 +11,7 @@ relatedComponents:
   - button-group
   - icon-button
   - link-button
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=420-6810
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=57138-300030
 githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3AButton
 webComponentTag: goa-button
 reactClassName: GoabButton

--- a/docs/src/content/components/callout.mdx
+++ b/docs/src/content/components/callout.mdx
@@ -10,7 +10,7 @@ tags:
 relatedComponents:
   - notification
   - badge
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=434-14122
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-453927
 githubUrl: https://github.com/GovAlta/ui-components/labels/Callout
 webComponentTag: goa-callout
 reactClassName: GoabCallout

--- a/docs/src/content/components/checkbox-list.mdx
+++ b/docs/src/content/components/checkbox-list.mdx
@@ -10,7 +10,7 @@ tags:
 relatedComponents:
   - checkbox
   - form-item
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=12692-378853&t=54qMhd7eCtf1AUlM-4
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-469340
 webComponentTag: goa-checkbox-list
 reactClassName: GoabCheckboxList
 angularSelector: goab-checkbox-list

--- a/docs/src/content/components/checkbox.mdx
+++ b/docs/src/content/components/checkbox.mdx
@@ -12,7 +12,7 @@ relatedComponents:
   - checkbox-list
   - form-item
   - radio-group
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=550-4843&t=54qMhd7eCtf1AUlM-4
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-469737
 githubUrl: https://github.com/GovAlta/ui-components/labels/Checkbox
 webComponentTag: goa-checkbox
 reactClassName: GoabCheckbox

--- a/docs/src/content/components/circular-progress.mdx
+++ b/docs/src/content/components/circular-progress.mdx
@@ -14,7 +14,7 @@ tags:
 relatedComponents:
   - linear-progress
   - spinner
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=622-13604
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=633-12563
 githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22Progress%20indicator%22
 webComponentTag: goa-circular-progress
 reactClassName: GoabCircularProgress

--- a/docs/src/content/components/container.mdx
+++ b/docs/src/content/components/container.mdx
@@ -12,7 +12,7 @@ tags:
 relatedComponents:
   - block
   - grid
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=1789-12623
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=1791-19104
 githubUrl: https://github.com/GovAlta/ui-components/labels/Container
 webComponentTag: goa-container
 reactClassName: GoabContainer

--- a/docs/src/content/components/date-picker.mdx
+++ b/docs/src/content/components/date-picker.mdx
@@ -13,7 +13,7 @@ relatedComponents:
   - form-item
   - input
   - calendar
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=33054-33175
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=61102-130736
 githubUrl: https://github.com/GovAlta/ui-components/labels/Date%20picker
 webComponentTag: goa-date-picker
 reactClassName: GoabDatePicker

--- a/docs/src/content/components/details.mdx
+++ b/docs/src/content/components/details.mdx
@@ -23,7 +23,7 @@ tags:
   - show more information
 relatedComponents:
   - accordion
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=15931-553576
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=15932-569233
 githubUrl: https://github.com/GovAlta/ui-components/labels/Accordion %2B Detail
 webComponentTag: goa-details
 reactClassName: GoabDetails

--- a/docs/src/content/components/divider.mdx
+++ b/docs/src/content/components/divider.mdx
@@ -9,7 +9,7 @@ tags:
   - utilities
 relatedComponents:
   - spacer
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=46-115
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=550-5137
 githubUrl: https://github.com/GovAlta/ui-components/labels/Divider
 webComponentTag: goa-divider
 reactClassName: GoabDivider

--- a/docs/src/content/components/drawer.mdx
+++ b/docs/src/content/components/drawer.mdx
@@ -12,6 +12,7 @@ tags:
 relatedComponents:
   - modal
   - push-drawer
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=60158-687174
 githubUrl: https://github.com/GovAlta/ui-components/labels/Drawer
 webComponentTag: goa-drawer
 reactClassName: GoabDrawer

--- a/docs/src/content/components/dropdown.mdx
+++ b/docs/src/content/components/dropdown.mdx
@@ -10,7 +10,7 @@ tags:
 relatedComponents:
   - form-item
   - input
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=105-42
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=28478-241608
 githubUrl: https://github.com/GovAlta/ui-components/labels/Dropdown
 webComponentTag: goa-dropdown
 reactClassName: GoabDropdown

--- a/docs/src/content/components/file-upload-input.mdx
+++ b/docs/src/content/components/file-upload-input.mdx
@@ -11,7 +11,7 @@ tags:
 relatedComponents:
   - file-upload-card
   - form-item
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=804-5767
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=14458-398119
 githubUrl: https://github.com/GovAlta/ui-components/labels/File%20uploader
 webComponentTag: goa-file-upload-input
 reactClassName: GoabFileUploadInput

--- a/docs/src/content/components/filter-chip.mdx
+++ b/docs/src/content/components/filter-chip.mdx
@@ -8,7 +8,7 @@ tags:
   - pill
 relatedComponents:
   - chip
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=911-5909
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-516598
 githubUrl: https://github.com/GovAlta/ui-components/labels/Filter%20chip
 webComponentTag: goa-filter-chip
 reactClassName: GoabFilterChip

--- a/docs/src/content/components/footer.mdx
+++ b/docs/src/content/components/footer.mdx
@@ -9,7 +9,7 @@ tags:
 relatedComponents:
   - footer-meta-section
   - footer-nav-section
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=582-5939
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=5652-228863
 githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22Footer%22
 webComponentTag: goa-footer
 reactClassName: GoabFooter

--- a/docs/src/content/components/form-item.mdx
+++ b/docs/src/content/components/form-item.mdx
@@ -16,7 +16,7 @@ relatedComponents:
   - file-upload-input
   - radio-group
   - text-area
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27284-300347
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-535065
 githubUrl: https://github.com/GovAlta/ui-components/labels/Form%20item
 webComponentTag: goa-form-item
 reactClassName: GoabFormItem

--- a/docs/src/content/components/form-stepper.mdx
+++ b/docs/src/content/components/form-stepper.mdx
@@ -14,7 +14,7 @@ tags:
 relatedComponents:
   - form-step
   - form
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=1014-6629
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=27335-606356
 githubUrl: https://github.com/GovAlta/ui-components/labels/Form%20stepper
 webComponentTag: goa-form-stepper
 reactClassName: GoabFormStepper

--- a/docs/src/content/components/hero-banner.mdx
+++ b/docs/src/content/components/hero-banner.mdx
@@ -7,7 +7,7 @@ tags:
   - promotion banner
   - hero panel
   - structure and navigation
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=622-14412
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=633-10280
 githubUrl: https://github.com/GovAlta/ui-components/labels/Hero banner
 webComponentTag: goa-hero-banner
 reactClassName: GoabHeroBanner

--- a/docs/src/content/components/icon-button.mdx
+++ b/docs/src/content/components/icon-button.mdx
@@ -10,7 +10,7 @@ tags:
 relatedComponents:
   - button
   - icon
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-302107
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-757260
 githubUrl: https://github.com/GovAlta/ui-components/labels/Icon%20button
 webComponentTag: goa-icon-button
 reactClassName: GoabIconButton

--- a/docs/src/content/components/icon.mdx
+++ b/docs/src/content/components/icon.mdx
@@ -7,7 +7,7 @@ tags:
   - utilities
 relatedComponents:
   - icon-button
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=24019-471310
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=24019-474002
 githubUrl: https://github.com/GovAlta/ui-components/labels/Icons
 webComponentTag: goa-icon
 reactClassName: GoabIcon

--- a/docs/src/content/components/input.mdx
+++ b/docs/src/content/components/input.mdx
@@ -13,7 +13,7 @@ relatedComponents:
   - form-item
   - text-area
   - dropdown
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-303447
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56970-136310
 githubUrl: https://github.com/GovAlta/ui-components/labels/Input
 webComponentTag: goa-input
 reactClassName: GoabInput

--- a/docs/src/content/components/linear-progress.mdx
+++ b/docs/src/content/components/linear-progress.mdx
@@ -13,7 +13,7 @@ tags:
 relatedComponents:
   - circular-progress
   - spinner
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=14458-398386&t=HRVpWQaAs9m4F8iq-4
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=14458-398386
 githubUrl: https://github.com/GovAlta/ui-components/issues?q=sort%3Aupdated-desc+is%3Aopen+label%3A%22Linear+progress+indicator%22
 webComponentTag: goa-linear-progress
 reactClassName: GoabLinearProgress

--- a/docs/src/content/components/link.mdx
+++ b/docs/src/content/components/link.mdx
@@ -8,7 +8,7 @@ tags:
   - text
 relatedComponents:
   - link-button
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-303448
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56970-352878
 githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22Link%22
 webComponentTag: goa-link
 reactClassName: GoabLink

--- a/docs/src/content/components/menu-button.mdx
+++ b/docs/src/content/components/menu-button.mdx
@@ -10,7 +10,7 @@ relatedComponents:
   - button
   - menu-action
   - popover
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=69366-164803
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=57138-308450
 githubUrl: https://github.com/GovAlta/ui-components/labels/Multi%20action%20button
 webComponentTag: goa-menu-button
 reactClassName: GoabMenuButton

--- a/docs/src/content/components/microsite-header.mdx
+++ b/docs/src/content/components/microsite-header.mdx
@@ -17,7 +17,6 @@ tags:
   - structure and navigation
 relatedComponents:
   - app-header
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=2-81
 githubUrl: https://github.com/GovAlta/ui-components/labels/Microsite%20header
 webComponentTag: goa-microsite-header
 reactClassName: GoabMicrositeHeader

--- a/docs/src/content/components/modal.mdx
+++ b/docs/src/content/components/modal.mdx
@@ -11,7 +11,7 @@ tags:
   - show more information
 relatedComponents:
   - drawer
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=622-13874
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56970-444330
 githubUrl: https://github.com/GovAlta/ui-components/labels/Modal
 webComponentTag: goa-modal
 reactClassName: GoabModal

--- a/docs/src/content/components/notification.mdx
+++ b/docs/src/content/components/notification.mdx
@@ -10,7 +10,7 @@ tags:
 relatedComponents:
   - callout
   - temporary-notification
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=622-12949
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56970-485993
 githubUrl: https://github.com/GovAlta/ui-components/labels/Notification%20banner
 webComponentTag: goa-notification
 reactClassName: GoabNotification

--- a/docs/src/content/components/pagination.mdx
+++ b/docs/src/content/components/pagination.mdx
@@ -10,7 +10,7 @@ tags:
 relatedComponents:
   - data-grid
   - table
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=622-13964
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=26318-193264
 githubUrl: https://github.com/GovAlta/ui-components/labels/Pagination
 webComponentTag: goa-pagination
 reactClassName: GoabPagination

--- a/docs/src/content/components/popover.mdx
+++ b/docs/src/content/components/popover.mdx
@@ -9,7 +9,7 @@ tags:
 relatedComponents:
   - tooltip
   - menu-button
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-302109
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=32486-707969
 githubUrl: https://github.com/GovAlta/ui-components/labels/Popover
 webComponentTag: goa-popover
 reactClassName: GoabPopover

--- a/docs/src/content/components/push-drawer.mdx
+++ b/docs/src/content/components/push-drawer.mdx
@@ -11,6 +11,7 @@ tags:
   - panel
 relatedComponents:
   - drawer
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=60151-367783
 githubUrl: https://github.com/GovAlta/ui-components/labels/Push%20Drawer
 webComponentTag: goa-push-drawer
 reactClassName: GoabPushDrawer

--- a/docs/src/content/components/radio-group.mdx
+++ b/docs/src/content/components/radio-group.mdx
@@ -12,7 +12,7 @@ relatedComponents:
   - radio-item
   - form-item
   - checkbox
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=102-26
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56970-509527
 githubUrl: https://github.com/GovAlta/ui-components/labels/Radio
 webComponentTag: goa-radio-group
 reactClassName: GoabRadioGroup

--- a/docs/src/content/components/side-menu.mdx
+++ b/docs/src/content/components/side-menu.mdx
@@ -12,7 +12,7 @@ relatedComponents:
   - side-menu-group
   - side-menu-heading
   - work-side-menu
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=24089-474089
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=58780-485596
 githubUrl: https://github.com/GovAlta/ui-components/labels/Side%20menu
 webComponentTag: goa-side-menu
 reactClassName: GoabSideMenu

--- a/docs/src/content/components/skeleton.mdx
+++ b/docs/src/content/components/skeleton.mdx
@@ -6,7 +6,6 @@ category: feedback-and-alerts
 tags:
   - content layout
   - loading
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-303445
 githubUrl: https://github.com/GovAlta/ui-components/labels/Skeleton%20loading
 webComponentTag: goa-skeleton
 reactClassName: GoabSkeleton

--- a/docs/src/content/components/spacer.mdx
+++ b/docs/src/content/components/spacer.mdx
@@ -12,7 +12,7 @@ tags:
 relatedComponents:
   - divider
   - grid
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-303446
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=21567-616073
 githubUrl: https://github.com/GovAlta/ui-components/labels/Spacer
 webComponentTag: goa-spacer
 reactClassName: GoabSpacer

--- a/docs/src/content/components/table.mdx
+++ b/docs/src/content/components/table.mdx
@@ -11,7 +11,7 @@ tags:
 relatedComponents:
   - data-grid
   - pagination
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=3785-18038
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=27343-613386
 githubUrl: https://github.com/GovAlta/ui-components/labels/Table
 webComponentTag: goa-table
 reactClassName: GoabTable

--- a/docs/src/content/components/tabs.mdx
+++ b/docs/src/content/components/tabs.mdx
@@ -9,7 +9,7 @@ tags:
   - tabbed interface
 relatedComponents:
   - tab
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=25293-519360
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=25293-550667
 githubUrl: https://github.com/GovAlta/ui-components/labels/Tabs
 webComponentTag: goa-tabs
 reactClassName: GoabTabs

--- a/docs/src/content/components/temporary-notification.mdx
+++ b/docs/src/content/components/temporary-notification.mdx
@@ -9,7 +9,7 @@ tags:
   - temporary notification
 relatedComponents:
   - notification
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=41625-353289&t=lFeSi0XicmNhlTsC-4
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=33183-290309
 githubUrl: https://github.com/GovAlta/ui-components/labels/Temporary%20notification
 webComponentTag: goa-temporary-notification
 reactClassName: GoabTemporaryNotification

--- a/docs/src/content/components/text-area.mdx
+++ b/docs/src/content/components/text-area.mdx
@@ -13,7 +13,7 @@ tags:
 relatedComponents:
   - form-item
   - input
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=133-186
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=12711-380735
 githubUrl: https://github.com/GovAlta/ui-components/labels/Text%20area
 webComponentTag: goa-text-area
 reactClassName: GoabTextArea

--- a/docs/src/content/components/text.mdx
+++ b/docs/src/content/components/text.mdx
@@ -7,7 +7,7 @@ tags:
   - text
   - body
   - copy
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=27301-303449
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=21567-615910
 githubUrl: https://github.com/GovAlta/ui-components/labels/Text
 webComponentTag: goa-text
 reactClassName: GoabText

--- a/docs/src/content/components/tooltip.mdx
+++ b/docs/src/content/components/tooltip.mdx
@@ -7,7 +7,7 @@ tags:
   - feedback and alerts
 relatedComponents:
   - popover
-figmaUrl: https://www.figma.com/design/3pb2IK8s2QUqWieH79KdN7/%E2%9D%96-Component-library-%7C-DDD?node-id=21932-557049
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=21932-557085
 githubUrl: https://github.com/GovAlta/ui-components/labels/Tooltip
 webComponentTag: goa-tooltip
 reactClassName: GoabTooltip

--- a/docs/src/content/components/work-side-menu.mdx
+++ b/docs/src/content/components/work-side-menu.mdx
@@ -7,6 +7,7 @@ relatedComponents:
   - side-menu
   - work-side-menu-group
   - work-side-menu-item
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=57622-159377
 webComponentTag: goa-work-side-menu
 reactClassName: GoabWorkSideMenu
 angularSelector: goab-work-side-menu


### PR DESCRIPTION
## Summary

- Updated figmaUrl in 39 component MDX files to point to the new Figma component library
- Removed figmaUrl from microsite-header and skeleton (not in 2.0 Figma library)

Closes #3744