### PR TITLE
fix(3760): close v1 filter chip when clicking icon

### DIFF
--- a/apps/prs/web/src/app/App.svelte
+++ b/apps/prs/web/src/app/App.svelte
@@ -3,6 +3,7 @@
   import { Router, Route } from "svelte-routing";
   import Issue2333 from "../routes/2333.svelte";
   import Issue3279 from "../routes/3279.svelte";
+  import Issue3760 from "../routes/3760.svelte";
 </script>
 
 <svelte:head>
@@ -12,4 +13,5 @@
 <Router>
   <Route path="/issues/2333" component={Issue2333} />
   <Route path="/issues/3279" component={Issue3279} />
+  <Route path="/issues/3760" component={Issue3760} />
 </Router>

--- a/apps/prs/web/src/routes/3760.svelte
+++ b/apps/prs/web/src/routes/3760.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  let clickCount = 0;
+  let lastEvent = "Waiting for _click from onDelete. Click the close icon once on the v1 filter chip.";
+  let eventLog: string[] = [];
+
+  function handleChipClick() {
+    const timestamp = new Date().toLocaleTimeString();
+    clickCount += 1;
+    lastEvent = `_click received from onDelete at ${timestamp}`;
+    eventLog = [lastEvent, ...eventLog].slice(0, 6);
+  }
+
+  function resetLog() {
+    clickCount = 0;
+    lastEvent = "Waiting for _click from onDelete. Click the close icon once on the v1 filter chip.";
+    eventLog = [];
+  }
+</script>
+
+<svelte:head>
+  <title>Issue 3760</title>
+</svelte:head>
+
+<div class="page">
+    <goa-text as="h5" mb="xs" color="secondary" class="eyebrow">Issue 3760</goa-text>
+    <goa-text as="h1" mt="0" mb="0">Version 1 Filter Chip Icon Click</goa-text>
+    <goa-text mb="0">
+      Use this page to verify that clicking the v1 close icon runs the component's
+      <code>onDelete</code> handler and emits one <code>_click</code> event.
+    </goa-text>
+
+  <div class="chip-area">
+    <goa-filter-chip
+      content="Status: Active filter"
+      version="1"
+      testid="filter-chip-v1"
+      on:_click={handleChipClick}
+    />
+  </div>
+
+  <goa-button size="compact" type="primary" on:click={resetLog}>Reset</goa-button>
+
+  <goa-text mb="0">
+    Click count <strong>{clickCount}</strong>
+  </goa-text>
+
+  <goa-text  mb="0">{lastEvent}</goa-text>
+
+  <goa-text as="h4" mt="s" mb="0">Recent Events</goa-text>
+  {#if eventLog.length > 0}
+    <ul>
+      {#each eventLog as entry}
+        <li>{entry}</li>
+      {/each}
+    </ul>
+  {:else}
+    <goa-text class="empty">No events captured yet.</goa-text>
+  {/if}
+</div>
+
+<style>
+  .page {
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>

--- a/libs/web-components/src/components/filter-chip/FilterChip.svelte
+++ b/libs/web-components/src/components/filter-chip/FilterChip.svelte
@@ -186,6 +186,7 @@
     flex-shrink: 0;
     display: flex;
     align-items: center;
+    pointer-events: none; /* Icon itself should not capture pointer events, the chip handles it */
   }
 
   .label-container {


### PR DESCRIPTION
# Before (the change)

When in Chrome, clicking the v1 filter chip icon doesn't trigger a `_click` event until the second click.

![click-issue](https://github.com/user-attachments/assets/8fc685db-ab8c-477c-ac1c-d14eb8238ff5)

# After (the change)

Clicking the v1 filter chip icon triggers a `_click` event.

![click-fixed](https://github.com/user-attachments/assets/cc77e5d2-2646-400e-b747-cbc7ed56a14e)

# The reason

The problem is a race between Chrome's focus event and the `goa-icon` shadow DOM re-render:

| Step | What happens in Chrome |
|------|------------------------|
| 1 | `mousedown` on `goa-icon` → browser focuses the parent `div` |
| 2 | `focus` fires → `_focused = true` → Svelte re-renders |
| 3 | `goa-icon` receives new `theme="filled"` prop → **shadow DOM re-renders under the cursor** |
| 4 | `mouseup` / `click` fire — but Chrome sees the hit-target changed, so **`click` is dropped** |

Firefox is more permissive and fires `click` even when the shadow DOM target shifts mid-gesture, which is why it works there on the first click.

Adding `pointer-events: none` to `.delete-icon` makes the `goa-icon` element transparent to all mouse events, so every click falls straight through to the outer `div.chip` that holds the `on:click={onDelete}` handler. The icon in the v1 chip is purely decorative anyway — the whole chip is meant to be the button.