### PR TITLE
fix(#3625): Accordion Refinements

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3625/bug3625.component.html
+++ b/apps/prs/angular/src/routes/bugs/3625/bug3625.component.html
@@ -1,0 +1,137 @@
+<div>
+  <h1>Bug 3625: Accordion Refinement</h1>
+  <goab-accordion heading="Small heading" headingSize="small">
+    Content with small heading.
+  </goab-accordion>
+  <goab-accordion heading="Medium heading" headingSize="medium">
+    Content with medium heading.
+  </goab-accordion>
+  <goab-accordion
+    heading="Small heading"
+    secondaryText="Secondary Text"
+    headingSize="small"
+  >
+    Content with small heading.
+  </goab-accordion>
+  <goab-accordion
+    heading="Medium heading"
+    secondaryText="Secondary Text"
+    headingSize="medium"
+  >
+    Content with medium heading.
+  </goab-accordion>
+  <div style="display: flex; gap: 1rem">
+    <div style="width: 50%">
+      <goab-accordion
+        heading="Small heading"
+        [headingContent]="importantBadge"
+        headingSize="small"
+      >
+        <ng-template #importantBadge>
+          <goab-badge type="important" content="Updated"></goab-badge>
+        </ng-template>
+        Content with small heading.
+      </goab-accordion>
+    </div>
+    <div style="width: 50%">
+      <goab-accordion
+        heading="Medium heading"
+        [headingContent]="importantBadge"
+        headingSize="medium"
+      >
+        <ng-template #importantBadge>
+          <goab-badge type="important" content="Updated"></goab-badge>
+        </ng-template>
+        Content with medium heading.
+      </goab-accordion>
+    </div>
+  </div>
+  <goab-accordion heading="Small Controls" headingSize="small" iconPosition="right">
+    <goab-block direction="column" gap="s">
+      <goab-text tag="p">Content with small heading.</goab-text>
+      <goab-block direction="column" gap="s">
+        <goab-text tag="p">Nested block content.</goab-text>
+        <goab-form-item label="Colour Dropdown">
+          <goab-dropdown width="500px">
+            <goab-dropdown-item value="red" label="Red" />
+            <goab-dropdown-item value="green" label="Green" />
+            <goab-dropdown-item value="blue" label="Blue" />
+          </goab-dropdown>
+        </goab-form-item>
+      </goab-block>
+    </goab-block>
+  </goab-accordion>
+  <goab-accordion heading="Medium Controls" headingSize="medium" iconPosition="right">
+    <goab-block direction="column" gap="s">
+      <goab-text tag="p">Content with medium heading.</goab-text>
+      <goab-form-item label="Colour Dropdown" maxWidth="100%">
+        <goab-dropdown width="500px">
+          <goab-dropdown-item value="red" label="Red" />
+          <goab-dropdown-item value="green" label="Green" />
+          <goab-dropdown-item value="blue" label="Blue" />
+        </goab-dropdown>
+      </goab-form-item>
+    </goab-block>
+  </goab-accordion>
+
+  <goab-accordion
+    heading="Verification checklist"
+    secondaryText="From Bug 2873 - open on start"
+    [open]="true"
+  >
+    <goab-block direction="column" gap="s">
+      <goab-text tag="p" maxWidth="400px">
+        Expand and collapse this accordion to confirm that layout changes do not jump the
+        scroll position unexpectedly.
+      </goab-text>
+      <goab-text tag="p" maxWidth="400px">
+        Keep the content long enough to require scrolling before and after the accordion
+        section.
+      </goab-text>
+    </goab-block>
+  </goab-accordion>
+
+  <goab-accordion
+    heading="Clickable Element in Heading"
+    headingSize="medium"
+    [headingContent]="buttonTemplate"
+    (onChange)="onAccordionChange()"
+  >
+    <ng-template #buttonTemplate>
+      <goab-button (click)="onButtonClicked()" size="compact">
+        This is a button
+      </goab-button>
+    </ng-template>
+    <p>
+      In the JavaScript console the text "Accordion toggled" will not appear if the button
+      is clicked, only if other parts of the heading are clicked.
+    </p>
+  </goab-accordion>
+
+  <h2>Controlled Accordion (toggle via button)</h2>
+  <goab-text tag="p">
+    Parent state: <strong>{{ controlledOpen ? "open" : "closed" }}</strong>
+  </goab-text>
+  <goab-block direction="row" gap="s" mb="m">
+    <goab-button (onClick)="toggleControlled()">
+      {{ controlledOpen ? "Collapse" : "Expand" }}
+    </goab-button>
+    <goab-button type="secondary" (onClick)="controlledOpen = false">
+      Force close
+    </goab-button>
+    <goab-button type="secondary" (onClick)="controlledOpen = true">
+      Force open
+    </goab-button>
+  </goab-block>
+  <goab-accordion
+    heading="Controlled Accordion"
+    secondaryText="open prop is bound to parent state"
+    [open]="controlledOpen"
+    (onChange)="onControlledChange($event)"
+  >
+    <goab-text tag="p">
+      Test the controlled pattern: click the accordion summary, click the buttons above,
+      and watch whether the parent state stays in sync with the visible UI state.
+    </goab-text>
+  </goab-accordion>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3625/bug3625.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3625/bug3625.component.ts
@@ -1,0 +1,48 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabAccordion,
+  GoabBadge,
+  GoabBlock,
+  GoabButton,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFormItem,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3625",
+  templateUrl: "./bug3625.component.html",
+  imports: [
+    CommonModule,
+    GoabAccordion,
+    GoabBadge,
+    GoabBlock,
+    GoabButton,
+    GoabDropdown,
+    GoabDropdownItem,
+    GoabFormItem,
+    GoabText,
+  ],
+})
+export class Bug3625Component {
+  controlledOpen = false;
+
+  onAccordionChange() {
+    console.log("Accordion toggled");
+  }
+
+  onButtonClicked() {
+    console.log("Button in heading clicked");
+  }
+
+  toggleControlled() {
+    this.controlledOpen = !this.controlledOpen;
+  }
+
+  onControlledChange(open: boolean) {
+    this.controlledOpen = open;
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3625/bug3625.route.json
+++ b/apps/prs/angular/src/routes/bugs/3625/bug3625.route.json
@@ -1,0 +1,6 @@
+{
+    "title": "Accordion Refinement",
+    "path": "bugs/3625",
+    "id": "3625",
+    "type": "bug"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3625.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3625.route.ts
@@ -1,0 +1,9 @@
+import { Bug3625Route } from "../../../routes/bugs/bug3625";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "bug",
+  id: "3625",
+  path: "bugs/3625",
+  title: "Accordion Refinement",
+  component: Bug3625Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3625.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3625.tsx
@@ -1,0 +1,165 @@
+import {
+  GoabAccordion,
+  GoabBadge,
+  GoabBlock,
+  GoabButton,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFormItem,
+  GoabText,
+} from "@abgov/react-components";
+import { useEffect, useState } from "react";
+import v2TokensUrl from "@abgov/design-tokens-v2/dist/tokens.css?url";
+
+export function Bug3625Route() {
+  const [controlledOpen, setControlledOpen] = useState(false);
+
+  // Inject the v2 design tokens
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = v2TokensUrl;
+    document.head.appendChild(link);
+    return () => {
+      document.head.removeChild(link);
+    };
+  }, []);
+
+  return (
+    <div>
+      <h1>Bug 3625: Accordion Refinement</h1>
+      <GoabAccordion heading="Small heading" headingSize="small">
+        Content with small heading.
+      </GoabAccordion>
+      <GoabAccordion heading="Medium heading" headingSize="medium">
+        Content with medium heading.
+      </GoabAccordion>
+      <GoabAccordion
+        heading="Small heading"
+        secondaryText="Secondary Text"
+        headingSize="small"
+      >
+        Content with small heading.
+      </GoabAccordion>
+      <GoabAccordion
+        heading="Medium heading"
+        secondaryText="Secondary Text"
+        headingSize="medium"
+      >
+        Content with medium heading.
+      </GoabAccordion>
+      <div style={{ display: "flex", gap: "1rem" }}>
+        <div style={{ width: "50%" }}>
+          <GoabAccordion
+            heading="Small heading"
+            headingContent={<GoabBadge type="important" content="Updated" />}
+            headingSize="small"
+          >
+            Content with small heading.
+          </GoabAccordion>
+        </div>
+        <div style={{ width: "50%" }}>
+          <GoabAccordion
+            heading="Medium heading"
+            headingContent={<GoabBadge type="important" content="Updated" />}
+            headingSize="medium"
+          >
+            Content with medium heading.
+          </GoabAccordion>
+        </div>
+      </div>
+      <GoabAccordion heading="Small Controls" headingSize="small" iconPosition="right">
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="p">Content with small heading.</GoabText>
+          <GoabBlock direction="column" gap="s">
+            <GoabText tag="p">Nested block content.</GoabText>
+            <GoabFormItem label="Colour Dropdown">
+              <GoabDropdown width="500px">
+                <GoabDropdownItem value="red" label="Red" />
+                <GoabDropdownItem value="green" label="Green" />
+                <GoabDropdownItem value="blue" label="Blue" />
+              </GoabDropdown>
+            </GoabFormItem>
+          </GoabBlock>
+        </GoabBlock>
+      </GoabAccordion>
+      <GoabAccordion heading="Medium Controls" headingSize="medium" iconPosition="right">
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="p">Content with medium heading.</GoabText>
+          <GoabFormItem label="Colour Dropdown" maxWidth="100%">
+            <GoabDropdown width="500px">
+              <GoabDropdownItem value="red" label="Red" />
+              <GoabDropdownItem value="green" label="Green" />
+              <GoabDropdownItem value="blue" label="Blue" />
+            </GoabDropdown>
+          </GoabFormItem>
+        </GoabBlock>
+      </GoabAccordion>
+      <GoabAccordion
+        heading="Verification checklist"
+        secondaryText="From Bug 2873 - open on start"
+        open={true}
+      >
+        <GoabBlock direction="column" gap="s">
+          <GoabText tag="p" maxWidth="400px">
+            Expand and collapse this accordion to confirm that layout changes do not jump
+            the scroll position unexpectedly.
+          </GoabText>
+          <GoabText tag="p" maxWidth="400px">
+            Keep the content long enough to require scrolling before and after the
+            accordion section.
+          </GoabText>
+        </GoabBlock>
+      </GoabAccordion>
+      <GoabAccordion
+        heading="Clickable Element in Heading"
+        headingSize="medium"
+        headingContent={
+          <GoabButton
+            onClick={() => console.log("Button in heading clicked")}
+            size="compact"
+          >
+            This is a button
+          </GoabButton>
+        }
+        onChange={() => console.log("Accordion toggled")}
+      >
+        <p>
+          In the JavaScript console the text "Accordion toggled" will not appear if the
+          button is clicked, only if other parts of the heading are clicked.
+        </p>
+      </GoabAccordion>
+
+      <h2>Controlled Accordion (toggle via button)</h2>
+      <GoabText tag="p">
+        Parent state: <strong>{controlledOpen ? "open" : "closed"}</strong>
+      </GoabText>
+      <GoabBlock direction="row" gap="s" mb="m">
+        <GoabButton onClick={() => setControlledOpen((v) => !v)}>
+          {controlledOpen ? "Collapse" : "Expand"}
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setControlledOpen(false)}>
+          Force close
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setControlledOpen(true)}>
+          Force open
+        </GoabButton>
+      </GoabBlock>
+      <GoabAccordion
+        heading="Controlled Accordion"
+        secondaryText="open prop is bound to parent state"
+        open={controlledOpen}
+        onChange={(open) => {
+          console.log("Accordion onChange → open:", open);
+          setControlledOpen(open);
+        }}
+      >
+        <GoabText tag="p">
+          Test the controlled pattern: click the accordion summary, click the buttons
+          above, and watch whether the parent state stays in sync with the visible UI
+          state.
+        </GoabText>
+      </GoabAccordion>
+    </div>
+  );
+}

--- a/libs/react-components/specs/accordion.browser.spec.tsx
+++ b/libs/react-components/specs/accordion.browser.spec.tsx
@@ -1,7 +1,8 @@
 import { render } from "vitest-browser-react";
 import { GoabAccordion, GoabButton } from "../src";
 import { useState } from "react";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { userEvent } from "@vitest/browser/context";
 
 describe("Accordion", () => {
   it("should pass", async () => {
@@ -34,7 +35,7 @@ describe("Accordion", () => {
 
   it("should not expand the accordion if a clickable element exists within the header slot", async () => {
     const handleClick = vi.fn();
-    const spy = vi.fn();
+    const accordionChangeSpy = vi.fn();
 
     const Component = () => {
       return (
@@ -42,14 +43,14 @@ describe("Accordion", () => {
           heading="Heading"
           headingSize="medium"
           headingContent={
-            <GoabButton testId="heading-button" onClick={() => handleClick}>
+            <GoabButton testId="heading-button" onClick={handleClick}>
               This is a button
             </GoabButton>
           }
-          onChange={spy}
+          onChange={accordionChangeSpy}
         >
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-          incididunt ut labore et dol;ore ma;gna aliqua. Ut enim ad minim veniam, quis
+          incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
           nostrud exercitation ullamco laboris nisi
         </GoabAccordion>
       );
@@ -57,8 +58,118 @@ describe("Accordion", () => {
 
     const result = render(<Component />);
     const button = result.getByTestId("heading-button");
-    await button.click();
+    await userEvent.click(button);
 
-    expect(spy).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(accordionChangeSpy).not.toHaveBeenCalled();
+    });
   });
-})
+
+  it("should set the aria-expanded attribute on the heading element", async () => {
+    const Component = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <>
+          <GoabButton testId="openButton" onClick={() => setOpen(true)}>
+            This button opens the Accordion
+          </GoabButton>
+          <GoabButton testId="closeButton" onClick={() => setOpen(false)}>
+            This button closes the Accordion
+          </GoabButton>
+          <GoabAccordion
+            testId="testAccordion"
+            heading="Heading"
+            headingSize="medium"
+            open={open}
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+            nostrud exercitation ullamco laboris nisi
+          </GoabAccordion>
+        </>
+      );
+    };
+
+    const result = render(<Component />);
+    const openButton = result.getByTestId("openButton");
+    const closeButton = result.getByTestId("closeButton");
+    const summary = result.getByTestId("testAccordion-summary");
+
+    await vi.waitFor(() => {
+      expect(summary).toHaveAttribute("aria-expanded", "false");
+    });
+
+    await openButton.click();
+
+    await vi.waitFor(() => {
+      expect(summary).toHaveAttribute("aria-expanded", "true");
+    });
+
+    await closeButton.click();
+
+    await vi.waitFor(() => {
+      expect(summary).toHaveAttribute("aria-expanded", "false");
+    });
+
+    await openButton.click();
+
+    await vi.waitFor(() => {
+      expect(summary).toHaveAttribute("aria-expanded", "true");
+    });
+  });
+
+  it("should set the open attribute on the details element", async () => {
+    const Component = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <>
+          <GoabButton testId="openButton" onClick={() => setOpen(true)}>
+            This button opens the Accordion
+          </GoabButton>
+          <GoabButton testId="closeButton" onClick={() => setOpen(false)}>
+            This button closes the Accordion
+          </GoabButton>
+          <GoabAccordion
+            testId="testAccordion"
+            heading="Heading"
+            headingSize="medium"
+            open={open}
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+            nostrud exercitation ullamco laboris nisi
+          </GoabAccordion>
+        </>
+      );
+    };
+
+    const result = render(<Component />);
+    const openButton = result.getByTestId("openButton");
+    const closeButton = result.getByTestId("closeButton");
+    const details = result.getByTestId("testAccordion-details");
+
+    await vi.waitFor(() => {
+      expect(details).not.toHaveAttribute("open");
+    });
+
+    await openButton.click();
+
+    await vi.waitFor(() => {
+      expect(details).toHaveAttribute("open");
+    });
+
+    await closeButton.click();
+
+    await vi.waitFor(() => {
+      expect(details).not.toHaveAttribute("open");
+    });
+
+    await openButton.click();
+
+    await vi.waitFor(() => {
+      expect(details).toHaveAttribute("open");
+    });
+  });
+});

--- a/libs/web-components/src/common/utils.spec.ts
+++ b/libs/web-components/src/common/utils.spec.ts
@@ -1,5 +1,14 @@
 import { waitFor } from "@testing-library/svelte";
-import { getTimestamp, performOnce, announceToScreenReader, typeValidator, getLocalDateValues, isFocusable, findFirstFocusableNode } from "./utils";
+import {
+  getTimestamp,
+  performOnce,
+  announceToScreenReader,
+  typeValidator,
+  getLocalDateValues,
+  isFocusable,
+  findFirstFocusableNode,
+  parseCssTimeToMilliseconds,
+} from "./utils";
 import { it, describe, expect, vi, beforeEach, afterEach } from "vitest";
 
 describe("getTimestamp", () => {
@@ -36,19 +45,19 @@ describe("getTimestamp", () => {
       29: "29th",
       30: "30th",
       31: "31st",
-    }
+    };
 
     for (const [day, val] of Object.entries(vals)) {
-      const d = new Date(2023, 2, parseInt(day, 10))
-      expect(getTimestamp(d)).toContain(val)
+      const d = new Date(2023, 2, parseInt(day, 10));
+      expect(getTimestamp(d)).toContain(val);
     }
-  })
+  });
 
   it("handles the 12th hour", () => {
-    expect(getTimestamp(new Date(2023, 1, 1, 12, 23))).toContain("12:23 PM")
-    expect(getTimestamp(new Date(2023, 1, 1, 0, 23))).toContain("12:23 AM")
-  })
-})
+    expect(getTimestamp(new Date(2023, 1, 1, 12, 23))).toContain("12:23 PM");
+    expect(getTimestamp(new Date(2023, 1, 1, 0, 23))).toContain("12:23 AM");
+  });
+});
 
 describe("performOnce", () => {
   it("calls the action only once", async () => {
@@ -62,14 +71,14 @@ describe("performOnce", () => {
     await waitFor(() => {
       expect(count).toBe(1);
     });
-  })
-})
+  });
+});
 
 describe("announceToScreenReader", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     if (!document.body) {
-      const body = document.createElement('body');
+      const body = document.createElement("body");
       document.documentElement.appendChild(body);
     }
   });
@@ -80,7 +89,7 @@ describe("announceToScreenReader", () => {
 
     // Clean up any announcer elements
     const announcers = document.querySelectorAll('[aria-live="polite"]');
-    announcers.forEach(el => el.parentNode?.removeChild(el));
+    announcers.forEach((el) => el.parentNode?.removeChild(el));
   });
 
   it("creates an accessible announcer element with the correct attributes", () => {
@@ -96,7 +105,7 @@ describe("announceToScreenReader", () => {
   });
 
   it("sets up timers to remove the announcer element", () => {
-    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
 
     const customDuration = 1500;
     announceToScreenReader("Test announcement", customDuration);
@@ -107,7 +116,7 @@ describe("announceToScreenReader", () => {
   });
 
   it("uses default duration when not specified", () => {
-    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
 
     announceToScreenReader("Test announcement");
 
@@ -119,7 +128,9 @@ describe("announceToScreenReader", () => {
   it("applies visually hidden styles to the announcer element", () => {
     announceToScreenReader("Test announcement");
 
-    const announcer = document.querySelector('[aria-live="polite"]') as HTMLElement;
+    const announcer = document.querySelector(
+      '[aria-live="polite"]',
+    ) as HTMLElement;
     expect(announcer).not.toBeNull();
 
     // Check that the element has visually hidden styles
@@ -296,11 +307,7 @@ describe("typeValidator", () => {
   });
 
   it("behaves like required=false when no options provided", () => {
-    const [, validator] = typeValidator(
-      "Color",
-      ["red", "blue", "green"],
-      {},
-    );
+    const [, validator] = typeValidator("Color", ["red", "blue", "green"], {});
 
     validator(null);
     expect(consoleErrorSpy).not.toHaveBeenCalled();
@@ -767,7 +774,7 @@ describe("findFirstFocusableNode", () => {
       const button = document.createElement("button");
 
       // Mock assignedNodes for testing
-      vi.spyOn(slot, 'assignedNodes').mockReturnValue([button]);
+      vi.spyOn(slot, "assignedNodes").mockReturnValue([button]);
 
       expect(findFirstFocusableNode([slot])).toBe(button);
     });
@@ -776,7 +783,7 @@ describe("findFirstFocusableNode", () => {
       const slot = document.createElement("slot");
 
       // Mock assignedNodes returning empty array
-      vi.spyOn(slot, 'assignedNodes').mockReturnValue([]);
+      vi.spyOn(slot, "assignedNodes").mockReturnValue([]);
 
       expect(findFirstFocusableNode([slot])).toBeNull();
     });
@@ -794,10 +801,14 @@ describe("findFirstFocusableNode", () => {
       button3.id = "third";
 
       // Normal order should find first button
-      expect(findFirstFocusableNode([button1, button2, button3], false)).toBe(button1);
+      expect(findFirstFocusableNode([button1, button2, button3], false)).toBe(
+        button1,
+      );
 
       // Reversed order should find last button
-      expect(findFirstFocusableNode([button1, button2, button3], true)).toBe(button3);
+      expect(findFirstFocusableNode([button1, button2, button3], true)).toBe(
+        button3,
+      );
     });
 
     it("finds last focusable element in nested structure when reversed", () => {
@@ -812,7 +823,9 @@ describe("findFirstFocusableNode", () => {
       container2.appendChild(button2);
 
       // Reversed should find the last focusable element
-      expect(findFirstFocusableNode([container1, container2], true)).toBe(button2);
+      expect(findFirstFocusableNode([container1, container2], true)).toBe(
+        button2,
+      );
     });
   });
 
@@ -826,7 +839,15 @@ describe("findFirstFocusableNode", () => {
       const hiddenInput = document.createElement("input");
       hiddenInput.type = "hidden"; // not focusable
 
-      expect(findFirstFocusableNode([span, div, disabledButton, enabledButton, hiddenInput])).toBe(enabledButton);
+      expect(
+        findFirstFocusableNode([
+          span,
+          div,
+          disabledButton,
+          enabledButton,
+          hiddenInput,
+        ]),
+      ).toBe(enabledButton);
     });
 
     it("handles deeply nested structure with mixed content", () => {
@@ -863,7 +884,9 @@ describe("findFirstFocusableNode", () => {
       const commentNode = document.createComment("comment");
       const button = document.createElement("button");
 
-      expect(findFirstFocusableNode([textNode, commentNode, button])).toBe(button);
+      expect(findFirstFocusableNode([textNode, commentNode, button])).toBe(
+        button,
+      );
     });
 
     it("handles elements with conflicting attributes", () => {
@@ -877,5 +900,28 @@ describe("findFirstFocusableNode", () => {
 
       expect(findFirstFocusableNode([input, button])).toBe(button);
     });
+  });
+});
+
+describe("parseCssTimeToMilliseconds", () => {
+  it("parses millisecond values", () => {
+    expect(parseCssTimeToMilliseconds("150ms")).toBe(150);
+    expect(parseCssTimeToMilliseconds(" 200 ms ")).toBe(200);
+  });
+
+  it("parses second values and converts to milliseconds", () => {
+    expect(parseCssTimeToMilliseconds("0.25s")).toBe(250);
+    expect(parseCssTimeToMilliseconds("2 s")).toBe(2000);
+  });
+
+  it("supports uppercase units", () => {
+    expect(parseCssTimeToMilliseconds("1.5S")).toBe(1500);
+    expect(parseCssTimeToMilliseconds("300MS")).toBe(300);
+  });
+
+  it("returns fallback for invalid values", () => {
+    expect(parseCssTimeToMilliseconds("invalid")).toBe(100);
+    expect(parseCssTimeToMilliseconds("1minute")).toBe(100);
+    expect(parseCssTimeToMilliseconds("", 250)).toBe(250);
   });
 });

--- a/libs/web-components/src/common/utils.ts
+++ b/libs/web-components/src/common/utils.ts
@@ -3,7 +3,7 @@
 // non-key properties change. Using the `watch` function provides the control and makes
 // it clear what the function is watching
 export function watch(fn: () => void, _: unknown[]) {
-  fn()
+  fn();
 }
 
 // Creates a style string from a list of styles.
@@ -53,7 +53,7 @@ export function receive(
   const listener = (e: Event) => {
     const ce = e as CustomEvent;
     handler(ce.detail.action, ce.detail.data, e);
-  }
+  };
 
   el?.addEventListener("msg", listener);
 
@@ -290,9 +290,14 @@ export function isPointInRectangle(
   rectX: number,
   rectY: number,
   rectWidth: number,
-  rectHeight: number
+  rectHeight: number,
 ): boolean {
-  return x >= rectX && x <= rectX + rectWidth && y >= rectY && y <= rectY + rectHeight;
+  return (
+    x >= rectX &&
+    x <= rectX + rectWidth &&
+    y >= rectY &&
+    y <= rectY + rectHeight
+  );
 }
 
 export function ensureSlotExists(el: HTMLElement) {
@@ -372,7 +377,7 @@ export function getLocalDateValues(input: string | Date): {
         year: +matches[1],
         month: +matches[2],
         day: +matches[3],
-      }
+      };
     }
   }
 
@@ -381,7 +386,7 @@ export function getLocalDateValues(input: string | Date): {
       year: input.getFullYear(),
       month: input.getMonth() + 1,
       day: input.getDate(),
-    }
+    };
   }
 
   return null;
@@ -495,7 +500,11 @@ export function isFocusable(node: Node): boolean {
     (element.tabIndex === 0 && element.getAttribute("tabindex") !== null);
   if (isTabbable) return true;
 
-  if (("disabled" in element && element.disabled) || element?.getAttribute("disabled")) return false;
+  if (
+    ("disabled" in element && element.disabled) ||
+    element?.getAttribute("disabled")
+  )
+    return false;
 
   // Allow elements with data-should-focus to be focusable even with tabindex=-1
   if (element.getAttribute?.("data-should-focus")) return true;
@@ -547,7 +556,10 @@ export function findFirstFocusableNode(
     }
 
     if (node.hasChildNodes()) {
-      focusableNode = findFirstFocusableNode(Array.from(node.childNodes), reversed);
+      focusableNode = findFirstFocusableNode(
+        Array.from(node.childNodes),
+        reversed,
+      );
       if (focusableNode) break;
     }
 
@@ -565,20 +577,39 @@ export function findFirstFocusableNode(
   return focusableNode;
 }
 
-function findFirstNodeOfSlot(
-  node: Node,
-  reversed: boolean,
-): Node | null {
+function findFirstNodeOfSlot(node: Node, reversed: boolean): Node | null {
   if (!(node instanceof HTMLSlotElement)) return null;
   return findFirstFocusableNode([...node.assignedNodes()], reversed);
 }
 
-function findFirstNodeOfShadowDOM(
-  node: Node,
-  reversed: boolean,
-): Node | null {
+function findFirstNodeOfShadowDOM(node: Node, reversed: boolean): Node | null {
   if (!(node instanceof HTMLElement)) return null;
-  return findFirstFocusableNode([...(node.shadowRoot?.childNodes || [])], reversed);
+  return findFirstFocusableNode(
+    [...(node.shadowRoot?.childNodes || [])],
+    reversed,
+  );
 }
 
+export function parseCssTimeToMilliseconds(
+  timeValue: string,
+  fallback = 100,
+): number {
+  const match = timeValue.trim().match(/^([0-9]*\.?[0-9]+)\s*(ms|s)$/i);
 
+  if (!match) {
+    return fallback;
+  }
+
+  const [, valueStr, unit] = match;
+  let durationInMs = Number.parseFloat(valueStr);
+
+  if (Number.isNaN(durationInMs)) {
+    return fallback;
+  }
+
+  if (unit.toLowerCase() === "s") {
+    durationInMs *= 1000;
+  }
+
+  return durationInMs;
+}

--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -10,8 +10,11 @@
     validateRequired,
     generateRandomId,
     ensureSlotExists,
+    dispatch,
+    parseCssTimeToMilliseconds,
   } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
+  import { Once } from "@abgov/ui-components-common";
 
   // Validators
 
@@ -20,9 +23,15 @@
     ["small", "medium"],
   );
 
+  const [IconPositions, validateIconPosition] = typeValidator(
+    "Accordion icon position",
+    ["left", "right"],
+  );
+
   // Types
 
   type HeadingSize = (typeof HeadingSizes)[number];
+  type IconPosition = (typeof IconPositions)[number];
 
   // Props
 
@@ -49,16 +58,27 @@
   /** Left margin. */
   export let ml: Spacing = null;
   /** Sets the position of the expand/collapse icon. */
-  export let iconposition: "left" | "right" = "left";
+  export let iconposition: IconPosition = "left";
 
   // Private
 
   let _hovering: boolean = false;
   let _titleEl: HTMLElement;
   let _rootEl: HTMLElement;
+  let _detailsEl: HTMLDetailsElement;
+  let _summaryEl: HTMLElement;
   let _slotEl: HTMLElement;
   let _headingSlotChildren: Element[] = [];
   let _accordionId: string = "";
+
+  // Store the animation object (so we can cancel it if needed)
+  let _animation: Animation | null = null;
+  // Store if the element is closing
+  let _isClosing = false;
+  // Store if the element is expanding
+  let _isExpanding = false;
+  // Show error messages only once
+  let _once: Once = new Once();
 
   // Reactive
 
@@ -69,6 +89,7 @@
   onMount(() => {
     validateRequired("GoAAccordion", { heading });
     validateHeadingSize(headingsize);
+    validateIconPosition(iconposition);
     ensureSlotExists(_slotEl);
 
     _headingSlotChildren = getHeadingChildren();
@@ -81,22 +102,172 @@
       if (slot) {
         return slot.assignedElements();
       } else {
-        // @ts-expect-error
         return [..._titleEl.children] as Element[]; // unit tests
       }
     }
     return [];
   }
 
-  function dispatchClickEvent(open?: boolean) {
+  function dispatchChangeEvent(accordionIsOpen: boolean) {
     if (!_rootEl) return;
 
-    _rootEl.dispatchEvent(
-      new CustomEvent("_change", {
-        composed: true,
-        bubbles: true,
-        detail: { open: open },
-      }),
+    dispatch(
+      _rootEl,
+      "_change",
+      {
+        open: accordionIsOpen,
+      },
+      { bubbles: true },
+    );
+  }
+
+  function onAccordionToggle(target: Event) {
+    // Stop default behaviour from the browser
+    target.preventDefault();
+    // Add an overflow on the <details> to avoid content overflowing
+    _detailsEl.style.overflow = "hidden";
+
+    // Check if the element is being closed or is already closed
+    if (_isClosing || !_detailsEl.open) {
+      openAccordion();
+      // Check if the element is being openned or is already open
+    } else if (_isExpanding || _detailsEl.open) {
+      shrink();
+    }
+  }
+
+  function shrink() {
+    // Set the element as "being closed"
+    _isClosing = true;
+
+    // Store the current height of the element
+    const startHeight = `${_detailsEl.offsetHeight}px`;
+    // Calculate the height of the summary
+    const endHeight = `${_summaryEl.offsetHeight}px`;
+
+    // If there is already an animation running
+    if (_animation) {
+      // Cancel the current animation
+      _animation.cancel();
+    }
+
+    // Start a WAAPI animation
+    const duration = getAnimationDuration();
+    const easing = getAnimationEasingExit();
+    _animation = _detailsEl.animate(
+      {
+        // Set the keyframes from the startHeight to endHeight
+        height: [startHeight, endHeight],
+      },
+      {
+        duration,
+        easing,
+      },
+    );
+
+    // When the animation is complete, call onAnimationFinish()
+    _animation.onfinish = () => onAnimationFinish(false);
+    // If the animation is cancelled, isClosing variable is set to false
+    _animation.oncancel = () => (_isClosing = false);
+  }
+
+  function openAccordion() {
+    // Apply a fixed height on the element
+    _detailsEl.style.height = `${_detailsEl.offsetHeight}px`;
+    // Force the [open] attribute on the details element
+    _detailsEl.open = true;
+    // Wait for the next frame to call the expand function
+    window.requestAnimationFrame(() => expand());
+  }
+
+  function expand() {
+    // Set the element as "being expanding"
+    _isExpanding = true;
+    // Get the current fixed height of the element
+    const startHeight = `${_detailsEl.offsetHeight}px`;
+    // Calculate the open height of the element (summary height + content height)
+    const endHeight = `${_summaryEl.offsetHeight + _slotEl.offsetHeight}px`;
+
+    // If there is already an animation running
+    if (_animation) {
+      // Cancel the current animation
+      _animation.cancel();
+    }
+
+    // Start a WAAPI animation
+    const duration = getAnimationDuration();
+    const easing = getAnimationEasingReveal();
+    _animation = _detailsEl.animate(
+      {
+        // Set the keyframes from the startHeight to endHeight
+        height: [startHeight, endHeight],
+      },
+      {
+        duration,
+        easing,
+      },
+    );
+    // When the animation is complete, call onAnimationFinish()
+    _animation.onfinish = () => onAnimationFinish(true);
+    // If the animation is cancelled, isExpanding variable is set to false
+    _animation.oncancel = () => (_isExpanding = false);
+
+    open = "true";
+  }
+
+  function onAnimationFinish(isAccordionOpen: boolean) {
+    // Set the open attribute based on the parameter
+    _detailsEl.open = isAccordionOpen;
+    // Clear the stored animation
+    _animation = null;
+    // Reset isClosing & isExpanding
+    _isClosing = false;
+    _isExpanding = false;
+    // Remove the overflow hidden and the fixed height
+    _detailsEl.style.height = _detailsEl.style.overflow = "";
+
+    dispatchChangeEvent(isAccordionOpen);
+
+    open = isAccordionOpen ? "true" : "false";
+  }
+
+  // Because the animation is done using JavaScript we can't use CSS variables
+  // in the animation, this helps to work around that.
+  function getCssVariableValue(variableName: string): string | null {
+    const value = getComputedStyle(_rootEl)
+      .getPropertyValue(variableName)
+      .trim();
+
+    if (!value || value === "") {
+      // Show a warning only once
+      _once.do(variableName, () =>
+        console.warn(
+          `CSS variable ${variableName} is not defined. Please make sure you're using the correct version of @abgov/design-tokens`,
+        ),
+      );
+      return null;
+    }
+    return value;
+  }
+
+  function getAnimationDuration(): number {
+    const durationValueStr =
+      getCssVariableValue("--goa-motion-duration-short-3") ?? "100ms";
+
+    return parseCssTimeToMilliseconds(durationValueStr, 100);
+  }
+
+  function getAnimationEasingReveal(): string {
+    return (
+      getCssVariableValue("--goa-motion-curve-expressive-reveal") ??
+      "cubic-bezier(0.7, 0, 0.25, 1)"
+    );
+  }
+
+  function getAnimationEasingExit(): string {
+    return (
+      getCssVariableValue("--goa-motion-curve-expressive-exit") ??
+      "cubic-bezier(0.42, 0, 1, 1)"
     );
   }
 </script>
@@ -111,8 +282,13 @@
   class="goa-accordion"
   bind:this={_rootEl}
   data-testid={testid}
+  {id}
 >
-<details open={isOpen} on:toggle={({ target }) => { open = `${target?.open}`; dispatchClickEvent(target?.open); }}>
+  <details
+    bind:this={_detailsEl}
+    open={isOpen}
+    data-testid={`${testid}-details`}
+  >
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <summary
       class={`container-${headingsize}`}
@@ -121,10 +297,12 @@
       on:focus={() => (_hovering = false)}
       on:blur={() => (_hovering = false)}
       aria-controls={`${_accordionId}-content`}
-      aria-expanded={open === "true"}
+      aria-expanded={isOpen}
       class:iconRight={iconposition === "right"}
+      bind:this={_summaryEl}
+      on:click={onAccordionToggle}
+      data-testid={`${testid}-summary`}
     >
-
       {#if iconposition === "left"}
         <goa-icon
           type="chevron-forward"
@@ -145,6 +323,7 @@
         <div
           class="heading-content"
           class:heading-content-top={_headingSlotChildren.length}
+          on:click|stopPropagation
         >
           <slot name="headingcontent" />
         </div>
@@ -207,6 +386,8 @@
 
     /* safari hack (see below) */
     position: relative;
+    transition: var(--goa-motion-duration-short-2) background-color
+      var(--goa-motion-curve-expressive);
   }
 
   summary.iconRight {
@@ -242,7 +423,7 @@
   }
 
   summary goa-icon {
-    padding: 0.125rem 1rem;
+    padding: 0.25rem 1rem;
   }
 
   .title {
@@ -250,27 +431,44 @@
     flex: 1;
   }
 
-  .title span {
-    padding-bottom: var(--goa-space-2xs, 0);
-  }
-
   .heading {
     font: var(--goa-accordion-heading);
-    padding-right: 1rem;
+    padding: 0.125rem 1rem 0 0;
+  }
+
+  .heading-small {
+    padding-top: 0.25rem;
+    line-height: 1.75rem;
+    font: var(--goa-accordion-heading);
+  }
+
+  .heading-medium {
+    line-height: 2rem;
+    font: var(--goa-accordion-heading-m);
   }
 
   .secondary-text {
-    font: var(--goa-accordion-heading-secondary-text, var(--goa-typography-body-s));
-    color: var(--goa-accordion-heading-secondary-text-color, var(--goa-color-text-default));
+    font: var(
+      --goa-accordion-heading-secondary-text,
+      var(--goa-typography-body-s)
+    );
+    color: var(
+      --goa-accordion-heading-secondary-text-color,
+      var(--goa-color-text-default)
+    );
     line-height: 1.5rem;
     padding-right: 1rem;
   }
-  .heading-content {
-    flex: 1;
+
+  .heading-medium + .secondary-text {
+    font: var(
+      --goa-accordion-heading-m-secondary-text,
+      var(--goa-typography-body-s)
+    );
   }
 
-  goa-icon {
-    padding: 0.125rem 1rem;
+  .heading-content {
+    flex: 1;
   }
 
   .container-medium {
@@ -278,7 +476,7 @@
   }
 
   .container-medium goa-icon {
-    padding: 0.375rem 1rem;
+    padding: 0.5rem 1rem;
   }
 
   .content {
@@ -305,30 +503,31 @@
   }
 
   details[open] summary:hover {
-    border-bottom: var(--goa-accordion-divider-hover, var(--goa-accordion-divider));
+    border-bottom: var(
+      --goa-accordion-divider-hover,
+      var(--goa-accordion-divider)
+    );
   }
 
   details[open] summary:focus-visible::before {
-    border-radius: var(--goa-accordion-border-radius-focus, var(--goa-accordion-border-radius));
-  }
-
-
-  /* Sizes */
-  .heading-medium {
-    line-height: 2rem;
-    font: var(--goa-accordion-heading-m);
-  }
-
-  .heading-medium + .secondary-text {
-    font: var(--goa-accordion-heading-m-secondary-text, var(--goa-typography-body-s));
+    border-radius: var(
+      --goa-accordion-border-radius-focus,
+      var(--goa-accordion-border-radius)
+    );
   }
 
   .container-medium {
-    padding: var(--goa-accordion-padding-heading-m-icon-left, var(--goa-accordion-padding-heading-icon-left));
+    padding: var(
+      --goa-accordion-padding-heading-m-icon-left,
+      var(--goa-accordion-padding-heading-icon-left)
+    );
   }
 
   .container-medium.iconRight {
-    padding: var(--goa-accordion-padding-heading-m-icon-right, var(--goa-accordion-padding-heading-icon-right));
+    padding: var(
+      --goa-accordion-padding-heading-m-icon-right,
+      var(--goa-accordion-padding-heading-icon-right)
+    );
   }
 
   @container self (--mobile) {
@@ -347,7 +546,7 @@
       padding: var(--goa-accordion-padding-content-wide);
     }
     .title {
-      align-items: center;
+      align-items: baseline;
     }
   }
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       },
       "devDependencies": {
         "@abgov/design-tokens": "1.10.0",
-        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.4.0",
+        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.4.3",
         "@abgov/nx-release": "12.0.0",
         "@angular-devkit/build-angular": "21.2.6",
         "@angular-devkit/core": "21.2.6",
@@ -132,9 +132,9 @@
     },
     "node_modules/@abgov/design-tokens-v2": {
       "name": "@abgov/design-tokens",
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.4.0.tgz",
-      "integrity": "sha512-GZmwdpYrbyVAOuAfqLaTBb8xBVu3ij9DiNOnJD88v9snS5Dexv//yr0hvoVSC+01zH2qizVUCOQc4FMrb/+pTA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.4.3.tgz",
+      "integrity": "sha512-5QbY7d5ofpd2x24dpqYUFDubIF6b9gUuL0E41lOQyYkNyUuyW53LgQ2R/+qAAfQVywPNcqUFEUMYd+CbHtYStA==",
       "dev": true
     },
     "node_modules/@abgov/nx-release": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@abgov/design-tokens": "1.10.0",
-    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.4.0",
+    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.4.3",
     "@abgov/nx-release": "12.0.0",
     "@angular-devkit/build-angular": "21.2.6",
     "@angular-devkit/core": "21.2.6",


### PR DESCRIPTION
# Before (the change)

Accordion is all unrefined and gross. 🤢

<img width="653" height="644" alt="image" src="https://github.com/user-attachments/assets/50de464f-3750-4452-b71d-cec831699498" />
	
# After (the change)

Fixed all discrepancies from issue #3625.

- Large heading Accordion is 64px tall
- Small heading Accordion is 48px tall
- After size adjustments above:
	- the small heading text is vertically centered for
		- primary text 
		- secondary text	
	- large heading secondary text is vertically centered
- Ensure other slotted elements are still vertically centered after update
- Add motion tokens to animate the following:
	- "hover" - Background transform from white to grey use `--goa-motion-duration-short-2`
	- "open" - Show accordion content area use `--goa-motion-curve-expressive` and `--goa-motionDuration-short-3`
	- "close" - Hide accordion content area, use `--goa-motion-curve-expressive-exit` and `--goa-motionDuration-short-3`

<img width="650" height="835" alt="image" src="https://github.com/user-attachments/assets/a169792e-6b19-4f38-aaa3-e81b99856301" />

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Make sure you check out [the `eric/3625-accordion-refinements` branch](https://github.com/GovAlta/design-tokens/pull/145) from design-tokens and update `package.json` `devDependencies` to use it:

```json
"@abgov/design-tokens": "file://../design-tokens",
"@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.2.1",
```

Run `npm i` after making the change.

This PR will close [Issue #3625](https://github.com/GovAlta/ui-components/issues/3625)
