### PR TITLE
fix(#3699): Notification popover has rounded corners added to it.

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -254,6 +254,10 @@
             url="/bugs/3635"
           ></goab-work-side-menu-item>
           <goab-work-side-menu-item
+          label="3699 Notification Popover rounded corners"
+          url="/bugs/3699"
+        ></goab-work-side-menu-item>
+          <goab-work-side-menu-item
             label="3637 Checkbox Table Header Row Height Bug"
             url="/bugs/3637"
           ></goab-work-side-menu-item>

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -53,6 +53,7 @@ import { Bug3505Component } from "../routes/bugs/3505/bug3505.component";
 import { Bug3614Component } from "../routes/bugs/3614/bug3614.component";
 import { Bug3685Component } from "../routes/bugs/3685/bug3685.component";
 import { Bug3635Component } from "../routes/bugs/3635/bug3635.component";
+import { Bug3699Component } from "../routes/bugs/3699/bug3699.component";
 import { Bug3637Component } from "../routes/bugs/3637/bug3637.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
@@ -149,6 +150,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3505", component: Bug3505Component },
   { path: "bugs/3685", component: Bug3685Component },
   { path: "bugs/3635", component: Bug3635Component },
+  { path: "bugs/3699", component: Bug3699Component },
   { path: "bugs/3637", component: Bug3637Component },
   // Feature routes
   { path: "features/1328", component: Feat1328Component },

--- a/apps/prs/angular/src/routes/bugs/3699/bug3699.component.html
+++ b/apps/prs/angular/src/routes/bugs/3699/bug3699.component.html
@@ -1,0 +1,66 @@
+<div>
+  <h1>3699 - Notification Popover rounded corners</h1>
+   <goab-work-side-menu heading="Bug 3279" url="#" userName="Jane Doe" userSecondaryText="jane.doe@gov.ab.ca"
+    [open]="open" (onToggle)="onToggle()" [primaryContent]="primaryTemplate" [secondaryContent]="secondaryTemplate">
+  </goab-work-side-menu>
+
+  <ng-template #primaryTemplate>
+    <goab-work-side-menu-item label="Primary item 1" icon="home" url="#primary-1" />
+    <goab-work-side-menu-item label="Primary item 2" icon="bookmark" badge="2" url="#primary-2" />
+
+    <goab-work-side-menu-group heading="Primary group" icon="folder">
+      <goab-work-side-menu-item label="Grouped item 1" icon="document" url="#primary-group-1" />
+      <goab-work-side-menu-item label="Grouped item 2" icon="document-text" url="#primary-group-2" />
+    </goab-work-side-menu-group>
+
+    <goab-work-side-menu-item label="Primary item 3" icon="list" url="#primary-3" />
+
+    <div style="display: flex; flex-direction: column; gap: 1rem">
+      <goab-container type="non-interactive" padding="compact">
+        <goab-button type="primary" (click)="onActionClick()">Action</goab-button>
+      </goab-container>
+
+      <goab-link href="#testthis">Link</goab-link>
+
+      <goab-details heading="Details">
+        <p>This is some details content inside the primary content area.</p>
+      </goab-details>
+    </div>
+  </ng-template>
+
+  <ng-template #secondaryTemplate>
+    <goab-work-side-menu-item label="Secondary item 1" icon="analytics" url="#secondary-1" />
+    <goab-work-side-menu-item label="Secondary item 2" icon="settings" url="#secondary-2" />
+    <goab-work-side-menu-item
+      icon="notifications"
+      label="Notifications"
+      badge="3"
+      type="success"
+      [popoverContent]="notificationsTpl"
+    ></goab-work-side-menu-item>
+  </ng-template>
+<ng-template #notificationsTpl>
+  <goab-work-side-notification-panel
+    heading="Notifications"
+    activeTab="unread"
+  >
+    <goab-work-side-notification-item
+      title="New case assigned"
+      description="Case #12345 has been assigned to you."
+      timestamp="2025-02-09T10:30:00Z"
+      type="info"
+      readStatus="unread"
+      priority="normal"
+    ></goab-work-side-notification-item>
+    <goab-work-side-notification-item
+      title="System maintenance"
+      description="Scheduled maintenance tonight at 11 PM."
+      timestamp="2025-02-09T09:00:00Z"
+      type="critical"
+      readStatus="unread"
+      priority="urgent"
+    ></goab-work-side-notification-item>
+  </goab-work-side-notification-panel>
+</ng-template>
+
+</div>

--- a/apps/prs/angular/src/routes/bugs/3699/bug3699.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3699/bug3699.component.ts
@@ -1,0 +1,42 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabWorkSideMenu,
+  GoabWorkSideMenuItem,
+  GoabWorkSideNotificationPanel,
+  GoabWorkSideMenuGroup,
+  GoabContainer,
+  GoabWorkSideNotificationItem,
+  GoabButton,
+  GoabLink,
+  GoabDetails,
+} from "@abgov/angular-components";
+
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3699",
+  templateUrl: "./bug3699.component.html",
+  imports: [CommonModule,
+  GoabWorkSideMenu,
+  GoabWorkSideMenuItem,
+  GoabWorkSideNotificationPanel,
+  GoabWorkSideNotificationItem,
+  GoabWorkSideMenuGroup,
+  GoabContainer,
+  GoabButton,
+  GoabLink,
+  GoabDetails,
+],
+})
+export class Bug3699Component {
+  open = true;
+
+  onToggle(): void {
+    this.open = !this.open;
+  }
+
+  onActionClick(): void {
+    alert("Action button in primary content clicked");
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -242,6 +242,10 @@ export function App() {
                   url="/bugs/3635"
                 />
                 <GoabWorkSideMenuItem
+                  label="3699 Notification Popover rounded corners"
+                  url="/bugs/3699"
+                />
+                <GoabWorkSideMenuItem
                   label="3637 Checkbox Table Header Row Height Bug"
                   url="/bugs/3637"
                 />

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -55,6 +55,7 @@ import { Bug3505Route } from "./routes/bugs/bug3505";
 import { Bug3614Route } from "./routes/bugs/bug3614";
 import { Bug3685Route } from "./routes/bugs/bug3685";
 import { Bug3635Route } from "./routes/bugs/bug3635";
+import { Bug3699Route } from "./routes/bugs/bug3699";
 import { Bug3637Route } from "./routes/bugs/bug3637";
 
 import { EverythingRoute } from "./routes/everything";
@@ -158,6 +159,7 @@ root.render(
           <Route path="bugs/3614" element={<Bug3614Route />} />
           <Route path="bugs/3685" element={<Bug3685Route />} />
           <Route path="bugs/3635" element={<Bug3635Route />} />
+          <Route path="bugs/3699" element={<Bug3699Route />} />
           <Route path="bugs/3637" element={<Bug3637Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3699.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3699.tsx
@@ -1,0 +1,55 @@
+import {
+ GoabWorkSideMenu,
+ GoabWorkSideMenuItem,
+ GoabWorkSideNotificationPanel,
+ GoabWorkSideNotificationItem
+} from "@abgov/react-components";
+
+export function Bug3699Route() {
+  return (
+     <div>
+      <h1>3699 - Notification Popover rounded corners</h1>
+      <GoabWorkSideMenu
+        heading="My Application"
+        url="/"
+        primaryContent={
+          <>
+            <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+            <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+          </>
+        }
+        secondaryContent={
+          <GoabWorkSideMenuItem
+            icon="notifications"
+            label="Notifications"
+            badge="3"
+            type="success"
+            popoverContent={
+              <GoabWorkSideNotificationPanel
+                heading="Notifications"
+                activeTab="unread"
+              >
+                <GoabWorkSideNotificationItem
+                  title="New case assigned"
+                  description="Case #12345 has been assigned to you."
+                  timestamp="2025-02-09T10:30:00Z"
+                  type="info"
+                  readStatus="unread"
+                  priority="normal"
+                />
+                <GoabWorkSideNotificationItem
+                  title="System maintenance"
+                  description="Scheduled maintenance tonight at 11 PM."
+                  timestamp="2025-02-09T09:00:00Z"
+                  type="critical"
+                  readStatus="unread"
+                  priority="urgent"
+                />
+              </GoabWorkSideNotificationPanel>
+            }
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/libs/web-components/src/components/work-side-menu/WorkSideNotificationPanel.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideNotificationPanel.svelte
@@ -335,6 +335,7 @@
     display: flex;
     flex-direction: column;
     background: var(--goa-color-greyscale-white);
+    border-radius: var(--goa-popover-border-radius);
     height: 710px;
   }
 


### PR DESCRIPTION
# Before (the change)
The Notification Panel in the side menu has pointed corners. Should be rounded like in the [previous version of the workspace](https://workspace-demo-v4.netlify.app/).

<img width="938" height="915" alt="image" src="https://github.com/user-attachments/assets/d7be3aaf-94c4-4db1-86a2-277be8e2f8f1" />

# After (the change)
Added the `--goa-popover-border-radius` token to the `.notification-panel` class and now displays the rounded corners.

<img width="604" height="759" alt="image" src="https://github.com/user-attachments/assets/2bb7fc83-5d01-424d-b094-e4b4075b5d0c" />

## Steps needed to test

- [ ] On Desktop, open the "Notifications" panel and confirm that corners are rounded.