### PR TITLE
fix(#3735): fix tooltip position in Work Side Menu and add to toggle button

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -36,7 +36,10 @@
       </goab-app-header>
     </section>
 
-    <div style="display: flex; flex: 1 1 auto">
+    <div
+      style="display: flex; flex: 1 1 auto; min-height: calc(100vh - 10.1875rem)"
+      [style.--goa-work-side-menu-height]="workSideMenuHeight"
+    >
       <goab-work-side-menu
         heading="Testing Playground"
         url="/"
@@ -258,6 +261,10 @@
           url="/bugs/3635"
         ></goab-work-side-menu-item>
         <goab-work-side-menu-item
+            label="3735 Work Side Menu tooltip fixes"
+            url="/bugs/3735"
+          ></goab-work-side-menu-item>
+          <goab-work-side-menu-item
             label="3635 Input Leading icon color"
             url="/bugs/3635"
           ></goab-work-side-menu-item>

--- a/apps/prs/angular/src/app/app.component.ts
+++ b/apps/prs/angular/src/app/app.component.ts
@@ -30,6 +30,7 @@ import {
 })
 export class AppComponent {
   isFullPage = false;
+  readonly workSideMenuHeight = "calc(100vh - 10.1875rem)";
 
   private fullPageRoutes = ["/features/2885"];
   private router = inject(Router);

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -53,6 +53,7 @@ import { Bug3505Component } from "../routes/bugs/3505/bug3505.component";
 import { Bug3614Component } from "../routes/bugs/3614/bug3614.component";
 import { Bug3685Component } from "../routes/bugs/3685/bug3685.component";
 import { Bug3640Component } from "../routes/bugs/3640/bug3640.component";
+import { Bug3735Component } from "../routes/bugs/3735/bug3735.component";
 import { Bug3635Component } from "../routes/bugs/3635/bug3635.component";
 import { Bug3699Component } from "../routes/bugs/3699/bug3699.component";
 import { Bug3637Component } from "../routes/bugs/3637/bug3637.component";
@@ -153,6 +154,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3505", component: Bug3505Component },
   { path: "bugs/3685", component: Bug3685Component },
   { path: "bugs/3640", component: Bug3640Component },
+  { path: "bugs/3735", component: Bug3735Component },
   { path: "bugs/3635", component: Bug3635Component },
   { path: "bugs/3699", component: Bug3699Component },
   { path: "bugs/3637", component: Bug3637Component },

--- a/apps/prs/angular/src/routes/bugs/3735/bug3735.component.css
+++ b/apps/prs/angular/src/routes/bugs/3735/bug3735.component.css
@@ -1,0 +1,10 @@
+.menu-shell {
+  --goa-work-side-menu-height: 26rem;
+
+  display: inline-block;
+}
+
+ul {
+  margin: 0 0 var(--goa-space-xl);
+  padding-left: 1.5rem;
+}

--- a/apps/prs/angular/src/routes/bugs/3735/bug3735.component.html
+++ b/apps/prs/angular/src/routes/bugs/3735/bug3735.component.html
@@ -1,0 +1,42 @@
+<goab-text tag="h1" mb="m">Bug 3735 - Work Side Menu tooltip fixes</goab-text>
+<goab-text mb="xl">
+  Hover the collapsed menu items and confirm that:
+</goab-text>
+
+<ul>
+  <li>The items are aligned horizontally and vertically.</li>
+  <li>A tooltip appears for the "Expand menu" item.</li>
+</ul>
+
+<div class="menu-shell">
+  <goab-work-side-menu
+    heading="Offset tooltip demo"
+    url="/bugs/3735"
+    [open]="false"
+    (onNavigate)="handleNavigate($event)"
+    [primaryContent]="primaryContent"
+    [secondaryContent]="emptySecondary"
+    [accountContent]="emptyAccount"
+  ></goab-work-side-menu>
+</div>
+
+<ng-template #primaryContent>
+  <goab-work-side-menu-item
+    icon="document-text"
+    label="Get started"
+    url="/bugs/3735"
+  ></goab-work-side-menu-item>
+  <goab-work-side-menu-item
+    icon="list"
+    label="Bug list"
+    url="/bugs/3735"
+  ></goab-work-side-menu-item>
+  <goab-work-side-menu-item
+    icon="settings"
+    label="Admin settings"
+    url="/bugs/3735"
+  ></goab-work-side-menu-item>
+</ng-template>
+
+<ng-template #emptySecondary></ng-template>
+<ng-template #emptyAccount></ng-template>

--- a/apps/prs/angular/src/routes/bugs/3735/bug3735.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3735/bug3735.component.ts
@@ -1,0 +1,19 @@
+import { Component } from "@angular/core";
+import {
+  GoabText,
+  GoabWorkSideMenu,
+  GoabWorkSideMenuItem,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3735",
+  templateUrl: "./bug3735.component.html",
+  styleUrls: ["./bug3735.component.css"],
+  imports: [GoabText, GoabWorkSideMenu, GoabWorkSideMenuItem],
+})
+export class Bug3735Component {
+  handleNavigate(_path: string): void {
+    // Intentionally no-op for this visual verification page.
+  }
+}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
 import {
   GoabAppFooter,
@@ -12,6 +13,12 @@ import {
 
 import "@abgov/style";
 import "@abgov/design-tokens-v2/dist/tokens.css"; // Production tokens. Comment out to test with legacy V1 token values.
+
+const appContentStyle: CSSProperties = {
+  display: "flex",
+  minHeight: "calc(100vh - 10.1875rem)",
+  "--goa-work-side-menu-height": "calc(100vh - 10.1875rem)",
+} as CSSProperties;
 
 export function App() {
   const navigate = useNavigate();
@@ -51,7 +58,7 @@ export function App() {
           </GoabAppHeaderMenu>
         </GoabAppHeader>
       </section>
-      <div style={{ display: "flex", minHeight: "100vh" }}>
+      <div style={appContentStyle}>
         <GoabWorkSideMenu
           heading="Testing Playground"
           url="/"
@@ -224,15 +231,14 @@ export function App() {
                   url="/bugs/3607"
                 />
                 <GoabWorkSideMenuItem label="3505 Link Icon Click" url="/bugs/3505" />
-                <GoabWorkSideMenuItem label="3548 Side Menu Scroll" url="/bugs/3548" />
                 <GoabWorkSideMenuItem label="3614 IconButton Hitboxes" url="/bugs/3614" />
                 <GoabWorkSideMenuItem
                   label="3685 Checkbox & Radio: Reveal width not aligned with item"
                   url="/bugs/3685"
                 />
                 <GoabWorkSideMenuItem
-                  label="3640 Work Side Menu Badge Alignment"
-                  url="/bugs/3640"
+                  label="3735 Work Side Menu tooltip fixes"
+                  url="/bugs/3735"
                 />
                 <GoabWorkSideMenuItem
                   label="3635 Input Leading icon color"
@@ -249,6 +255,10 @@ export function App() {
                 <GoabWorkSideMenuItem
                   label="3667 Notification banner refinements"
                   url="/bugs/3667"
+                />
+                <GoabWorkSideMenuItem
+                  label="3735 Work Side Menu tooltip fixes"
+                  url="/bugs/3735"
                 />
               </GoabWorkSideMenuGroup>
 

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -55,6 +55,7 @@ import { Bug3607Route } from "./routes/bugs/bug3607";
 import { Bug3505Route } from "./routes/bugs/bug3505";
 import { Bug3614Route } from "./routes/bugs/bug3614";
 import { Bug3640Route } from "./routes/bugs/bug3640";
+import { Bug3735Route } from "./routes/bugs/bug3735";
 import { Bug3635Route } from "./routes/bugs/bug3635";
 import { Bug3699Route } from "./routes/bugs/bug3699";
 import { Bug3637Route } from "./routes/bugs/bug3637";
@@ -163,6 +164,7 @@ root.render(
           <Route path="bugs/3614" element={<Bug3614Route />} />
           <Route path="bugs/3685" element={<Bug3685Route />} />
           <Route path="bugs/3640" element={<Bug3640Route />} />
+          <Route path="bugs/3735" element={<Bug3735Route />} />
           <Route path="bugs/3635" element={<Bug3635Route />} />
           <Route path="bugs/3699" element={<Bug3699Route />} />
           <Route path="bugs/3637" element={<Bug3637Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3735.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3735.tsx
@@ -1,0 +1,75 @@
+import type { CSSProperties } from "react";
+import {
+  GoabText,
+  GoabWorkSideMenu,
+  GoabWorkSideMenuItem,
+} from "@abgov/react-components";
+
+const noop = () => undefined;
+
+const menuShellStyle: CSSProperties = {
+  "--goa-work-side-menu-height": "26rem",
+  display: "inline-block",
+} as CSSProperties;
+
+const demoGridStyle: CSSProperties = {
+  display: "grid",
+  gap: "2rem",
+};
+
+const checklistStyle: CSSProperties = {
+  margin: 0,
+  paddingLeft: "1.5rem",
+};
+
+function renderPrimaryContent(prefix: string) {
+  return (
+    <>
+      <GoabWorkSideMenuItem
+        key={`${prefix}-get-started`}
+        icon="document-text"
+        label="Get started"
+        url="/bugs/3735"
+      />
+      <GoabWorkSideMenuItem
+        key={`${prefix}-bugs`}
+        icon="list"
+        label="Bug list"
+        url="/bugs/3735"
+      />
+      <GoabWorkSideMenuItem
+        key={`${prefix}-settings`}
+        icon="settings"
+        label="Admin settings"
+        url="/bugs/3735"
+      />
+    </>
+  );
+}
+
+export function Bug3735Route() {
+  return (
+    <div style={demoGridStyle}>
+      <div>
+        <GoabText tag="h1" mb="m">
+          Bug 3735 - Work Side Menu tooltip fixes
+        </GoabText>
+        <GoabText mb="xl">Hover the collapsed menu items and confirm that:</GoabText>
+        <ul style={checklistStyle}>
+          <li>The items are aligned horizontally and vertically.</li>
+          <li>A tooltip appears for the "Expand menu" item.</li>
+        </ul>
+      </div>
+
+      <div style={menuShellStyle}>
+        <GoabWorkSideMenu
+          heading="Offset tooltip demo"
+          url="/bugs/3735"
+          open={false}
+          onNavigate={noop}
+          primaryContent={renderPrimaryContent("offset")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/docs/src/components/nav/MenuSecondaryContent.tsx
+++ b/docs/src/components/nav/MenuSecondaryContent.tsx
@@ -8,10 +8,7 @@
  */
 
 import { useCallback, useState, useEffect } from "react";
-import {
-  GoabSpacer,
-  GoabWorkSideMenuItem,
-} from "@abgov/react-components";
+import { GoabIcon, GoabSpacer, GoabWorkSideMenuItem } from "@abgov/react-components";
 
 import "./menu-secondary.css";
 
@@ -33,15 +30,51 @@ export function MenuSecondaryContent({ isOpen }: MenuSecondaryContentProps) {
     window.dispatchEvent(new CustomEvent("goa-search-open"));
   }, []);
 
+  const showSearchTooltip = useCallback(
+    (
+      event: React.MouseEvent<HTMLButtonElement> | React.FocusEvent<HTMLButtonElement>,
+    ) => {
+      event.currentTarget.dispatchEvent(
+        new CustomEvent("_hoverItem", {
+          bubbles: true,
+          composed: true,
+          detail: {
+            label: "Search",
+            el: event.currentTarget,
+          },
+        }),
+      );
+    },
+    [],
+  );
+
+  const hideSearchTooltip = useCallback(
+    (
+      event: React.MouseEvent<HTMLButtonElement> | React.FocusEvent<HTMLButtonElement>,
+    ) => {
+      event.currentTarget.dispatchEvent(
+        new CustomEvent("_blurItem", {
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    },
+    [],
+  );
+
   return (
     <>
       <button
         className="search-menu-button"
         onClick={openSearch}
+        onMouseEnter={showSearchTooltip}
+        onMouseLeave={hideSearchTooltip}
+        onFocus={showSearchTooltip}
+        onBlur={hideSearchTooltip}
         type="button"
         aria-label="Search"
       >
-        <goa-icon type="search" size="small" />
+        <GoabIcon type="search" size="small" />
         {isOpen && (
           <>
             <span className="search-menu-label">Search</span>

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
@@ -55,8 +55,10 @@
 
   let _menuEl: HTMLElement;
   let _menuLinks: HTMLElement[] = [];
+  let _containerEl: HTMLElement;
   let _rootEl: HTMLElement;
   let _scrollEl: HTMLElement;
+  let _toggleButtonEl: HTMLElement;
   let _tooltipEl: HTMLElement;
   let _tooltipLabel: string = "";
 
@@ -196,16 +198,30 @@
   }
 
   function setTooltipPos(label: string, el: HTMLElement) {
-    let top = el?.getBoundingClientRect().top - 2;
+    const rect = el?.getBoundingClientRect();
+    const containerRect = _containerEl.getBoundingClientRect();
+    const top = rect.top - containerRect.top + rect.height / 2;
+    const left = rect.right - containerRect.left;
+
     _tooltipEl.style.top = `${top}px`;
+    _tooltipEl.style.left = `${left + 14}px`;
+
     _tooltipLabel = label;
   }
 
   function hideTooltip() {
+    clearTimeout(_mouseEnterTimeoutId);
     clearTimeout(_mouseLeaveTimeoutId);
     _mouseLeaveTimeoutId = setTimeout(() => {
       _showTooltip = false;
     }, 300);
+  }
+
+  function handleToggleHover() {
+    if (open) return;
+
+    setTooltipPos("Expand menu", _toggleButtonEl);
+    showTooltip();
   }
 
   // Account menu
@@ -262,12 +278,6 @@
   // Menu-scoped keyboard navigation (only fires when focus is inside menu)
   function handleMenuKeyDown(e: KeyboardEvent) {
     switch (e?.key) {
-      case "ArrowDown":
-        onArrow("down");
-        break;
-      case "ArrowUp":
-        onArrow("up");
-        break;
       case "Escape":
         closeAccountMenu();
         break;
@@ -489,13 +499,15 @@
   }
 
   .closed .tooltip {
-    position: fixed;
-    left: var(--goa-space-3xl);
+    position: absolute;
     background-color: var(--goa-color-greyscale-700);
     font: var(--goa-typography-body-xs);
     color: var(--goa-color-text-light);
     border-radius: var(--goa-border-radius-m);
     padding: var(--goa-space-xs) var(--goa-space-s);
+    width: max-content;
+    white-space: nowrap;
+    transform: translateY(-50%);
   }
 
   .closed .tooltip::before {
@@ -532,7 +544,7 @@
   .root {
     position: relative;
     z-index: 101;
-    height: 100vh;
+    height: var(--goa-work-side-menu-height, 100vh);
   }
 
   .background {
@@ -619,7 +631,7 @@
     animation: none;
   }
 
-  .scroll-area {
+ .scroll-area {
     flex: 1 1 0;
     min-height: 0;
     overflow: hidden;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       },
       "devDependencies": {
         "@abgov/design-tokens": "1.10.0",
-        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.2.2",
+        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.4.0",
         "@abgov/nx-release": "12.0.0",
         "@angular-devkit/build-angular": "21.2.6",
         "@angular-devkit/core": "21.2.6",
@@ -132,9 +132,9 @@
     },
     "node_modules/@abgov/design-tokens-v2": {
       "name": "@abgov/design-tokens",
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.2.2.tgz",
-      "integrity": "sha512-z98ET4AF2Hx4iVSr1fZF82p+N0a+Fs2Wii4twVL2GdCL/nETzg0W5wcTAGvAXZoJ3GSlTEVT8pyO2prm2uqNBw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.4.0.tgz",
+      "integrity": "sha512-GZmwdpYrbyVAOuAfqLaTBb8xBVu3ij9DiNOnJD88v9snS5Dexv//yr0hvoVSC+01zH2qizVUCOQc4FMrb/+pTA==",
       "dev": true
     },
     "node_modules/@abgov/nx-release": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@abgov/design-tokens": "1.10.0",
-    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.2.2",
+    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.4.0",
     "@abgov/nx-release": "12.0.0",
     "@angular-devkit/build-angular": "21.2.6",
     "@angular-devkit/core": "21.2.6",


### PR DESCRIPTION
This PR adds the following fixes to the Work Side Menu:

- Adds tooltips to the Toggle button and the Search button in Docs for better usability.
- Ensures consistent tooltip alignment, both horizontally and vertically, even when the menu is offset.
- Adds a component token to allow dynamic setting of the menu height.


![tooltip-fixed](https://github.com/user-attachments/assets/b0aa154c-91b1-49ff-8943-2c250165490c)
