### PR TITLE
fix(#3654): modal border removal, status close button hover colors

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3654/bug3654.component.html
+++ b/apps/prs/angular/src/routes/bugs/3654/bug3654.component.html
@@ -1,0 +1,89 @@
+<div>
+  <h1>3654 - Modal refinements</h1>
+  <p>
+    <a
+      href="https://github.com/GovAlta/ui-components/issues/3654"
+      target="_blank"
+      rel="noopener"
+    >
+      View on GitHub
+    </a>
+  </p>
+
+  <h2>Test 1: Basic modal (border check)</h2>
+  <p>Inspect the modal surface. There should be no visible border.</p>
+  <goab-button (onClick)="basicOpen = true">Open basic modal</goab-button>
+  <goab-modal
+    heading="Basic Modal"
+    [open]="basicOpen"
+    [closable]="true"
+    (onClose)="basicOpen = false"
+  >
+    <p>Inspect this modal surface for a visible border.</p>
+    <goab-button-group alignment="end" slot="actions">
+      <goab-button type="tertiary" (onClick)="basicOpen = false">Close</goab-button>
+    </goab-button-group>
+  </goab-modal>
+
+  <hr />
+
+  <h2>Test 2: Status modals (close button hover colors)</h2>
+  <p>Hover over the close X button on each status modal.</p>
+
+  <goab-button type="secondary" (onClick)="infoOpen = true">Information</goab-button>
+  <goab-button type="secondary" (onClick)="successOpen = true">Success</goab-button>
+  <goab-button type="secondary" (onClick)="importantOpen = true">Important</goab-button>
+  <goab-button type="secondary" (onClick)="emergencyOpen = true">Emergency</goab-button>
+
+  <goab-modal
+    heading="Information Modal"
+    calloutVariant="information"
+    [open]="infoOpen"
+    [closable]="true"
+    (onClose)="infoOpen = false"
+  >
+    <p>Hover the close button. Check hover color.</p>
+    <goab-button-group alignment="end" slot="actions">
+      <goab-button type="tertiary" (onClick)="infoOpen = false">Close</goab-button>
+    </goab-button-group>
+  </goab-modal>
+
+  <goab-modal
+    heading="Success Modal"
+    calloutVariant="success"
+    [open]="successOpen"
+    [closable]="true"
+    (onClose)="successOpen = false"
+  >
+    <p>Hover the close button. Check hover color.</p>
+    <goab-button-group alignment="end" slot="actions">
+      <goab-button type="tertiary" (onClick)="successOpen = false">Close</goab-button>
+    </goab-button-group>
+  </goab-modal>
+
+  <goab-modal
+    heading="Important Modal"
+    calloutVariant="important"
+    [open]="importantOpen"
+    [closable]="true"
+    (onClose)="importantOpen = false"
+  >
+    <p>Hover the close button. Check hover color.</p>
+    <goab-button-group alignment="end" slot="actions">
+      <goab-button type="tertiary" (onClick)="importantOpen = false">Close</goab-button>
+    </goab-button-group>
+  </goab-modal>
+
+  <goab-modal
+    heading="Emergency Modal"
+    calloutVariant="emergency"
+    [open]="emergencyOpen"
+    [closable]="true"
+    (onClose)="emergencyOpen = false"
+  >
+    <p>Hover the close button. Check hover color.</p>
+    <goab-button-group alignment="end" slot="actions">
+      <goab-button type="tertiary" (onClick)="emergencyOpen = false">Close</goab-button>
+    </goab-button-group>
+  </goab-modal>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3654/bug3654.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3654/bug3654.component.ts
@@ -1,0 +1,16 @@
+import { Component } from "@angular/core";
+import { GoabButton, GoabButtonGroup, GoabModal } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3654",
+  templateUrl: "./bug3654.component.html",
+  imports: [GoabButton, GoabButtonGroup, GoabModal],
+})
+export class Bug3654Component {
+  basicOpen = false;
+  infoOpen = false;
+  successOpen = false;
+  importantOpen = false;
+  emergencyOpen = false;
+}

--- a/apps/prs/angular/src/routes/bugs/3654/bug3654.route.json
+++ b/apps/prs/angular/src/routes/bugs/3654/bug3654.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Modal refinements",
+  "path": "bugs/3654",
+  "id": "3654",
+  "type": "bug"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3654.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3654.route.ts
@@ -1,0 +1,9 @@
+import { Bug3654Route } from "../../../routes/bugs/bug3654";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "bug",
+  id: "3654",
+  path: "bugs/3654",
+  title: "Modal refinements",
+  component: Bug3654Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3654.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3654.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabDetails,
+  GoabLink,
+  GoabButton,
+  GoabButtonGroup,
+  GoabModal,
+} from "@abgov/react-components";
+
+export function Bug3654Route() {
+  const [basicOpen, setBasicOpen] = useState(false);
+  const [infoOpen, setInfoOpen] = useState(false);
+  const [successOpen, setSuccessOpen] = useState(false);
+  const [importantOpen, setImportantOpen] = useState(false);
+  const [emergencyOpen, setEmergencyOpen] = useState(false);
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug #3654: Modal refinements
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a
+            href="https://github.com/GovAlta/ui-components/issues/3654"
+            target="_blank"
+            rel="noopener"
+          >
+            View on GitHub
+          </a>
+        </GoabLink>
+
+        <GoabDetails heading="Issue Description">
+          <GoabText tag="p">
+            1. Remove border from modal surface. 2. For status type modals, the close icon
+            button hover color should reuse the same per-status hover colors used by
+            notification banner close buttons. 3. Silently undocument the Event variant
+            (docs only).
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      <GoabText tag="h3">Test 1: Basic modal (border check)</GoabText>
+      <GoabText tag="p">
+        Inspect the modal surface. There should be no visible border.
+      </GoabText>
+      <GoabButton onClick={() => setBasicOpen(true)}>Open basic modal</GoabButton>
+      <GoabModal
+        heading="Basic Modal"
+        open={basicOpen}
+        onClose={() => setBasicOpen(false)}
+        actions={
+          <GoabButtonGroup alignment="end">
+            <GoabButton type="tertiary" onClick={() => setBasicOpen(false)}>
+              Close
+            </GoabButton>
+          </GoabButtonGroup>
+        }
+      >
+        <GoabText tag="p">
+          Inspect this modal surface for a visible border (shadow, outline, or border
+          property).
+        </GoabText>
+      </GoabModal>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h3">Test 2: Status modals (close button hover colors)</GoabText>
+      <GoabText tag="p">
+        Hover over the close X button on each status modal. The hover color should match
+        the notification banner close button hover colors.
+      </GoabText>
+      <GoabButtonGroup alignment="start">
+        <GoabButton type="secondary" onClick={() => setInfoOpen(true)}>
+          Information
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setSuccessOpen(true)}>
+          Success
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setImportantOpen(true)}>
+          Important
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setEmergencyOpen(true)}>
+          Emergency
+        </GoabButton>
+      </GoabButtonGroup>
+
+      <GoabModal
+        heading="Information Modal"
+        calloutVariant="information"
+        open={infoOpen}
+        onClose={() => setInfoOpen(false)}
+        actions={
+          <GoabButtonGroup alignment="end">
+            <GoabButton type="tertiary" onClick={() => setInfoOpen(false)}>
+              Close
+            </GoabButton>
+          </GoabButtonGroup>
+        }
+      >
+        <GoabText tag="p">Hover the close button. Check hover color.</GoabText>
+      </GoabModal>
+
+      <GoabModal
+        heading="Success Modal"
+        calloutVariant="success"
+        open={successOpen}
+        onClose={() => setSuccessOpen(false)}
+        actions={
+          <GoabButtonGroup alignment="end">
+            <GoabButton type="tertiary" onClick={() => setSuccessOpen(false)}>
+              Close
+            </GoabButton>
+          </GoabButtonGroup>
+        }
+      >
+        <GoabText tag="p">Hover the close button. Check hover color.</GoabText>
+      </GoabModal>
+
+      <GoabModal
+        heading="Important Modal"
+        calloutVariant="important"
+        open={importantOpen}
+        onClose={() => setImportantOpen(false)}
+        actions={
+          <GoabButtonGroup alignment="end">
+            <GoabButton type="tertiary" onClick={() => setImportantOpen(false)}>
+              Close
+            </GoabButton>
+          </GoabButtonGroup>
+        }
+      >
+        <GoabText tag="p">Hover the close button. Check hover color.</GoabText>
+      </GoabModal>
+
+      <GoabModal
+        heading="Emergency Modal"
+        calloutVariant="emergency"
+        open={emergencyOpen}
+        onClose={() => setEmergencyOpen(false)}
+        actions={
+          <GoabButtonGroup alignment="end">
+            <GoabButton type="tertiary" onClick={() => setEmergencyOpen(false)}>
+              Close
+            </GoabButton>
+          </GoabButtonGroup>
+        }
+      >
+        <GoabText tag="p">Hover the close button. Check hover color.</GoabText>
+      </GoabModal>
+    </div>
+  );
+}
+
+export default Bug3654Route;

--- a/docs/src/data/configurations/modal.ts
+++ b/docs/src/data/configurations/modal.ts
@@ -284,30 +284,6 @@ export const modalConfigurations: ComponentConfigurations = {
       },
     },
     {
-      id: "callout-event",
-      name: "Event callout",
-      description: "Modal with event callout header",
-      code: {
-        react: {
-          ts: reactModalSetup,
-          jsx: `<GoabModal heading="Scheduled maintenance" open={isOpen} calloutVariant="event" onClose={handleClose}>
-  <p>The system will be unavailable on March 28 from 10:00 PM to 2:00 AM for scheduled maintenance.</p>
-</GoabModal>`,
-        },
-        angular: {
-          ts: angularModalSetup,
-          template: `<goab-modal heading="Scheduled maintenance" [open]="isOpen" [closable]="true" calloutVariant="event" (onClose)="handleClose()">
-  <p>The system will be unavailable on March 28 from 10:00 PM to 2:00 AM for scheduled maintenance.</p>
-</goab-modal>`,
-        },
-        webComponents: `<goa-button version="2" id="open-modal">Open modal</goa-button>
-<goa-modal version="2" id="demo-modal" heading="Scheduled maintenance" closable calloutvariant="event">
-  <p>The system will be unavailable on March 28 from 10:00 PM to 2:00 AM for scheduled maintenance.</p>
-</goa-modal>
-<script>${modalScript}</script>`,
-      },
-    },
-    {
       id: "custom-width",
       name: "Custom width",
       description: "Modal with specified maximum width",

--- a/libs/web-components/src/components/modal/Modal.svelte
+++ b/libs/web-components/src/components/modal/Modal.svelte
@@ -72,7 +72,8 @@
   // ********
 
   $: _isClosable = toBoolean(closable);
-  $: _headingExists = heading !== "" || ($$slots.heading && _headingSlotHasContent);
+  $: _headingExists =
+    heading !== "" || ($$slots.heading && _headingSlotHasContent);
   $: _headerHasContent = _headingExists || _isClosable;
 
   // Moving the reactive var into a timeout prevents accessing null stylesheet
@@ -160,10 +161,12 @@
       return true;
     }
 
-    return children?.length === 1 // there should only be one child element
-      && children[0].tagName === "DIV" // angular renders a <div>
-      && children[0].getAttribute("slot") === slotName // the div is a slot
-      && children[0]?.textContent?.trim() === "" // the div is empty
+    return (
+      children?.length === 1 && // there should only be one child element
+      children[0].tagName === "DIV" && // angular renders a <div>
+      children[0].getAttribute("slot") === slotName && // the div is a slot
+      children[0]?.textContent?.trim() === ""
+    ); // the div is empty
   }
 
   function close(e: Event) {
@@ -250,11 +253,7 @@
           >
             <div class="modal-heading-content">
               {#if version === "2" && _iconType}
-                <goa-icon
-                  type={_iconType}
-                  size="medium"
-                  theme="filled"
-                />
+                <goa-icon type={_iconType} size="medium" theme="filled" />
               {/if}
               <div
                 data-testid="modal-title"
@@ -378,13 +377,18 @@
     flex: 0 0 3rem;
     text-align: center;
     padding: var(--goa-modal-callout-bar-padding) 0 0 0;
-    border-radius: var(--goa-modal-border-radius) 0px 0px var(--goa-modal-border-radius);
+    border-radius: var(--goa-modal-border-radius) 0px 0px
+      var(--goa-modal-border-radius);
   }
 
   .content {
     flex: 1 1 auto;
     width: 100%;
-    padding: var(--goa-modal-content-wrapper-padding, var(--goa-modal-padding) var(--goa-modal-padding) 0 var(--goa-modal-padding));
+    padding: var(
+      --goa-modal-content-wrapper-padding,
+      var(--goa-modal-padding) var(--goa-modal-padding) 0
+        var(--goa-modal-padding)
+    );
   }
 
   .content header {
@@ -405,11 +409,18 @@
 
   @media (--mobile) {
     .content {
-      padding: var(--goa-modal-content-wrapper-padding, var(--goa-modal-padding-small-screen) var(--goa-modal-padding-small-screen) 0 var(--goa-modal-padding-small-screen));
+      padding: var(
+        --goa-modal-content-wrapper-padding,
+        var(--goa-modal-padding-small-screen)
+          var(--goa-modal-padding-small-screen) 0
+          var(--goa-modal-padding-small-screen)
+      );
     }
 
     .content header.has-content {
-      margin-bottom: var(--goa-modal-content-gap-small-screen); /* space under heading */
+      margin-bottom: var(
+        --goa-modal-content-gap-small-screen
+      ); /* space under heading */
     }
 
     .modal-actions :global(::slotted(*)) {
@@ -427,7 +438,8 @@
     .callout-bar {
       text-align: left;
       padding: var(--goa-modal-callout-bar-padding-small-screen);
-      border-radius: var(--goa-modal-border-radius) var(--goa-modal-border-radius) 0px 0px;
+      border-radius: var(--goa-modal-border-radius)
+        var(--goa-modal-border-radius) 0px 0px;
       height: var(--goa-space-2xl);
     }
 
@@ -438,7 +450,10 @@
     }
 
     :host {
-      --scrollable-padding: var(--goa-modal-scrollable-padding-mobile, var(--goa-scrollable-padding-mobile));
+      --scrollable-padding: var(
+        --goa-modal-scrollable-padding-mobile,
+        var(--goa-scrollable-padding-mobile)
+      );
     }
 
     /* V2 Mobile Overrides */
@@ -447,17 +462,26 @@
     }
 
     .v2 .content header.callout {
-      padding: var(--goa-modal-callout-heading-padding-mobile, var(--goa-space-m));
+      padding: var(
+        --goa-modal-callout-heading-padding-mobile,
+        var(--goa-space-m)
+      );
     }
 
     .v2 .modal-content {
-      padding: var(--goa-modal-content-padding-mobile, var(--goa-space-l) var(--goa-space-m) var(--goa-space-xl) var(--goa-space-m));
+      padding: var(
+        --goa-modal-content-padding-mobile,
+        var(--goa-space-l) var(--goa-space-m) var(--goa-space-xl)
+          var(--goa-space-m)
+      );
     }
 
     .v2 .modal-actions {
-      padding: var(--goa-modal-actions-padding-mobile, 0 var(--goa-space-m) var(--goa-space-m) var(--goa-space-m));
+      padding: var(
+        --goa-modal-actions-padding-mobile,
+        0 var(--goa-space-m) var(--goa-space-m) var(--goa-space-m)
+      );
     }
-
   }
 
   @media (--not-mobile) {
@@ -472,9 +496,11 @@
     }
 
     :host {
-      --scrollable-padding: var(--goa-modal-scrollable-padding-desktop, var(--goa-scrollable-padding-desktop));
+      --scrollable-padding: var(
+        --goa-modal-scrollable-padding-desktop,
+        var(--goa-scrollable-padding-desktop)
+      );
     }
-
   }
 
   .modal-pane {
@@ -485,6 +511,10 @@
     display: flex;
     box-shadow: var(--goa-shadow-modal);
     border-radius: var(--goa-modal-border-radius);
+  }
+
+  .v2.modal-pane {
+    border: none;
   }
 
   .modal-content :global(::slotted(:last-child)) {
@@ -506,7 +536,10 @@
 
   .modal-actions {
     width: 100%;
-    padding: var(--goa-modal-actions-padding, var(--goa-space-m) 0 var(--goa-modal-padding) 0);
+    padding: var(
+      --goa-modal-actions-padding,
+      var(--goa-space-m) 0 var(--goa-modal-padding) 0
+    );
     margin: auto 0 0 0;
     text-align: right;
   }
@@ -529,8 +562,9 @@
   }
 
   .modal.middle .modal-content {
-    box-shadow: inset 0 8px 8px -8px rgba(0, 0, 0, 0.2),
-    inset 0 -8px 8px -8px rgba(0, 0, 0, 0.2);
+    box-shadow:
+      inset 0 8px 8px -8px rgba(0, 0, 0, 0.2),
+      inset 0 -8px 8px -8px rgba(0, 0, 0, 0.2);
   }
 
   /* V2 Callout Styles */
@@ -542,7 +576,8 @@
 
   .v2 .content header.callout {
     padding: var(--goa-modal-callout-heading-padding);
-    border-radius: var(--goa-modal-border-radius) var(--goa-modal-border-radius) 0 0;
+    border-radius: var(--goa-modal-border-radius) var(--goa-modal-border-radius)
+      0 0;
   }
 
   .v2 header.callout goa-icon {
@@ -592,5 +627,30 @@
 
   .v2 header.event goa-icon {
     color: var(--goa-modal-callout-event-icon);
+  }
+
+  /* V2 callout close button hover colors — override icon-button's dark hover bg */
+  .v2 header.information .modal-close goa-icon-button {
+    --goa-icon-button-dark-hover-color-bg: var(
+      --goa-modal-callout-information-close-bg-hover
+    );
+  }
+
+  .v2 header.success .modal-close goa-icon-button {
+    --goa-icon-button-dark-hover-color-bg: var(
+      --goa-modal-callout-success-close-bg-hover
+    );
+  }
+
+  .v2 header.important .modal-close goa-icon-button {
+    --goa-icon-button-dark-hover-color-bg: var(
+      --goa-modal-callout-important-close-bg-hover
+    );
+  }
+
+  .v2 header.emergency .modal-close goa-icon-button {
+    --goa-icon-button-dark-hover-color-bg: var(
+      --goa-modal-callout-emergency-close-bg-hover
+    );
   }
 </style>


### PR DESCRIPTION
## Summary
- Remove visible border from V2 modal surface (was `--goa-modal-border`, a greyscale-150 solid border)
- Add per-status hover background colors on the close icon button for callout modals (information, success, important, emergency), matching the notification banner low emphasis pattern
- Remove event callout variant from docs configurations (silently undocument, component code unchanged)

Note: Close button hover tokens are defined inline in Modal.svelte temporarily. A follow-up design-tokens PR will add proper `modal-callout-*-close-bg-hover` tokens, and that PR will also fix a pre-existing bug where the notification banner important high/low close hover colors are swapped.

Fixes #3654

## Steps needed to test
1. Run the React playground (`npm run serve:prs:react`)
2. Navigate to bugs/3654
3. Open the basic modal, verify no visible border on the modal surface
4. Open each status modal (Information, Success, Important, Emergency)
5. Hover the X close button on each, verify the hover background matches the callout header color family
6. Verify the event callout variant no longer appears in the docs site modal configurations

<img width="842" height="532" alt="image" src="https://github.com/user-attachments/assets/3873b2c9-c8df-491e-b1c5-348a064ac81f" />
<img width="842" height="532" alt="image" src="https://github.com/user-attachments/assets/87f6eded-23d8-4073-accb-7b3f8ece712d" />
<img width="842" height="532" alt="image" src="https://github.com/user-attachments/assets/06f90a7e-d0e8-42c6-9551-cdad09dc2f01" />
<img width="842" height="532" alt="image" src="https://github.com/user-attachments/assets/a2d0aa47-0d88-42f2-82fb-314fdd3f3910" />
<img width="842" height="532" alt="image" src="https://github.com/user-attachments/assets/f8fba6c8-c6a5-4e7f-b3e8-b943fae6b91f" />
