### PR TITLE
fix(#3796): Updated angular package to include new ui-components-common

### DIFF
--- a/libs/angular-components/package.json
+++ b/libs/angular-components/package.json
@@ -17,7 +17,7 @@
     "directory": "libs/angular-components"
   },
   "peerDependencies": {
-    "@abgov/ui-components-common": "^0.0.0 || ^1.0.0",
+    "@abgov/ui-components-common": "^0.0.0 || ^1.0.0 || ^2.0.0",
     "@angular/forms": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
     "@angular/common": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
     "@angular/core": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"


### PR DESCRIPTION
# Before (the change)

There were install issues using `npm i` when trying to install the latest Angular Components alongside the latest `ui-components-common`.

# After (the change)

There should be no issues when installing `ui-components-common`, alongside the latest Angular components anymore.

## Steps needed to test

Try installing in a new environment the latest angular-components and the latest ui-components-common
