### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,71 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of the Government of Alberta Design System
+pledge to make participation in our project and community a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, caste, colour, religion,
+or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behaviour:
+
+- The use of sexualized language or imagery, and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including the repository,
+issue tracker, pull requests, and any other communication channels used by the project.
+It also applies when an individual is representing the project in public spaces.
+
+## Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to
+the project maintainers at **TI.DesignSystemSupport@gov.ab.ca**.
+
+All complaints will be reviewed and investigated promptly and fairly. All project
+maintainers are obligated to respect the privacy and security of the reporter of any
+incident.
+
+## Enforcement
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by other members of the project's
+leadership.
+
+### Enforcement Guidelines
+
+1. **Correction** — A private written warning, providing clarity around the nature of
+   the violation and an explanation of why the behaviour was inappropriate.
+
+2. **Warning** — A warning with consequences for continued behaviour. No interaction
+   with the people involved for a specified period of time.
+
+3. **Temporary Ban** — A temporary ban from any sort of interaction or public
+   communication with the project community.
+
+4. **Permanent Ban** — A permanent ban from any sort of public interaction within the
+   project community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.


### PR DESCRIPTION
## Summary
- Adds CODE_OF_CONDUCT.md based on Contributor Covenant v2.1
- Reports go to TI.DesignSystemSupport@gov.ab.ca
- Required for Netlify open source team plan (deploy previews)

## Test plan
- [ ] Review code of conduct content
- [ ] Confirm reporting email is correct