### PR TITLE
fix(#3627): remove container shadow, undocument status types

### DIFF
--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -284,6 +284,10 @@
             label="3772 Deprecated Angular FormItem slot helper"
             url="/bugs/3772"
           ></goab-work-side-menu-item>
+          <goab-work-side-menu-item
+            label="3627 Container refinements"
+            url="/bugs/3627"
+          ></goab-work-side-menu-item>
         </goab-work-side-menu-group>
         <goab-work-side-menu-group icon="star" heading="Features">
           <goab-work-side-menu-item

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -59,6 +59,7 @@ import { Bug3699Component } from "../routes/bugs/3699/bug3699.component";
 import { Bug3637Component } from "../routes/bugs/3637/bug3637.component";
 import { Bug3667Component } from "../routes/bugs/3667/bug3667.component";
 import { Bug3772Component } from "../routes/bugs/3772/bug3772.component";
+import { Bug3627Component } from "../routes/bugs/3627/bug3627.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -160,6 +161,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3637", component: Bug3637Component },
   { path: "bugs/3667", component: Bug3667Component },
   { path: "bugs/3772", component: Bug3772Component },
+  { path: "bugs/3627", component: Bug3627Component },
   // Feature routes
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1383", component: Feat1383Component },

--- a/apps/prs/angular/src/routes/bugs/3627/bug3627.component.html
+++ b/apps/prs/angular/src/routes/bugs/3627/bug3627.component.html
@@ -1,0 +1,61 @@
+<div>
+  <h1>3627 - Container refinements</h1>
+  <p>
+    <a
+      href="https://github.com/GovAlta/ui-components/issues/3627"
+      target="_blank"
+      rel="noopener"
+    >
+      View on GitHub
+    </a>
+  </p>
+
+  <h2>Test 1: Basic containers (shadow should be removed)</h2>
+  <goab-container [title]="interactiveTitle" mb="l">
+    <p>Check for bottom shadow. Should be none.</p>
+  </goab-container>
+  <ng-template #interactiveTitle>Interactive (default)</ng-template>
+
+  <goab-container [title]="nonInteractiveTitle" type="non-interactive" mb="l">
+    <p>Non-interactive container for comparison.</p>
+  </goab-container>
+  <ng-template #nonInteractiveTitle>Non-interactive</ng-template>
+
+  <div style="display: flex; gap: 1rem; margin-bottom: 2rem">
+    <goab-container [title]="thickTitle" accent="thick">
+      <p>Accent: thick</p>
+    </goab-container>
+    <ng-template #thickTitle>Thick accent</ng-template>
+
+    <goab-container [title]="thinTitle" accent="thin">
+      <p>Accent: thin</p>
+    </goab-container>
+    <ng-template #thinTitle>Thin accent</ng-template>
+
+    <goab-container accent="filled">
+      <p>Accent: filled</p>
+    </goab-container>
+  </div>
+
+  <h2>Test 2: Status type containers (silently undocumented)</h2>
+  <p>These remain functional but are removed from docs.</p>
+  <goab-container [title]="infoTitle" type="info" mb="l">
+    <p>Type: info</p>
+  </goab-container>
+  <ng-template #infoTitle>Info</ng-template>
+
+  <goab-container [title]="errorTitle" type="error" mb="l">
+    <p>Type: error</p>
+  </goab-container>
+  <ng-template #errorTitle>Error</ng-template>
+
+  <goab-container [title]="successTitle" type="success" mb="l">
+    <p>Type: success</p>
+  </goab-container>
+  <ng-template #successTitle>Success</ng-template>
+
+  <goab-container [title]="importantTitle" type="important" mb="l">
+    <p>Type: important</p>
+  </goab-container>
+  <ng-template #importantTitle>Important</ng-template>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3627/bug3627.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3627/bug3627.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabContainer } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3627",
+  templateUrl: "./bug3627.component.html",
+  imports: [GoabContainer],
+})
+export class Bug3627Component {}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -233,6 +233,10 @@ export function App() {
                 <GoabWorkSideMenuItem label="3505 Link Icon Click" url="/bugs/3505" />
                 <GoabWorkSideMenuItem label="3614 IconButton Hitboxes" url="/bugs/3614" />
                 <GoabWorkSideMenuItem
+                  label="3627 Container refinements"
+                  url="/bugs/3627"
+                />
+                <GoabWorkSideMenuItem
                   label="3685 Checkbox & Radio: Reveal width not aligned with item"
                   url="/bugs/3685"
                 />

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -56,6 +56,7 @@ import { Bug3505Route } from "./routes/bugs/bug3505";
 import { Bug3614Route } from "./routes/bugs/bug3614";
 import { Bug3640Route } from "./routes/bugs/bug3640";
 import { Bug3735Route } from "./routes/bugs/bug3735";
+import { Bug3627Route } from "./routes/bugs/bug3627";
 import { Bug3635Route } from "./routes/bugs/bug3635";
 import { Bug3699Route } from "./routes/bugs/bug3699";
 import { Bug3637Route } from "./routes/bugs/bug3637";
@@ -165,6 +166,7 @@ root.render(
           <Route path="bugs/3685" element={<Bug3685Route />} />
           <Route path="bugs/3640" element={<Bug3640Route />} />
           <Route path="bugs/3735" element={<Bug3735Route />} />
+          <Route path="bugs/3627" element={<Bug3627Route />} />
           <Route path="bugs/3635" element={<Bug3635Route />} />
           <Route path="bugs/3699" element={<Bug3699Route />} />
           <Route path="bugs/3637" element={<Bug3637Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3627.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3627.tsx
@@ -1,0 +1,102 @@
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabDetails,
+  GoabLink,
+  GoabContainer,
+} from "@abgov/react-components";
+
+export function Bug3627Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug #3627: Container refinements
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a
+            href="https://github.com/GovAlta/ui-components/issues/3627"
+            target="_blank"
+            rel="noopener"
+          >
+            View on GitHub
+          </a>
+        </GoabLink>
+
+        <GoabDetails heading="Issue Description">
+          <GoabText tag="p">
+            Discrepancies between Container browser implementation and Figma design specs.
+            1) Remove the bottom shadow from the container (Figma has no shadow). 2)
+            Quietly remove documentation for info, error, success, and important types.
+            Keep the component code so existing implementations don't break. These types
+            duplicate Callout functionality and have accessibility concerns.
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      <GoabText tag="h3">
+        Test 1: Basic Container (check for bottom shadow in V2)
+      </GoabText>
+      <GoabText tag="p">
+        Inspect the container below. In V2 tokens, the bottom shadow should be removed per
+        Figma. Check DevTools for box-shadow on the container element.
+      </GoabText>
+      <GoabContainer heading="Interactive (default)" mb="l">
+        <GoabText tag="p">
+          This is a basic interactive container. Inspect whether there is a bottom shadow
+          applied. The shadow should be removed in V2.
+        </GoabText>
+      </GoabContainer>
+
+      <GoabContainer heading="Non-interactive" type="non-interactive" mb="l">
+        <GoabText tag="p">Non-interactive container for comparison.</GoabText>
+      </GoabContainer>
+
+      <GoabBlock gap="m" direction="row" mb="l">
+        <GoabContainer heading="Thick accent" accent="thick">
+          <GoabText tag="p">Accent: thick</GoabText>
+        </GoabContainer>
+        <GoabContainer heading="Thin accent" accent="thin">
+          <GoabText tag="p">Accent: thin</GoabText>
+        </GoabContainer>
+        <GoabContainer accent="filled">
+          <GoabText tag="p">Accent: filled (no heading bar)</GoabText>
+        </GoabContainer>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h3">
+        Test 2: Status type containers (to be silently undocumented)
+      </GoabText>
+      <GoabText tag="p">
+        These status types (info, error, success, important) will be silently removed from
+        docs but remain functional. Shown here for reference and regression testing.
+      </GoabText>
+
+      <GoabContainer heading="Info container" type="info" mb="l">
+        <GoabText tag="p">Type: info</GoabText>
+      </GoabContainer>
+
+      <GoabContainer heading="Error container" type="error" mb="l">
+        <GoabText tag="p">Type: error</GoabText>
+      </GoabContainer>
+
+      <GoabContainer heading="Success container" type="success" mb="l">
+        <GoabText tag="p">Type: success</GoabText>
+      </GoabContainer>
+
+      <GoabContainer heading="Important container" type="important" mb="l">
+        <GoabText tag="p">Type: important</GoabText>
+      </GoabContainer>
+    </div>
+  );
+}
+
+export default Bug3627Route;

--- a/docs/src/data/configurations/container.ts
+++ b/docs/src/data/configurations/container.ts
@@ -39,56 +39,20 @@ export const containerConfigurations: ComponentConfigurations = {
         react: `<GoabContainer type="non-interactive" mb="m">
   <p>Non-interactive content container</p>
 </GoabContainer>
-<GoabContainer type="interactive" mb="m">
+<GoabContainer type="interactive">
   <p>Interactive container</p>
-</GoabContainer>
-<GoabContainer type="info" mb="m">
-  <p>Informational container</p>
-</GoabContainer>
-<GoabContainer type="error" mb="m">
-  <p>Error container</p>
-</GoabContainer>
-<GoabContainer type="success" mb="m">
-  <p>Success container</p>
-</GoabContainer>
-<GoabContainer type="important">
-  <p>Important container</p>
 </GoabContainer>`,
         angular: `<goab-container type="non-interactive" mb="m">
   <p>Non-interactive content container</p>
 </goab-container>
-<goab-container type="interactive" mb="m">
+<goab-container type="interactive">
   <p>Interactive container</p>
-</goab-container>
-<goab-container type="info" mb="m">
-  <p>Informational container</p>
-</goab-container>
-<goab-container type="error" mb="m">
-  <p>Error container</p>
-</goab-container>
-<goab-container type="success" mb="m">
-  <p>Success container</p>
-</goab-container>
-<goab-container type="important">
-  <p>Important container</p>
 </goab-container>`,
         webComponents: `<goa-container type="non-interactive" mb="m">
   <p>Non-interactive content container</p>
 </goa-container>
-<goa-container type="interactive" mb="m">
+<goa-container type="interactive">
   <p>Interactive container</p>
-</goa-container>
-<goa-container type="info" mb="m">
-  <p>Informational container</p>
-</goa-container>
-<goa-container type="error" mb="m">
-  <p>Error container</p>
-</goa-container>
-<goa-container type="success" mb="m">
-  <p>Success container</p>
-</goa-container>
-<goa-container type="important">
-  <p>Important container</p>
 </goa-container>`,
       },
     },


### PR DESCRIPTION
## Summary
- Remove box-shadow from container by setting `--goa-container-shadow` to `none` (temporary inline token in `:host`, pending design-tokens PR)
- Remove info, error, success, and important types from docs configurations (silently undocument). Component code is unchanged so existing consumers are not affected.

Fixes #3627

## Steps needed to test
1. Run the React playground (`npm run serve:prs:react`)
2. Navigate to bugs/3627
3. Verify containers (interactive, non-interactive, accent variants) have no visible shadow
4. Verify status type containers (info, error, success, important) still render correctly (code unchanged)
5. Verify the docs site container types example only shows non-interactive and interactive

<img width="946" height="533" alt="image" src="https://github.com/user-attachments/assets/72d16202-8b65-40be-85a1-ec1389693aa6" />
