### PR TITLE
fix(#3787): Updated token generation to use kebab case

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,7 +37,7 @@ Svelte source code                    Manual MDX content
 | Guidance atoms (~130+)               | `src/content/guidance/*.mdx`                              | Manual                        |
 | Examples (~80)                       | `src/content/examples/*/`                                 | Manual                        |
 | Configuration previews (~65)         | `src/data/configurations/*.ts`                            | Manual (curated)              |
-| Design tokens                        | `@abgov/design-tokens-v2` npm package                     | Yes (npm import)              |
+| Design tokens                        | `@abgov/design-tokens` npm package                        | Yes (npm import)              |
 | Search index                         | `search-index.json`                                       | Yes (build step)              |
 
 ---

--- a/docs/src/lib/tokens.ts
+++ b/docs/src/lib/tokens.ts
@@ -58,8 +58,13 @@ function isTokenValue(obj: unknown): obj is TokenValue {
  * Convert a path array to a CSS variable name
  * e.g., ['color', 'interactive', 'default'] -> '--goa-color-interactive-default'
  */
+function toKebabCase(segment: string): string {
+  // Insert a hyphen between a lowercase/digit character and the following uppercase character, then lowercase the full segment.
+  return segment.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
 function pathToCssVar(path: string[]): string {
-  return `--goa-${path.join("-")}`;
+  return `--goa-${path.map(toKebabCase).join("-")}`;
 }
 
 /**


### PR DESCRIPTION
# Before (the change)

In the docs tokens page, there were tokens like `borderWidth`, `borderRadius`, `iconSize` that all used camelCasing, when the tokens themselves use kebab-casing.

# After (the change)

All tokens on the docs Tokens page should use proper kebab-casing, including minor token names like `textDark` and `textInverse`.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

```bash
cd docs
npm run dev
```

Check Tokens page, verify all tokens listed use proper kebab-casing, instead of camelCasing.
