### PR TITLE
fix(#3681): dropdown selected item highlight state

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3681/bug3681.component.html
+++ b/apps/prs/angular/src/routes/bugs/3681/bug3681.component.html
@@ -1,0 +1,43 @@
+<div>
+  <h1>3681 - Dropdown refinements</h1>
+  <p>
+    <a
+      href="https://github.com/GovAlta/ui-components/issues/3681"
+      target="_blank"
+      rel="noopener"
+    >
+      View on GitHub
+    </a>
+  </p>
+  <p>
+    Four menu option color states need fixing: Default (not chosen, not hovered),
+    Hovered (not chosen), Currently chosen (not hovered), Currently chosen + hovered.
+  </p>
+
+  <h2>Dropdown with pre-selected value</h2>
+  <p>
+    Open the dropdown and inspect the 4 states: 1) Default items (not Red),
+    2) Hover a non-chosen item, 3) The chosen item (Red), 4) Hover the chosen item.
+  </p>
+  <goab-form-item label="Favorite color">
+    <goab-dropdown [value]="value" (onChange)="handleChange($event)">
+      <goab-dropdown-item value="red" label="Red"></goab-dropdown-item>
+      <goab-dropdown-item value="blue" label="Blue"></goab-dropdown-item>
+      <goab-dropdown-item value="green" label="Green"></goab-dropdown-item>
+      <goab-dropdown-item value="yellow" label="Yellow"></goab-dropdown-item>
+      <goab-dropdown-item value="purple" label="Purple"></goab-dropdown-item>
+    </goab-dropdown>
+  </goab-form-item>
+
+  <h2>Dropdown with no initial value</h2>
+  <p>All items should show as default state. Select one to see the chosen state.</p>
+  <goab-form-item label="Select a province">
+    <goab-dropdown>
+      <goab-dropdown-item value="ab" label="Alberta"></goab-dropdown-item>
+      <goab-dropdown-item value="bc" label="British Columbia"></goab-dropdown-item>
+      <goab-dropdown-item value="sk" label="Saskatchewan"></goab-dropdown-item>
+      <goab-dropdown-item value="mb" label="Manitoba"></goab-dropdown-item>
+      <goab-dropdown-item value="on" label="Ontario"></goab-dropdown-item>
+    </goab-dropdown>
+  </goab-form-item>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3681/bug3681.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3681/bug3681.component.ts
@@ -1,0 +1,21 @@
+import { Component } from "@angular/core";
+import {
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFormItem,
+} from "@abgov/angular-components";
+import { GoabDropdownOnChangeDetail } from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3681",
+  templateUrl: "./bug3681.component.html",
+  imports: [GoabDropdown, GoabDropdownItem, GoabFormItem],
+})
+export class Bug3681Component {
+  value = "red";
+
+  handleChange(detail: GoabDropdownOnChangeDetail) {
+    this.value = detail.value ?? "";
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3681/bug3681.route.json
+++ b/apps/prs/angular/src/routes/bugs/3681/bug3681.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Dropdown selected item highlight",
+  "path": "bugs/3681",
+  "id": "3681",
+  "type": "bug"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3681.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3681.route.ts
@@ -1,0 +1,9 @@
+import { Bug3681Route } from "../../../routes/bugs/bug3681";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "bug",
+  id: "3681",
+  path: "bugs/3681",
+  title: "Dropdown selected item highlight",
+  component: Bug3681Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3681.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3681.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabDetails,
+  GoabLink,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFormItem,
+} from "@abgov/react-components";
+
+export function Bug3681Route() {
+  const [value, setValue] = useState("red");
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug #3681: Dropdown refinements
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a
+            href="https://github.com/GovAlta/ui-components/issues/3681"
+            target="_blank"
+            rel="noopener"
+          >
+            View on GitHub
+          </a>
+        </GoabLink>
+
+        <GoabDetails heading="Issue Description">
+          <GoabText tag="p">
+            Four menu option color states need fixing: Default (not chosen, not hovered)
+            should be text-secondary. Hovered (not chosen) should be text-default +
+            greyscale-100 bg. Currently chosen (not hovered) should be text-light +
+            interactive bg. Currently chosen + hovered should be text-light +
+            interactive-hover bg.
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      <GoabText tag="h3">Dropdown with pre-selected value</GoabText>
+      <GoabText tag="p">
+        Open the dropdown and inspect the 4 states: 1) Default items (not Red), 2) Hover a
+        non-chosen item, 3) The chosen item (Red), 4) Hover the chosen item. Check text
+        color and background for each state.
+      </GoabText>
+
+      <GoabFormItem label="Favorite color" mt="m">
+        <GoabDropdown value={value} onChange={(detail) => setValue(detail.value ?? "")}>
+          <GoabDropdownItem value="red" label="Red" />
+          <GoabDropdownItem value="blue" label="Blue" />
+          <GoabDropdownItem value="green" label="Green" />
+          <GoabDropdownItem value="yellow" label="Yellow" />
+          <GoabDropdownItem value="purple" label="Purple" />
+          <GoabDropdownItem value="orange" label="Orange" />
+          <GoabDropdownItem value="teal" label="Teal" />
+        </GoabDropdown>
+      </GoabFormItem>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h3">Dropdown with no initial value</GoabText>
+      <GoabText tag="p">
+        All items should show as default state (text-secondary). Select one to see the
+        chosen state.
+      </GoabText>
+
+      <GoabFormItem label="Select a province" mt="m">
+        <GoabDropdown>
+          <GoabDropdownItem value="ab" label="Alberta" />
+          <GoabDropdownItem value="bc" label="British Columbia" />
+          <GoabDropdownItem value="sk" label="Saskatchewan" />
+          <GoabDropdownItem value="mb" label="Manitoba" />
+          <GoabDropdownItem value="on" label="Ontario" />
+        </GoabDropdown>
+      </GoabFormItem>
+    </div>
+  );
+}
+
+export default Bug3681Route;

--- a/libs/web-components/src/components/dropdown/Dropdown.spec.ts
+++ b/libs/web-components/src/components/dropdown/Dropdown.spec.ts
@@ -471,9 +471,7 @@ describe("GoADropdown", () => {
         const option = result.queryByTestId(`dropdown-item-${items[0]}`);
         option && (await user.click(option));
         const liElements = result.container.querySelectorAll("li");
-        expect(liElements[0].getAttribute("class")).toContain(
-          "dropdown-item--highlighted",
-        );
+        expect(liElements[0].getAttribute("class")).toContain("selected");
       });
 
       const input = result.getByTestId("input") as HTMLInputElement;

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -500,7 +500,7 @@
     if (!_native) {
       syncFilteredOptions();
       setDisplayedValue();
-      setHighlightedToSelected();
+      _highlightedIndex = -1;
       hideMenu();
     }
     dispatchValue(option.value);


### PR DESCRIPTION
## Summary
- Clear the highlighted index when an item is selected and when the menu opens, so the selected item shows its proper selected state (regular blue) instead of the selected-hover state (darker blue)
- Previously, selecting an item set `_highlightedIndex` to that item's index, which persisted when the menu reopened, causing both `.dropdown-item--highlighted` and `[aria-selected="true"]` to apply simultaneously

Note: The default (non-selected, non-hovered) menu item text color should also change from `text-default` to `text-secondary` per the issue. This is a token value fix tracked in a separate design-tokens PR.

Fixes #3681

## Steps needed to test
1. Run the React playground (`npm run serve:prs:react`)
2. Navigate to bugs/3681
3. Open the first dropdown (Red is pre-selected). Verify Red shows regular blue background.
4. Select a different item (e.g. Blue). Reopen the dropdown.
5. Verify the newly selected item shows regular blue (not the darker hover blue).
6. Hover the selected item. Verify it gets the darker blue on hover only.
7. Test keyboard navigation (arrow keys + Enter) still works.

<img width="725" height="428" alt="image" src="https://github.com/user-attachments/assets/8fbe23de-adea-4a45-88cd-47d7fa502931" />
<img width="725" height="428" alt="image" src="https://github.com/user-attachments/assets/2ce71cca-e687-49d2-b7c9-0213a17c1953" />
