### PR TITLE
fix(#3667): notification banner height refinements

### DIFF
--- a/apps/prs/angular/project.json
+++ b/apps/prs/angular/project.json
@@ -24,7 +24,10 @@
             "output": "/v2-tokens"
           }
         ],
-        "styles": ["apps/prs/angular/src/styles.css"],
+        "styles": [
+          "apps/prs/angular/src/styles.css",
+          "node_modules/@abgov/design-tokens-v2/dist/tokens.css"
+        ],
         "scripts": []
       },
       "configurations": {

--- a/apps/prs/angular/src/app/app.component.html
+++ b/apps/prs/angular/src/app/app.component.html
@@ -257,6 +257,10 @@
             label="3637 Checkbox Table Header Row Height Bug"
             url="/bugs/3637"
           ></goab-work-side-menu-item>
+          <goab-work-side-menu-item
+            label="3667 Notification Banner refinements"
+            url="/bugs/3667"
+          ></goab-work-side-menu-item>
         </goab-work-side-menu-group>
         <goab-work-side-menu-group icon="star" heading="Features">
           <goab-work-side-menu-item

--- a/apps/prs/angular/src/app/app.routes.ts
+++ b/apps/prs/angular/src/app/app.routes.ts
@@ -54,6 +54,7 @@ import { Bug3614Component } from "../routes/bugs/3614/bug3614.component";
 import { Bug3685Component } from "../routes/bugs/3685/bug3685.component";
 import { Bug3635Component } from "../routes/bugs/3635/bug3635.component";
 import { Bug3637Component } from "../routes/bugs/3637/bug3637.component";
+import { Bug3667Component } from "../routes/bugs/3667/bug3667.component";
 
 import { Feat1328Component } from "../routes/features/feat1328/feat1328.component";
 import { Feat1383Component } from "../routes/features/feat1383/feat1383.component";
@@ -150,6 +151,7 @@ export const appRoutes: Route[] = [
   { path: "bugs/3685", component: Bug3685Component },
   { path: "bugs/3635", component: Bug3635Component },
   { path: "bugs/3637", component: Bug3637Component },
+  { path: "bugs/3667", component: Bug3667Component },
   // Feature routes
   { path: "features/1328", component: Feat1328Component },
   { path: "features/1383", component: Feat1383Component },

--- a/apps/prs/angular/src/routes/bugs/3667/bug3667.component.html
+++ b/apps/prs/angular/src/routes/bugs/3667/bug3667.component.html
@@ -1,0 +1,93 @@
+<div>
+  <goab-text tag="h1" mt="m">Bug #3667: Notification banner refinements</goab-text>
+
+  <goab-block>
+    <goab-link trailingIcon="open">
+      <a
+        href="https://github.com/GovAlta/ui-components/issues/3667"
+        target="_blank"
+        rel="noopener"
+      >
+        View on GitHub
+      </a>
+    </goab-link>
+
+    <goab-details heading="Issue Description">
+      <goab-text tag="p">
+        Notification banner height refinements. Compact should be 64px (currently ~66px),
+        default should be 80px (currently ~82px). Also need to verify vertical centering of
+        content (icon, text, dismiss button) at both sizes. The Event type should be silently
+        undocumented (docs removal only, no code change needed).
+      </goab-text>
+    </goab-details>
+  </goab-block>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <goab-text tag="h2">Test Cases</goab-text>
+
+  <!-- Test 1: Height measurements -->
+  <goab-text tag="h3">Test 1: Height at default and compact sizes</goab-text>
+  <goab-text tag="p">
+    Measure the rendered height of each banner. Default should be 80px, compact should be
+    64px. Use browser dev tools to inspect the goa-notification element and measure the outer
+    height.
+  </goab-text>
+
+  <goab-text tag="h4" mt="m">Default size (target: 80px)</goab-text>
+  <goab-notification type="information">
+    Default information banner for height measurement.
+  </goab-notification>
+
+  <goab-text tag="h4" mt="m">Compact size (target: 64px)</goab-text>
+  <goab-notification type="information" [compact]="true">
+    Compact information banner for height measurement.
+  </goab-notification>
+
+  <goab-text tag="h4" mt="m">Default important (target: 80px)</goab-text>
+  <goab-notification type="important">
+    Default important banner for height measurement.
+  </goab-notification>
+
+  <goab-text tag="h4" mt="m">Compact important (target: 64px)</goab-text>
+  <goab-notification type="important" [compact]="true">
+    Compact important banner for height measurement.
+  </goab-notification>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- Test 2: Vertical centering -->
+  <goab-text tag="h3">Test 2: Vertical centering of content</goab-text>
+  <goab-text tag="p">
+    Check that the icon, text, and close button are vertically centered at both sizes.
+  </goab-text>
+
+  <goab-text tag="h4" mt="m">Default emergency</goab-text>
+  <goab-notification type="emergency">
+    Emergency banner. Check vertical alignment of icon, text, and close button.
+  </goab-notification>
+
+  <goab-text tag="h4" mt="m">Compact emergency</goab-text>
+  <goab-notification type="emergency" [compact]="true">
+    Compact emergency. Check vertical alignment.
+  </goab-notification>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- Test 3: Event type reference -->
+  <goab-text tag="h3">Test 3: Event type banner (to be undocumented)</goab-text>
+  <goab-text tag="p">
+    The Event type should be silently removed from documentation only (no code change).
+    Showing it here for reference to confirm it still renders correctly.
+  </goab-text>
+
+  <goab-text tag="h4" mt="m">Default event</goab-text>
+  <goab-notification type="event">
+    Event banner at default size. This type will be removed from docs but the code stays.
+  </goab-notification>
+
+  <goab-text tag="h4" mt="m">Compact event</goab-text>
+  <goab-notification type="event" [compact]="true">
+    Event banner at compact size.
+  </goab-notification>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3667/bug3667.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3667/bug3667.component.ts
@@ -1,0 +1,18 @@
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import {
+  GoabBlock,
+  GoabDetails,
+  GoabDivider,
+  GoabLink,
+  GoabNotification,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3667",
+  templateUrl: "./bug3667.component.html",
+  imports: [GoabBlock, GoabDetails, GoabDivider, GoabLink, GoabNotification, GoabText],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class Bug3667Component {}

--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -11,6 +11,7 @@ import {
 } from "@abgov/react-components";
 
 import "@abgov/style";
+import "@abgov/design-tokens-v2/dist/tokens.css"; // Production tokens. Comment out to test with legacy V1 token values.
 
 export function App() {
   const navigate = useNavigate();
@@ -236,6 +237,10 @@ export function App() {
                 <GoabWorkSideMenuItem
                   label="3637 Checkbox Table Header Row Height Bug"
                   url="/bugs/3637"
+                />
+                <GoabWorkSideMenuItem
+                  label="3667 Notification banner refinements"
+                  url="/bugs/3667"
                 />
               </GoabWorkSideMenuGroup>
 

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -56,6 +56,7 @@ import { Bug3505Route } from "./routes/bugs/bug3505";
 import { Bug3614Route } from "./routes/bugs/bug3614";
 import { Bug3635Route } from "./routes/bugs/bug3635";
 import { Bug3637Route } from "./routes/bugs/bug3637";
+import { Bug3667Route } from "./routes/bugs/bug3667";
 import { Bug3685Route } from "./routes/bugs/bug3685";
 
 import { EverythingRoute } from "./routes/everything";
@@ -160,6 +161,7 @@ root.render(
           <Route path="bugs/3614" element={<Bug3614Route />} />
           <Route path="bugs/3635" element={<Bug3635Route />} />
           <Route path="bugs/3637" element={<Bug3637Route />} />
+          <Route path="bugs/3667" element={<Bug3667Route />} />
           <Route path="bugs/3685" element={<Bug3685Route />} />
 
           <Route path="features/1383" element={<Feat1383Route />} />

--- a/apps/prs/react/src/routes/bugs/bug3667.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3667.tsx
@@ -1,0 +1,128 @@
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabDetails,
+  GoabLink,
+  GoabNotification,
+} from "@abgov/react-components";
+
+export function Bug3667Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug #3667: Notification banner refinements
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a
+            href="https://github.com/GovAlta/ui-components/issues/3667"
+            target="_blank"
+            rel="noopener"
+          >
+            View on GitHub
+          </a>
+        </GoabLink>
+
+        <GoabDetails heading="Issue Description">
+          <GoabText tag="p">
+            Notification banner height refinements. Compact should be 64px (currently
+            ~66px), default should be 80px (currently ~82px). Also need to verify vertical
+            centering of content (icon, text, dismiss button) at both sizes. The Event
+            type should be silently undocumented (docs removal only, no code change
+            needed).
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      {/* ── Test 1: Height measurements ── */}
+      <GoabText tag="h3">Test 1: Height at default and compact sizes</GoabText>
+      <GoabText tag="p">
+        Measure the rendered height of each banner. Default should be 80px, compact should
+        be 64px. Use browser dev tools to inspect the goa-notification element and measure
+        the outer height.
+      </GoabText>
+
+      <GoabText tag="h4" mt="m">
+        Default size (target: 80px)
+      </GoabText>
+      <GoabNotification type="information">
+        Default information banner for height measurement.
+      </GoabNotification>
+
+      <GoabText tag="h4" mt="m">
+        Compact size (target: 64px)
+      </GoabText>
+      <GoabNotification type="information" compact={true}>
+        Compact information banner for height measurement.
+      </GoabNotification>
+
+      <GoabText tag="h4" mt="m">
+        Default important (target: 80px)
+      </GoabText>
+      <GoabNotification type="important">
+        Default important banner for height measurement.
+      </GoabNotification>
+
+      <GoabText tag="h4" mt="m">
+        Compact important (target: 64px)
+      </GoabText>
+      <GoabNotification type="important" compact={true}>
+        Compact important banner for height measurement.
+      </GoabNotification>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* ── Test 2: Vertical centering ── */}
+      <GoabText tag="h3">Test 2: Vertical centering of content</GoabText>
+      <GoabText tag="p">
+        Check that the icon, text, and close button are vertically centered at both sizes.
+      </GoabText>
+
+      <GoabText tag="h4" mt="m">
+        Default emergency
+      </GoabText>
+      <GoabNotification type="emergency">
+        Emergency banner. Check vertical alignment of icon, text, and close button.
+      </GoabNotification>
+
+      <GoabText tag="h4" mt="m">
+        Compact emergency
+      </GoabText>
+      <GoabNotification type="emergency" compact={true}>
+        Compact emergency. Check vertical alignment.
+      </GoabNotification>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* ── Test 3: Event type reference ── */}
+      <GoabText tag="h3">Test 3: Event type banner (to be undocumented)</GoabText>
+      <GoabText tag="p">
+        The Event type should be silently removed from documentation only (no code
+        change). Showing it here for reference to confirm it still renders correctly.
+      </GoabText>
+
+      <GoabText tag="h4" mt="m">
+        Default event
+      </GoabText>
+      <GoabNotification type="event">
+        Event banner at default size. This type will be removed from docs but the code
+        stays.
+      </GoabNotification>
+
+      <GoabText tag="h4" mt="m">
+        Compact event
+      </GoabText>
+      <GoabNotification type="event" compact={true}>
+        Event banner at compact size.
+      </GoabNotification>
+    </div>
+  );
+}
+
+export default Bug3667Route;

--- a/libs/web-components/src/components/notification/Notification.svelte
+++ b/libs/web-components/src/components/notification/Notification.svelte
@@ -92,11 +92,7 @@
         aria-atomic="true"
       >
         <div class="icon">
-          <goa-icon
-            type={iconType}
-            inverted={iconInverted}
-            theme={iconTheme}
-          />
+          <goa-icon type={iconType} inverted={iconInverted} theme={iconTheme} />
         </div>
         <div class="content">
           <slot />
@@ -104,11 +100,7 @@
         <div class="close">
           <!-- svelte-ignore a11y-click-events-have-key-events -->
           <button class={type} on:click={close}>
-            <goa-icon
-              type="close"
-              inverted={iconInverted}
-              theme="filled"
-            />
+            <goa-icon type="close" inverted={iconInverted} theme="filled" />
           </button>
         </div>
       </div>
@@ -130,19 +122,22 @@
   /* Screen sizes */
 
   .notification {
-    padding: var(--goa-notification-banner-padding-tb) var(--goa-notification-banner-padding-lr-small-screen);
+    padding: var(--goa-notification-banner-padding-tb)
+      var(--goa-notification-banner-padding-lr-small-screen);
     display: flex;
   }
 
   @container self (--not-mobile) {
     .notification {
-      padding: var(--goa-notification-banner-padding-tb) var(--goa-notification-banner-padding-lr-medium-screen);
+      padding: var(--goa-notification-banner-padding-tb)
+        var(--goa-notification-banner-padding-lr-medium-screen);
     }
   }
 
   @container self (--desktop) {
     .notification {
-      padding: var(--goa-notification-banner-padding-tb) var(--goa-notification-banner-padding-lr-large-screen);
+      padding: var(--goa-notification-banner-padding-tb)
+        var(--goa-notification-banner-padding-lr-large-screen);
     }
   }
 
@@ -189,7 +184,7 @@
 
   /* V2: Improved vertical alignment with icon */
   .v2 .content {
-    margin-top: 4px;
+    margin-top: 3px;
   }
 
   :global(::slotted(a)) {
@@ -275,15 +270,23 @@
 
   @container self (--not-mobile) {
     .v2.compact .notification {
-      padding-left: var(--goa-notification-banner-padding-lr-medium-screen-compact);
-      padding-right: var(--goa-notification-banner-padding-lr-medium-screen-compact);
+      padding-left: var(
+        --goa-notification-banner-padding-lr-medium-screen-compact
+      );
+      padding-right: var(
+        --goa-notification-banner-padding-lr-medium-screen-compact
+      );
     }
   }
 
   @container self (--desktop) {
     .v2.compact .notification {
-      padding-left: var(--goa-notification-banner-padding-lr-large-screen-compact);
-      padding-right: var(--goa-notification-banner-padding-lr-large-screen-compact);
+      padding-left: var(
+        --goa-notification-banner-padding-lr-large-screen-compact
+      );
+      padding-right: var(
+        --goa-notification-banner-padding-lr-large-screen-compact
+      );
     }
   }
 
@@ -296,7 +299,8 @@
   .v2 .notification.information.low {
     background-color: var(--goa-notification-banner-information-low-color-bg);
     color: var(--goa-notification-banner-information-low-color-text);
-    border: var(--goa-border-width-s) solid var(--goa-notification-banner-information-low-color-border);
+    border: var(--goa-border-width-s) solid
+      var(--goa-notification-banner-information-low-color-border);
   }
 
   /* V2 emphasis-based colors - Important */
@@ -308,7 +312,8 @@
   .v2 .notification.important.low {
     background-color: var(--goa-notification-banner-important-low-color-bg);
     color: var(--goa-notification-banner-important-low-color-text);
-    border: var(--goa-border-width-s) solid var(--goa-notification-banner-important-low-color-border);
+    border: var(--goa-border-width-s) solid
+      var(--goa-notification-banner-important-low-color-border);
   }
 
   /* V2 emphasis-based colors - Emergency */
@@ -320,7 +325,8 @@
   .v2 .notification.emergency.low {
     background-color: var(--goa-notification-banner-emergency-low-color-bg);
     color: var(--goa-notification-banner-emergency-low-color-text);
-    border: var(--goa-border-width-s) solid var(--goa-notification-banner-emergency-low-color-border);
+    border: var(--goa-border-width-s) solid
+      var(--goa-notification-banner-emergency-low-color-border);
   }
 
   /* V2 close button icon colors */
@@ -351,32 +357,44 @@
   /* V2 close button hover and focus background colors */
   .v2 .notification.information.high .close button:hover,
   .v2 .notification.information.high .close button:focus-visible {
-    background-color: var(--goa-notification-banner-information-high-close-bg-hover);
+    background-color: var(
+      --goa-notification-banner-information-high-close-bg-hover
+    );
   }
 
   .v2 .notification.information.low .close button:hover,
   .v2 .notification.information.low .close button:focus-visible {
-    background-color: var(--goa-notification-banner-information-low-close-bg-hover);
+    background-color: var(
+      --goa-notification-banner-information-low-close-bg-hover
+    );
   }
 
   .v2 .notification.important.high .close button:hover,
   .v2 .notification.important.high .close button:focus-visible {
-    background-color: var(--goa-notification-banner-important-high-close-bg-hover);
+    background-color: var(
+      --goa-notification-banner-important-high-close-bg-hover
+    );
   }
 
   .v2 .notification.important.low .close button:hover,
   .v2 .notification.important.low .close button:focus-visible {
-    background-color: var(--goa-notification-banner-important-low-close-bg-hover);
+    background-color: var(
+      --goa-notification-banner-important-low-close-bg-hover
+    );
   }
 
   .v2 .notification.emergency.high .close button:hover,
   .v2 .notification.emergency.high .close button:focus-visible {
-    background-color: var(--goa-notification-banner-emergency-high-close-bg-hover);
+    background-color: var(
+      --goa-notification-banner-emergency-high-close-bg-hover
+    );
   }
 
   .v2 .notification.emergency.low .close button:hover,
   .v2 .notification.emergency.low .close button:focus-visible {
-    background-color: var(--goa-notification-banner-emergency-low-close-bg-hover);
+    background-color: var(
+      --goa-notification-banner-emergency-low-close-bg-hover
+    );
   }
 
   /* V2 contrast-based focus borders */


### PR DESCRIPTION
## Summary
- Adjust V2 notification banner padding to hit exact target heights: 80px default, 64px compact
- Nudge text content up 1px for improved vertical centering (margin-top 4px to 3px)
- Event type was already not documented in configs, no docs change needed

Fixes #3667

## Steps needed to test
1. Run the React playground (`npm run serve:prs:react`)
2. Navigate to bugs/3667
3. Inspect the default information banner height. Should be exactly 80px.
4. Inspect the compact information banner height. Should be exactly 64px.
5. Check vertical centering of icon, text, and close button at both sizes.


<img width="988" height="273" alt="image" src="https://github.com/user-attachments/assets/745ff9e2-09ee-4267-8664-311c75f8e753" />
