### PR TITLE
fix(#3630): drawer exit animation, close button alignment, docs updates

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3630/bug3630.component.html
+++ b/apps/prs/angular/src/routes/bugs/3630/bug3630.component.html
@@ -1,0 +1,107 @@
+<div>
+  <h1>Bug #3630: Drawer refinements</h1>
+  <p>
+    <a
+      href="https://github.com/GovAlta/ui-components/issues/3630"
+      target="_blank"
+      rel="noopener"
+    >
+      View on GitHub
+    </a>
+  </p>
+
+  <hr />
+
+  <h2>Test Cases</h2>
+
+  <h3>Test 1: Right drawer (animation + alignment)</h3>
+  <p>
+    Open and close. Check slide-in and slide-out animation. Check heading and close button
+    vertical alignment.
+  </p>
+  <goab-button (onClick)="rightOpen = true">Open right drawer</goab-button>
+
+  <goab-drawer
+    heading="Right drawer"
+    position="right"
+    maxSize="400px"
+    [open]="rightOpen"
+    (onClose)="rightOpen = false"
+  >
+    <p>
+      Check the slide-out animation when closing. The close button should align well with
+      the heading text.
+    </p>
+  </goab-drawer>
+
+  <hr />
+
+  <h3>Test 2: Right drawer with actions</h3>
+  <p>Actions should use start alignment with compact buttons.</p>
+  <goab-button (onClick)="rightActionsOpen = true">Open right drawer with actions</goab-button>
+
+  <ng-template #rightActionsTemplate>
+    <goab-button-group alignment="start">
+      <goab-button type="primary" size="compact">Save</goab-button>
+      <goab-button type="tertiary" size="compact" (onClick)="rightActionsOpen = false">Cancel</goab-button>
+    </goab-button-group>
+  </ng-template>
+
+  <goab-drawer
+    heading="Edit settings"
+    position="right"
+    maxSize="400px"
+    [open]="rightActionsOpen"
+    [actions]="rightActionsTemplate"
+    (onClose)="rightActionsOpen = false"
+  >
+    <p>The action buttons below should be left-aligned and compact.</p>
+  </goab-drawer>
+
+  <hr />
+
+  <h3>Test 3: Left drawer</h3>
+  <p>Check slide-in from left and slide-out animation.</p>
+  <goab-button (onClick)="leftOpen = true">Open left drawer</goab-button>
+
+  <goab-drawer
+    heading="Left drawer"
+    position="left"
+    maxSize="400px"
+    [open]="leftOpen"
+    (onClose)="leftOpen = false"
+  >
+    <p>Check the slide-out animation when closing from the left side.</p>
+  </goab-drawer>
+
+  <hr />
+
+  <h3>Test 4: Bottom drawer</h3>
+  <p>Check slide-up from bottom and slide-down animation.</p>
+  <goab-button (onClick)="bottomOpen = true">Open bottom drawer</goab-button>
+
+  <goab-drawer
+    heading="Bottom drawer"
+    position="bottom"
+    [open]="bottomOpen"
+    (onClose)="bottomOpen = false"
+  >
+    <p>Check the slide-down animation when closing from the bottom.</p>
+  </goab-drawer>
+
+  <hr />
+
+  <h3>Test 5: Long heading</h3>
+  <p>Check alignment when the heading wraps to two lines.</p>
+  <goab-button (onClick)="longHeadingOpen = true">Open drawer with long heading</goab-button>
+
+  <goab-drawer
+    heading="This is a much longer heading that should wrap to two lines in the drawer"
+    position="right"
+    maxSize="400px"
+    [open]="longHeadingOpen"
+    (onClose)="longHeadingOpen = false"
+  >
+    <p>Check that the close button stays aligned properly when the heading wraps.</p>
+  </goab-drawer>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3630/bug3630.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3630/bug3630.component.ts
@@ -1,0 +1,17 @@
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { GoabDrawer, GoabButton, GoabButtonGroup } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3630",
+  templateUrl: "./bug3630.component.html",
+  imports: [GoabDrawer, GoabButton, GoabButtonGroup],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class Bug3630Component {
+  rightOpen = false;
+  rightActionsOpen = false;
+  leftOpen = false;
+  bottomOpen = false;
+  longHeadingOpen = false;
+}

--- a/apps/prs/angular/src/routes/bugs/3630/bug3630.route.json
+++ b/apps/prs/angular/src/routes/bugs/3630/bug3630.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Drawer refinements",
+  "path": "bugs/3630",
+  "id": "3630",
+  "type": "bug"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3630.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3630.route.ts
@@ -1,0 +1,9 @@
+import { Bug3630Route } from "../../../routes/bugs/bug3630";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "bug",
+  id: "3630",
+  path: "bugs/3630",
+  title: "Drawer refinements",
+  component: Bug3630Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3630.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3630.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import {
+  GoabBlock,
+  GoabButton,
+  GoabButtonGroup,
+  GoabDetails,
+  GoabDivider,
+  GoabDrawer,
+  GoabLink,
+  GoabText,
+} from "@abgov/react-components";
+
+export function Bug3630Route() {
+  const [rightOpen, setRightOpen] = useState(false);
+  const [rightActionsOpen, setRightActionsOpen] = useState(false);
+  const [leftOpen, setLeftOpen] = useState(false);
+  const [bottomOpen, setBottomOpen] = useState(false);
+  const [longHeadingOpen, setLongHeadingOpen] = useState(false);
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug #3630: Drawer refinements
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a
+            href="https://github.com/GovAlta/ui-components/issues/3630"
+            target="_blank"
+            rel="noopener"
+          >
+            View on GitHub
+          </a>
+        </GoabLink>
+
+        <GoabDetails heading="Issue Description">
+          <GoabText tag="p">
+            1. Exit animation should slide out (not just disappear). 2. Close button
+            alignment with heading. 3. Actions should use start alignment with compact
+            buttons. 4. Move category from content-layout to structure-navigation.
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      <GoabText tag="h3">Test 1: Right drawer (animation + alignment)</GoabText>
+      <GoabText tag="p">
+        Open and close. Check slide-in and slide-out animation. Check heading and close
+        button vertical alignment.
+      </GoabText>
+      <GoabBlock gap="s" direction="column" mb="l">
+        <GoabButton onClick={() => setRightOpen(true)}>Open right drawer</GoabButton>
+      </GoabBlock>
+
+      <GoabDrawer
+        open={rightOpen}
+        position="right"
+        heading="Right drawer"
+        maxSize="400px"
+        onClose={() => setRightOpen(false)}
+      >
+        <GoabText mt="none" mb="none">
+          Check the slide-out animation when closing. The close button should align well
+          with the heading text.
+        </GoabText>
+      </GoabDrawer>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h3">Test 2: Right drawer with actions</GoabText>
+      <GoabText tag="p">
+        Actions should use start alignment with compact buttons.
+      </GoabText>
+      <GoabBlock gap="s" direction="column" mb="l">
+        <GoabButton onClick={() => setRightActionsOpen(true)}>
+          Open right drawer with actions
+        </GoabButton>
+      </GoabBlock>
+
+      <GoabDrawer
+        open={rightActionsOpen}
+        position="right"
+        heading="Edit settings"
+        maxSize="400px"
+        onClose={() => setRightActionsOpen(false)}
+        actions={
+          <GoabButtonGroup alignment="start">
+            <GoabButton type="primary" size="compact">
+              Save
+            </GoabButton>
+            <GoabButton
+              type="tertiary"
+              size="compact"
+              onClick={() => setRightActionsOpen(false)}
+            >
+              Cancel
+            </GoabButton>
+          </GoabButtonGroup>
+        }
+      >
+        <GoabText mt="none" mb="none">
+          The action buttons below should be left-aligned and compact.
+        </GoabText>
+      </GoabDrawer>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h3">Test 3: Left drawer</GoabText>
+      <GoabText tag="p">Check slide-in from left and slide-out animation.</GoabText>
+      <GoabBlock gap="s" direction="column" mb="l">
+        <GoabButton onClick={() => setLeftOpen(true)}>Open left drawer</GoabButton>
+      </GoabBlock>
+
+      <GoabDrawer
+        open={leftOpen}
+        position="left"
+        heading="Left drawer"
+        maxSize="400px"
+        onClose={() => setLeftOpen(false)}
+      >
+        <GoabText mt="none" mb="none">
+          Check the slide-out animation when closing from the left side.
+        </GoabText>
+      </GoabDrawer>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h3">Test 4: Bottom drawer</GoabText>
+      <GoabText tag="p">Check slide-up from bottom and slide-down animation.</GoabText>
+      <GoabBlock gap="s" direction="column" mb="l">
+        <GoabButton onClick={() => setBottomOpen(true)}>Open bottom drawer</GoabButton>
+      </GoabBlock>
+
+      <GoabDrawer
+        open={bottomOpen}
+        position="bottom"
+        heading="Bottom drawer"
+        onClose={() => setBottomOpen(false)}
+      >
+        <GoabText mt="none" mb="none">
+          Check the slide-down animation when closing from the bottom.
+        </GoabText>
+      </GoabDrawer>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h3">Test 5: Long heading</GoabText>
+      <GoabText tag="p">Check alignment when the heading wraps to two lines.</GoabText>
+      <GoabBlock gap="s" direction="column" mb="l">
+        <GoabButton onClick={() => setLongHeadingOpen(true)}>
+          Open drawer with long heading
+        </GoabButton>
+      </GoabBlock>
+
+      <GoabDrawer
+        open={longHeadingOpen}
+        position="right"
+        heading="This is a much longer heading that should wrap to two lines in the drawer"
+        maxSize="400px"
+        onClose={() => setLongHeadingOpen(false)}
+      >
+        <GoabText mt="none" mb="none">
+          Check that the close button stays aligned properly when the heading wraps.
+        </GoabText>
+      </GoabDrawer>
+    </div>
+  );
+}
+
+export default Bug3630Route;

--- a/docs/src/content/components/drawer.mdx
+++ b/docs/src/content/components/drawer.mdx
@@ -2,7 +2,7 @@
 name: Drawer
 description: A panel that slides in from the side of the screen to display additional content or actions without navigating away from the current view.
 status: stable
-category: content-layout
+category: structure-and-navigation
 tags:
   - sections
   - structure and navigation

--- a/docs/src/data/configurations/drawer.ts
+++ b/docs/src/data/configurations/drawer.ts
@@ -205,7 +205,7 @@ const handleSave = () => {
   open={isOpen}
   onClose={handleClose}
   actions={
-    <GoabButtonGroup alignment="end">
+    <GoabButtonGroup alignment="start">
       <GoabButton size="compact" onClick={handleSave}>
         Save
       </GoabButton>
@@ -244,7 +244,7 @@ const handleSave = () => {
   [actions]="actionsTpl"
 >
   <ng-template #actionsTpl>
-    <goab-button-group alignment="end">
+    <goab-button-group alignment="start">
       <goab-button size="compact" (onClick)="handleSave()">Save</goab-button>
       <goab-button type="tertiary" size="compact" (onClick)="handleClose()"
         >Cancel</goab-button
@@ -258,7 +258,7 @@ const handleSave = () => {
 <goa-drawer version="2" id="demo-drawer" heading="Edit settings" position="right">
   <p>Make changes to your settings here.</p>
   <div slot="actions">
-    <goa-button-group alignment="end">
+    <goa-button-group alignment="start">
       <goa-button version="2" type="primary" size="compact">Save</goa-button>
       <goa-button version="2" type="tertiary" size="compact">Cancel</goa-button>
     </goa-button-group>

--- a/libs/react-components/specs/drawer.browser.spec.tsx
+++ b/libs/react-components/specs/drawer.browser.spec.tsx
@@ -16,7 +16,7 @@ describe("Drawer", () => {
     await vi.waitFor(async () => {
       const drawer = getByTestId(testId);
       expect(drawer).toBeInTheDocument();
-      expect(drawer).toHaveStyle({ visibility: "hidden" });
+      expect(drawer).toHaveStyle({ pointerEvents: "none" });
     });
   });
 
@@ -34,21 +34,20 @@ describe("Drawer", () => {
 
       await vi.waitFor(async () => {
         const drawer = getByTestId(testId);
-        expect(drawer).toHaveStyle({ visibility: "visible" });
+        expect(drawer).toHaveStyle({ pointerEvents: "auto" });
       });
     });
 
     it("calls onClose when the close button is clicked", async () => {
       const { getByTestId } = await render(<Component />);
 
-      await vi.waitFor(async () => {
-        const closeButton = getByTestId("drawer-close-button");
-        expect(closeButton).toBeTruthy();
-        await closeButton.click();
-
-        vi.waitFor(() => {
-          expect(handleOnClose).toHaveBeenCalled();
-        });
+      const closeButton = getByTestId("drawer-close-button");
+      await vi.waitFor(() => {
+        expect(closeButton.element()).toBeTruthy();
+      });
+      await closeButton.click();
+      await vi.waitFor(() => {
+        expect(handleOnClose).toHaveBeenCalled();
       });
     });
   });
@@ -63,7 +62,7 @@ describe("Drawer", () => {
 
       await vi.waitFor(async () => {
         const drawer = getByTestId(testId);
-        expect(drawer).toHaveStyle({ visibility: "hidden" });
+        expect(drawer).toHaveStyle({ pointerEvents: "none" });
       });
     });
   });

--- a/libs/react-components/specs/pushdrawer.browser.spec.tsx
+++ b/libs/react-components/specs/pushdrawer.browser.spec.tsx
@@ -64,21 +64,20 @@ describe("PushDrawer", () => {
 
       await vi.waitFor(async () => {
         const drawer = getByTestId(`drawer-${testId}`);
-        expect(drawer).toHaveStyle({ visibility: "visible" });
+        expect(drawer).toHaveStyle({ pointerEvents: "auto" });
       });
     });
 
     it("calls onClose when the close button is clicked", async () => {
       const { getByTestId } = await render(<Component />);
 
-      await vi.waitFor(async () => {
-        const closeButton = getByTestId("drawer-close-button");
-        expect(closeButton).toBeTruthy();
-        await closeButton.click();
-
-        vi.waitFor(() => {
-          expect(handleOnClose).toHaveBeenCalled();
-        });
+      const closeButton = getByTestId("drawer-close-button");
+      await vi.waitFor(() => {
+        expect(closeButton.element()).toBeTruthy();
+      });
+      await closeButton.click();
+      await vi.waitFor(() => {
+        expect(handleOnClose).toHaveBeenCalled();
       });
     });
   });
@@ -93,7 +92,7 @@ describe("PushDrawer", () => {
 
       await vi.waitFor(async () => {
         const drawer = getByTestId(`drawer-${testId}`);
-        expect(drawer).toHaveStyle({ visibility: "hidden" });
+        expect(drawer).toHaveStyle({ pointerEvents: "none" });
       });
     });
   });

--- a/libs/web-components/src/components/drawer/Drawer.svelte
+++ b/libs/web-components/src/components/drawer/Drawer.svelte
@@ -3,7 +3,10 @@
     tag: "goa-drawer",
     props: {
       open: { type: "Boolean", reflect: true },
-      closeButtonVisibility: { type: "String", attribute: "close-button-visibility" },
+      closeButtonVisibility: {
+        type: "String",
+        attribute: "close-button-visibility",
+      },
     },
   }}
 />
@@ -12,12 +15,7 @@
   import { fly } from "svelte/transition";
   import noscroll from "../../common/no-scroll";
   import { onDestroy, onMount, tick } from "svelte";
-  import {
-    dispatch,
-    style,
-    styles,
-    typeValidator,
-  } from "../../common/utils";
+  import { dispatch, style, styles, typeValidator } from "../../common/utils";
   import { DrawerPosition, DrawerSize } from "../../common/types";
 
   // ******
@@ -220,7 +218,7 @@
 <goa-focus-trap {open} prevent-scroll-into-view={true}>
   <div
     class={`root ${_scrollPos ?? ""}`}
-    style={style("visibility", open ? "visible" : "hidden")}
+    style={style("pointer-events", open ? "auto" : "none")}
     data-testid={testid}
   >
     <button
@@ -262,7 +260,7 @@
         ),
       )}
       in:fly={_flyParams}
-      out:fly={{ ..._flyParams, delay: 200 }}
+      out:fly={_flyParams}
       class:open
       class:closing={!open}
       class:v2={version === "2"}
@@ -434,6 +432,10 @@
     border-bottom: none; /* Remove border by default */
   }
 
+  .v2 .header goa-icon-button {
+    margin-top: -0.1875rem;
+  }
+
   /* V2: Show header border when scrolled from top (middle or bottom position) */
   .root.middle .drawer.v2 .header,
   .root.bottom .drawer.v2 .header {
@@ -534,7 +536,11 @@
     border-radius: var(--goa-drawer-border-radius, 24px); /* All corners 24px */
     box-shadow: var(--goa-drawer-shadow);
     transform: translateY(100%); /* Start off-screen at bottom */
-    transition: transform 0.2s ease-out;
+    transition:
+      bottom var(--goa-motion-duration-medium-1)
+        var(--goa-motion-curve-expressive),
+      transform var(--goa-motion-duration-medium-1)
+        var(--goa-motion-curve-expressive);
   }
   .drawer-bottom.v2.open,
   .drawer-bottom.v2.drawer-open-bottom {
@@ -571,8 +577,12 @@
     transform: translateX(100%); /* Start off-screen to the right */
     /* Smooth transitions for position and transform */
     transition:
-      bottom 0.15s ease-out,
-      transform 0.2s ease-out;
+      right var(--goa-motion-duration-medium-1)
+        var(--goa-motion-curve-expressive),
+      bottom var(--goa-motion-duration-short-4)
+        var(--goa-motion-curve-expressive),
+      transform var(--goa-motion-duration-medium-1)
+        var(--goa-motion-curve-expressive);
   }
   .v2.drawer-open-right {
     right: var(--goa-drawer-offset, 0);
@@ -613,8 +623,12 @@
     transform: translateX(-100%); /* Start off-screen to the left */
     /* Smooth transitions for position and transform */
     transition:
-      bottom 0.15s ease-out,
-      transform 0.2s ease-out;
+      left var(--goa-motion-duration-medium-1)
+        var(--goa-motion-curve-expressive),
+      bottom var(--goa-motion-duration-short-4)
+        var(--goa-motion-curve-expressive),
+      transform var(--goa-motion-duration-medium-1)
+        var(--goa-motion-curve-expressive);
   }
   .v2.drawer-open-left {
     left: var(--goa-drawer-offset, 0);

--- a/libs/web-components/src/components/drawer/drawer.spec.ts
+++ b/libs/web-components/src/components/drawer/drawer.spec.ts
@@ -10,45 +10,51 @@ beforeEach(() => {
 });
 
 describe("Drawer", () => {
-
   it("renders content in closed state", async () => {
     const el = await render(DrawerWrapper, {
       open: false,
-      testid: "drawer"
+      testid: "drawer",
     });
 
     await waitFor(() => {
       const drawerEl = el.queryByTestId("drawer");
-      expect(drawerEl?.style.visibility).toBe("hidden");
+      expect(drawerEl?.style.pointerEvents).toBe("none");
     });
   });
 
   it("closes when clicking the background or close button", async () => {
     const el = render(DrawerWrapper, {
       open: false,
-      testid: "drawer"
+      testid: "drawer",
     });
 
     // Initial state - wait for first render
     const drawer = el.queryByTestId("drawer");
-    expect(drawer?.style.visibility).toBe("hidden");
+    expect(drawer?.style.pointerEvents).toBe("none");
 
     // Open drawer
     const buttonEl = await el.findByTestId("open");
     await fireEvent.click(buttonEl);
 
-    await waitFor(() => {
-      const drawer = el.queryByTestId("drawer");
-      expect(drawer?.style.visibility).toBe("visible");
-    }, { timeout: 1000 });
+    await waitFor(
+      () => {
+        const drawer = el.queryByTestId("drawer");
+        expect(drawer?.style.pointerEvents).toBe("auto");
+      },
+      { timeout: 1000 },
+    );
 
     // Click background to close
     const background = el.queryByTestId("background");
     await fireEvent.click(background);
 
+    // TODO: The close event doesn't propagate correctly in the unit test
+    // environment, so this assertion can't be properly awaited. The original
+    // test on dev had the same issue (setTimeout that silently skipped).
+    // This needs investigation in a separate PR.
     setTimeout(() => {
       const drawer = el.queryByTestId("drawer");
-      expect(drawer?.style.visibility).toBe("hidden");
+      expect(drawer?.style.pointerEvents).toBe("none");
     }, 1000);
   });
 
@@ -72,36 +78,40 @@ describe("Drawer", () => {
     const el = await render(DrawerWrapper, {
       open: true,
       testid: "drawer",
-      heading: "Heading"
-    });
-    await waitFor(() => {
-      const actionsEl = el.queryByTestId("drawer-actions");
-      expect(actionsEl?.classList.contains("empty-actions")).toBe(true);
-    }, { timeout: 1000 });
-  });
-
-  it.each([
-    "bottom",
-    "left",
-    "right",
-  ])("renders with position %s", async (position) => {
-    const el = render(DrawerWrapper, {
-      position,
       heading: "Heading",
-      content: "Content",
-      testid: "drawer",
     });
-
-    const buttonEl = await el.findByTestId("open");
-    await fireEvent.click(buttonEl);
-
-    const drawerEl = await el.findByTestId("drawer");
-    await waitFor(() => {
-      const drawer = drawerEl.querySelector(".drawer") as HTMLElement;
-      expect(drawer?.classList.contains(`drawer-${position}`)).toBe(true);
-      expect(drawer?.classList.contains(`drawer-open-${position}`)).toBe(true);
-    });
+    await waitFor(
+      () => {
+        const actionsEl = el.queryByTestId("drawer-actions");
+        expect(actionsEl?.classList.contains("empty-actions")).toBe(true);
+      },
+      { timeout: 1000 },
+    );
   });
+
+  it.each(["bottom", "left", "right"])(
+    "renders with position %s",
+    async (position) => {
+      const el = render(DrawerWrapper, {
+        position,
+        heading: "Heading",
+        content: "Content",
+        testid: "drawer",
+      });
+
+      const buttonEl = await el.findByTestId("open");
+      await fireEvent.click(buttonEl);
+
+      const drawerEl = await el.findByTestId("drawer");
+      await waitFor(() => {
+        const drawer = drawerEl.querySelector(".drawer") as HTMLElement;
+        expect(drawer?.classList.contains(`drawer-${position}`)).toBe(true);
+        expect(drawer?.classList.contains(`drawer-open-${position}`)).toBe(
+          true,
+        );
+      });
+    },
+  );
 
   it("respects maxsize prop", async () => {
     const maxsize = "400px";
@@ -170,7 +180,7 @@ describe("Drawer", () => {
     await fireEvent.click(buttonEl);
     const drawerEl = await el.findByTestId("drawer");
     await waitFor(() => {
-      expect(drawerEl.style.visibility).toBe("visible");
+      expect(drawerEl.style.pointerEvents).toBe("auto");
     });
 
     const scrollableEl = drawerEl.querySelector("goa-scrollable");


### PR DESCRIPTION
## Summary
- Enable exit animation on drawer close (was disappearing instantly due to `visibility: hidden`)
- Replace hardcoded transition durations with motion tokens (`motion-duration-medium-1`, `motion-duration-short-4`, `motion-curve-expressive`)
- Nudge close icon button up for better alignment with heading text
- Update docs example to use `alignment="start"` on button group (was `end`)
- Move drawer category from content-layout to structure-navigation in docs

Fixes #3630

## Steps needed to test
1. Run the React playground (`npm run serve:prs:react`)
2. Navigate to bugs/3630
3. Open and close the right drawer. Verify it slides out smoothly (not just disappearing).
4. Open the right drawer with actions. Verify buttons are left-aligned and compact.
5. Open the left drawer. Verify slide-in from left and slide-out animation.
6. Open the bottom drawer. Verify slide-up and slide-down animation.
7. Open the long heading drawer. Verify close button alignment with wrapped heading.
8. Check that the heading and close button are vertically aligned in all drawers.


https://github.com/user-attachments/assets/e7ddee31-7110-4592-be09-f1e9cf123e17

<img width="571" height="337" alt="image" src="https://github.com/user-attachments/assets/699c3e4a-019e-4df2-87b5-bc368aac36f0" />
