### PR TITLE
fix(#3643): Popover aligns right when out of space

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3643/bug3643.component.html
+++ b/apps/prs/angular/src/routes/bugs/3643/bug3643.component.html
@@ -1,0 +1,67 @@
+<div>
+  <goab-text tag="h1" mt="m">Bug 3643 - Popover right alignment at viewport edge</goab-text>
+  <goab-text tag="p" mb="m">
+    Open each corner popover to verify alignment and overflow behavior in different
+    viewport locations.
+  </goab-text>
+
+  <div
+    style="
+      position: relative;
+      min-height: 75vh;
+      border: 1px dashed var(--goa-color-greyscale-300);
+      border-radius: 0.5rem;
+      padding: 1rem;
+    "
+  >
+    <div style="position: absolute; top: 1rem; left: 1rem;">
+      <goab-popover [target]="topLeftTarget" maxWidth="22rem">
+        <ng-template #topLeftTarget>
+          <goab-button type="secondary">Top Left</goab-button>
+        </ng-template>
+        <div style="width: 300px;">
+          <goab-text tag="p">Top-left corner popover content.</goab-text>
+        </div>
+      </goab-popover>
+    </div>
+
+    <div style="position: absolute; top: 1rem; right: 1rem;">
+      <goab-popover [target]="topRightTarget" maxWidth="22rem">
+        <ng-template #topRightTarget>
+          <goab-button type="secondary">Top Right</goab-button>
+        </ng-template>
+        <div style="width: 300px;">
+          <goab-text tag="p">
+            Top-right corner popover content with longer text to test right-edge alignment
+            fallback.
+          </goab-text>
+        </div>
+      </goab-popover>
+    </div>
+
+    <div style="position: absolute; bottom: 1rem; left: 1rem;">
+      <goab-popover [target]="bottomLeftTarget" maxWidth="22rem">
+        <ng-template #bottomLeftTarget>
+          <goab-button type="secondary">Bottom Left</goab-button>
+        </ng-template>
+        <div style="width: 300px;">
+          <goab-text tag="p">Bottom-left corner popover content.</goab-text>
+        </div>
+      </goab-popover>
+    </div>
+
+    <div style="position: absolute; bottom: 1rem; right: 1rem;">
+      <goab-popover [target]="bottomRightTarget" maxWidth="22rem">
+        <ng-template #bottomRightTarget>
+          <goab-button type="secondary">Bottom Right</goab-button>
+        </ng-template>
+        <div style="width: 300px;">
+          <goab-text tag="p">
+            Bottom-right corner popover content with longer text to validate overflow
+            handling.
+          </goab-text>
+        </div>
+      </goab-popover>
+    </div>
+  </div>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3643/bug3643.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3643/bug3643.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabButton, GoabPopover, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3643",
+  templateUrl: "./bug3643.component.html",
+  imports: [GoabButton, GoabPopover, GoabText],
+})
+export class Bug3643Component {}

--- a/apps/prs/angular/src/routes/bugs/3643/bug3643.route.json
+++ b/apps/prs/angular/src/routes/bugs/3643/bug3643.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3643",
+  "path": "bugs/3643",
+  "title": "Popover right alignment at viewport edge"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3643.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3643.route.ts
@@ -1,0 +1,9 @@
+import { Bug3643Route } from "../../../routes/bugs/bug3643";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "bug",
+  id: "3643",
+  path: "bugs/3643",
+  title: "Popover right alignment at viewport edge",
+  component: Bug3643Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3643.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3643.tsx
@@ -1,0 +1,79 @@
+import { GoabButton, GoabPopover, GoabText } from "@abgov/react-components";
+
+const testAreaStyle: React.CSSProperties = {
+  position: "relative",
+  minHeight: "75vh",
+  border: "1px dashed var(--goa-color-greyscale-300)",
+  borderRadius: "0.5rem",
+  padding: "1rem",
+};
+
+const cornerStyle: React.CSSProperties = {
+  position: "absolute",
+};
+
+export function Bug3643Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug 3643 - Popover right alignment at viewport edge
+      </GoabText>
+      <GoabText tag="p" mb="m">
+        Open each corner popover to verify alignment and overflow behavior in different
+        viewport locations.
+      </GoabText>
+
+      <div style={testAreaStyle}>
+        <div style={{ ...cornerStyle, top: "1rem", left: "1rem" }}>
+          <GoabPopover
+            target={<GoabButton type="secondary">Top Left</GoabButton>}
+            maxWidth="22rem"
+          >
+            <div style={{ width: "300px" }}>
+              <GoabText tag="p">Top-left corner popover content.</GoabText>
+            </div>
+          </GoabPopover>
+        </div>
+
+        <div style={{ ...cornerStyle, top: "1rem", right: "1rem" }}>
+          <GoabPopover
+            target={<GoabButton type="secondary">Top Right</GoabButton>}
+            maxWidth="22rem"
+          >
+            <div style={{ width: "300px" }}>
+              <GoabText tag="p">
+                Top-right corner popover content with longer text to test right-edge
+                alignment fallback.
+              </GoabText>
+            </div>
+          </GoabPopover>
+        </div>
+
+        <div style={{ ...cornerStyle, bottom: "1rem", left: "1rem" }}>
+          <GoabPopover
+            target={<GoabButton type="secondary">Bottom Left</GoabButton>}
+            maxWidth="22rem"
+          >
+            <div style={{ width: "300px" }}>
+              <GoabText tag="p">Bottom-left corner popover content.</GoabText>
+            </div>
+          </GoabPopover>
+        </div>
+
+        <div style={{ ...cornerStyle, bottom: "1rem", right: "1rem" }}>
+          <GoabPopover
+            target={<GoabButton type="secondary">Bottom Right</GoabButton>}
+            maxWidth="22rem"
+          >
+            <div style={{ width: "300px" }}>
+              <GoabText tag="p">
+                Bottom-right corner popover content with longer text to validate overflow
+                handling.
+              </GoabText>
+            </div>
+          </GoabPopover>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/react-components/specs/popover.browser.spec.tsx
+++ b/libs/react-components/specs/popover.browser.spec.tsx
@@ -202,6 +202,50 @@ describe("Popover", () => {
     expect(aboveWidth!).toBe(belowWidth!);
   });
 
+  it("should align popover to the right edge of the target when there is not enough space on the right", async () => {
+    const Component = () => {
+      return (
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "flex-end",
+            padding: "0.5rem",
+          }}
+        >
+          <GoabPopover
+            testId="popover-right-overflow"
+            target={
+              <GoabButton testId={"target-right-overflow"}>Open popover</GoabButton>
+            }
+            maxWidth="none"
+          >
+            <div style={{ width: "300px" }}>
+              This popover is wide enough to require right alignment near the viewport
+              edge.
+            </div>
+          </GoabPopover>
+        </div>
+      );
+    };
+
+    const result = render(<Component />);
+    const target = result.getByTestId("target-right-overflow");
+    const popover = result.getByTestId("popover-right-overflow");
+    const popoverContent = popover.getByTestId("popover-content");
+
+    await target.click();
+
+    await vi.waitFor(() => {
+      expect(popoverContent).toBeVisible();
+      const targetRect = target.element().getBoundingClientRect();
+      const contentRect = popoverContent.element().getBoundingClientRect();
+
+      // The right edges of the popover content and target should be aligned (within a small tolerance)
+      expect(Math.abs(contentRect.right - targetRect.right)).toBeLessThanOrEqual(2);
+    });
+  });
+
   describe("Popover within a modal", () => {
     it("should open the popover within a modal even with long content", async () => {
       const Component = () => {

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -76,6 +76,7 @@
   let _targetEl: HTMLElement;
   let _isOpen = false;
   let _autoPosition: "above" | "below" = "below";
+  let _alignment: "left" | "right" = "left";
   const _popoverId = `goa-popover-${generateRandomId()}`;
 
   $: _disabled = toBoolean(disabled);
@@ -122,14 +123,14 @@
 
     showDeprecationWarnings();
     addGlobalCloseListener();
-    window.addEventListener("resize", updateAutoPosition);
+    window.addEventListener("resize", recalculatePosition);
   });
 
   onDestroy(() => {
     if (_needsManualPositioning || _positionRafId) {
       stopManualPositioning();
     }
-    window.removeEventListener("resize", updateAutoPosition);
+    window.removeEventListener("resize", recalculatePosition);
     // true was passed when the listener was added, so it's necesary to be passed here as well
     window.removeEventListener("popstate", handleUrlChange, true);
   });
@@ -140,12 +141,12 @@
     if (!_isOpen || !_targetEl || !_popoverEl) return;
 
     const targetRect = _targetEl.getBoundingClientRect();
+    const popoverRect = _popoverEl.getBoundingClientRect();
     const xOffset = hoffset ? parseFloat(hoffset) : 0;
     const yOffset = voffset ? parseFloat(voffset) : 3;
 
     // Recalculate auto position based on current viewport space
     if (position === "auto") {
-      const popoverRect = _popoverEl.getBoundingClientRect();
       const spaceAbove = targetRect.top;
       const spaceBelow = window.innerHeight - targetRect.bottom;
 
@@ -161,12 +162,16 @@
 
     if (isAbove) {
       _popoverEl.style.top = `${targetRect.top - yOffset}px`;
-      _popoverEl.style.left = `${targetRect.left + xOffset}px`;
       _popoverEl.style.transform = "translateY(-100%)";
     } else {
       _popoverEl.style.top = `${targetRect.bottom + yOffset}px`;
-      _popoverEl.style.left = `${targetRect.left + xOffset}px`;
       _popoverEl.style.transform = "";
+    }
+
+    if (_alignment === "left") {
+      _popoverEl.style.left = `${targetRect.left + xOffset}px`;
+    } else {
+      _popoverEl.style.left = `${targetRect.right - xOffset - popoverRect.width}px`;
     }
   }
 
@@ -261,7 +266,7 @@
     // (MenuButton, AppHeader, AppHeaderMenu, Dropdown)
     if (_isOpen) {
       dispatch(_rootEl, "_open", {}, { bubbles: true });
-      requestAnimationFrame(updateAutoPosition); // same vs await tick(), make sure popover element is fully rendered before we measure its dimension
+      requestAnimationFrame(recalculatePosition); // same vs await tick(), make sure popover element is fully rendered before we measure its dimension
       if (_needsManualPositioning) {
         startManualPositioning();
       }
@@ -306,17 +311,26 @@
       }
       _popoverEl.showPopover();
       _isOpen = true;
-      requestAnimationFrame(updateAutoPosition);
+      requestAnimationFrame(recalculatePosition);
     }
   }
 
-  function updateAutoPosition() {
-    if (position !== "auto" || !_isOpen || !_targetEl || !_popoverEl) {
+  function recalculatePosition() {
+    if (!_isOpen || !_targetEl || !_popoverEl) {
       return;
     }
 
     const targetRect = _targetEl.getBoundingClientRect();
     const popoverRect = _popoverEl.getBoundingClientRect();
+    updateAutoPosition(targetRect, popoverRect);
+    updateAlignment(targetRect, popoverRect);
+  }
+
+  function updateAutoPosition(targetRect: DOMRect, popoverRect: DOMRect) {
+    if (position !== "auto") {
+      return;
+    }
+
     const spaceAbove = targetRect.top;
     const spaceBelow = window.innerHeight - targetRect.bottom;
 
@@ -324,6 +338,22 @@
       spaceBelow < popoverRect.height && spaceAbove > spaceBelow
         ? "above"
         : "below";
+  }
+
+  function updateAlignment(targetRect: DOMRect, popoverRect: DOMRect) {
+    if (position === "right") {
+      return;
+    }
+
+    const spaceRight = window.innerWidth - targetRect.left;
+    if (
+      spaceRight < popoverRect.width &&
+      targetRect.right > popoverRect.width
+    ) {
+      _alignment = "right";
+    } else {
+      _alignment = "left";
+    }
   }
 </script>
 
@@ -372,6 +402,7 @@
       (position === "auto" && _autoPosition === "below")}
     class:position-right={position === "right"}
     class:use-anchor-based-positioning={!_needsManualPositioning}
+    class:align-right={_alignment === "right"}
     style={styles(
       style("width", position !== "right" ? width : undefined),
       style("min-width", minwidth),
@@ -462,6 +493,11 @@
     --popover-translate-x: var(--offset-left, 8px);
     --popover-translate-y: var(--offset-bottom, 0px);
     position-try-fallbacks: none;
+  }
+
+  .popover-content.align-right:not(.position-right) {
+    inset-inline-start: unset;
+    inset-inline-end: anchor(right);
   }
 
   :global(::slotted(ul)) {


### PR DESCRIPTION
This PR right aligns the popover with the right edge target if...
- The popover is positioned `above` or `below`
- There isn't enough horizontal space to show the left-aligned popover in the viewport

<img width="740" height="370" alt="popover-alignment" src="https://github.com/user-attachments/assets/f4ca0f65-f784-4b71-a0d8-3f514205a9d1" />

It supports both our popover position implementations:
- Anchor positioning for browsers that support it
- JS fallback for browsers that don't (Safari 18)

<img width="642" height="248" alt="safari-test" src="https://github.com/user-attachments/assets/e2869797-6b08-4882-9537-bb83704b8cab" />

### Not included

It doesn't include an additional feature of a public alignment property. We'll need to decide how it fits with the current "position" property.