### PR TITLE
fix(#3847): Use missing container interactive bg-color token

### DIFF
--- a/apps/prs/angular/src/app/everything.component.html
+++ b/apps/prs/angular/src/app/everything.component.html
@@ -95,6 +95,12 @@
               </goab-text>
             </goab-container>
           }
+          <goab-container type="interactive" accent="filled" padding="relaxed" width="content">
+            <goab-text tag="p" size="body-m">
+              Type: interactive<br />
+              Accent: filled
+            </goab-text>
+          </goab-container>
         </goab-grid>
       </goab-container>
       <goab-container type="interactive" padding="relaxed">

--- a/apps/prs/react/src/routes/everything.tsx
+++ b/apps/prs/react/src/routes/everything.tsx
@@ -657,6 +657,13 @@ export function EverythingRoute(): JSX.Element {
                 </GoabText>
               </GoabContainer>
             ))}
+            <GoabContainer type="interactive" accent="filled" padding="relaxed" width="content">
+              <GoabText tag="p" size="body-m">
+                Type: interactive
+                <br />
+                Accent: filled
+              </GoabText>
+            </GoabContainer>
           </GoabGrid>
         </GoabContainer>
         <GoabContainer type="interactive" padding="relaxed">

--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -219,6 +219,10 @@
     border: var(--goa-container-interactive-border);
     color: var(--goa-container-interactive-heading-text-color);
   }
+  .goa-container--interactive.accent--filled .content {
+    border: var(--goa-container-interactive-border);
+    background-color: var(--goa-container-interactive-bg-color);
+  }
 
   .goa-container--non-interactive header {
     background-color: var(--goa-container-non-interactive-heading-bg-color);


### PR DESCRIPTION
## Summary
- The `--goa-container-interactive-bg-color` token is defined in the design tokens JSON but the Container component had no CSS rule referencing it
- Every other container type (non-interactive, info, error, success, important) wires up its corresponding token on the `.accent--filled .content` selector. The interactive variant was missing.
- No visual change. The token default value (`greyscale-white`) matches the current browser-rendered appearance.

## Changes

**Container** (interactive filled-accent content): Added `.goa-container--interactive.accent--filled .content` rule with `background-color` and `border`, matching the pattern of all other container types.

Fixes #3847

## Test plan
- [ ] Verify light mode appearance is unchanged for Container (interactive, filled accent)
- [ ] No wrapper changes needed (CSS-only)