### PR TITLE
fix(#3851): render example CSS correctly in code tab and preview

### DIFF
--- a/docs/src/components/ExamplePreview.tsx
+++ b/docs/src/components/ExamplePreview.tsx
@@ -18,6 +18,8 @@ import DOMPurify from "dompurify";
 // By default, DOMPurify strips all custom elements (tags containing hyphens).
 // Our previews render <goa-*> web components, so we must whitelist them.
 const DOMPURIFY_CONFIG = {
+  ADD_TAGS: ["style"], // allow example-authored <style> blocks through (CSS content still sanitised)
+  FORCE_BODY: true, // parse input as body content so <style> tags are kept in place (not moved to head)
   CUSTOM_ELEMENT_HANDLING: {
     tagNameCheck: /^goa-/, // allow all <goa-*> elements
     attributeNameCheck: () => true, // allow their attributes (type, name, label, etc.)

--- a/docs/src/lib/extract-code-parts.ts
+++ b/docs/src/lib/extract-code-parts.ts
@@ -252,7 +252,7 @@ export function extractAngularCode(tsCode: string | undefined, htmlTemplate: str
   if (tsCode) {
     // Extract CSS from styles array in @Component decorator
     // styles: [`...`] or styles: ["..."]
-    const stylesMatch = tsCode.match(/styles:\s*\[\s*[`"]([\s\S]*?)[`"]\s*\]/);
+    const stylesMatch = tsCode.match(/styles:\s*\[\s*[`"]([\s\S]*?)[`"]\s*,?\s*\]/);
     if (stylesMatch) {
       css = cleanIndentation(stylesMatch[1]);
     }


### PR DESCRIPTION
## Summary

- Two fixes for example CSS that were silently broken in different ways.
- **`docs/src/lib/extract-code-parts.ts`**: the Angular styles regex was over-capturing past a trailing comma in the `styles: [...]` array. Tightened the regex with an optional trailing comma pattern so the CSS block stops at the closing backtick.
- **`docs/src/components/ExamplePreview.tsx`**: DOMPurify was stripping `<style>` blocks from WC previews because it treats them as head content. Added `ADD_TAGS: ["style"]` and `FORCE_BODY: true` so authored `<style>` blocks survive into the preview. CSS content still passes through DOMPurify's CSS sanitiser.
- Closes #3851.

## Affected examples

### Angular code tab (over-capture bug)

Three existing examples were showing CSS content followed by class-body fragments ending mid-token:

- `review-and-action`
- `review-page`
- `show-more-information-to-help-answer-a-question`

### WC preview (`<style>` strip bug)

Three existing examples have `<style>` blocks in their `web-components.html` and were rendering without the CSS applied:

- `card-view-of-case-files`
- `copy-to-clipboard`
- `expand-or-collapse-part-of-a-form`

## Test plan

- [ ] Load `/examples/review-and-action` and flip to the Angular tab. First code block contains only CSS, no class-body leakage. Repeat for `/examples/review-page` and `/examples/show-more-information-to-help-answer-a-question`.
- [ ] Load `/examples/card-view-of-case-files`. Preview shows rows with badges and buttons aligned to the right via `space-between`. Repeat for `/examples/copy-to-clipboard` and `/examples/expand-or-collapse-part-of-a-form`.
- [ ] Load an example without custom CSS (e.g. `/examples/button-with-icon`). No regression.
- [ ] `npm run serve:docs` renders cleanly.

### Before
<img width="1143" height="932" alt="image" src="https://github.com/user-attachments/assets/6b6ba82d-43c3-468f-b972-3ce441ffa202" />

<img width="1143" height="932" alt="image" src="https://github.com/user-attachments/assets/dc643111-be02-4572-bfa0-18bfbd71284e" />

### After
<img width="1143" height="932" alt="image" src="https://github.com/user-attachments/assets/92cfab1c-050e-4fdb-bdd7-b66215db60d8" />

<img width="1143" height="932" alt="image" src="https://github.com/user-attachments/assets/41131141-6073-4abc-a400-d20ebbf752dc" />
