### PR TITLE
feat(#1553): add 401, 404, 500 error page examples

### DIFF
--- a/docs/src/content/examples/401-error-page/angular.html
+++ b/docs/src/content/examples/401-error-page/angular.html
@@ -1,0 +1,27 @@
+<goab-page-block>
+  <div class="error-page-content">
+    <goab-block direction="column" alignment="center" gap="xl" width="100%" mt="3xl" mb="3xl">
+      <goab-block direction="column" alignment="center" gap="m" width="100%">
+        <div class="error-page-icon">
+          <goab-icon role="presentation" type="warning" size="xlarge"></goab-icon>
+        </div>
+        <goab-text size="body-m" color="secondary" mt="none" mb="none">Error 401</goab-text>
+        <div class="error-page-underline" aria-hidden="true"></div>
+      </goab-block>
+
+      <goab-block direction="column" alignment="center" gap="l" width="100%">
+        <goab-text tag="h1" size="heading-l" mt="none" mb="none">Restricted access</goab-text>
+        <goab-text size="body-m" mt="none" mb="none">
+          We cannot provide access to this page without valid credentials. Please sign in or
+          contact support at
+          <goab-link>
+            <a href="mailto:cs.licensingsupport@gov.ab.ca">cs.licensingsupport@gov.ab.ca</a>
+          </goab-link>
+          to request access.
+        </goab-text>
+      </goab-block>
+
+      <goab-button type="primary" size="compact" (onClick)="goHome()">Go to home page</goab-button>
+    </goab-block>
+  </div>
+</goab-page-block>

--- a/docs/src/content/examples/401-error-page/angular.ts
+++ b/docs/src/content/examples/401-error-page/angular.ts
@@ -1,0 +1,38 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "app-error-page-401",
+  templateUrl: "./angular.html",
+  styles: [
+    `
+      .error-page-content {
+        text-align: center;
+      }
+      .error-page-icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 7.5rem;
+        height: 7.5rem;
+        border-radius: 50%;
+        background-color: var(--goa-color-greyscale-100);
+      }
+      /* Icon scaled beyond xlarge (2.5rem cap) to match the page-scale visual weight. */
+      /* Tracked in icon-sizes-above-xlarge gap ticket. */
+      .error-page-icon goa-icon,
+      .error-page-icon goab-icon {
+        transform: scale(1.35);
+      }
+      .error-page-underline {
+        width: 6.875rem;
+        height: var(--goa-space-xs);
+        background-color: var(--goa-color-info-default);
+      }
+    `,
+  ],
+})
+export class RestrictedAccessComponent {
+  goHome() {
+    window.location.href = "/";
+  }
+}

--- a/docs/src/content/examples/401-error-page/index.mdx
+++ b/docs/src/content/examples/401-error-page/index.mdx
@@ -1,0 +1,38 @@
+---
+id: 401-error-page
+title: Restricted access (401)
+categories:
+  - content-layout
+scale: page
+userType: both
+tags:
+  - error
+  - page-structure
+  - "401"
+components:
+  - page-block
+  - block
+  - text
+  - icon
+  - link
+  - button
+status: published
+fullWidth: true
+previewStyle: "padding: 0"
+accessibilityNotes: 'Uses a plain h1 as the page landmark. The decorative icon and accent bar are aria-hidden. The support email is a real mailto link inside GoabLink so keyboard users can activate it. No role="alert" is applied because the ARIA alert role is reserved for dynamically inserted messages.'
+---
+
+A full page that tells the user they cannot access the requested resource, with a clear next step and a way to contact support.
+
+## When to use
+
+- A user lands on a page that requires authentication they don't have.
+- A user's session has expired and you need to prompt them to sign in again.
+- A user is signed in but lacks the role or permission for the requested resource.
+
+## Considerations
+
+- Keep the message short and give the user one clear next step (usually sign in or go home).
+- Include a support contact when the user may not be able to self-serve (for example, a role they need to be granted).
+- A small amount of custom CSS covers the icon-in-circle treatment, the brand-color accent bar, centred text, and the icon scaled beyond `xlarge`. Each is a pattern the design system doesn't yet cover and is tracked as a gap for the library to absorb over time.
+- The `<h1>` uses `heading-l` (not the default `heading-xl`) to match the Figma spec for page-scale error states.

--- a/docs/src/content/examples/401-error-page/react.tsx
+++ b/docs/src/content/examples/401-error-page/react.tsx
@@ -1,0 +1,81 @@
+import {
+  GoabBlock,
+  GoabButton,
+  GoabIcon,
+  GoabLink,
+  GoabPageBlock,
+  GoabText,
+} from "@abgov/react-components";
+
+export function RestrictedAccess() {
+  return (
+    <>
+      <style>{`
+        .error-page-content {
+          text-align: center;
+        }
+        .error-page-icon {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 7.5rem;
+          height: 7.5rem;
+          border-radius: 50%;
+          background-color: var(--goa-color-greyscale-100);
+        }
+        /* Icon scaled beyond xlarge (2.5rem cap) to match the page-scale visual weight. */
+        /* Tracked in icon-sizes-above-xlarge gap ticket. */
+        .error-page-icon goa-icon,
+        .error-page-icon goab-icon {
+          transform: scale(1.35);
+        }
+        .error-page-underline {
+          width: 6.875rem;
+          height: var(--goa-space-xs);
+          background-color: var(--goa-color-info-default);
+        }
+      `}</style>
+
+      <GoabPageBlock>
+        <div className="error-page-content">
+          <GoabBlock
+            direction="column"
+            alignment="center"
+            gap="xl"
+            width="100%"
+            mt="3xl"
+            mb="3xl"
+          >
+            <GoabBlock direction="column" alignment="center" gap="m" width="100%">
+              <div className="error-page-icon">
+                <GoabIcon role="presentation" type="warning" size="xlarge" />
+              </div>
+              <GoabText size="body-m" color="secondary" mt="none" mb="none">
+                Error 401
+              </GoabText>
+              <div className="error-page-underline" aria-hidden="true" />
+            </GoabBlock>
+
+            <GoabBlock direction="column" alignment="center" gap="l" width="100%">
+              <GoabText tag="h1" size="heading-l" mt="none" mb="none">
+                Restricted access
+              </GoabText>
+              <GoabText size="body-m" mt="none" mb="none">
+                We cannot provide access to this page without valid credentials. Please sign in or
+                contact support at{" "}
+                <GoabLink>
+                  <a href="mailto:cs.licensingsupport@gov.ab.ca">cs.licensingsupport@gov.ab.ca</a>
+                </GoabLink>{" "}
+                to request access.
+              </GoabText>
+            </GoabBlock>
+
+            <GoabButton type="primary" size="compact" onClick={() => (window.location.href = "/")}>
+              Go to home page
+            </GoabButton>
+          </GoabBlock>
+        </div>
+      </GoabPageBlock>
+    </>
+  );
+}

--- a/docs/src/content/examples/401-error-page/web-components.html
+++ b/docs/src/content/examples/401-error-page/web-components.html
@@ -1,0 +1,32 @@
+<goa-page-block>
+  <div style="text-align: center;">
+    <goa-block direction="column" alignment="center" gap="xl" width="100%" mt="3xl" mb="3xl">
+      <goa-block direction="column" alignment="center" gap="m" width="100%">
+        <div
+          style="display: flex; align-items: center; justify-content: center; width: 7.5rem; height: 7.5rem; border-radius: 50%; background-color: var(--goa-color-greyscale-100);"
+        >
+          <goa-icon role="presentation" type="warning" size="xlarge" style="transform: scale(1.35);"></goa-icon>
+        </div>
+        <goa-text size="body-m" color="secondary" mt="none" mb="none">Error 401</goa-text>
+        <div
+          aria-hidden="true"
+          style="width: 6.875rem; height: 0.5rem; background-color: var(--goa-color-info-default);"
+        ></div>
+      </goa-block>
+
+      <goa-block direction="column" alignment="center" gap="l" width="100%">
+        <goa-text as="h1" size="heading-l" mt="none" mb="none">Restricted access</goa-text>
+        <goa-text size="body-m" mt="none" mb="none">
+          We cannot provide access to this page without valid credentials. Please sign in or
+          contact support at
+          <goa-link>
+            <a href="mailto:cs.licensingsupport@gov.ab.ca">cs.licensingsupport@gov.ab.ca</a>
+          </goa-link>
+          to request access.
+        </goa-text>
+      </goa-block>
+
+      <goa-button version="2" type="primary" size="compact" onclick="window.location.href='/'">Go to home page</goa-button>
+    </goa-block>
+  </div>
+</goa-page-block>

--- a/docs/src/content/examples/404-error-page/angular.html
+++ b/docs/src/content/examples/404-error-page/angular.html
@@ -1,0 +1,20 @@
+<goab-page-block>
+  <div class="error-page-content">
+    <goab-block direction="column" alignment="center" gap="xl" width="100%" mt="3xl" mb="3xl">
+      <goab-block direction="column" alignment="center" gap="m" width="100%">
+        <div class="error-page-icon">
+          <goab-icon role="presentation" type="warning" size="xlarge"></goab-icon>
+        </div>
+        <goab-text size="body-m" color="secondary" mt="none" mb="none">Error 404</goab-text>
+        <div class="error-page-underline" aria-hidden="true"></div>
+      </goab-block>
+
+      <goab-block direction="column" alignment="center" gap="l" width="100%">
+        <goab-text tag="h1" size="heading-l" mt="none" mb="none">Page not found</goab-text>
+        <goab-text size="body-m" mt="none" mb="none">The page you're looking for doesn't exist or has been moved.</goab-text>
+      </goab-block>
+
+      <goab-button type="primary" size="compact" (onClick)="goHome()">Go to home page</goab-button>
+    </goab-block>
+  </div>
+</goab-page-block>

--- a/docs/src/content/examples/404-error-page/angular.ts
+++ b/docs/src/content/examples/404-error-page/angular.ts
@@ -1,0 +1,38 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "app-error-page-404",
+  templateUrl: "./angular.html",
+  styles: [
+    `
+      .error-page-content {
+        text-align: center;
+      }
+      .error-page-icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 7.5rem;
+        height: 7.5rem;
+        border-radius: 50%;
+        background-color: var(--goa-color-greyscale-100);
+      }
+      /* Icon scaled beyond xlarge (2.5rem cap) to match the page-scale visual weight. */
+      /* Tracked in icon-sizes-above-xlarge gap ticket. */
+      .error-page-icon goa-icon,
+      .error-page-icon goab-icon {
+        transform: scale(1.35);
+      }
+      .error-page-underline {
+        width: 6.875rem;
+        height: var(--goa-space-xs);
+        background-color: var(--goa-color-info-default);
+      }
+    `,
+  ],
+})
+export class PageNotFoundComponent {
+  goHome() {
+    window.location.href = "/";
+  }
+}

--- a/docs/src/content/examples/404-error-page/index.mdx
+++ b/docs/src/content/examples/404-error-page/index.mdx
@@ -1,0 +1,37 @@
+---
+id: 404-error-page
+title: Page not found (404)
+categories:
+  - content-layout
+scale: page
+userType: both
+tags:
+  - error
+  - page-structure
+  - "404"
+components:
+  - page-block
+  - block
+  - text
+  - icon
+  - button
+status: published
+fullWidth: true
+previewStyle: "padding: 0"
+accessibilityNotes: 'Uses a plain h1 as the page landmark. The decorative icon and accent bar are aria-hidden. No role="alert" is applied because the ARIA alert role is reserved for dynamically inserted messages; a static error route does not meet that criterion.'
+---
+
+A full page that tells the user a page can't be found, with an action to get them back on track.
+
+## When to use
+
+- A user navigates to a URL that doesn't exist in your service.
+- A resource has been moved or deleted and you need a catch-all route.
+- As the fallback route rendered by your router's outlet.
+
+## Considerations
+
+- Keep the message short and give the user one clear next step.
+- Render the pattern inside your existing layout (e.g. as the route in a `GoabOneColumnLayout` outlet) so it sits below your service's header and above its footer.
+- A small amount of custom CSS covers the icon-in-circle treatment, the brand-color accent bar, centred text, and the icon scaled beyond `xlarge`. Each is a pattern the design system doesn't yet cover and is tracked as a gap for the library to absorb over time.
+- The `<h1>` uses `heading-l` (not the default `heading-xl`) to match the Figma spec for page-scale error states.

--- a/docs/src/content/examples/404-error-page/react.tsx
+++ b/docs/src/content/examples/404-error-page/react.tsx
@@ -1,0 +1,75 @@
+import {
+  GoabBlock,
+  GoabButton,
+  GoabIcon,
+  GoabPageBlock,
+  GoabText,
+} from "@abgov/react-components";
+
+export function PageNotFound() {
+  return (
+    <>
+      <style>{`
+        .error-page-content {
+          text-align: center;
+        }
+        .error-page-icon {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 7.5rem;
+          height: 7.5rem;
+          border-radius: 50%;
+          background-color: var(--goa-color-greyscale-100);
+        }
+        /* Icon scaled beyond xlarge (2.5rem cap) to match the page-scale visual weight. */
+        /* Tracked in icon-sizes-above-xlarge gap ticket. */
+        .error-page-icon goa-icon,
+        .error-page-icon goab-icon {
+          transform: scale(1.35);
+        }
+        .error-page-underline {
+          width: 6.875rem;
+          height: var(--goa-space-xs);
+          background-color: var(--goa-color-info-default);
+        }
+      `}</style>
+
+      <GoabPageBlock>
+        <div className="error-page-content">
+          <GoabBlock
+            direction="column"
+            alignment="center"
+            gap="xl"
+            width="100%"
+            mt="3xl"
+            mb="3xl"
+          >
+            <GoabBlock direction="column" alignment="center" gap="m" width="100%">
+              <div className="error-page-icon">
+                <GoabIcon role="presentation" type="warning" size="xlarge" />
+              </div>
+              <GoabText size="body-m" color="secondary" mt="none" mb="none">
+                Error 404
+              </GoabText>
+              <div className="error-page-underline" aria-hidden="true" />
+            </GoabBlock>
+
+            <GoabBlock direction="column" alignment="center" gap="l" width="100%">
+              <GoabText tag="h1" size="heading-l" mt="none" mb="none">
+                Page not found
+              </GoabText>
+              <GoabText size="body-m" mt="none" mb="none">
+                The page you're looking for doesn't exist or has been moved.
+              </GoabText>
+            </GoabBlock>
+
+            <GoabButton type="primary" size="compact" onClick={() => (window.location.href = "/")}>
+              Go to home page
+            </GoabButton>
+          </GoabBlock>
+        </div>
+      </GoabPageBlock>
+    </>
+  );
+}

--- a/docs/src/content/examples/404-error-page/web-components.html
+++ b/docs/src/content/examples/404-error-page/web-components.html
@@ -1,0 +1,25 @@
+<goa-page-block>
+  <div style="text-align: center;">
+    <goa-block direction="column" alignment="center" gap="xl" width="100%" mt="3xl" mb="3xl">
+      <goa-block direction="column" alignment="center" gap="m" width="100%">
+        <div
+          style="display: flex; align-items: center; justify-content: center; width: 7.5rem; height: 7.5rem; border-radius: 50%; background-color: var(--goa-color-greyscale-100);"
+        >
+          <goa-icon role="presentation" type="warning" size="xlarge" style="transform: scale(1.35);"></goa-icon>
+        </div>
+        <goa-text size="body-m" color="secondary" mt="none" mb="none">Error 404</goa-text>
+        <div
+          aria-hidden="true"
+          style="width: 6.875rem; height: 0.5rem; background-color: var(--goa-color-info-default);"
+        ></div>
+      </goa-block>
+
+      <goa-block direction="column" alignment="center" gap="l" width="100%">
+        <goa-text as="h1" size="heading-l" mt="none" mb="none">Page not found</goa-text>
+        <goa-text size="body-m" mt="none" mb="none">The page you're looking for doesn't exist or has been moved.</goa-text>
+      </goa-block>
+
+      <goa-button version="2" type="primary" size="compact" onclick="window.location.href='/'">Go to home page</goa-button>
+    </goa-block>
+  </div>
+</goa-page-block>

--- a/docs/src/content/examples/500-error-page/angular.html
+++ b/docs/src/content/examples/500-error-page/angular.html
@@ -1,0 +1,22 @@
+<goab-page-block>
+  <div class="error-page-content">
+    <goab-block direction="column" alignment="center" gap="xl" width="100%" mt="3xl" mb="3xl">
+      <goab-block direction="column" alignment="center" gap="m" width="100%">
+        <div class="error-page-icon">
+          <goab-icon role="presentation" type="warning" size="xlarge"></goab-icon>
+        </div>
+        <goab-text size="body-m" color="secondary" mt="none" mb="none">Error 500</goab-text>
+        <div class="error-page-underline" aria-hidden="true"></div>
+      </goab-block>
+
+      <goab-block direction="column" alignment="center" gap="l" width="100%">
+        <goab-text tag="h1" size="heading-l" mt="none" mb="none">We are experiencing a problem</goab-text>
+        <goab-text size="body-m" mt="none" mb="none">
+          We cannot load this page right now. Please try again in a few minutes. We apologize for the inconvenience.
+        </goab-text>
+      </goab-block>
+
+      <goab-button type="primary" size="compact" (onClick)="goHome()">Go to home page</goab-button>
+    </goab-block>
+  </div>
+</goab-page-block>

--- a/docs/src/content/examples/500-error-page/angular.ts
+++ b/docs/src/content/examples/500-error-page/angular.ts
@@ -1,0 +1,38 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "app-error-page-500",
+  templateUrl: "./angular.html",
+  styles: [
+    `
+      .error-page-content {
+        text-align: center;
+      }
+      .error-page-icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 7.5rem;
+        height: 7.5rem;
+        border-radius: 50%;
+        background-color: var(--goa-color-greyscale-100);
+      }
+      /* Icon scaled beyond xlarge (2.5rem cap) to match the page-scale visual weight. */
+      /* Tracked in icon-sizes-above-xlarge gap ticket. */
+      .error-page-icon goa-icon,
+      .error-page-icon goab-icon {
+        transform: scale(1.35);
+      }
+      .error-page-underline {
+        width: 6.875rem;
+        height: var(--goa-space-xs);
+        background-color: var(--goa-color-info-default);
+      }
+    `,
+  ],
+})
+export class ServerProblemComponent {
+  goHome() {
+    window.location.href = "/";
+  }
+}

--- a/docs/src/content/examples/500-error-page/index.mdx
+++ b/docs/src/content/examples/500-error-page/index.mdx
@@ -1,0 +1,37 @@
+---
+id: 500-error-page
+title: Server problem (500)
+categories:
+  - content-layout
+scale: page
+userType: both
+tags:
+  - error
+  - page-structure
+  - "500"
+components:
+  - page-block
+  - block
+  - text
+  - icon
+  - button
+status: published
+fullWidth: true
+previewStyle: "padding: 0"
+accessibilityNotes: 'Uses a plain h1 as the page landmark. The decorative icon and accent bar are aria-hidden. No role="alert" is applied because the ARIA alert role is reserved for dynamically inserted messages; a static error route does not meet that criterion.'
+---
+
+A full page that tells the user the service is temporarily unable to respond, with an action to try again or return home.
+
+## When to use
+
+- A server-side error interrupted the user's request and there is nothing they can do to fix it themselves.
+- A background dependency of your service is down.
+- As a fallback for uncaught errors that reach the outer error boundary of your app.
+
+## Considerations
+
+- Take responsibility in the copy. The user did not cause this; acknowledge that and give them one clear action.
+- This example uses "Go to home page" as the safe fallback action. If the failure is likely transient and the user can recover by retrying, swap the button's `onClick` for your retry handler and change the label to "Try again".
+- A small amount of custom CSS covers the icon-in-circle treatment, the brand-color accent bar, centred text, and the icon scaled beyond `xlarge`. Each is a pattern the design system doesn't yet cover and is tracked as a gap for the library to absorb over time.
+- The `<h1>` uses `heading-l` (not the default `heading-xl`) to match the Figma spec for page-scale error states.

--- a/docs/src/content/examples/500-error-page/react.tsx
+++ b/docs/src/content/examples/500-error-page/react.tsx
@@ -1,0 +1,76 @@
+import {
+  GoabBlock,
+  GoabButton,
+  GoabIcon,
+  GoabPageBlock,
+  GoabText,
+} from "@abgov/react-components";
+
+export function ServerProblem() {
+  return (
+    <>
+      <style>{`
+        .error-page-content {
+          text-align: center;
+        }
+        .error-page-icon {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 7.5rem;
+          height: 7.5rem;
+          border-radius: 50%;
+          background-color: var(--goa-color-greyscale-100);
+        }
+        /* Icon scaled beyond xlarge (2.5rem cap) to match the page-scale visual weight. */
+        /* Tracked in icon-sizes-above-xlarge gap ticket. */
+        .error-page-icon goa-icon,
+        .error-page-icon goab-icon {
+          transform: scale(1.35);
+        }
+        .error-page-underline {
+          width: 6.875rem;
+          height: var(--goa-space-xs);
+          background-color: var(--goa-color-info-default);
+        }
+      `}</style>
+
+      <GoabPageBlock>
+        <div className="error-page-content">
+          <GoabBlock
+            direction="column"
+            alignment="center"
+            gap="xl"
+            width="100%"
+            mt="3xl"
+            mb="3xl"
+          >
+            <GoabBlock direction="column" alignment="center" gap="m" width="100%">
+              <div className="error-page-icon">
+                <GoabIcon role="presentation" type="warning" size="xlarge" />
+              </div>
+              <GoabText size="body-m" color="secondary" mt="none" mb="none">
+                Error 500
+              </GoabText>
+              <div className="error-page-underline" aria-hidden="true" />
+            </GoabBlock>
+
+            <GoabBlock direction="column" alignment="center" gap="l" width="100%">
+              <GoabText tag="h1" size="heading-l" mt="none" mb="none">
+                We are experiencing a problem
+              </GoabText>
+              <GoabText size="body-m" mt="none" mb="none">
+                We cannot load this page right now. Please try again in a few minutes. We apologize
+                for the inconvenience.
+              </GoabText>
+            </GoabBlock>
+
+            <GoabButton type="primary" size="compact" onClick={() => (window.location.href = "/")}>
+              Go to home page
+            </GoabButton>
+          </GoabBlock>
+        </div>
+      </GoabPageBlock>
+    </>
+  );
+}

--- a/docs/src/content/examples/500-error-page/web-components.html
+++ b/docs/src/content/examples/500-error-page/web-components.html
@@ -1,0 +1,27 @@
+<goa-page-block>
+  <div style="text-align: center;">
+    <goa-block direction="column" alignment="center" gap="xl" width="100%" mt="3xl" mb="3xl">
+      <goa-block direction="column" alignment="center" gap="m" width="100%">
+        <div
+          style="display: flex; align-items: center; justify-content: center; width: 7.5rem; height: 7.5rem; border-radius: 50%; background-color: var(--goa-color-greyscale-100);"
+        >
+          <goa-icon role="presentation" type="warning" size="xlarge" style="transform: scale(1.35);"></goa-icon>
+        </div>
+        <goa-text size="body-m" color="secondary" mt="none" mb="none">Error 500</goa-text>
+        <div
+          aria-hidden="true"
+          style="width: 6.875rem; height: 0.5rem; background-color: var(--goa-color-info-default);"
+        ></div>
+      </goa-block>
+
+      <goa-block direction="column" alignment="center" gap="l" width="100%">
+        <goa-text as="h1" size="heading-l" mt="none" mb="none">We are experiencing a problem</goa-text>
+        <goa-text size="body-m" mt="none" mb="none">
+          We cannot load this page right now. Please try again in a few minutes. We apologize for the inconvenience.
+        </goa-text>
+      </goa-block>
+
+      <goa-button version="2" type="primary" size="compact" onclick="window.location.href='/'">Go to home page</goa-button>
+    </goa-block>
+  </div>
+</goa-page-block>

--- a/libs/angular-components/src/lib/components/icon/icon.spec.ts
+++ b/libs/angular-components/src/lib/components/icon/icon.spec.ts
@@ -23,6 +23,7 @@ import { By } from "@angular/platform-browser";
       [opacity]="opacity"
       [title]="title"
       [ariaLabel]="ariaLabel"
+      [role]="role"
       [testId]="testId"
       [mt]="mt"
       [mb]="mb"
@@ -40,6 +41,7 @@ class TestIconComponent {
   opacity?: number;
   title?: string;
   ariaLabel?: string;
+  role?: string;
   testId?: string;
   mt?: Spacing;
   mb?: Spacing;
@@ -67,6 +69,7 @@ describe("GoABIcon", () => {
     component.opacity = 0.5;
     component.title = "foo";
     component.ariaLabel = "bar";
+    component.role = "presentation";
     component.testId = "foo";
     component.mt = "s";
     component.mr = "m";
@@ -88,6 +91,7 @@ describe("GoABIcon", () => {
     expect(el?.getAttribute("opacity")).toBe(`${component.opacity}`);
     expect(el?.getAttribute("title")).toBe(component.title);
     expect(el?.getAttribute("arialabel")).toBe(component.ariaLabel);
+    expect(el?.getAttribute("role")).toBe(component.role);
     expect(el?.getAttribute("testid")).toBe(component.testId);
     expect(el?.getAttribute("mt")).toBe(component.mt);
     expect(el?.getAttribute("mb")).toBe(component.mb);

--- a/libs/angular-components/src/lib/components/icon/icon.ts
+++ b/libs/angular-components/src/lib/components/icon/icon.ts
@@ -31,6 +31,7 @@ import { GoabBaseComponent } from "../base.component";
         [attr.opacity]="opacity"
         [attr.title]="title"
         [attr.arialabel]="ariaLabel"
+        [attr.role]="role"
         [attr.mt]="mt"
         [attr.mb]="mb"
         [attr.ml]="ml"
@@ -63,6 +64,8 @@ export class GoabIcon extends GoabBaseComponent implements OnInit {
   @Input() title?: string;
   /** Defines how the icon will be announced by screen readers. */
   @Input() ariaLabel?: string;
+  /** Sets the ARIA role for the icon. Use 'presentation' for decorative icons. */
+  @Input() role?: string;
 
   isReady = false;
 

--- a/libs/react-components/src/lib/icon/icon.spec.tsx
+++ b/libs/react-components/src/lib/icon/icon.spec.tsx
@@ -21,6 +21,7 @@ describe("GoabIcon", () => {
         opacity={0.5}
         title="foo"
         ariaLabel="bar"
+        role="presentation"
         testId="foo"
         mt="s"
         mr="m"
@@ -38,6 +39,7 @@ describe("GoabIcon", () => {
     expect(el?.getAttribute("opacity")).toBe("0.5");
     expect(el?.getAttribute("title")).toBe("foo");
     expect(el?.getAttribute("arialabel")).toBe("bar");
+    expect(el?.getAttribute("role")).toBe("presentation");
     expect(el?.getAttribute("testid")).toBe("foo");
     expect(el?.getAttribute("mt")).toBe("s");
     expect(el?.getAttribute("mr")).toBe("m");

--- a/libs/react-components/src/lib/icon/icon.tsx
+++ b/libs/react-components/src/lib/icon/icon.tsx
@@ -39,6 +39,8 @@ export interface GoabIconProps extends Margins, DataAttributes {
   title?: string;
   /** Defines how the icon will be announced by screen readers. */
   ariaLabel?: string;
+  /** Sets the ARIA role for the icon. Use 'presentation' for decorative icons. @default "img" */
+  role?: string;
   /** Sets a data-testid attribute for automated testing. */
   testId?: string;
 }
@@ -52,6 +54,7 @@ interface WCProps extends Margins {
   opacity?: number;
   title?: string;
   arialabel?: string;
+  role?: string;
   testid?: string;
 }
 


### PR DESCRIPTION
## Summary

- Adds three error page examples (401 Restricted access, 404 Page not found, 500 Server problem) under `docs/src/content/examples/`. Each covers React, Angular, and Web Components.
- Examples composed from goa components (`GoabPageBlock`, `GoabBlock`, `GoabIcon`, `GoabText`, `GoabButton`, `GoabLink`). A small amount of class-based CSS covers the icon-in-circle, brand accent bar, centred text, and the icon scaled beyond `xlarge`.
- Also exposes `role` on the React and Angular icon wrappers (`feat(#3871)`, issue #3871) so decorative icons can use `role="presentation"`. Came up during review.
- Closes #1553.

## Custom things that could be components (maybe)

The examples surfaced a few gaps thinking about if we would ever want components for:

1. Icon sizes above `xlarge` (2.5rem cap) for page-scale illustrations.
2. A primitive for the icon-in-circle emphasis treatment used here and in empty, onboarding, and status screens.
3. A `textAlign` prop on `GoabText` for centred layouts where body copy wraps.

## Test plan

- [ ] `/examples/404-error-page`, `/examples/401-error-page`, `/examples/500-error-page` render with the correct visual treatment.
- [ ] All three code tabs (React, Angular, Web Components) render cleanly with no truncation.
- [ ] Resize across mobile, tablet, and desktop; horizontal padding shifts 16, 32, 64 via `GoabPageBlock`.
- [ ] Keyboard: can reach the "Go to home page" button and, on 401, the support email link.
- [ ] Accessibility section below each preview surfaces the `accessibilityNotes`.

<img width="1556" height="1306" alt="image" src="https://github.com/user-attachments/assets/c5627015-8279-46f7-9663-29537e618c09" />
<img width="1556" height="1306" alt="image" src="https://github.com/user-attachments/assets/44daab99-a061-4ce8-9a22-b7dbc230f1b2" />
<img width="1556" height="1306" alt="image" src="https://github.com/user-attachments/assets/5aa27203-2db7-42c7-945f-785aae8fe138" />
