### PR TITLE
fix(#3854): Hide empty menu slots for Work Side Menu in Angular

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3854/bug3854.component.html
+++ b/apps/prs/angular/src/routes/bugs/3854/bug3854.component.html
@@ -1,0 +1,44 @@
+<goab-text tag="h1" mb="m">Bug 3854 - Work Side Menu without extra sections</goab-text>
+<goab-text mb="xl">
+  This test page renders a Work Side Menu with only primary content. Confirm the
+  following:
+  <ul>
+    <li>The primary menu is visible.</li>
+    <li>The secondary and account menu is hidden.</li>
+  </ul>
+</goab-text>
+
+<div
+  style="
+    max-width: 20rem;
+    border: 1px solid #ddd;
+    min-height: 28rem;
+    --goa-work-side-menu-height: 400px;
+  "
+>
+  <goab-work-side-menu
+    heading="Primary-only menu"
+    url="/bugs/3854"
+    [open]="true"
+    (onNavigate)="handleNavigate($event)"
+    [primaryContent]="primaryContent"
+  ></goab-work-side-menu>
+</div>
+
+<ng-template #primaryContent>
+  <goab-work-side-menu-item
+    icon="home"
+    label="Dashboard"
+    url="/bugs/3854"
+  ></goab-work-side-menu-item>
+  <goab-work-side-menu-item
+    icon="list"
+    label="Cases"
+    url="/bugs/3854"
+  ></goab-work-side-menu-item>
+  <goab-work-side-menu-item
+    icon="settings"
+    label="Settings"
+    url="/bugs/3854"
+  ></goab-work-side-menu-item>
+</ng-template>

--- a/apps/prs/angular/src/routes/bugs/3854/bug3854.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3854/bug3854.component.ts
@@ -1,0 +1,18 @@
+import { Component } from "@angular/core";
+import {
+  GoabText,
+  GoabWorkSideMenu,
+  GoabWorkSideMenuItem,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3854",
+  templateUrl: "./bug3854.component.html",
+  imports: [GoabText, GoabWorkSideMenu, GoabWorkSideMenuItem],
+})
+export class Bug3854Component {
+  handleNavigate(_path: string): void {
+    // Intentionally no-op for visual verification.
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3854/bug3854.route.json
+++ b/apps/prs/angular/src/routes/bugs/3854/bug3854.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3854",
+  "path": "bugs/3854",
+  "title": "Work Side Menu without secondary/account"
+}

--- a/libs/angular-components/src/lib/components/work-side-menu/work-side-menu.spec.ts
+++ b/libs/angular-components/src/lib/components/work-side-menu/work-side-menu.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, tick, fakeAsync } from "@angular/core/testing";
 import { GoabWorkSideMenu } from "./work-side-menu";
-import { Component } from "@angular/core";
+import { Component, TemplateRef } from "@angular/core";
 import { By } from "@angular/platform-browser";
 
 @Component({
@@ -44,13 +44,40 @@ class TestWorkSideMenuComponent {
     this.navigatedUrl = path;
   }
 }
+
+@Component({
+  standalone: true,
+  imports: [GoabWorkSideMenu],
+  template: `
+    <goab-work-side-menu
+      [open]="open"
+      [heading]="heading"
+      [url]="url"
+      [primaryContent]="primaryTemplate"
+      [secondaryContent]="secondaryContent"
+      [accountContent]="accountContent"
+    >
+    </goab-work-side-menu>
+    <ng-template #primaryTemplate>
+      <div>Primary content</div>
+    </ng-template>
+  `,
+})
+class TestWorkSideMenuEmptySlotsComponent {
+  open = true;
+  heading = "Test heading";
+  url = "/test";
+  secondaryContent?: TemplateRef<unknown>;
+  accountContent?: TemplateRef<unknown>;
+}
+
 describe("GoabBWorkSideMenu", () => {
   let fixture: ComponentFixture<TestWorkSideMenuComponent>;
   let component: TestWorkSideMenuComponent;
 
   beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
-      imports: [TestWorkSideMenuComponent],
+      imports: [TestWorkSideMenuComponent, TestWorkSideMenuEmptySlotsComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestWorkSideMenuComponent);
@@ -83,4 +110,18 @@ describe("GoabBWorkSideMenu", () => {
 
     expect(component.navigatedUrl).toBe("/dashboard");
   }));
+
+  it("should not render secondary or account slot content when those inputs are empty", fakeAsync(() => {
+    const emptyFixture = TestBed.createComponent(TestWorkSideMenuEmptySlotsComponent);
+    emptyFixture.detectChanges();
+    tick(); // Wait for setTimeout in ngOnInit
+    emptyFixture.detectChanges();
+
+    const menuElement = emptyFixture.debugElement.query(By.css("goa-work-side-menu"))
+      .nativeElement as HTMLElement;
+
+    expect(menuElement.querySelector('[slot="secondary"]')).toBeNull();
+    expect(menuElement.querySelector('[slot="account"]')).toBeNull();
+  }));
+
 });

--- a/libs/angular-components/src/lib/components/work-side-menu/work-side-menu.ts
+++ b/libs/angular-components/src/lib/components/work-side-menu/work-side-menu.ts
@@ -27,15 +27,21 @@ import { NgTemplateOutlet } from "@angular/common";
         (_toggle)="_onToggle()"
         (_navigate)="_onNavigate($event)"
       >
-        <div slot="primary">
-          <ng-container [ngTemplateOutlet]="primaryContent"></ng-container>
-        </div>
-        <div slot="secondary">
-          <ng-container [ngTemplateOutlet]="secondaryContent"></ng-container>
-        </div>
-        <div slot="account">
-          <ng-container [ngTemplateOutlet]="accountContent"></ng-container>
-        </div>
+        @if (primaryContent) {
+          <div slot="primary">
+            <ng-container [ngTemplateOutlet]="primaryContent"></ng-container>
+          </div>
+        }
+        @if (secondaryContent) {
+          <div slot="secondary">
+            <ng-container [ngTemplateOutlet]="secondaryContent"></ng-container>
+          </div>
+        }
+        @if (accountContent) {
+          <div slot="account">
+            <ng-container [ngTemplateOutlet]="accountContent"></ng-container>
+          </div>
+        }
       </goa-work-side-menu>
     }
   `,
@@ -58,11 +64,11 @@ export class GoabWorkSideMenu implements OnInit {
   /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
   /** Template reference for the primary navigation slot content. */
-  @Input() primaryContent!: TemplateRef<any>;
+  @Input() primaryContent!: TemplateRef<unknown>;
   /** Template reference for the secondary navigation slot content. */
-  @Input() secondaryContent!: TemplateRef<any>;
+  @Input() secondaryContent!: TemplateRef<unknown>;
   /** Template reference for the account slot content. */
-  @Input() accountContent!: TemplateRef<any>;
+  @Input() accountContent!: TemplateRef<unknown>;
   /** Emits when the side menu is toggled open or closed. */
   @Output() onToggle = new EventEmitter<void>();
   /** Emits when a navigation link is clicked. Emits the URL as a string. */


### PR DESCRIPTION
This PR fixes a bug in the Angular wrapper which always renders the primary, secondary, and account menus even when they are empty. You can view the change at the following URL:
https://govalta.github.io/ui-components/pr-preview-angular/pr-3855/bugs/3854

# Before (the change)

The primary, secondary, and account menus were always rendered in Angular.

# After (the change)

The primary, secondary, and account menus are only rendered when you add the corresponding `TemplateRef`.
