### PR TITLE
feat(#3636) Accordion actions and List View Variant

### DIFF
--- a/apps/prs/angular/src/routes/docs/accordion/accordion.component.html
+++ b/apps/prs/angular/src/routes/docs/accordion/accordion.component.html
@@ -2,8 +2,8 @@
 
 <h3>Basic</h3>
 <goab-accordion heading="What documents do I need?">
-  You will need to provide proof of identity, proof of address,
-  and any relevant supporting documentation.
+  You will need to provide proof of identity, proof of address, and any relevant
+  supporting documentation.
 </goab-accordion>
 
 <h3>Open by default</h3>
@@ -82,7 +82,8 @@
   heading="How do I create an account?"
   headingSize="medium"
   [open]="expandedList[0]"
-  (onChange)="toggleAccordion(0, $event)">
+  (onChange)="toggleAccordion(0, $event)"
+>
   To create an account you will need to contact your office admin.
 </goab-accordion>
 
@@ -90,22 +91,50 @@
   heading="What verification is needed to sign documents digitally?"
   headingSize="medium"
   [open]="expandedList[1]"
-  (onChange)="toggleAccordion(1, $event)">
-  You will need to verify your identity through our two factor authentication in addition to the digital signature.
+  (onChange)="toggleAccordion(1, $event)"
+>
+  You will need to verify your identity through our two factor authentication in addition
+  to the digital signature.
 </goab-accordion>
 
 <goab-accordion
   heading="Can I track the status of my service requests online?"
   headingSize="medium"
   [open]="expandedList[2]"
-  (onChange)="toggleAccordion(2, $event)">
-  Yes, you can see the status of your application on the main service dashboard when you login. You will receive updates and notifications in your email as your request progresses.
+  (onChange)="toggleAccordion(2, $event)"
+>
+  Yes, you can see the status of your application on the main service dashboard when you
+  login. You will receive updates and notifications in your email as your request
+  progresses.
 </goab-accordion>
 
 <goab-accordion
   heading="Are there accessibility features for people with disabilities?"
   headingSize="medium"
   [open]="expandedList[3]"
-  (onChange)="toggleAccordion(3, $event)">
-  Yes, our digital service is designed with accessibility in mind. <a href="#">More information on accessibility.</a>
+  (onChange)="toggleAccordion(3, $event)"
+>
+  Yes, our digital service is designed with accessibility in mind.
+  <a href="#">More information on accessibility.</a>
 </goab-accordion>
+
+<goab-accordion heading="What documents do I need?" headingType="filled">
+  You will need to provide proof of identity, proof of address, and any relevant
+  supporting documentation.
+</goab-accordion>
+
+<goab-accordion
+  heading="Actions with button and badge"
+  secondaryText="Right icon"
+  iconPosition="right"
+  [actions]="actionsViewAll"
+>
+  <goab-text> This example mixes badges and controls inside the actions slot. </goab-text>
+</goab-accordion>
+
+<ng-template #actionsViewAll>
+  <div style="display: flex; align-items: center; gap: 0.5rem">
+    <goab-badge type="important" content="3"></goab-badge>
+    <goab-button type="tertiary" size="compact">View all</goab-button>
+  </div>
+</ng-template>

--- a/apps/prs/angular/src/routes/features/feat3636/feat3636.component.html
+++ b/apps/prs/angular/src/routes/features/feat3636/feat3636.component.html
@@ -1,0 +1,453 @@
+<div
+  style="
+    display: flex;
+    flex-direction: column;
+    gap: var(--goa-spacing-xl);
+    max-width: 72rem;
+  "
+>
+  <goab-text tag="h1"
+    >Feature 3636: Accordion actions slot and list view variant</goab-text
+  >
+  <goab-text>
+    The GoAAccordion component now includes an optional slot for action buttons in the
+    header, as well as a new "list view" variant that features a filled header background
+    and hover state.
+  </goab-text>
+
+  <div style="display: grid; gap: var(--goa-spacing-l)">
+    <goab-text tag="h2">Actions slot examples</goab-text>
+
+    <goab-accordion
+      heading="Actions with button"
+      secondaryText="Left icon"
+      iconPosition="left"
+      [actions]="actionsEdit"
+      [open]="true"
+    >
+      <goab-text>
+        This example places a button in the actions slot while keeping heading text and
+        content as standard body copy.
+      </goab-text>
+    </goab-accordion>
+
+    <ng-template #actionsEdit>
+      <goab-button type="secondary" size="compact">Edit</goab-button>
+    </ng-template>
+
+    <goab-accordion
+      heading="Actions with button and badge"
+      secondaryText="Right icon"
+      iconPosition="right"
+      [actions]="actionsViewAll"
+    >
+      <goab-text>
+        This example mixes badges and controls inside the actions slot.
+      </goab-text>
+    </goab-accordion>
+
+    <ng-template #actionsViewAll>
+      <div style="display: flex; align-items: center; gap: 0.5rem">
+        <goab-badge type="important" content="3"></goab-badge>
+        <goab-button type="tertiary" size="compact">View all</goab-button>
+      </div>
+    </ng-template>
+  </div>
+
+  <div style="display: grid; gap: var(--goa-spacing-l)">
+    <goab-text tag="h2">Heading content examples</goab-text>
+
+    <goab-accordion
+      heading="Heading with badge"
+      [headingContent]="headingBadgeBeta"
+      [actions]="actionsPreview"
+      [open]="true"
+    >
+      <goab-text>
+        The heading content slot can display status indicators such as badges.
+      </goab-text>
+    </goab-accordion>
+
+    <ng-template #headingBadgeBeta>
+      <goab-badge type="information" content="Beta"></goab-badge>
+    </ng-template>
+
+    <ng-template #actionsPreview>
+      <goab-button type="tertiary" size="compact">Preview</goab-button>
+    </ng-template>
+
+    <goab-accordion
+      heading="Heading with multiple badges"
+      [headingContent]="headingBadgesMultiple"
+      [actions]="actionsManage"
+    >
+      <goab-text>
+        Multiple indicators can be grouped in heading content when more context is needed.
+      </goab-text>
+    </goab-accordion>
+
+    <ng-template #headingBadgesMultiple>
+      <div style="display: flex; gap: 0.5rem">
+        <goab-badge type="success" content="Stable"></goab-badge>
+        <goab-badge type="important" content="Requires review"></goab-badge>
+      </div>
+    </ng-template>
+
+    <ng-template #actionsManage>
+      <div style="display: flex; align-items: center; gap: 0.5rem">
+        <goab-badge type="important" content="2"></goab-badge>
+        <goab-button type="tertiary" size="compact">Manage</goab-button>
+      </div>
+    </ng-template>
+  </div>
+
+  <div style="display: grid; gap: var(--goa-spacing-l)">
+    <goab-text tag="h2">Icon position and fixed width examples</goab-text>
+
+    <div
+      style="
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+        gap: var(--goa-spacing-l);
+      "
+    >
+      <goab-accordion
+        heading="Fixed 24rem, icon left"
+        iconPosition="left"
+        maxWidth="24rem"
+        [actions]="actionsOpen"
+        [open]="true"
+      >
+        <goab-text>
+          A narrow fixed-width accordion using the default icon position.
+        </goab-text>
+      </goab-accordion>
+
+      <ng-template #actionsOpen>
+        <goab-button type="secondary" size="compact">Open</goab-button>
+      </ng-template>
+
+      <goab-accordion
+        heading="Fixed 30rem, icon right"
+        iconPosition="right"
+        maxWidth="30rem"
+        [actions]="actionsDetails"
+        [open]="true"
+      >
+        <goab-text>
+          A wider fixed-width accordion with the icon moved to the right side.
+        </goab-text>
+      </goab-accordion>
+
+      <ng-template #actionsDetails>
+        <div style="display: flex; align-items: center; gap: 0.5rem">
+          <goab-badge type="important" content="4"></goab-badge>
+          <goab-button type="tertiary" size="compact">Details</goab-button>
+        </div>
+      </ng-template>
+    </div>
+  </div>
+
+  <div style="display: grid; gap: var(--goa-spacing-l)">
+    <goab-text tag="h2">Filled/List View Style</goab-text>
+
+    <goab-accordion
+      heading="Randall Sanford"
+      [headingContent]="headingAcceptedRandall"
+      [actions]="actionsCommentViewRandall"
+      [open]="true"
+      headingType="filled"
+    >
+      <goab-text>stuff goes in here</goab-text>
+    </goab-accordion>
+
+    <ng-template #headingAcceptedRandall>
+      <goab-badge type="success" content="Accepted"></goab-badge>
+    </ng-template>
+
+    <ng-template #actionsCommentViewRandall>
+      <div style="display: flex; align-items: center; gap: 0.5rem">
+        <goab-button type="tertiary" size="compact">1 Comment(s)</goab-button>
+        <goab-button type="secondary" size="compact">View</goab-button>
+      </div>
+    </ng-template>
+
+    <goab-accordion
+      heading="Virginia Johns"
+      [headingContent]="headingEmailSentVirginia"
+      [actions]="actionsCommentViewVirginia"
+      [open]="true"
+      headingType="filled"
+    >
+      <goab-text>stuff goes in here</goab-text>
+    </goab-accordion>
+
+    <ng-template #headingEmailSentVirginia>
+      <goab-badge type="information" content="Email sent"></goab-badge>
+    </ng-template>
+
+    <ng-template #actionsCommentViewVirginia>
+      <div style="display: flex; align-items: center; gap: 0.5rem">
+        <goab-button type="tertiary" size="compact">4 Comment(s)</goab-button>
+        <goab-button type="secondary" size="compact">View</goab-button>
+      </div>
+    </ng-template>
+
+    <goab-accordion
+      heading="Mable Macejkovic"
+      [headingContent]="headingAcceptedMable"
+      [actions]="actionsCommentViewMable"
+      [open]="true"
+      headingType="filled"
+    >
+      <goab-text>stuff goes in here</goab-text>
+    </goab-accordion>
+
+    <ng-template #headingAcceptedMable>
+      <goab-badge type="success" content="Accepted"></goab-badge>
+    </ng-template>
+
+    <ng-template #actionsCommentViewMable>
+      <div style="display: flex; align-items: center; gap: 0.5rem">
+        <goab-button type="tertiary" size="compact">3 Comment(s)</goab-button>
+        <goab-button type="secondary" size="compact">View</goab-button>
+      </div>
+    </ng-template>
+
+    <goab-accordion
+      heading="Noah Clark"
+      [headingContent]="headingAcceptedNoah"
+      [actions]="actionsCommentViewNoah"
+      [open]="true"
+      headingType="filled"
+    >
+      <goab-text>stuff goes in here</goab-text>
+    </goab-accordion>
+
+    <ng-template #headingAcceptedNoah>
+      <goab-badge type="success" content="Accepted"></goab-badge>
+    </ng-template>
+
+    <ng-template #actionsCommentViewNoah>
+      <div style="display: flex; align-items: center; text-align: center; gap: 0.5rem">
+        <goab-button type="tertiary" size="compact">8 Comment(s)</goab-button>
+        <goab-button type="secondary" size="compact">View</goab-button>
+      </div>
+    </ng-template>
+
+    <h2>Multi-line Heading with Centered Chevron</h2>
+    <div style="margin-top: 2rem; width: 500px">
+      <goab-accordion
+        heading="Randall Sanford"
+        [headingContent]="headingTemplate"
+        headingType="filled"
+        [actions]="actionsTemplate"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #headingTemplate>
+        <goab-badge type="success" content="Accepted"></goab-badge>
+      </ng-template>
+
+      <ng-template #actionsTemplate>
+        <div style="display: flex; align-items: center; gap: 0.5rem">
+          <goab-button type="tertiary" size="compact"> 1 Comment(s) </goab-button>
+          <goab-button type="secondary" size="compact"> View </goab-button>
+        </div>
+      </ng-template>
+
+      <goab-accordion
+        heading="Randall Sanford"
+        [headingContent]="headingTemplateR"
+        headingType="filled"
+        [actions]="actionsTemplate"
+        iconPosition="right"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #headingTemplateR>
+        <goab-badge type="success" content="Accepted"></goab-badge>
+      </ng-template>
+
+      <ng-template #actionsTemplateR>
+        <div style="display: flex; align-items: center; gap: 0.5rem">
+          <goab-button type="tertiary" size="compact"> 1 Comment(s) </goab-button>
+          <goab-button type="secondary" size="compact"> View </goab-button>
+        </div>
+      </ng-template>
+
+      <goab-accordion
+        heading="Randall Sanford"
+        [headingContent]="headingTemplateR"
+        headingType="filled"
+        headingSize="medium"
+        [actions]="actionsTemplate"
+        iconPosition="right"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #headingTemplateR>
+        <goab-badge type="success" content="Accepted"></goab-badge>
+      </ng-template>
+
+      <ng-template #actionsTemplateR>
+        <div style="display: flex; align-items: center; gap: 0.5rem">
+          <goab-button type="tertiary" size="compact"> 1 Comment(s) </goab-button>
+          <goab-button type="secondary" size="compact"> View </goab-button>
+        </div>
+      </ng-template>
+
+      <goab-accordion
+        heading="Randall Sanford"
+        headingType="filled"
+        [actions]="actionsTemplate2"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #actionsTemplate2>
+        <div style="display: flex; align-items: center; gap: 0.5rem">
+          <goab-button type="tertiary" size="compact"> 1 Comment(s) </goab-button>
+          <goab-button type="secondary" size="compact"> View </goab-button>
+        </div>
+      </ng-template>
+
+      <goab-accordion
+        heading="Randall Sanford"
+        headingType="filled"
+        [actions]="actionsTemplate2R"
+        iconPosition="right"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #actionsTemplate2R>
+        <div style="display: flex; align-items: center; gap: 0.5rem">
+          <goab-button type="tertiary" size="compact"> 1 Comment(s) </goab-button>
+          <goab-button type="secondary" size="compact"> View </goab-button>
+        </div>
+      </ng-template>
+
+      <goab-accordion
+        heading="Randall Sanford"
+        [headingContent]="headingTemplate3"
+        headingType="filled"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #headingTemplate3>
+        <goab-badge type="success" content="Accepted"></goab-badge>
+      </ng-template>
+
+      <goab-accordion
+        heading="Randall Sanford"
+        headingType="filled"
+        [actions]="actionsTemplate4"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #actionsTemplate4>
+        <goab-badge type="success" content="Accepted"></goab-badge>
+      </ng-template>
+
+      <ng-template #headingTemplate3>
+        <goab-badge type="success" content="Accepted"></goab-badge>
+      </ng-template>
+
+      <goab-accordion
+        heading="Randall Sanford"
+        headingType="filled"
+        [actions]="actionsTemplate4R"
+        iconPosition="right"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #actionsTemplate4R>
+        <goab-badge type="success" content="Accepted"></goab-badge>
+      </ng-template>
+
+      <goab-accordion
+        heading="Randall Sanford"
+        headingType="filled"
+        [actions]="actionsTemplate4"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #actionsTemplate4>
+        <goab-badge type="success" content="Accepted"></goab-badge>
+      </ng-template>
+
+      <goab-accordion
+        heading="Randall Sanford"
+        [headingContent]="headingTemplateB"
+        headingType="filled"
+        [actions]="actionsTemplateB"
+        [secondaryText]="'Secondary text that is long enough to wrap onto multiple lines and push the heading content and actions down'"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #headingTemplateB>
+        <goab-badge type="success" content="Accepted"></goab-badge>
+      </ng-template>
+
+      <ng-template #actionsTemplateB>
+        <div style="display: flex; align-items: center; gap: 0.5rem">
+          <goab-button type="tertiary" size="compact"> 1 Comment(s) </goab-button>
+          <goab-button type="secondary" size="compact"> View </goab-button>
+        </div>
+      </ng-template>
+
+      <goab-accordion
+        heading="Randall Sanford"
+        [headingContent]="headingTemplateBR"
+        headingType="filled"
+        [actions]="actionsTemplateBR"
+        [secondaryText]="'Secondary text that is long enough to wrap onto multiple lines and push the heading content and actions down'"
+        iconPosition="right"
+      >
+        <p>
+          <span role="img" aria-label="eyes">👀</span>The chevron should be centered here
+        </p>
+      </goab-accordion>
+
+      <ng-template #headingTemplateBR>
+        <goab-badge type="success" content="Accepted"></goab-badge>
+      </ng-template>
+
+      <ng-template #actionsTemplateBR>
+        <div style="display: flex; align-items: center; gap: 0.5rem">
+          <goab-button type="tertiary" size="compact"> 1 Comment(s) </goab-button>
+          <goab-button type="secondary" size="compact"> View </goab-button>
+        </div>
+      </ng-template>
+    </div>
+  </div>
+</div>

--- a/apps/prs/angular/src/routes/features/feat3636/feat3636.component.ts
+++ b/apps/prs/angular/src/routes/features/feat3636/feat3636.component.ts
@@ -1,0 +1,15 @@
+import { Component } from "@angular/core";
+import {
+  GoabAccordion,
+  GoabBadge,
+  GoabButton,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat3636",
+  templateUrl: "./feat3636.component.html",
+  imports: [GoabAccordion, GoabBadge, GoabButton, GoabText],
+})
+export class Feat3636Component {}

--- a/apps/prs/angular/src/routes/features/feat3636/feat3636.route.json
+++ b/apps/prs/angular/src/routes/features/feat3636/feat3636.route.json
@@ -1,0 +1,6 @@
+{
+    "title": "Accordion actions slot and list view variant",
+    "path": "features/3636",
+    "id": "3636",
+    "type": "feature"
+}

--- a/apps/prs/react/src/app/routes/features/feat3636.route.ts
+++ b/apps/prs/react/src/app/routes/features/feat3636.route.ts
@@ -1,0 +1,9 @@
+import { Feat3636Route } from "../../../routes/features/feat3636";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "feature",
+  id: "3636",
+  path: "features/3636",
+  title: "Accordion actions slot and list view variant",
+  component: Feat3636Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/docs/accordion/accordion.tsx
+++ b/apps/prs/react/src/routes/docs/accordion/accordion.tsx
@@ -33,8 +33,8 @@ export function DocsAccordionRoute() {
 
       <h3>Basic</h3>
       <GoabAccordion heading="What documents do I need?">
-        You will need to provide proof of identity, proof of address,
-        and any relevant supporting documentation.
+        You will need to provide proof of identity, proof of address, and any relevant
+        supporting documentation.
       </GoabAccordion>
 
       <h3>Open by default</h3>
@@ -77,11 +77,14 @@ export function DocsAccordionRoute() {
       <h2>Examples</h2>
 
       <h3>Expand or collapse part of a form</h3>
-      <GoabText as="h3" mt="none" mb="m">Review your application</GoabText>
+      <GoabText as="h3" mt="none" mb="m">
+        Review your application
+      </GoabText>
 
       <GoabAccordion
         heading="Referral details"
-        headingContent={<GoabBadge type="important" content="Updated" />}>
+        headingContent={<GoabBadge type="important" content="Updated" />}
+      >
         <dl className="accordion-example">
           <dt>Date of referral</dt>
           <dd>January 27, 2021</dd>
@@ -104,7 +107,12 @@ export function DocsAccordionRoute() {
       </GoabAccordion>
 
       <h3>Hide and show many sections of information</h3>
-      <GoabButton type="tertiary" size="compact" mb="m" onClick={() => expandOrCollapseAll()}>
+      <GoabButton
+        type="tertiary"
+        size="compact"
+        mb="m"
+        onClick={() => expandOrCollapseAll()}
+      >
         {expandedAll ? "Hide all sections" : "Show all sections"}
       </GoabButton>
 
@@ -123,8 +131,8 @@ export function DocsAccordionRoute() {
         headingSize="medium"
         onChange={(open) => updateAccordion(2, open)}
       >
-        You will need to verify your identity through our two factor
-        authentication in addition to the digital signature.
+        You will need to verify your identity through our two factor authentication in
+        addition to the digital signature.
       </GoabAccordion>
 
       <GoabAccordion
@@ -133,9 +141,9 @@ export function DocsAccordionRoute() {
         headingSize="medium"
         onChange={(open) => updateAccordion(3, open)}
       >
-        Yes, you can see the status of your application on the main service
-        dashboard when you login. You will receive updates and notifications in
-        your email as your request progresses.
+        Yes, you can see the status of your application on the main service dashboard when
+        you login. You will receive updates and notifications in your email as your
+        request progresses.
       </GoabAccordion>
 
       <GoabAccordion
@@ -147,6 +155,58 @@ export function DocsAccordionRoute() {
         Yes, our digital service is designed with accessibility in mind.{" "}
         <a href="#">More information on accessibility.</a>
       </GoabAccordion>
+
+      <GoabAccordion heading="What documents do I need?" headingType="filled">
+        You will need to provide proof of identity, proof of address, and any relevant
+        supporting documentation.
+      </GoabAccordion>
+
+      <GoabAccordion
+        heading="Actions with button and badge"
+        secondaryText="Right icon"
+        iconPosition="right"
+        actions={
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            <GoabBadge type="important" content="3" />
+            <GoabButton type="tertiary" size="compact">
+              View all
+            </GoabButton>
+          </div>
+        }
+      >
+        <GoabText>
+          This example mixes badges and controls inside the actions slot.
+        </GoabText>
+      </GoabAccordion>
+
+      <div style={{ marginTop: "2rem", width: "10%" }}>
+        <h2>Benji</h2>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingContent={<GoabBadge type="success" content="Accepted" />}
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabButton type="tertiary" size="compact">
+                1 Comment(s)
+              </GoabButton>
+              <GoabButton type="tertiary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+        >
+          <dl className="accordion-example">
+            <dt>Date of referral</dt>
+            <dd>January 27, 2021</dd>
+            <dt>Work safety concerns</dt>
+            <dd>None</dd>
+            <dt>Type of referral</dt>
+            <dd>Word of mouth, internet search</dd>
+            <dt>Intake received from another site</dt>
+            <dd>Yes</dd>
+          </dl>
+        </GoabAccordion>
+      </div>
     </div>
   );
 }

--- a/apps/prs/react/src/routes/features/feat3636.tsx
+++ b/apps/prs/react/src/routes/features/feat3636.tsx
@@ -1,0 +1,436 @@
+import { GoabAccordion, GoabBadge, GoabButton, GoabText } from "@abgov/react-components";
+import v2TokensUrl from "@abgov/design-tokens-v2/dist/tokens.css?url";
+import { useEffect } from "react";
+
+export function Feat3636Route() {
+  // Inject the v2 design tokens
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = v2TokensUrl;
+    document.head.appendChild(link);
+    return () => {
+      document.head.removeChild(link);
+    };
+  }, []);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--goa-spacing-xl)",
+        maxWidth: "72rem",
+      }}
+    >
+      <GoabText tag="h1">
+        Feature 3636: Accordion actions slot and list view variant
+      </GoabText>
+      <GoabText>
+        The GoAAccordion component now includes an optional slot for action buttons in the
+        header, as well as a new "list view" variant that features a filled header
+        background and hover state.
+      </GoabText>
+
+      <div style={{ display: "grid", gap: "var(--goa-spacing-l)" }}>
+        <GoabText tag="h2">Actions slot examples</GoabText>
+
+        <GoabAccordion
+          heading="Actions with button"
+          secondaryText="Left icon"
+          iconPosition="left"
+          open
+          actions={
+            <GoabButton type="secondary" size="compact">
+              Edit
+            </GoabButton>
+          }
+        >
+          <GoabText>
+            This example places a button in the actions slot while keeping heading text
+            and content as standard body copy.
+          </GoabText>
+        </GoabAccordion>
+
+        <GoabAccordion
+          heading="Actions with button and badge"
+          secondaryText="Right icon"
+          iconPosition="right"
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabBadge type="important" content="3" />
+              <GoabButton type="tertiary" size="compact">
+                View all
+              </GoabButton>
+            </div>
+          }
+        >
+          <GoabText>
+            This example mixes badges and controls inside the actions slot.
+          </GoabText>
+        </GoabAccordion>
+      </div>
+
+      <div style={{ display: "grid", gap: "var(--goa-spacing-l)" }}>
+        <GoabText tag="h2">Heading content examples</GoabText>
+
+        <GoabAccordion
+          heading="Heading with badge"
+          headingContent={<GoabBadge type="information" content="Beta" />}
+          actions={
+            <GoabButton type="tertiary" size="compact">
+              Preview
+            </GoabButton>
+          }
+          open
+        >
+          <GoabText>
+            The heading content slot can display status indicators such as badges.
+          </GoabText>
+        </GoabAccordion>
+
+        <GoabAccordion
+          heading="Heading with multiple badges"
+          headingContent={
+            <div style={{ display: "flex", gap: "0.5rem" }}>
+              <GoabBadge type="success" content="Stable" />
+              <GoabBadge type="important" content="Requires review" />
+            </div>
+          }
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabBadge type="important" content="2" />
+              <GoabButton type="tertiary" size="compact">
+                Manage
+              </GoabButton>
+            </div>
+          }
+        >
+          <GoabText>
+            Multiple indicators can be grouped in heading content when more context is
+            needed.
+          </GoabText>
+        </GoabAccordion>
+      </div>
+
+      <div style={{ display: "grid", gap: "var(--goa-spacing-l)" }}>
+        <GoabText tag="h2">Icon position and fixed width examples</GoabText>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(20rem, 1fr))",
+            gap: "var(--goa-spacing-l)",
+          }}
+        >
+          <GoabAccordion
+            heading="Fixed 24rem, icon left"
+            iconPosition="left"
+            maxWidth="24rem"
+            actions={
+              <GoabButton type="secondary" size="compact">
+                Open
+              </GoabButton>
+            }
+            open
+          >
+            <GoabText>
+              A narrow fixed-width accordion using the default icon position.
+            </GoabText>
+          </GoabAccordion>
+
+          <GoabAccordion
+            heading="Fixed 30rem, icon right"
+            iconPosition="right"
+            maxWidth="30rem"
+            actions={
+              <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                <GoabBadge type="important" content="4" />
+                <GoabButton type="tertiary" size="compact">
+                  Details
+                </GoabButton>
+              </div>
+            }
+            open
+          >
+            <GoabText>
+              A wider fixed-width accordion with the icon moved to the right side.
+            </GoabText>
+          </GoabAccordion>
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gap: "var(--goa-spacing-l)" }}>
+        <GoabText tag="h2">Filled/List View Style</GoabText>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingContent={<GoabBadge type="success" content="Accepted" />}
+          headingType="filled"
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabButton type="tertiary" size="compact">
+                1 Comment(s)
+              </GoabButton>
+              <GoabButton type="secondary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+          open
+        >
+          <GoabText>stuff goes in here</GoabText>
+        </GoabAccordion>
+
+        <GoabAccordion
+          heading="Virginia Johns"
+          headingContent={<GoabBadge type="information" content="Email sent" />}
+          headingType="filled"
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabButton type="tertiary" size="compact">
+                4 Comment(s)
+              </GoabButton>
+              <GoabButton type="secondary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+          open
+        >
+          <GoabText>stuff goes in here</GoabText>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Mable Macejkovic"
+          headingContent={<GoabBadge type="success" content="Accepted" />}
+          headingType="filled"
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabButton type="tertiary" size="compact">
+                3 Comment(s)
+              </GoabButton>
+              <GoabButton type="secondary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+          open
+        >
+          <GoabText>stuff goes in here</GoabText>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Noah Clark"
+          headingContent={<GoabBadge type="success" content="Accepted" />}
+          headingType="filled"
+          actions={
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                textAlign: "center",
+                gap: "0.5rem",
+              }}
+            >
+              <GoabButton type="tertiary" size="compact">
+                8 Comment(s)
+              </GoabButton>
+              <GoabButton type="secondary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+          open
+        >
+          <GoabText>stuff goes in here</GoabText>
+        </GoabAccordion>
+      </div>
+      <h2>Multi-line Heading with Centered Chevron</h2>
+      <div style={{ marginTop: "2rem", width: "500px" }}>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingContent={<GoabBadge type="success" content="Accepted" />}
+          headingType="filled"
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabButton type="tertiary" size="compact">
+                1 Comment(s)
+              </GoabButton>
+              <GoabButton type="secondary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+        >
+          <p>
+            <span role="img" aria-label="eyes">
+              👀
+            </span>
+            The chevron should be centered in the heading
+          </p>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingContent={<GoabBadge type="success" content="Accepted" />}
+          headingType="filled"
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabButton type="tertiary" size="compact">
+                1 Comment(s)
+              </GoabButton>
+              <GoabButton type="secondary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+          iconPosition="right"
+        >
+          <p>
+            <span role="img" aria-label="eyes">
+              👀
+            </span>
+            The chevron should be centered here
+          </p>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingType="filled"
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabButton type="tertiary" size="compact">
+                1 Comment(s)
+              </GoabButton>
+              <GoabButton type="secondary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+        >
+          <p>
+            <span role="img" aria-label="eyes">
+              👀
+            </span>
+            The chevron should be centered here
+          </p>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingType="filled"
+          iconPosition="right"
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabButton type="tertiary" size="compact">
+                1 Comment(s)
+              </GoabButton>
+              <GoabButton type="secondary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+        >
+          <p>
+            <span role="img" aria-label="eyes">
+              👀
+            </span>
+            The chevron should be centered here
+          </p>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingContent={<GoabBadge type="success" content="Accepted" />}
+          headingType="filled"
+        >
+          <p>
+            <span role="img" aria-label="eyes">
+              👀
+            </span>
+            The chevron should be centered here
+          </p>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingContent={<GoabBadge type="success" content="Accepted" />}
+          headingType="filled"
+          iconPosition="right"
+        >
+          <p>
+            <span role="img" aria-label="eyes">
+              👀
+            </span>
+            The chevron should be centered here
+          </p>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingType="filled"
+          actions={<GoabBadge type="success" content="Accepted" />}
+        >
+          <p>
+            <span role="img" aria-label="eyes">
+              👀
+            </span>
+            The chevron should be centered here
+          </p>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingType="filled"
+          actions={<GoabBadge type="success" content="Accepted" />}
+          iconPosition="right"
+        >
+          <p>
+            <span role="img" aria-label="eyes">
+              👀
+            </span>
+            The chevron should be centered here
+          </p>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingContent={<GoabBadge type="success" content="Accepted" />}
+          headingType="filled"
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabButton type="tertiary" size="compact">
+                1 Comment(s)
+              </GoabButton>
+              <GoabButton type="secondary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+          secondaryText="Secondary text that is long enough to wrap onto multiple lines and push the heading content and actions down"
+        >
+          <p>
+            <span role="img" aria-label="eyes">
+              👀
+            </span>
+            The chevron should be centered here
+          </p>
+        </GoabAccordion>
+        <GoabAccordion
+          heading="Randall Sanford"
+          headingContent={<GoabBadge type="success" content="Accepted" />}
+          headingType="filled"
+          actions={
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <GoabButton type="tertiary" size="compact">
+                1 Comment(s)
+              </GoabButton>
+              <GoabButton type="secondary" size="compact">
+                View
+              </GoabButton>
+            </div>
+          }
+          secondaryText="Secondary text that is long enough to wrap onto multiple lines and push the heading content and actions down"
+          iconPosition="right"
+        >
+          <p>
+            <span role="img" aria-label="eyes">
+              👀
+            </span>
+            The chevron should be centered here
+          </p>
+        </GoabAccordion>
+      </div>
+    </div>
+  );
+}

--- a/docs/generated/component-apis/accordion.json
+++ b/docs/generated/component-apis/accordion.json
@@ -19,6 +19,13 @@
           "description": "Sets the heading size of the accordion container heading."
         },
         {
+          "name": "headingType",
+          "type": "GoabAccordionHeadingType",
+          "required": false,
+          "default": "normal",
+          "description": "Sets the accordion style variant."
+        },
+        {
           "name": "iconPosition",
           "type": "GoabAccordionIconPosition",
           "required": false,
@@ -94,6 +101,12 @@
       ],
       "slots": [
         {
+          "name": "actions",
+          "type": "ReactNode",
+          "description": "Sets content rendered in the accordion heading, right-aligned before the expand/collapse icon.",
+          "required": false
+        },
+        {
           "name": "headingContent",
           "type": "ReactNode",
           "description": "Sets content rendered within the accordion heading, alongside the heading text.",
@@ -116,6 +129,13 @@
           "required": false,
           "default": null,
           "description": "Sets the heading size of the accordion container heading."
+        },
+        {
+          "name": "headingType",
+          "type": "GoabAccordionHeadingType",
+          "required": false,
+          "default": null,
+          "description": "Sets the accordion style variant."
         },
         {
           "name": "iconPosition",
@@ -193,6 +213,12 @@
       ],
       "slots": [
         {
+          "name": "actions",
+          "type": "TemplateRef",
+          "description": "Sets content rendered in the accordion heading, right-aligned before the expand/collapse icon.",
+          "required": false
+        },
+        {
           "name": "headingContent",
           "type": "TemplateRef",
           "description": "Sets content rendered within the accordion heading, alongside the heading text.",
@@ -208,6 +234,18 @@
           "required": true,
           "default": "",
           "description": "Sets the heading text."
+        },
+        {
+          "name": "heading-type",
+          "type": "\"normal\" | \"filled\"",
+          "typeLabel": "GoabAccordionHeadingType",
+          "values": [
+            "normal",
+            "filled"
+          ],
+          "required": false,
+          "default": "normal",
+          "description": "Sets the accordion style variant. @default \"normal\""
         },
         {
           "name": "headingsize",
@@ -312,6 +350,11 @@
         }
       ],
       "slots": [
+        {
+          "name": "actions",
+          "description": "Sets content rendered in the accordion heading, right-aligned before the expand/collapse icon.",
+          "required": false
+        },
         {
           "name": "headingcontent",
           "description": "Sets content rendered within the accordion heading, alongside the heading text.",

--- a/docs/src/data/configurations/accordion.ts
+++ b/docs/src/data/configurations/accordion.ts
@@ -147,5 +147,77 @@ export const accordionConfigurations: ComponentConfigurations = {
 </goa-accordion>`,
       },
     },
+    {
+      id: "filled",
+      name: "Filled accordion",
+      description: "Single accordion with filled type",
+      code: {
+        react: `<GoabAccordion heading="What documents do I need?" headingType="filled">
+  You will need to provide proof of identity, proof of address,
+  and any relevant supporting documentation.
+</GoabAccordion>`,
+        angular: `<goab-accordion heading="What documents do I need?" headingType="filled">
+  You will need to provide proof of identity, proof of address,
+  and any relevant supporting documentation.
+</goab-accordion>`,
+        webComponents: `<goa-accordion heading="What documents do I need?" heading-type="filled">
+  You will need to provide proof of identity, proof of address,
+  and any relevant supporting documentation.
+</goa-accordion>`,
+      },
+    },
+    {
+      id: "actions",
+      name: "Accordion with actions",
+      description: "Accordion with actions slot content",
+      code: {
+        react: `<GoabAccordion
+  heading="Actions with button and badge"
+  secondaryText="Right icon"
+  actions={
+    <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+      <GoabBadge type="important" content="3" />
+      <GoabButton type="primary" size="compact">
+        View all
+      </GoabButton>
+    </div>
+  }
+>
+  <GoabText>
+    This example mixes badges and controls inside the actions slot.
+  </GoabText>
+</GoabAccordion>`,
+        angular: `<goab-accordion
+  heading="Actions with button and badge"
+  secondaryText="Right icon"
+  [actions]="actionsViewAll"
+>
+  <goab-text>
+    This example mixes badges and controls inside the actions slot.
+  </goab-text>
+</goab-accordion>
+
+<ng-template #actionsViewAll>
+  <div style="display: flex; align-items: center; gap: 0.5rem">
+    <goab-badge type="important" content="3"></goab-badge>
+    <goab-button type="primary" size="compact">View all</goab-button>
+  </div>
+</ng-template>`,
+        webComponents: `<goa-accordion
+  heading="Actions with button and badge"
+  secondarytext="Right icon"
+>
+  <goa-text>
+    This example mixes badges and controls inside the actions slot.
+  </goa-text>
+  <div slot="actions">
+    <div style="display: flex; align-items: center; gap: 0.5rem">
+      <goa-badge type="important" content="3"></goa-badge>
+      <goa-button type="primary" size="compact">View all</goa-button>
+    </div>
+  </div>
+</goa-accordion>`,
+      },
+    },
   ],
 };

--- a/libs/angular-components/src/lib/components/accordion/accordion.spec.ts
+++ b/libs/angular-components/src/lib/components/accordion/accordion.spec.ts
@@ -5,6 +5,7 @@ import { By } from "@angular/platform-browser";
 import {
   GoabAccordionHeadingSize,
   GoabAccordionIconPosition,
+  GoabAccordionHeadingType,
 } from "@abgov/ui-components-common";
 
 @Component({
@@ -17,6 +18,7 @@ import {
     [headingSize]="headingSize"
     [headingContent]="headingContent"
     [iconPosition]="iconPosition"
+    [headingType]="headingType"
     maxWidth="480px"
   >
     test content
@@ -29,7 +31,20 @@ class TestAccordionComponent {
   open?: boolean;
   headingSize?: GoabAccordionHeadingSize;
   iconPosition?: GoabAccordionIconPosition;
+  headingType?: GoabAccordionHeadingType;
 }
+
+@Component({
+  standalone: true,
+  imports: [GoabAccordion],
+  template: `
+    <goab-accordion heading="Title" [actions]="actionsTemplate">
+      test content
+      <ng-template #actionsTemplate>This is the actions content</ng-template>
+    </goab-accordion>
+  `,
+})
+class TestAccordionWithActionsComponent {}
 
 describe("GoabAccordion", () => {
   let fixture: ComponentFixture<TestAccordionComponent>;
@@ -48,6 +63,7 @@ describe("GoabAccordion", () => {
     component.open = true;
     component.headingSize = "large" as GoabAccordionHeadingSize;
     component.iconPosition = "right" as GoabAccordionIconPosition;
+    component.headingType = "filled" as GoabAccordionHeadingType;
 
     fixture.detectChanges();
     tick();
@@ -64,7 +80,33 @@ describe("GoabAccordion", () => {
     expect(accordionElement.getAttribute("headingsize")).toBe("large");
     expect(accordionElement.getAttribute("maxwidth")).toBe("480px");
     expect(accordionElement.getAttribute("iconposition")).toBe("right");
+    expect(accordionElement.getAttribute("heading-type")).toBe("filled");
     const headingContent = accordionElement.querySelector("[slot='headingcontent']");
     expect(headingContent.textContent).toContain("This is the headingcontent");
+  });
+});
+
+describe("GoabAccordion actions slot", () => {
+  let fixture: ComponentFixture<TestAccordionWithActionsComponent>;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [GoabAccordion, TestAccordionWithActionsComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestAccordionWithActionsComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+  }));
+
+  it("should render the actions slot content", () => {
+    const accordionElement = fixture.debugElement.query(
+      By.css("goa-accordion"),
+    ).nativeElement;
+    const actionsSlot = accordionElement.querySelector("[slot='actions']");
+    expect(actionsSlot).toBeTruthy();
+    expect(actionsSlot.textContent).toContain("This is the actions content");
   });
 });

--- a/libs/angular-components/src/lib/components/accordion/accordion.ts
+++ b/libs/angular-components/src/lib/components/accordion/accordion.ts
@@ -1,6 +1,7 @@
 import {
   GoabAccordionHeadingSize,
   GoabAccordionIconPosition,
+  GoabAccordionHeadingType,
 } from "@abgov/ui-components-common";
 import {
   CUSTOM_ELEMENTS_SCHEMA,
@@ -28,9 +29,11 @@ import { GoabBaseComponent } from "../base.component";
         [attr.secondarytext]="secondaryText"
         [attr.open]="open"
         [attr.headingsize]="headingSize"
+        [attr.heading-type]="headingType"
         [attr.maxwidth]="maxWidth"
         [attr.testid]="testId"
         [attr.iconposition]="iconPosition"
+        [attr.heading-type]="headingType"
         [attr.mt]="mt"
         [attr.mb]="mb"
         [attr.ml]="ml"
@@ -40,6 +43,11 @@ import { GoabBaseComponent } from "../base.component";
         <div slot="headingcontent">
           <ng-container [ngTemplateOutlet]="headingContent"></ng-container>
         </div>
+        @if (actions) {
+          <div slot="actions">
+            <ng-container [ngTemplateOutlet]="actions"></ng-container>
+          </div>
+        }
         <ng-content></ng-content>
       </goa-accordion>
     }
@@ -60,10 +68,14 @@ export class GoabAccordion extends GoabBaseComponent implements OnInit {
   @Input() headingSize?: GoabAccordionHeadingSize;
   /** Sets the heading content template reference. */
   @Input() headingContent!: TemplateRef<any>;
+  /** Sets the actions content template reference, rendered right-aligned in the heading before the expand/collapse icon. */
+  @Input() actions?: TemplateRef<any>;
   /** Sets the maximum width of the accordion. */
   @Input() maxWidth?: string;
   /** Sets the position of the expand/collapse icon. */
   @Input() iconPosition?: GoabAccordionIconPosition;
+  /** Sets the accordion style variant. */
+  @Input() headingType?: GoabAccordionHeadingType;
 
   /** Emits when the accordion opens or closes. Emits the new open state as a boolean. */
   @Output() onChange = new EventEmitter<boolean>();

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -265,6 +265,7 @@ export type GoabButtonGroupGap = "relaxed" | "compact";
 // Accordion
 export type GoabAccordionHeadingSize = "small" | "medium";
 export type GoabAccordionIconPosition = "left" | "right";
+export type GoabAccordionHeadingType = "normal" | "filled";
 
 // Tooltip
 

--- a/libs/react-components/specs/accordion.browser.spec.tsx
+++ b/libs/react-components/specs/accordion.browser.spec.tsx
@@ -119,6 +119,59 @@ describe("Accordion", () => {
     });
   });
 
+  it("should not expand the accordion when a button in the actions slot is clicked", async () => {
+    const accordionChangeSpy = vi.fn();
+
+    const Component = () => {
+      return (
+        <GoabAccordion
+          heading="Heading"
+          testId="testAccordion"
+          actions={
+            <GoabButton testId="actions-button">Action</GoabButton>
+          }
+          onChange={accordionChangeSpy}
+        >
+          Accordion content
+        </GoabAccordion>
+      );
+    };
+
+    const result = render(<Component />);
+    const button = result.getByTestId("actions-button");
+    await userEvent.click(button);
+
+    await vi.waitFor(() => {
+      expect(accordionChangeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should fire the actions button onClick when the actions button is clicked", async () => {
+    const handleClick = vi.fn();
+
+    const Component = () => {
+      return (
+        <GoabAccordion
+          heading="Heading"
+          testId="testAccordion"
+          actions={
+            <GoabButton testId="actions-button" onClick={handleClick}>Action</GoabButton>
+          }
+        >
+          Accordion content
+        </GoabAccordion>
+      );
+    };
+
+    const result = render(<Component />);
+    const button = result.getByTestId("actions-button");
+    await userEvent.click(button);
+
+    await vi.waitFor(() => {
+      expect(handleClick).toHaveBeenCalled();
+    });
+  });
+
   it("should set the open attribute on the details element", async () => {
     const Component = () => {
       const [open, setOpen] = useState(false);

--- a/libs/react-components/src/lib/accordion/accordion.spec.tsx
+++ b/libs/react-components/src/lib/accordion/accordion.spec.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
 import { GoabBadge } from "../badge/badge";
+import { GoabButton } from "../button/button";
 
 import { GoabAccordion } from "./accordion";
 
@@ -20,6 +21,7 @@ describe("Accordion", () => {
         heading="The heading"
         secondaryText="Secondary Text"
         open
+        headingType="filled"
         headingContent={<GoabBadge type="success" content="test-badge"></GoabBadge>}
         maxWidth="480px"
       >
@@ -30,17 +32,26 @@ describe("Accordion", () => {
     const headingContent = el?.querySelector("[slot='headingcontent']");
     expect(el?.getAttribute("secondarytext")).toBe("Secondary Text");
     expect(el?.getAttribute("open")).toBe("true");
+    expect(el?.getAttribute("heading-type")).toBe("filled");
     const badge = headingContent?.querySelector("goa-badge");
     expect(badge?.getAttribute("content")).toBe("test-badge");
     expect(el?.getAttribute("maxwidth")).toBe("480px");
   });
 
+  it("should render the actions slot", () => {
+    const { baseElement } = render(
+      <GoabAccordion heading="The heading" actions={<GoabButton>Action</GoabButton>}>
+        Content
+      </GoabAccordion>,
+    );
+    const el = baseElement.querySelector("goa-accordion");
+    const actions = el?.querySelector("[slot='actions']");
+    expect(actions).toBeTruthy();
+  });
+
   it("should pass data-grid attributes", () => {
     const { baseElement } = render(
-      <GoabAccordion
-        heading="Test heading"
-        data-grid="row"
-      >
+      <GoabAccordion heading="Test heading" data-grid="row">
         Content
       </GoabAccordion>,
     );

--- a/libs/react-components/src/lib/accordion/accordion.tsx
+++ b/libs/react-components/src/lib/accordion/accordion.tsx
@@ -3,6 +3,7 @@ import { ReactNode, useEffect, useRef, type JSX } from "react";
 import type {
   GoabAccordionHeadingSize,
   GoabAccordionIconPosition,
+  GoabAccordionHeadingType,
   Margins,
   DataAttributes,
 } from "@abgov/ui-components-common";
@@ -17,6 +18,7 @@ interface WCProps extends Margins {
   maxwidth?: string;
   testid?: string;
   iconposition?: GoabAccordionIconPosition;
+  headingType?: GoabAccordionHeadingType;
 }
 
 declare module "react" {
@@ -42,12 +44,16 @@ export interface GoabAccordionProps extends Margins, DataAttributes {
   secondaryText?: string;
   /** Sets content rendered within the accordion heading, alongside the heading text. */
   headingContent?: ReactNode;
+  /** Sets content rendered in the accordion heading, right-aligned before the expand/collapse icon. */
+  actions?: ReactNode;
   /** Sets the maximum width of the accordion. @default "none" */
   maxWidth?: string;
   /** Sets a data-testid attribute for automated testing. */
   testId?: string;
   /** Sets the position of the expand/collapse icon. @default "left" */
   iconPosition?: GoabAccordionIconPosition;
+  /** Sets the accordion style variant. @default "normal" */
+  headingType?: GoabAccordionHeadingType;
   /** Callback fired when the accordion is opened or closed. Receives the new open state as a boolean. */
   onChange?: (open: boolean) => void;
   /** Content rendered inside the accordion body. */
@@ -59,6 +65,8 @@ export function GoabAccordion({
   open,
   onChange,
   headingContent,
+  headingType,
+  actions,
   children,
   ...rest
 }: GoabAccordionProps): JSX.Element {
@@ -81,8 +89,14 @@ export function GoabAccordion({
   }, [onChange]);
 
   return (
-    <goa-accordion ref={ref} open={open ? "true" : undefined} {..._props}>
+    <goa-accordion
+      ref={ref}
+      open={open ? "true" : undefined}
+      heading-type={headingType}
+      {..._props}
+    >
       {headingContent && <div slot="headingcontent">{headingContent}</div>}
+      {actions && <div slot="actions">{actions}</div>}
       {children}
     </goa-accordion>
   );

--- a/libs/web-components/src/components/accordion/Accordion.html-data.json
+++ b/libs/web-components/src/components/accordion/Accordion.html-data.json
@@ -1,6 +1,8 @@
 {
   "name": "goa-accordion",
-  "required": ["heading"],
+  "required": [
+    "heading"
+  ],
   "attributes": [
     {
       "name": "heading",
@@ -40,6 +42,22 @@
         {
           "name": "medium",
           "description": "Heading size of the accordion container is medium."
+        }
+      ],
+      "type": "string"
+    },
+    {
+      "name": "heading-type",
+      "default": "normal",
+      "description": "Sets the accordion style variant.",
+      "values": [
+        {
+          "name": "normal",
+          "description": "Normal accordion style."
+        },
+        {
+          "name": "filled",
+          "description": "Filled accordion style."
         }
       ],
       "type": "string"

--- a/libs/web-components/src/components/accordion/Accordion.spec.ts
+++ b/libs/web-components/src/components/accordion/Accordion.spec.ts
@@ -1,5 +1,6 @@
 import Accordion from "./Accordion.svelte";
 import AccordionWithHeadingContent from "./AccordionWithHeadingContentWrapper.test.svelte";
+import AccordionWithActions from "./AccordionWithActionsWrapper.test.svelte";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { it, describe } from "vitest";
 
@@ -31,7 +32,7 @@ describe("Accordion", () => {
     const { container } = render(Accordion, {
       heading: "Title",
       maxwidth: "480px",
-      testid: "accordion"
+      testid: "accordion",
     });
     const elm = container.querySelector("[data-testid=accordion]");
     expect(elm?.getAttribute("style")).toContain("max-width: 480px;");
@@ -68,6 +69,18 @@ describe("Accordion", () => {
     });
   });
 
+  it("does not render the actions slot container when actions slot is empty", async () => {
+    const { container } = render(Accordion, { heading: "Title" });
+    const actionsDiv = container.querySelector("summary .actions");
+    expect(actionsDiv).toBeNull();
+  });
+
+  it("renders the actions slot container when actions slot content exists", async () => {
+    const { queryByTestId } = render(AccordionWithActions);
+    const actionsButton = queryByTestId("actions-button");
+    expect(actionsButton).toBeTruthy();
+  });
+
   it("handle accessibility features", async () => {
     const { container } = render(Accordion, {
       heading: "Title",
@@ -77,7 +90,9 @@ describe("Accordion", () => {
     const summary = container.querySelector("summary");
     expect(summary?.getAttribute("aria-expanded")).toBe("false");
     expect(summary?.getAttribute("aria-controls")).length.greaterThan(0);
-    const accordionId = summary?.getAttribute("aria-controls")?.split("-content")[0]; // generate random id
+    const accordionId = summary
+      ?.getAttribute("aria-controls")
+      ?.split("-content")[0]; // generate random id
     expect(summary?.getAttribute("aria-controls")).toBe(
       `${accordionId}-content`,
     );

--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -1,4 +1,11 @@
-<svelte:options customElement="goa-accordion" />
+<svelte:options
+  customElement={{
+    tag: "goa-accordion",
+    props: {
+      headingType: { type: "String", attribute: "heading-type", reflect: true },
+    },
+  }}
+/>
 
 <!-- Script -->
 <script lang="ts">
@@ -28,10 +35,16 @@
     ["left", "right"],
   );
 
+  const [AccordionHeadingTypes, validateAccordionTypes] = typeValidator(
+    "Accordion Type",
+    ["normal", "filled"],
+  );
+
   // Types
 
   type HeadingSize = (typeof HeadingSizes)[number];
   type IconPosition = (typeof IconPositions)[number];
+  type AccordionHeadingType = (typeof AccordionHeadingTypes)[number];
 
   // Props
 
@@ -59,6 +72,8 @@
   export let ml: Spacing = null;
   /** Sets the position of the expand/collapse icon. */
   export let iconposition: IconPosition = "left";
+  /** Sets the accordion style variant. @default "normal" */
+  export let headingType: AccordionHeadingType = "normal";
 
   // Private
 
@@ -90,6 +105,7 @@
     validateRequired("GoAAccordion", { heading });
     validateHeadingSize(headingsize);
     validateIconPosition(iconposition);
+    validateAccordionTypes(headingType);
     ensureSlotExists(_slotEl);
 
     _headingSlotChildren = getHeadingChildren();
@@ -299,6 +315,7 @@
       aria-controls={`${_accordionId}-content`}
       aria-expanded={isOpen}
       class:iconRight={iconposition === "right"}
+      class:filled={headingType === "filled"}
       bind:this={_summaryEl}
       on:click={onAccordionToggle}
       data-testid={`${testid}-summary`}
@@ -320,6 +337,7 @@
         {#if secondarytext}
           <span class="secondary-text">{secondarytext}</span>
         {/if}
+        <!-- svelte-ignore a11y-click-events-have-key-events because the enter and space handlers are blocked too-->
         <div
           class="heading-content"
           class:heading-content-top={_headingSlotChildren.length}
@@ -328,6 +346,14 @@
           <slot name="headingcontent" />
         </div>
       </div>
+
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      {#if $$slots.actions}
+        <div class="actions" on:click|stopPropagation>
+          <slot name="actions" />
+        </div>
+      {/if}
 
       {#if iconposition === "right"}
         <goa-icon
@@ -382,12 +408,26 @@
     cursor: pointer;
     list-style: none;
     display: flex;
-    align-items: flex-start;
+    align-items: center;
 
     /* safari hack (see below) */
     position: relative;
     transition: var(--goa-motion-duration-short-2) background-color
       var(--goa-motion-curve-expressive);
+  }
+
+  summary.filled {
+    background-color: var(
+      --goa-accordion-color-filled-bg-heading,
+      var(--goa-color-greyscale-100)
+    );
+  }
+
+  summary.filled:hover {
+    background-color: var(
+      --goa-accordion-color-filled-bg-heading-hover,
+      var(--goa-color-greyscale-150)
+    );
   }
 
   summary.iconRight {
@@ -403,6 +443,14 @@
   summary:active {
     background-color: var(--goa-accordion-color-bg-heading);
     outline: none;
+  }
+
+  summary.filled:focus-visible,
+  summary.filled:active {
+    background-color: var(
+      --goa-accordion-color-filled-bg-heading,
+      var(--goa-color-greyscale-100)
+    );
   }
 
   /* Hack to make outline radius work on Safari */
@@ -469,6 +517,13 @@
 
   .heading-content {
     flex: 1;
+  }
+
+  .actions {
+    display: flex;
+    align-items: center;
+    align-self: center;
+    padding-left: var(--goa-space-xs, 0.5rem);
   }
 
   .container-medium {

--- a/libs/web-components/src/components/accordion/AccordionWithActionsWrapper.test.svelte
+++ b/libs/web-components/src/components/accordion/AccordionWithActionsWrapper.test.svelte
@@ -1,0 +1,15 @@
+<svelte:options customElement="test-accordion-with-actions" />
+
+<goa-accordion heading="This is a heading" testid="accordion">
+  <p>Content</p>
+  <div slot="actions" data-testid="actions-slot">
+    <goa-button
+      slot="actions"
+      data-testid="actions-button"
+      size="compact"
+      type="secondary"
+    >
+      Action
+    </goa-button>
+  </div>
+</goa-accordion>


### PR DESCRIPTION
# Before (the change)

Accordions only had one version, and could not include an Actions slot for the header.

<img width="1220" height="266" alt="image" src="https://github.com/user-attachments/assets/04164a79-ca92-4ad9-ac86-90c578f22dd6" />

# After (the change)

**Filled Accordion**

<img width="1215" height="205" alt="image" src="https://github.com/user-attachments/assets/927546a1-8d26-4f0d-b321-a11fbac1de6f" />

**Accordion with actions slot contents**

This has a badge and button:

<img width="1214" height="245" alt="image" src="https://github.com/user-attachments/assets/99f45d4c-b5d1-4dd5-b609-a2e5078dc580" />

- Clicking the button will not cause the accordion to close
- This is different from the `headingcontent` slot in that `headingcontent` is left aligned, while `actions` is right aligned

This pr closes #3636.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

See http://localhost:4200/features/3636 for various examples.
- test the `type=filled` attribute
- test the `actions` slot