### PR TITLE
fix(#3605): use :focus-visible across interactive components

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3605/bug3605.component.html
+++ b/apps/prs/angular/src/routes/bugs/3605/bug3605.component.html
@@ -1,0 +1,445 @@
+<div style="padding: 2rem; display: flex; flex-direction: column; gap: 1rem; max-width: 72rem; margin: 0 auto;">
+  <goab-text tag="h5" mb="xs" color="secondary">Issue 3605</goab-text>
+  <goab-text tag="h1" mt="0" mb="0">
+    Use <code>:focus-visible</code> across interactive components
+  </goab-text>
+
+  <goab-block>
+    <goab-link version="2" trailingIcon="open">
+      <a href="https://github.com/GovAlta/ui-components/issues/3605" target="_blank" rel="noopener">
+        View on GitHub
+      </a>
+    </goab-link>
+  </goab-block>
+
+  <goab-text mb="0">
+    For every section: <strong>Tab</strong> should show the focus ring with the correct gap/offset.
+    <strong>Click</strong> should not leave a lingering ring. <strong>Mouse-down (<code>:active</code>)</strong>
+    on buttons should still show the pressed/focused look.
+  </goab-text>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 1. MicrositeHeader -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      1. MicrositeHeader — <code>a:focus</code> → <code>a:focus-visible</code>
+    </goab-text>
+    <goab-text mb="s">Tab through the links inside the header. Click any link.</goab-text>
+    <goab-microsite-header type="alpha" version="1" headerUrl="https://www.alberta.ca" feedbackUrl="#"></goab-microsite-header>
+    <div style="margin-top: var(--goa-space-m);">
+      <goab-microsite-header type="beta" version="2" headerUrl="https://www.alberta.ca" feedbackUrl="#"></goab-microsite-header>
+    </div>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 2. Chip + FilterChip -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      2. Chip — <code>.chip:focus</code> → <code>.chip:focus-visible</code>
+    </goab-text>
+    <goab-text mb="s">V1 Chip (deprecated, still in scope per brief).</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-chip content="Status: active"></goab-chip>
+      <goab-chip content="Priority: high" [deletable]="true"></goab-chip>
+      <goab-chip content="Owner: Tom"></goab-chip>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">FilterChip V2 (production)</goab-text>
+    <goab-text mb="s">
+      Chip div is <code>role="presentation"</code>; the close icon button is the focusable element.
+      It already uses <code>:focus-visible</code> (no change needed here).
+    </goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-filter-chip content="Status: active" version="2"></goab-filter-chip>
+      <goab-filter-chip content="Priority: high" version="2"></goab-filter-chip>
+      <goab-filter-chip content="Owner: Tom" version="2"></goab-filter-chip>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">FilterChip V1 (fixed in this PR)</goab-text>
+    <goab-text mb="s">
+      Whole chip is <code>tabindex="0" role="button"</code>. Removed <code>class:focused</code> binding;
+      outline now on <code>.chip:focus-visible .delete-icon</code>.
+    </goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-filter-chip content="Status: active" version="1"></goab-filter-chip>
+      <goab-filter-chip content="Priority: high" version="1"></goab-filter-chip>
+      <goab-filter-chip content="Owner: Tom" version="1"></goab-filter-chip>
+    </goab-block>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 3. Plain link reset -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      3. Plain link reset — use <code>:focus-visible</code> only
+    </goab-text>
+    <goab-text mb="s">
+      Unstyled anchors pick up the global reset from <code>assets/css/reset.css</code>.
+      Dropped both <code>:focus</code> and <code>:focus-within</code>.
+    </goab-text>
+    <div style="display: flex; flex-wrap: wrap; gap: 1rem;">
+      <a href="#first">First link</a>
+      <a href="#second">Second link</a>
+      <a href="#third">Third link</a>
+    </div>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 4. TextArea error state -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      4. TextArea error state — <code>.error:focus</code> + V2 combined selector
+    </goab-text>
+    <goab-text mb="s">
+      Tab into each error text area. Click into each. The <code>:focus-within</code> container
+      pattern should still apply on focus (correct for text inputs).
+    </goab-text>
+    <goab-text tag="h4" mt="s" mb="xs">V1 error</goab-text>
+    <goab-textarea name="v1-error" [error]="true" version="1"></goab-textarea>
+    <goab-text tag="h4" mt="m" mb="xs">V2 error</goab-text>
+    <goab-textarea name="v2-error" [error]="true" version="2"></goab-textarea>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 5. Button variants -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      5. Button — drop <code>:focus</code> from combined selectors
+    </goab-text>
+    <goab-text mb="s">
+      Click and Tab each variant across V1 and V2. Watch for lingering rings after mouse-up.
+    </goab-text>
+
+    <goab-text tag="h4" mt="s" mb="xs">V1 — default</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-button type="primary" version="1">Primary</goab-button>
+      <goab-button type="secondary" version="1">Secondary</goab-button>
+      <goab-button type="tertiary" version="1">Tertiary</goab-button>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">V1 — destructive</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-button type="primary" variant="destructive" version="1">Primary destructive</goab-button>
+      <goab-button type="secondary" variant="destructive" version="1">Secondary destructive</goab-button>
+      <goab-button type="tertiary" variant="destructive" version="1">Tertiary destructive</goab-button>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">V1 — inverse (on dark bg)</goab-text>
+    <div style="background-color: var(--goa-color-greyscale-black, #1f1f1f); padding: 1rem; border-radius: 0.25rem; display: flex; flex-wrap: wrap; gap: 1rem; align-items: center;">
+      <goab-button type="primary" variant="inverse" version="1">Primary inverse</goab-button>
+      <goab-button type="secondary" variant="inverse" version="1">Secondary inverse</goab-button>
+      <goab-button type="tertiary" variant="inverse" version="1">Tertiary inverse</goab-button>
+    </div>
+
+    <goab-text tag="h4" mt="m" mb="xs">V2 — default</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-button type="primary" version="2">Primary</goab-button>
+      <goab-button type="secondary" version="2">Secondary</goab-button>
+      <goab-button type="tertiary" version="2">Tertiary</goab-button>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">V2 — destructive</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-button type="primary" variant="destructive" version="2">Primary destructive</goab-button>
+      <goab-button type="secondary" variant="destructive" version="2">Secondary destructive</goab-button>
+      <goab-button type="tertiary" variant="destructive" version="2">Tertiary destructive</goab-button>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">V2 — inverse (on dark bg)</goab-text>
+    <div style="background-color: var(--goa-color-greyscale-black, #1f1f1f); padding: 1rem; border-radius: 0.25rem; display: flex; flex-wrap: wrap; gap: 1rem; align-items: center;">
+      <goab-button type="primary" variant="inverse" version="2">Primary inverse</goab-button>
+      <goab-button type="secondary" variant="inverse" version="2">Secondary inverse</goab-button>
+      <goab-button type="tertiary" variant="inverse" version="2">Tertiary inverse</goab-button>
+    </div>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 6. Checkbox -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      6. Checkbox — drop <code>:has(:focus)</code> duplicates from V1
+    </goab-text>
+    <goab-text mb="s">
+      V1 had 10 rules pairing <code>:has(:focus-visible)</code> with <code>:has(:focus)</code>.
+      The <code>:focus</code> duplicate fired on mouse click. V2 already correct.
+    </goab-text>
+
+    <goab-text tag="h4" mt="s" mb="xs">V1 — normal</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-checkbox name="v1-a" text="Option A" version="1"></goab-checkbox>
+      <goab-checkbox name="v1-b" text="Option B" version="1" [checked]="true"></goab-checkbox>
+      <goab-checkbox name="v1-c" text="Option C" version="1"></goab-checkbox>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">V1 — error</goab-text>
+    <goab-checkbox name="v1-err" text="With error" version="1" [error]="true"></goab-checkbox>
+
+    <goab-text tag="h4" mt="m" mb="xs">V2 — normal</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-checkbox name="v2-a" text="Option A" version="2"></goab-checkbox>
+      <goab-checkbox name="v2-b" text="Option B" version="2" [checked]="true"></goab-checkbox>
+      <goab-checkbox name="v2-c" text="Option C" version="2"></goab-checkbox>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">V2 — error</goab-text>
+    <goab-checkbox name="v2-err" text="With error" version="2" [error]="true"></goab-checkbox>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 7. Link -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      7. Link — <code>::slotted(a:focus-visible)</code>
+    </goab-text>
+    <goab-text mb="s">
+      Ring is now on the slotted anchor directly (reliable across shadow DOM).
+      <strong>Trade-off:</strong> ring wraps the anchor text only, not the icons.
+    </goab-text>
+
+    <goab-text tag="h4" mt="s" mb="xs">Plain links</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-link version="2"><a href="#link-a">First link</a></goab-link>
+      <goab-link version="2"><a href="#link-b">Second link</a></goab-link>
+      <goab-link version="2"><a href="#link-c">Third link</a></goab-link>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">Links with leading icons</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-link version="2" leadingIcon="download"><a href="#link-dl">Download file</a></goab-link>
+      <goab-link version="2" leadingIcon="information-circle"><a href="#link-info">Learn more</a></goab-link>
+      <goab-link version="2" leadingIcon="open"><a href="#link-ext">Open in new tab</a></goab-link>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">Links with trailing icons</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-link version="2" trailingIcon="arrow-forward"><a href="#link-next">Continue</a></goab-link>
+      <goab-link version="2" trailingIcon="chevron-forward"><a href="#link-more">See more</a></goab-link>
+      <goab-link version="2" trailingIcon="open"><a href="#link-ext2">External resource</a></goab-link>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">Links with both icons</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-link version="2" leadingIcon="download" trailingIcon="arrow-forward"><a href="#link-both">Download and continue</a></goab-link>
+    </goab-block>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 8. Notification -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      8. Notification — <code>::slotted(a:focus)</code> → <code>:focus-visible</code>
+    </goab-text>
+    <goab-text mb="s">
+      8 rules (V1 + V2 variants) styled slotted anchors on <code>:focus</code>. Now keyboard only.
+    </goab-text>
+
+    <goab-text tag="h4" mt="s" mb="xs">V1 Notifications</goab-text>
+    <goab-notification type="information">
+      Info notification with a <a href="#n-v1-info">link</a> inside.
+    </goab-notification>
+    <div style="margin-top: var(--goa-space-s);">
+      <goab-notification type="important">
+        Important notification with a <a href="#n-v1-imp">link</a> inside.
+      </goab-notification>
+    </div>
+
+    <goab-text tag="h4" mt="m" mb="xs">V2 Notifications</goab-text>
+    <goab-notification type="information" importance="high" version="2">
+      Information high with a <a href="#n-v2-info-h">link</a> inside.
+    </goab-notification>
+    <div style="margin-top: var(--goa-space-s);">
+      <goab-notification type="important" importance="high" version="2">
+        Important high with a <a href="#n-v2-imp-h">link</a> inside.
+      </goab-notification>
+    </div>
+    <div style="margin-top: var(--goa-space-s);">
+      <goab-notification type="emergency" importance="high" version="2">
+        Emergency high with a <a href="#n-v2-em-h">link</a> inside.
+      </goab-notification>
+    </div>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 9. Tooltip -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      9. Tooltip — <code>.tooltip:focus .tooltip-text</code> → <code>:focus-visible</code>
+    </goab-text>
+    <goab-text mb="s">
+      Previously mouse-clicking the tooltip trigger revealed the tooltip. Now hover for mouse,
+      keyboard focus for keyboard.
+    </goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-tooltip content="Helpful tip goes here" version="2">
+        <goab-button type="secondary" version="2">Hover or Tab me</goab-button>
+      </goab-tooltip>
+    </goab-block>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 10. Details -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      10. Details — <code>summary:focus</code> → <code>:focus-visible</code>
+    </goab-text>
+    <goab-text mb="s">
+      Previously clicking the summary left a hover-ish style. Now click just toggles open;
+      keyboard focus shows the focused look.
+    </goab-text>
+    <goab-details heading="Click me to expand" version="2">
+      Content inside the details component.
+    </goab-details>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 11. DataGrid -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      11. DataGrid — realistic table usage
+    </goab-text>
+    <goab-text mb="s">
+      Typical pattern: <code>goab-data-grid</code> wrapping a <code>goab-table</code>. Focus styling
+      is JS-driven, now guarded with a keyboard-input tracker so mouse click doesn't show the ring.
+    </goab-text>
+    <goab-data-grid keyboardNav="table" keyboardIconPosition="right">
+      <goab-table width="100%" version="2">
+        <thead>
+          <tr data-grid="row">
+            <th data-grid="cell">Name</th>
+            <th data-grid="cell">Role</th>
+            <th data-grid="cell">Status</th>
+            <th data-grid="cell">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-grid="row">
+            <td data-grid="cell">Alice Johnson</td>
+            <td data-grid="cell">Developer</td>
+            <td data-grid="cell"><goab-badge version="2" type="success" content="Active"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell">Bob Smith</td>
+            <td data-grid="cell">Designer</td>
+            <td data-grid="cell"><goab-badge version="2" type="success" content="Active"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell">Carol White</td>
+            <td data-grid="cell">Manager</td>
+            <td data-grid="cell"><goab-badge version="2" type="information" content="Away"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell">David Brown</td>
+            <td data-grid="cell">Analyst</td>
+            <td data-grid="cell"><goab-badge version="2" type="success" content="Active"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+        </tbody>
+      </goab-table>
+    </goab-data-grid>
+
+    <goab-text tag="h4" mt="l" mb="xs">DataGrid around cards (layout mode)</goab-text>
+    <goab-text mb="s">
+      <code>keyboardNav="layout"</code>. Each card is a row, cells include the checkbox, name,
+      badge, stat blocks, and menu button.
+    </goab-text>
+    <goab-data-grid keyboardNav="layout" keyboardIconPosition="right">
+      <goab-container version="2" mt="m" data-grid="row" maxWidth="100%">
+        <div style="display: flex; flex-direction: row; gap: var(--goa-space-m); align-items: flex-start;">
+          <goab-checkbox version="2" data-grid="cell-0" name="user-1"></goab-checkbox>
+          <div style="display: flex; flex-direction: column; gap: var(--goa-space-m); flex: 1; min-width: 0;">
+            <goab-block version="2" direction="row" gap="s" alignment="center">
+              <strong data-grid="cell-1">Mike Zwei</strong>
+              <goab-block data-grid="cell-2">
+                <goab-badge version="2" type="success" content="Removed"></goab-badge>
+              </goab-block>
+            </goab-block>
+            <div style="display: flex; flex-wrap: wrap; gap: var(--goa-space-xl);">
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-4">
+                <strong>Updated</strong>
+                <span>Jun 30, 2022 at 2:30 PM</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-5">
+                <strong>Email</strong>
+                <span>mike.zwei&#64;gmail.com</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-6">
+                <strong>Program</strong>
+                <span>Wee Wild Ones Curry</span>
+              </goab-block>
+            </div>
+            <div style="display: flex; flex-wrap: wrap; gap: var(--goa-space-xl);">
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-7">
+                <strong>Program ID</strong>
+                <span>74528567</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-8">
+                <strong>Service access</strong>
+                <span>Claims Adjustments</span>
+              </goab-block>
+            </div>
+          </div>
+          <goab-menu-button version="2" data-grid="cell-3" text="Actions" type="tertiary" size="compact">
+            <goab-menu-action version="2" action="open" text="Open"></goab-menu-action>
+            <goab-menu-action version="2" action="delete" text="Delete"></goab-menu-action>
+          </goab-menu-button>
+        </div>
+      </goab-container>
+
+      <goab-container version="2" mt="m" data-grid="row" maxWidth="100%">
+        <div style="display: flex; flex-direction: row; gap: var(--goa-space-m); align-items: flex-start;">
+          <goab-checkbox version="2" data-grid="cell-0" name="user-2"></goab-checkbox>
+          <div style="display: flex; flex-direction: column; gap: var(--goa-space-m); flex: 1; min-width: 0;">
+            <goab-block version="2" direction="row" gap="s" alignment="center">
+              <strong data-grid="cell-1">Emma Stroman</strong>
+              <goab-block data-grid="cell-2">
+                <goab-badge version="2" type="emergency" content="To be removed"></goab-badge>
+              </goab-block>
+            </goab-block>
+            <div style="display: flex; flex-wrap: wrap; gap: var(--goa-space-xl);">
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-4">
+                <strong>Updated</strong>
+                <span>Nov 28, 2021 at 1:30 PM</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-5">
+                <strong>Email</strong>
+                <span>emma.stroman&#64;gmail.com</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-6">
+                <strong>Program</strong>
+                <span>Fort McMurray</span>
+              </goab-block>
+            </div>
+            <div style="display: flex; flex-wrap: wrap; gap: var(--goa-space-xl);">
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-7">
+                <strong>Program ID</strong>
+                <span>74522643</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-8">
+                <strong>Service access</strong>
+                <span>Claims Adjustments</span>
+              </goab-block>
+            </div>
+          </div>
+          <goab-menu-button version="2" data-grid="cell-3" text="Actions" type="tertiary" size="compact">
+            <goab-menu-action version="2" action="open" text="Open"></goab-menu-action>
+            <goab-menu-action version="2" action="delete" text="Delete"></goab-menu-action>
+          </goab-menu-button>
+        </div>
+      </goab-container>
+    </goab-data-grid>
+  </section>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3605/bug3605.component.html
+++ b/apps/prs/angular/src/routes/bugs/3605/bug3605.component.html
@@ -1,0 +1,445 @@
+<div style="padding: 2rem; display: flex; flex-direction: column; gap: 1rem; max-width: 72rem; margin: 0 auto;">
+  <goab-text tag="h5" mb="xs" color="secondary">Issue 3605</goab-text>
+  <goab-text tag="h1" mt="0" mb="0">
+    Use <code>:focus-visible</code> across interactive components
+  </goab-text>
+
+  <goab-block>
+    <goab-link version="2" trailingIcon="open">
+      <a href="https://github.com/GovAlta/ui-components/issues/3605" target="_blank" rel="noopener">
+        View on GitHub
+      </a>
+    </goab-link>
+  </goab-block>
+
+  <goab-text mb="0">
+    For every section: <strong>Tab</strong> should show the focus ring with the correct gap/offset.
+    <strong>Click</strong> should not leave a lingering ring. <strong>Mouse-down (<code>:active</code>)</strong>
+    on buttons should still show the pressed/focused look.
+  </goab-text>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 1. MicrositeHeader -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">MicrositeHeader</goab-text>
+    <goab-text mb="s">Tab through the links inside the header. Click any link.</goab-text>
+    <goab-microsite-header type="beta" version="2" headerUrl="https://www.alberta.ca" feedbackUrl="#"></goab-microsite-header>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 2. Chip + FilterChip -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">Chip and FilterChip</goab-text>
+    <goab-text tag="h4" mt="s" mb="xs">Chip (deprecated)</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-chip content="Status: active"></goab-chip>
+      <goab-chip content="Priority: high" [deletable]="true"></goab-chip>
+      <goab-chip content="Owner: Tom"></goab-chip>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">FilterChip</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-filter-chip content="Status: active" version="2"></goab-filter-chip>
+      <goab-filter-chip content="Priority: high" version="2"></goab-filter-chip>
+      <goab-filter-chip content="Owner: Tom" version="2"></goab-filter-chip>
+    </goab-block>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 3. Plain link reset -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">Plain link reset</goab-text>
+    <goab-text mb="s">Unstyled anchors pick up the global reset from <code>assets/css/reset.css</code>.</goab-text>
+    <div style="display: flex; flex-wrap: wrap; gap: 1rem;">
+      <a href="#first">First link</a>
+      <a href="#second">Second link</a>
+      <a href="#third">Third link</a>
+    </div>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 4. TextArea error state -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">TextArea error state</goab-text>
+    <goab-text mb="s">
+      Tab into the error text area. Click into it. The focus-within container pattern
+      applies on focus, which is correct for text inputs.
+    </goab-text>
+    <goab-textarea name="err" [error]="true" version="2"></goab-textarea>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 5. Button variants -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">Button</goab-text>
+    <goab-text mb="s">
+      Click and Tab each variant. Watch for lingering rings after mouse-up.
+    </goab-text>
+
+    <goab-text tag="h4" mt="s" mb="xs">Default</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-button type="primary" version="2">Primary</goab-button>
+      <goab-button type="secondary" version="2">Secondary</goab-button>
+      <goab-button type="tertiary" version="2">Tertiary</goab-button>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">Destructive</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-button type="primary" variant="destructive" version="2">Primary destructive</goab-button>
+      <goab-button type="secondary" variant="destructive" version="2">Secondary destructive</goab-button>
+      <goab-button type="tertiary" variant="destructive" version="2">Tertiary destructive</goab-button>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">Inverse (on dark bg)</goab-text>
+    <div style="background-color: var(--goa-color-greyscale-black, #1f1f1f); padding: 1rem; border-radius: 0.25rem; display: flex; flex-wrap: wrap; gap: 1rem; align-items: center;">
+      <goab-button type="primary" variant="inverse" version="2">Primary inverse</goab-button>
+      <goab-button type="secondary" variant="inverse" version="2">Secondary inverse</goab-button>
+      <goab-button type="tertiary" variant="inverse" version="2">Tertiary inverse</goab-button>
+    </div>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 6. Checkbox -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">Checkbox</goab-text>
+    <goab-text mb="s">Tab to each. Click each. No ring on mouse click.</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-checkbox name="a" text="Option A" version="2"></goab-checkbox>
+      <goab-checkbox name="b" text="Option B" version="2" [checked]="true"></goab-checkbox>
+      <goab-checkbox name="c" text="Option C" version="2"></goab-checkbox>
+    </goab-block>
+    <div style="margin-top: var(--goa-space-m);">
+      <goab-checkbox name="err" text="With error" version="2" [error]="true"></goab-checkbox>
+    </div>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 7. Link -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      7. Link — <code>::slotted(a:focus-visible)</code>
+    </goab-text>
+    <goab-text mb="s">
+      Ring is now on the slotted anchor directly (reliable across shadow DOM).
+      <strong>Trade-off:</strong> ring wraps the anchor text only, not the icons.
+    </goab-text>
+
+    <goab-text tag="h4" mt="s" mb="xs">Plain links</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-link version="2"><a href="#link-a">First link</a></goab-link>
+      <goab-link version="2"><a href="#link-b">Second link</a></goab-link>
+      <goab-link version="2"><a href="#link-c">Third link</a></goab-link>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">Links with leading icons</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-link version="2" leadingIcon="download"><a href="#link-dl">Download file</a></goab-link>
+      <goab-link version="2" leadingIcon="information-circle"><a href="#link-info">Learn more</a></goab-link>
+      <goab-link version="2" leadingIcon="open"><a href="#link-ext">Open in new tab</a></goab-link>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">Links with trailing icons</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-link version="2" trailingIcon="arrow-forward"><a href="#link-next">Continue</a></goab-link>
+      <goab-link version="2" trailingIcon="chevron-forward"><a href="#link-more">See more</a></goab-link>
+      <goab-link version="2" trailingIcon="open"><a href="#link-ext2">External resource</a></goab-link>
+    </goab-block>
+
+    <goab-text tag="h4" mt="m" mb="xs">Links with both icons</goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-link version="2" leadingIcon="download" trailingIcon="arrow-forward"><a href="#link-both">Download and continue</a></goab-link>
+    </goab-block>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 8. Notification -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">Notification</goab-text>
+    <goab-text mb="s">
+      Slotted anchors in notifications now use focus-visible. Keyboard only.
+    </goab-text>
+
+    <goab-notification type="information" importance="high" version="2">
+      Info notification with a <a href="#n-info">link</a> inside.
+    </goab-notification>
+    <div style="margin-top: var(--goa-space-s);">
+      <goab-notification type="important" importance="high" version="2">
+        Important notification with a <a href="#n-imp">link</a> inside.
+      </goab-notification>
+    </div>
+    <div style="margin-top: var(--goa-space-s);">
+      <goab-notification type="emergency" importance="high" version="2">
+        Emergency notification with a <a href="#n-em">link</a> inside.
+      </goab-notification>
+    </div>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 9. Tooltip -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      9. Tooltip — <code>.tooltip:focus .tooltip-text</code> → <code>:focus-visible</code>
+    </goab-text>
+    <goab-text mb="s">
+      Previously mouse-clicking the tooltip trigger revealed the tooltip. Now hover for mouse,
+      keyboard focus for keyboard.
+    </goab-text>
+    <goab-block gap="m" alignment="center">
+      <goab-tooltip content="Helpful tip goes here" version="2">
+        <goab-button type="secondary" version="2">Hover or Tab me</goab-button>
+      </goab-tooltip>
+    </goab-block>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 10. Details -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      10. Details — <code>summary:focus</code> → <code>:focus-visible</code>
+    </goab-text>
+    <goab-text mb="s">
+      Previously clicking the summary left a hover-ish style. Now click just toggles open;
+      keyboard focus shows the focused look.
+    </goab-text>
+    <goab-details heading="Click me to expand" version="2">
+      Content inside the details component.
+    </goab-details>
+  </section>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <!-- 11. DataGrid -->
+  <section>
+    <goab-text tag="h2" mt="0" mb="xs">
+      11. DataGrid — realistic table usage
+    </goab-text>
+    <goab-text mb="s">
+      Typical pattern: <code>goab-data-grid</code> wrapping a <code>goab-table</code>. Focus styling
+      is JS-driven, now guarded with a keyboard-input tracker so mouse click doesn't show the ring.
+    </goab-text>
+    <goab-data-grid keyboardNav="table" keyboardIconPosition="right">
+      <goab-table width="100%" version="2">
+        <thead>
+          <tr data-grid="row">
+            <th data-grid="cell">Name</th>
+            <th data-grid="cell">Role</th>
+            <th data-grid="cell">Status</th>
+            <th data-grid="cell">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-grid="row">
+            <td data-grid="cell">Alice Johnson</td>
+            <td data-grid="cell">Developer</td>
+            <td data-grid="cell"><goab-badge version="2" type="success" content="Active"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell">Bob Smith</td>
+            <td data-grid="cell">Designer</td>
+            <td data-grid="cell"><goab-badge version="2" type="success" content="Active"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell">Carol White</td>
+            <td data-grid="cell">Manager</td>
+            <td data-grid="cell"><goab-badge version="2" type="information" content="Away"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell">David Brown</td>
+            <td data-grid="cell">Analyst</td>
+            <td data-grid="cell"><goab-badge version="2" type="success" content="Active"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+        </tbody>
+      </goab-table>
+    </goab-data-grid>
+
+    <goab-text tag="h4" mt="l" mb="xs">DataGrid around a table with row checkboxes</goab-text>
+    <goab-text mb="s">
+      Adds a select-all checkbox to the header row and per-row checkboxes. When focus
+      lands on a cell whose only focusable child is the checkbox, focus delegates to
+      the checkbox itself. The corner cells should still show the rounded focus
+      treatment.
+    </goab-text>
+    <goab-data-grid keyboardNav="table" keyboardIconPosition="right">
+      <goab-table width="100%" version="2">
+        <thead>
+          <tr data-grid="row">
+            <th data-grid="cell"><goab-checkbox name="select-all"></goab-checkbox></th>
+            <th data-grid="cell">Name</th>
+            <th data-grid="cell">Role</th>
+            <th data-grid="cell">Status</th>
+            <th data-grid="cell">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-grid="row">
+            <td data-grid="cell"><goab-checkbox name="select-alice"></goab-checkbox></td>
+            <td data-grid="cell">Alice Johnson</td>
+            <td data-grid="cell">Developer</td>
+            <td data-grid="cell"><goab-badge version="2" type="success" content="Active"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell"><goab-checkbox name="select-bob"></goab-checkbox></td>
+            <td data-grid="cell">Bob Smith</td>
+            <td data-grid="cell">Designer</td>
+            <td data-grid="cell"><goab-badge version="2" type="success" content="Active"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell"><goab-checkbox name="select-carol"></goab-checkbox></td>
+            <td data-grid="cell">Carol White</td>
+            <td data-grid="cell">Manager</td>
+            <td data-grid="cell"><goab-badge version="2" type="information" content="Away"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell"><goab-checkbox name="select-david"></goab-checkbox></td>
+            <td data-grid="cell">David Brown</td>
+            <td data-grid="cell">Analyst</td>
+            <td data-grid="cell"><goab-badge version="2" type="success" content="Active"></goab-badge></td>
+            <td data-grid="cell"><goab-button version="2" type="tertiary" size="compact">View</goab-button></td>
+          </tr>
+        </tbody>
+      </goab-table>
+    </goab-data-grid>
+
+    <goab-text tag="h4" mt="l" mb="xs">DataGrid around a sortable table</goab-text>
+    <goab-text mb="s">
+      goab-table with onSort handler and goab-table-sort-header on each column. Age
+      column starts ascending. Tab into a sort header, press Enter or Space to
+      toggle. Click a sort header with mouse should sort but not leave a lingering
+      ring. Arrow keys still navigate cells.
+    </goab-text>
+    <goab-data-grid keyboardNav="table" keyboardIconPosition="right">
+      <goab-table width="100%" version="2" (onSort)="onSort($event)">
+        <thead>
+          <tr data-grid="row">
+            <th data-grid="cell">
+              <goab-table-sort-header name="name">Name</goab-table-sort-header>
+            </th>
+            <th data-grid="cell">
+              <goab-table-sort-header name="role">Role</goab-table-sort-header>
+            </th>
+            <th data-grid="cell">
+              <goab-table-sort-header name="age" direction="asc">Age</goab-table-sort-header>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (p of sortablePeople; track p.name) {
+            <tr data-grid="row">
+              <td data-grid="cell">{{ p.name }}</td>
+              <td data-grid="cell">{{ p.role }}</td>
+              <td data-grid="cell">{{ p.age }}</td>
+            </tr>
+          }
+        </tbody>
+      </goab-table>
+    </goab-data-grid>
+
+    <goab-text tag="h4" mt="l" mb="xs">DataGrid around cards (layout mode)</goab-text>
+    <goab-text mb="s">
+      <code>keyboardNav="layout"</code>. Each card is a row, cells include the checkbox, name,
+      badge, stat blocks, and menu button.
+    </goab-text>
+    <goab-data-grid keyboardNav="layout" keyboardIconPosition="right">
+      <goab-container version="2" mt="m" data-grid="row" maxWidth="100%">
+        <div style="display: flex; flex-direction: row; gap: var(--goa-space-m); align-items: flex-start;">
+          <goab-checkbox version="2" data-grid="cell-0" name="user-1"></goab-checkbox>
+          <div style="display: flex; flex-direction: column; gap: var(--goa-space-m); flex: 1; min-width: 0;">
+            <goab-block version="2" direction="row" gap="s" alignment="center">
+              <strong data-grid="cell-1">Mike Zwei</strong>
+              <goab-block data-grid="cell-2">
+                <goab-badge version="2" type="success" content="Removed"></goab-badge>
+              </goab-block>
+            </goab-block>
+            <div style="display: flex; flex-wrap: wrap; gap: var(--goa-space-xl);">
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-4">
+                <strong>Updated</strong>
+                <span>Jun 30, 2022 at 2:30 PM</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-5">
+                <strong>Email</strong>
+                <span>mike.zwei&#64;gmail.com</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-6">
+                <strong>Program</strong>
+                <span>Wee Wild Ones Curry</span>
+              </goab-block>
+            </div>
+            <div style="display: flex; flex-wrap: wrap; gap: var(--goa-space-xl);">
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-7">
+                <strong>Program ID</strong>
+                <span>74528567</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-8">
+                <strong>Service access</strong>
+                <span>Claims Adjustments</span>
+              </goab-block>
+            </div>
+          </div>
+          <goab-menu-button version="2" data-grid="cell-3" text="Actions" type="tertiary" size="compact">
+            <goab-menu-action version="2" action="open" text="Open"></goab-menu-action>
+            <goab-menu-action version="2" action="delete" text="Delete"></goab-menu-action>
+          </goab-menu-button>
+        </div>
+      </goab-container>
+
+      <goab-container version="2" mt="m" data-grid="row" maxWidth="100%">
+        <div style="display: flex; flex-direction: row; gap: var(--goa-space-m); align-items: flex-start;">
+          <goab-checkbox version="2" data-grid="cell-0" name="user-2"></goab-checkbox>
+          <div style="display: flex; flex-direction: column; gap: var(--goa-space-m); flex: 1; min-width: 0;">
+            <goab-block version="2" direction="row" gap="s" alignment="center">
+              <strong data-grid="cell-1">Emma Stroman</strong>
+              <goab-block data-grid="cell-2">
+                <goab-badge version="2" type="emergency" content="To be removed"></goab-badge>
+              </goab-block>
+            </goab-block>
+            <div style="display: flex; flex-wrap: wrap; gap: var(--goa-space-xl);">
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-4">
+                <strong>Updated</strong>
+                <span>Nov 28, 2021 at 1:30 PM</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-5">
+                <strong>Email</strong>
+                <span>emma.stroman&#64;gmail.com</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-6">
+                <strong>Program</strong>
+                <span>Fort McMurray</span>
+              </goab-block>
+            </div>
+            <div style="display: flex; flex-wrap: wrap; gap: var(--goa-space-xl);">
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-7">
+                <strong>Program ID</strong>
+                <span>74522643</span>
+              </goab-block>
+              <goab-block version="2" direction="column" gap="xs" data-grid="cell-8">
+                <strong>Service access</strong>
+                <span>Claims Adjustments</span>
+              </goab-block>
+            </div>
+          </div>
+          <goab-menu-button version="2" data-grid="cell-3" text="Actions" type="tertiary" size="compact">
+            <goab-menu-action version="2" action="open" text="Open"></goab-menu-action>
+            <goab-menu-action version="2" action="delete" text="Delete"></goab-menu-action>
+          </goab-menu-button>
+        </div>
+      </goab-container>
+    </goab-data-grid>
+  </section>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3605/bug3605.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3605/bug3605.component.ts
@@ -1,0 +1,52 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabBadge,
+  GoabBlock,
+  GoabButton,
+  GoabCheckbox,
+  GoabChip,
+  GoabContainer,
+  GoabDataGrid,
+  GoabDetails,
+  GoabDivider,
+  GoabFilterChip,
+  GoabLink,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabMicrositeHeader,
+  GoabNotification,
+  GoabTable,
+  GoabText,
+  GoabTextArea,
+  GoabTooltip,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3605",
+  templateUrl: "./bug3605.component.html",
+  imports: [
+    CommonModule,
+    GoabBadge,
+    GoabBlock,
+    GoabButton,
+    GoabCheckbox,
+    GoabChip,
+    GoabContainer,
+    GoabDataGrid,
+    GoabDetails,
+    GoabDivider,
+    GoabFilterChip,
+    GoabLink,
+    GoabMenuAction,
+    GoabMenuButton,
+    GoabMicrositeHeader,
+    GoabNotification,
+    GoabTable,
+    GoabText,
+    GoabTextArea,
+    GoabTooltip,
+  ],
+})
+export class Bug3605Component {}

--- a/apps/prs/angular/src/routes/bugs/3605/bug3605.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3605/bug3605.component.ts
@@ -1,0 +1,72 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabBadge,
+  GoabBlock,
+  GoabButton,
+  GoabCheckbox,
+  GoabChip,
+  GoabContainer,
+  GoabDataGrid,
+  GoabDetails,
+  GoabDivider,
+  GoabFilterChip,
+  GoabLink,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabMicrositeHeader,
+  GoabNotification,
+  GoabTable,
+  GoabTableSortHeader,
+  GoabText,
+  GoabTextArea,
+  GoabTooltip,
+} from "@abgov/angular-components";
+import { GoabTableOnSortDetail } from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3605",
+  templateUrl: "./bug3605.component.html",
+  imports: [
+    CommonModule,
+    GoabBadge,
+    GoabBlock,
+    GoabButton,
+    GoabCheckbox,
+    GoabChip,
+    GoabContainer,
+    GoabDataGrid,
+    GoabDetails,
+    GoabDivider,
+    GoabFilterChip,
+    GoabLink,
+    GoabMenuAction,
+    GoabMenuButton,
+    GoabMicrositeHeader,
+    GoabNotification,
+    GoabTable,
+    GoabTableSortHeader,
+    GoabText,
+    GoabTextArea,
+    GoabTooltip,
+  ],
+})
+export class Bug3605Component {
+  sortablePeople = [
+    { name: "Alice Johnson", role: "Developer", age: 32 },
+    { name: "Bob Smith", role: "Designer", age: 28 },
+    { name: "Carol White", role: "Manager", age: 45 },
+    { name: "David Brown", role: "Analyst", age: 38 },
+  ];
+
+  onSort(detail: GoabTableOnSortDetail) {
+    const by = detail.sortBy as "name" | "role" | "age";
+    const dir = detail.sortDir;
+    this.sortablePeople = [...this.sortablePeople].sort((a, b) => {
+      if (a[by] < b[by]) return dir === 1 ? -1 : 1;
+      if (a[by] > b[by]) return dir === 1 ? 1 : -1;
+      return 0;
+    });
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3605/bug3605.route.json
+++ b/apps/prs/angular/src/routes/bugs/3605/bug3605.route.json
@@ -1,0 +1,6 @@
+{
+    "title":  "Focus visible across interactive components",
+    "path":  "bugs/3605",
+    "id":  "3605",
+    "type":  "bug"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3605.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3605.route.ts
@@ -1,0 +1,9 @@
+import { Bug3605Route } from "../../../routes/bugs/bug3605";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "bug",
+  id: "3605",
+  path: "bugs/3605",
+  title: "Focus visible across interactive components",
+  component: Bug3605Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3605.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3605.tsx
@@ -1,0 +1,378 @@
+import "@abgov/style";
+import {
+  GoabBadge,
+  GoabBlock,
+  GoabButton,
+  GoabCheckbox,
+  GoabChip,
+  GoabContainer,
+  GoabDataGrid,
+  GoabDetails,
+  GoabDivider,
+  GoabFilterChip,
+  GoabLink,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabMicrositeHeader,
+  GoabNotification,
+  GoabTable,
+  GoabText,
+  GoabTextarea,
+  GoabTooltip,
+} from "@abgov/react-components";
+
+export function Bug3605Route() {
+  return (
+    <div style={{ padding: "2rem", display: "flex", flexDirection: "column", gap: "1rem", maxWidth: "72rem", margin: "0 auto" }}>
+      <GoabText tag="h5" mb="xs" color="secondary">
+        Issue 3605
+      </GoabText>
+      <GoabText tag="h1" mt="0" mb="0">
+        Use focus-visible across interactive components
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a href="https://github.com/GovAlta/ui-components/issues/3605" target="_blank" rel="noopener">
+            View on GitHub
+          </a>
+        </GoabLink>
+      </GoabBlock>
+
+      <GoabText mb="0">
+        For every section: Tab should show the focus ring with the correct gap and offset.
+        Click should not leave a lingering ring. Mouse-down on buttons should still show the
+        pressed state.
+      </GoabText>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* MicrositeHeader */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">MicrositeHeader</GoabText>
+        <GoabText mb="s">Tab through the links inside the header. Click any link.</GoabText>
+        <GoabMicrositeHeader type="alpha" version="UAT" />
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Chip + FilterChip */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Chip and FilterChip</GoabText>
+        <GoabText tag="h4" mt="s" mb="xs">Chip (deprecated)</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabChip content="Status: active" />
+          <GoabChip content="Priority: high" deletable />
+          <GoabChip content="Owner: Tom" />
+        </GoabBlock>
+
+        <GoabText tag="h4" mt="m" mb="xs">FilterChip</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabFilterChip content="Status: active" />
+          <GoabFilterChip content="Priority: high" />
+          <GoabFilterChip content="Owner: Tom" />
+        </GoabBlock>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Plain link reset */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Plain link reset</GoabText>
+        <GoabText mb="s">Unstyled anchors pick up the global reset from assets/css/reset.css.</GoabText>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "1rem" }}>
+          <a href="#first">First link</a>
+          <a href="#second">Second link</a>
+          <a href="#third">Third link</a>
+        </div>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* TextArea error */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">TextArea error state</GoabText>
+        <GoabText mb="s">
+          Tab into the error text area. Click into it. The focus-within container pattern
+          applies on focus, which is correct for text inputs.
+        </GoabText>
+        <GoabTextarea name="err" error />
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Button variants */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Button</GoabText>
+        <GoabText mb="s">
+          Click and Tab each variant. Watch for lingering rings after mouse-up.
+        </GoabText>
+
+        <GoabText tag="h4" mt="s" mb="xs">Default</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabButton type="primary">Primary</GoabButton>
+          <GoabButton type="secondary">Secondary</GoabButton>
+          <GoabButton type="tertiary">Tertiary</GoabButton>
+        </GoabBlock>
+
+        <GoabText tag="h4" mt="m" mb="xs">Destructive</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabButton type="primary" variant="destructive">Primary destructive</GoabButton>
+          <GoabButton type="secondary" variant="destructive">Secondary destructive</GoabButton>
+          <GoabButton type="tertiary" variant="destructive">Tertiary destructive</GoabButton>
+        </GoabBlock>
+
+        <GoabText tag="h4" mt="m" mb="xs">Inverse (on dark bg)</GoabText>
+        <div style={{ backgroundColor: "var(--goa-color-greyscale-black, #1f1f1f)", padding: "1rem", borderRadius: "0.25rem", display: "flex", flexWrap: "wrap", gap: "1rem", alignItems: "center" }}>
+          <GoabButton type="primary" variant="inverse">Primary inverse</GoabButton>
+          <GoabButton type="secondary" variant="inverse">Secondary inverse</GoabButton>
+          <GoabButton type="tertiary" variant="inverse">Tertiary inverse</GoabButton>
+        </div>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Checkbox */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Checkbox</GoabText>
+        <GoabText mb="s">Tab to each. Click each. No ring on mouse click.</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabCheckbox name="a" text="Option A" />
+          <GoabCheckbox name="b" text="Option B" checked />
+          <GoabCheckbox name="c" text="Option C" />
+        </GoabBlock>
+        <div style={{ marginTop: "var(--goa-space-m)" }}>
+          <GoabCheckbox name="err" text="With error" error />
+        </div>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Link */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Link</GoabText>
+        <GoabText mb="s">
+          Ring is on the slotted anchor directly (reliable across shadow DOM). Ring wraps
+          the anchor text only, not the icons.
+        </GoabText>
+
+        <GoabText tag="h4" mt="s" mb="xs">Plain links</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabLink><a href="#link-a">First link</a></GoabLink>
+          <GoabLink><a href="#link-b">Second link</a></GoabLink>
+          <GoabLink><a href="#link-c">Third link</a></GoabLink>
+        </GoabBlock>
+
+        <GoabText tag="h4" mt="m" mb="xs">Links with leading icons</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabLink leadingIcon="download"><a href="#link-dl">Download file</a></GoabLink>
+          <GoabLink leadingIcon="information-circle"><a href="#link-info">Learn more</a></GoabLink>
+          <GoabLink leadingIcon="open"><a href="#link-ext">Open in new tab</a></GoabLink>
+        </GoabBlock>
+
+        <GoabText tag="h4" mt="m" mb="xs">Links with trailing icons</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabLink trailingIcon="arrow-forward"><a href="#link-next">Continue</a></GoabLink>
+          <GoabLink trailingIcon="chevron-forward"><a href="#link-more">See more</a></GoabLink>
+          <GoabLink trailingIcon="open"><a href="#link-ext2">External resource</a></GoabLink>
+        </GoabBlock>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Notification */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Notification</GoabText>
+        <GoabText mb="s">
+          Slotted anchors in notifications now use focus-visible. Keyboard only.
+        </GoabText>
+
+        <GoabNotification type="information">
+          Info notification with a <a href="#n-info">link</a> inside.
+        </GoabNotification>
+        <div style={{ marginTop: "var(--goa-space-s)" }}>
+          <GoabNotification type="important">
+            Important notification with a <a href="#n-imp">link</a> inside.
+          </GoabNotification>
+        </div>
+        <div style={{ marginTop: "var(--goa-space-s)" }}>
+          <GoabNotification type="emergency">
+            Emergency notification with a <a href="#n-em">link</a> inside.
+          </GoabNotification>
+        </div>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Tooltip */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Tooltip</GoabText>
+        <GoabText mb="s">
+          Hover for mouse, keyboard focus for keyboard. Mouse click on the trigger does
+          not reveal the tooltip.
+        </GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabTooltip content="Helpful tip goes here">
+            <GoabButton type="secondary">Hover or Tab me</GoabButton>
+          </GoabTooltip>
+        </GoabBlock>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Details */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Details</GoabText>
+        <GoabText mb="s">
+          Click just toggles open. Keyboard focus shows the focused look.
+        </GoabText>
+        <GoabDetails heading="Click me to expand">
+          Content inside the details component.
+        </GoabDetails>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* DataGrid */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">DataGrid around a table</GoabText>
+        <GoabText mb="s">
+          Typical pattern: GoabDataGrid wrapping a GoabTable. Focus styling is JS-driven,
+          now guarded with a keyboard-input tracker so mouse click does not show the ring.
+          Arrow keys navigate cells.
+        </GoabText>
+        <GoabDataGrid keyboardNav="table" keyboardIconPosition="right">
+          <GoabTable width="100%">
+            <thead>
+              <tr data-grid="row">
+                <th data-grid="cell">Name</th>
+                <th data-grid="cell">Role</th>
+                <th data-grid="cell">Status</th>
+                <th data-grid="cell">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-grid="row">
+                <td data-grid="cell">Alice Johnson</td>
+                <td data-grid="cell">Developer</td>
+                <td data-grid="cell"><GoabBadge type="success" content="Active" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+              <tr data-grid="row">
+                <td data-grid="cell">Bob Smith</td>
+                <td data-grid="cell">Designer</td>
+                <td data-grid="cell"><GoabBadge type="success" content="Active" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+              <tr data-grid="row">
+                <td data-grid="cell">Carol White</td>
+                <td data-grid="cell">Manager</td>
+                <td data-grid="cell"><GoabBadge type="information" content="Away" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+              <tr data-grid="row">
+                <td data-grid="cell">David Brown</td>
+                <td data-grid="cell">Analyst</td>
+                <td data-grid="cell"><GoabBadge type="success" content="Active" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+            </tbody>
+          </GoabTable>
+        </GoabDataGrid>
+
+        <GoabText tag="h4" mt="l" mb="xs">DataGrid around cards (layout mode)</GoabText>
+        <GoabText mb="s">
+          keyboardNav=&quot;layout&quot;. Each card is a row, cells include the checkbox,
+          name, badge, stat blocks, and menu button.
+        </GoabText>
+        <GoabDataGrid keyboardNav="layout" keyboardIconPosition="right">
+          <GoabContainer mt="m" data-grid="row">
+            <div style={{ display: "flex", flexDirection: "row", gap: "var(--goa-space-m)", alignItems: "flex-start" }}>
+              <GoabCheckbox data-grid="cell-0" name="user-1" />
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--goa-space-m)", flex: 1, minWidth: 0 }}>
+                <GoabBlock direction="row" gap="s" alignment="center">
+                  <strong data-grid="cell-1">Mike Zwei</strong>
+                  <GoabBlock data-grid="cell-2">
+                    <GoabBadge type="success" content="Removed" />
+                  </GoabBlock>
+                </GoabBlock>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--goa-space-xl)" }}>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-4">
+                    <strong>Updated</strong>
+                    <span>Jun 30, 2022 at 2:30 PM</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-5">
+                    <strong>Email</strong>
+                    <span>mike.zwei@gmail.com</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-6">
+                    <strong>Program</strong>
+                    <span>Wee Wild Ones Curry</span>
+                  </GoabBlock>
+                </div>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--goa-space-xl)" }}>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-7">
+                    <strong>Program ID</strong>
+                    <span>74528567</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-8">
+                    <strong>Service access</strong>
+                    <span>Claims Adjustments</span>
+                  </GoabBlock>
+                </div>
+              </div>
+              <GoabMenuButton data-grid="cell-3" text="Actions" type="tertiary" size="compact">
+                <GoabMenuAction action="open" text="Open" />
+                <GoabMenuAction action="delete" text="Delete" />
+              </GoabMenuButton>
+            </div>
+          </GoabContainer>
+
+          <GoabContainer mt="m" data-grid="row">
+            <div style={{ display: "flex", flexDirection: "row", gap: "var(--goa-space-m)", alignItems: "flex-start" }}>
+              <GoabCheckbox data-grid="cell-0" name="user-2" />
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--goa-space-m)", flex: 1, minWidth: 0 }}>
+                <GoabBlock direction="row" gap="s" alignment="center">
+                  <strong data-grid="cell-1">Emma Stroman</strong>
+                  <GoabBlock data-grid="cell-2">
+                    <GoabBadge type="emergency" content="To be removed" />
+                  </GoabBlock>
+                </GoabBlock>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--goa-space-xl)" }}>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-4">
+                    <strong>Updated</strong>
+                    <span>Nov 28, 2021 at 1:30 PM</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-5">
+                    <strong>Email</strong>
+                    <span>emma.stroman@gmail.com</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-6">
+                    <strong>Program</strong>
+                    <span>Fort McMurray</span>
+                  </GoabBlock>
+                </div>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--goa-space-xl)" }}>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-7">
+                    <strong>Program ID</strong>
+                    <span>74522643</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-8">
+                    <strong>Service access</strong>
+                    <span>Claims Adjustments</span>
+                  </GoabBlock>
+                </div>
+              </div>
+              <GoabMenuButton data-grid="cell-3" text="Actions" type="tertiary" size="compact">
+                <GoabMenuAction action="open" text="Open" />
+                <GoabMenuAction action="delete" text="Delete" />
+              </GoabMenuButton>
+            </div>
+          </GoabContainer>
+        </GoabDataGrid>
+      </section>
+    </div>
+  );
+}
+
+export default Bug3605Route;

--- a/apps/prs/react/src/routes/bugs/bug3605.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3605.tsx
@@ -1,0 +1,483 @@
+import "@abgov/style";
+import { useState } from "react";
+import {
+  GoabBadge,
+  GoabBlock,
+  GoabButton,
+  GoabCheckbox,
+  GoabChip,
+  GoabContainer,
+  GoabDataGrid,
+  GoabDetails,
+  GoabDivider,
+  GoabFilterChip,
+  GoabLink,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabMicrositeHeader,
+  GoabNotification,
+  GoabTable,
+  GoabTableSortHeader,
+  GoabText,
+  GoabTextarea,
+  GoabTooltip,
+} from "@abgov/react-components";
+
+export function Bug3605Route() {
+  const [sortablePeople, setSortablePeople] = useState([
+    { name: "Alice Johnson", role: "Developer", age: 32 },
+    { name: "Bob Smith", role: "Designer", age: 28 },
+    { name: "Carol White", role: "Manager", age: 45 },
+    { name: "David Brown", role: "Analyst", age: 38 },
+  ]);
+
+  return (
+    <div style={{ padding: "2rem", display: "flex", flexDirection: "column", gap: "1rem", maxWidth: "72rem", margin: "0 auto" }}>
+      <GoabText tag="h5" mb="xs" color="secondary">
+        Issue 3605
+      </GoabText>
+      <GoabText tag="h1" mt="0" mb="0">
+        Use focus-visible across interactive components
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a href="https://github.com/GovAlta/ui-components/issues/3605" target="_blank" rel="noopener">
+            View on GitHub
+          </a>
+        </GoabLink>
+      </GoabBlock>
+
+      <GoabText mb="0">
+        For every section: Tab should show the focus ring with the correct gap and offset.
+        Click should not leave a lingering ring. Mouse-down on buttons should still show the
+        pressed state.
+      </GoabText>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* MicrositeHeader */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">MicrositeHeader</GoabText>
+        <GoabText mb="s">Tab through the links inside the header. Click any link.</GoabText>
+        <GoabMicrositeHeader type="alpha" version="UAT" />
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Chip + FilterChip */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Chip and FilterChip</GoabText>
+        <GoabText tag="h4" mt="s" mb="xs">Chip (deprecated)</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabChip content="Status: active" />
+          <GoabChip content="Priority: high" deletable />
+          <GoabChip content="Owner: Tom" />
+        </GoabBlock>
+
+        <GoabText tag="h4" mt="m" mb="xs">FilterChip</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabFilterChip content="Status: active" />
+          <GoabFilterChip content="Priority: high" />
+          <GoabFilterChip content="Owner: Tom" />
+        </GoabBlock>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Plain link reset */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Plain link reset</GoabText>
+        <GoabText mb="s">Unstyled anchors pick up the global reset from assets/css/reset.css.</GoabText>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "1rem" }}>
+          <a href="#first">First link</a>
+          <a href="#second">Second link</a>
+          <a href="#third">Third link</a>
+        </div>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* TextArea error */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">TextArea error state</GoabText>
+        <GoabText mb="s">
+          Tab into the error text area. Click into it. The focus-within container pattern
+          applies on focus, which is correct for text inputs.
+        </GoabText>
+        <GoabTextarea name="err" error />
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Button variants */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Button</GoabText>
+        <GoabText mb="s">
+          Click and Tab each variant. Watch for lingering rings after mouse-up.
+        </GoabText>
+
+        <GoabText tag="h4" mt="s" mb="xs">Default</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabButton type="primary">Primary</GoabButton>
+          <GoabButton type="secondary">Secondary</GoabButton>
+          <GoabButton type="tertiary">Tertiary</GoabButton>
+        </GoabBlock>
+
+        <GoabText tag="h4" mt="m" mb="xs">Destructive</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabButton type="primary" variant="destructive">Primary destructive</GoabButton>
+          <GoabButton type="secondary" variant="destructive">Secondary destructive</GoabButton>
+          <GoabButton type="tertiary" variant="destructive">Tertiary destructive</GoabButton>
+        </GoabBlock>
+
+        <GoabText tag="h4" mt="m" mb="xs">Inverse (on dark bg)</GoabText>
+        <div style={{ backgroundColor: "var(--goa-color-greyscale-black, #1f1f1f)", padding: "1rem", borderRadius: "0.25rem", display: "flex", flexWrap: "wrap", gap: "1rem", alignItems: "center" }}>
+          <GoabButton type="primary" variant="inverse">Primary inverse</GoabButton>
+          <GoabButton type="secondary" variant="inverse">Secondary inverse</GoabButton>
+          <GoabButton type="tertiary" variant="inverse">Tertiary inverse</GoabButton>
+        </div>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Checkbox */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Checkbox</GoabText>
+        <GoabText mb="s">Tab to each. Click each. No ring on mouse click.</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabCheckbox name="a" text="Option A" />
+          <GoabCheckbox name="b" text="Option B" checked />
+          <GoabCheckbox name="c" text="Option C" />
+        </GoabBlock>
+        <div style={{ marginTop: "var(--goa-space-m)" }}>
+          <GoabCheckbox name="err" text="With error" error />
+        </div>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Link */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Link</GoabText>
+        <GoabText mb="s">
+          Ring is on the slotted anchor directly (reliable across shadow DOM). Ring wraps
+          the anchor text only, not the icons.
+        </GoabText>
+
+        <GoabText tag="h4" mt="s" mb="xs">Plain links</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabLink><a href="#link-a">First link</a></GoabLink>
+          <GoabLink><a href="#link-b">Second link</a></GoabLink>
+          <GoabLink><a href="#link-c">Third link</a></GoabLink>
+        </GoabBlock>
+
+        <GoabText tag="h4" mt="m" mb="xs">Links with leading icons</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabLink leadingIcon="download"><a href="#link-dl">Download file</a></GoabLink>
+          <GoabLink leadingIcon="information-circle"><a href="#link-info">Learn more</a></GoabLink>
+          <GoabLink leadingIcon="open"><a href="#link-ext">Open in new tab</a></GoabLink>
+        </GoabBlock>
+
+        <GoabText tag="h4" mt="m" mb="xs">Links with trailing icons</GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabLink trailingIcon="arrow-forward"><a href="#link-next">Continue</a></GoabLink>
+          <GoabLink trailingIcon="chevron-forward"><a href="#link-more">See more</a></GoabLink>
+          <GoabLink trailingIcon="open"><a href="#link-ext2">External resource</a></GoabLink>
+        </GoabBlock>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Notification */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Notification</GoabText>
+        <GoabText mb="s">
+          Slotted anchors in notifications now use focus-visible. Keyboard only.
+        </GoabText>
+
+        <GoabNotification type="information">
+          Info notification with a <a href="#n-info">link</a> inside.
+        </GoabNotification>
+        <div style={{ marginTop: "var(--goa-space-s)" }}>
+          <GoabNotification type="important">
+            Important notification with a <a href="#n-imp">link</a> inside.
+          </GoabNotification>
+        </div>
+        <div style={{ marginTop: "var(--goa-space-s)" }}>
+          <GoabNotification type="emergency">
+            Emergency notification with a <a href="#n-em">link</a> inside.
+          </GoabNotification>
+        </div>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Tooltip */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Tooltip</GoabText>
+        <GoabText mb="s">
+          Hover for mouse, keyboard focus for keyboard. Mouse click on the trigger does
+          not reveal the tooltip.
+        </GoabText>
+        <GoabBlock gap="m" alignment="center">
+          <GoabTooltip content="Helpful tip goes here">
+            <GoabButton type="secondary">Hover or Tab me</GoabButton>
+          </GoabTooltip>
+        </GoabBlock>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* Details */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">Details</GoabText>
+        <GoabText mb="s">
+          Click just toggles open. Keyboard focus shows the focused look.
+        </GoabText>
+        <GoabDetails heading="Click me to expand">
+          Content inside the details component.
+        </GoabDetails>
+      </section>
+
+      <GoabDivider mt="l" mb="l" />
+
+      {/* DataGrid */}
+      <section>
+        <GoabText tag="h2" mt="0" mb="xs">DataGrid around a table</GoabText>
+        <GoabText mb="s">
+          Typical pattern: GoabDataGrid wrapping a GoabTable. Focus styling is JS-driven,
+          now guarded with a keyboard-input tracker so mouse click does not show the ring.
+          Arrow keys navigate cells.
+        </GoabText>
+        <GoabDataGrid keyboardNav="table" keyboardIconPosition="right">
+          <GoabTable width="100%">
+            <thead>
+              <tr data-grid="row">
+                <th data-grid="cell">Name</th>
+                <th data-grid="cell">Role</th>
+                <th data-grid="cell">Status</th>
+                <th data-grid="cell">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-grid="row">
+                <td data-grid="cell">Alice Johnson</td>
+                <td data-grid="cell">Developer</td>
+                <td data-grid="cell"><GoabBadge type="success" content="Active" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+              <tr data-grid="row">
+                <td data-grid="cell">Bob Smith</td>
+                <td data-grid="cell">Designer</td>
+                <td data-grid="cell"><GoabBadge type="success" content="Active" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+              <tr data-grid="row">
+                <td data-grid="cell">Carol White</td>
+                <td data-grid="cell">Manager</td>
+                <td data-grid="cell"><GoabBadge type="information" content="Away" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+              <tr data-grid="row">
+                <td data-grid="cell">David Brown</td>
+                <td data-grid="cell">Analyst</td>
+                <td data-grid="cell"><GoabBadge type="success" content="Active" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+            </tbody>
+          </GoabTable>
+        </GoabDataGrid>
+
+        <GoabText tag="h4" mt="l" mb="xs">DataGrid around a table with row checkboxes</GoabText>
+        <GoabText mb="s">
+          Adds a select-all checkbox to the header row and per-row checkboxes.
+          When focus lands on a cell whose only focusable child is the checkbox,
+          focus delegates to the checkbox itself. The corner cells should still
+          show the rounded focus treatment.
+        </GoabText>
+        <GoabDataGrid keyboardNav="table" keyboardIconPosition="right">
+          <GoabTable width="100%">
+            <thead>
+              <tr data-grid="row">
+                <th data-grid="cell"><GoabCheckbox name="select-all" /></th>
+                <th data-grid="cell">Name</th>
+                <th data-grid="cell">Role</th>
+                <th data-grid="cell">Status</th>
+                <th data-grid="cell">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-grid="row">
+                <td data-grid="cell"><GoabCheckbox name="select-alice" /></td>
+                <td data-grid="cell">Alice Johnson</td>
+                <td data-grid="cell">Developer</td>
+                <td data-grid="cell"><GoabBadge type="success" content="Active" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+              <tr data-grid="row">
+                <td data-grid="cell"><GoabCheckbox name="select-bob" /></td>
+                <td data-grid="cell">Bob Smith</td>
+                <td data-grid="cell">Designer</td>
+                <td data-grid="cell"><GoabBadge type="success" content="Active" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+              <tr data-grid="row">
+                <td data-grid="cell"><GoabCheckbox name="select-carol" /></td>
+                <td data-grid="cell">Carol White</td>
+                <td data-grid="cell">Manager</td>
+                <td data-grid="cell"><GoabBadge type="information" content="Away" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+              <tr data-grid="row">
+                <td data-grid="cell"><GoabCheckbox name="select-david" /></td>
+                <td data-grid="cell">David Brown</td>
+                <td data-grid="cell">Analyst</td>
+                <td data-grid="cell"><GoabBadge type="success" content="Active" /></td>
+                <td data-grid="cell"><GoabButton type="tertiary" size="compact">View</GoabButton></td>
+              </tr>
+            </tbody>
+          </GoabTable>
+        </GoabDataGrid>
+
+        <GoabText tag="h4" mt="l" mb="xs">DataGrid around a sortable table</GoabText>
+        <GoabText mb="s">
+          GoabTable with onSort handler and GoabTableSortHeader on each column. Age
+          column starts ascending. Tab into a sort header, press Enter or Space to
+          toggle. Click a sort header with mouse should sort but not leave a
+          lingering ring. Arrow keys still navigate cells.
+        </GoabText>
+        <GoabDataGrid keyboardNav="table" keyboardIconPosition="right">
+          <GoabTable
+            width="100%"
+            onSort={(e) => {
+              const by = e.sortBy as "name" | "role" | "age";
+              const dir = e.sortDir;
+              setSortablePeople([...sortablePeople].sort((a, b) => {
+                if (a[by] < b[by]) return dir === 1 ? -1 : 1;
+                if (a[by] > b[by]) return dir === 1 ? 1 : -1;
+                return 0;
+              }));
+            }}
+          >
+            <thead>
+              <tr data-grid="row">
+                <th data-grid="cell">
+                  <GoabTableSortHeader name="name">Name</GoabTableSortHeader>
+                </th>
+                <th data-grid="cell">
+                  <GoabTableSortHeader name="role">Role</GoabTableSortHeader>
+                </th>
+                <th data-grid="cell">
+                  <GoabTableSortHeader name="age" direction="asc">Age</GoabTableSortHeader>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortablePeople.map((p) => (
+                <tr key={p.name} data-grid="row">
+                  <td data-grid="cell">{p.name}</td>
+                  <td data-grid="cell">{p.role}</td>
+                  <td data-grid="cell">{p.age}</td>
+                </tr>
+              ))}
+            </tbody>
+          </GoabTable>
+        </GoabDataGrid>
+
+        <GoabText tag="h4" mt="l" mb="xs">DataGrid around cards (layout mode)</GoabText>
+        <GoabText mb="s">
+          keyboardNav=&quot;layout&quot;. Each card is a row, cells include the checkbox,
+          name, badge, stat blocks, and menu button.
+        </GoabText>
+        <GoabDataGrid keyboardNav="layout" keyboardIconPosition="right">
+          <GoabContainer mt="m" data-grid="row">
+            <div style={{ display: "flex", flexDirection: "row", gap: "var(--goa-space-m)", alignItems: "flex-start" }}>
+              <GoabCheckbox data-grid="cell-0" name="user-1" />
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--goa-space-m)", flex: 1, minWidth: 0 }}>
+                <GoabBlock direction="row" gap="s" alignment="center">
+                  <strong data-grid="cell-1">Mike Zwei</strong>
+                  <GoabBlock data-grid="cell-2">
+                    <GoabBadge type="success" content="Removed" />
+                  </GoabBlock>
+                </GoabBlock>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--goa-space-xl)" }}>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-4">
+                    <strong>Updated</strong>
+                    <span>Jun 30, 2022 at 2:30 PM</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-5">
+                    <strong>Email</strong>
+                    <span>mike.zwei@gmail.com</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-6">
+                    <strong>Program</strong>
+                    <span>Wee Wild Ones Curry</span>
+                  </GoabBlock>
+                </div>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--goa-space-xl)" }}>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-7">
+                    <strong>Program ID</strong>
+                    <span>74528567</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-8">
+                    <strong>Service access</strong>
+                    <span>Claims Adjustments</span>
+                  </GoabBlock>
+                </div>
+              </div>
+              <GoabMenuButton data-grid="cell-3" text="Actions" type="tertiary" size="compact">
+                <GoabMenuAction action="open" text="Open" />
+                <GoabMenuAction action="delete" text="Delete" />
+              </GoabMenuButton>
+            </div>
+          </GoabContainer>
+
+          <GoabContainer mt="m" data-grid="row">
+            <div style={{ display: "flex", flexDirection: "row", gap: "var(--goa-space-m)", alignItems: "flex-start" }}>
+              <GoabCheckbox data-grid="cell-0" name="user-2" />
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--goa-space-m)", flex: 1, minWidth: 0 }}>
+                <GoabBlock direction="row" gap="s" alignment="center">
+                  <strong data-grid="cell-1">Emma Stroman</strong>
+                  <GoabBlock data-grid="cell-2">
+                    <GoabBadge type="emergency" content="To be removed" />
+                  </GoabBlock>
+                </GoabBlock>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--goa-space-xl)" }}>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-4">
+                    <strong>Updated</strong>
+                    <span>Nov 28, 2021 at 1:30 PM</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-5">
+                    <strong>Email</strong>
+                    <span>emma.stroman@gmail.com</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-6">
+                    <strong>Program</strong>
+                    <span>Fort McMurray</span>
+                  </GoabBlock>
+                </div>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--goa-space-xl)" }}>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-7">
+                    <strong>Program ID</strong>
+                    <span>74522643</span>
+                  </GoabBlock>
+                  <GoabBlock direction="column" gap="xs" data-grid="cell-8">
+                    <strong>Service access</strong>
+                    <span>Claims Adjustments</span>
+                  </GoabBlock>
+                </div>
+              </div>
+              <GoabMenuButton data-grid="cell-3" text="Actions" type="tertiary" size="compact">
+                <GoabMenuAction action="open" text="Open" />
+                <GoabMenuAction action="delete" text="Delete" />
+              </GoabMenuButton>
+            </div>
+          </GoabContainer>
+        </GoabDataGrid>
+      </section>
+    </div>
+  );
+}
+
+export default Bug3605Route;

--- a/apps/prs/web/src/app/App.svelte
+++ b/apps/prs/web/src/app/App.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import "@abgov/style";
+  import "@abgov/design-tokens-v2/dist/tokens.css"; // Production tokens. Comment out to test with legacy V1 token values.
   import { Router, Route } from "svelte-routing";
   import Issue2333 from "../routes/2333.svelte";
   import Issue3279 from "../routes/3279.svelte";
+  import Issue3605 from "../routes/3605.svelte";
   import Issue3760 from "../routes/3760.svelte";
 </script>
 
@@ -13,5 +15,6 @@
 <Router>
   <Route path="/issues/2333" component={Issue2333} />
   <Route path="/issues/3279" component={Issue3279} />
+  <Route path="/issues/3605" component={Issue3605} />
   <Route path="/issues/3760" component={Issue3760} />
 </Router>

--- a/apps/prs/web/src/routes/3605.svelte
+++ b/apps/prs/web/src/routes/3605.svelte
@@ -1,0 +1,478 @@
+<script lang="ts">
+  // Issue #3605 — use :focus-visible across remaining interactive components.
+  // Verification surface for MicrositeHeader, Chip, reset.css links, TextArea (error state), Button variants.
+</script>
+
+<svelte:head>
+  <title>Issue 3605</title>
+</svelte:head>
+
+<div class="page">
+  <goa-text as="h5" mb="xs" color="secondary" class="eyebrow">Issue 3605</goa-text>
+  <goa-text as="h1" mt="0" mb="0">Use <code>:focus-visible</code> across interactive components</goa-text>
+  <goa-text mb="0">
+    For every section: <strong>Tab</strong> should show the focus ring with the correct gap/offset.
+    <strong>Click</strong> should not leave a lingering ring. <strong>Mouse-down (<code>:active</code>)</strong>
+    on buttons should still show the pressed/focused look.
+  </goa-text>
+
+  <hr />
+
+  <!-- 1. MicrositeHeader -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">1. MicrositeHeader — <code>a:focus</code> → <code>a:focus-visible</code></goa-text>
+    <goa-text mb="s">Tab through the links inside the header. Click any link.</goa-text>
+    <goa-microsite-header type="alpha" version="1" headerurl="https://www.alberta.ca">
+      <span slot="feedback">Report a problem</span>
+    </goa-microsite-header>
+    <goa-microsite-header type="beta" version="2" headerurl="https://www.alberta.ca" mt="m">
+      <span slot="feedback">Report a problem</span>
+    </goa-microsite-header>
+  </section>
+
+  <hr />
+
+  <!-- 2. Chip (V1, deprecated but in scope) + FilterChip (V2 equivalent) -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">2. Chip — <code>.chip:focus</code> → <code>.chip:focus-visible</code></goa-text>
+    <goa-text mb="s">V1 Chip (deprecated, still in scope per brief).</goa-text>
+    <div class="row">
+      <goa-chip content="Status: active" />
+      <goa-chip content="Priority: high" deletable="true" />
+      <goa-chip content="Owner: Tom" />
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">FilterChip V2 (production)</goa-text>
+    <goa-text mb="s">
+      Chip div is <code>role="presentation"</code>; the close <code>goa-icon-button</code> is
+      the focusable element. <code>goa-icon-button</code> already uses <code>:focus-visible</code>
+      (no change needed here).
+    </goa-text>
+    <div class="row">
+      <goa-filter-chip content="Status: active" version="2" />
+      <goa-filter-chip content="Priority: high" version="2" />
+      <goa-filter-chip content="Owner: Tom" version="2" />
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">FilterChip V1 (fixed in this PR)</goa-text>
+    <goa-text mb="s">
+      Whole chip is <code>tabindex="0" role="button"</code>. Removed <code>class:focused</code>
+      binding; outline now on <code>.chip:focus-visible .delete-icon</code>.
+    </goa-text>
+    <div class="row">
+      <goa-filter-chip content="Status: active" version="1" />
+      <goa-filter-chip content="Priority: high" version="1" />
+      <goa-filter-chip content="Owner: Tom" version="1" />
+    </div>
+  </section>
+
+  <hr />
+
+  <!-- 3. Global link reset (reset.css) -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">3. Plain link reset — use <code>:focus-visible</code> only</goa-text>
+    <goa-text mb="s">
+      Unstyled anchors pick up the global reset from <code>assets/css/reset.css</code>.
+      Dropped both <code>:focus</code> and <code>:focus-within</code> — on plain
+      <code>&lt;a&gt;</code> they both match on mouse click (HTML doesn't allow focusable
+      children inside <code>&lt;a&gt;</code>, so <code>:focus-within</code> has no real use
+      here).
+    </goa-text>
+    <div class="row">
+      <a href="#first">First link</a>
+      <a href="#second">Second link</a>
+      <a href="#third">Third link</a>
+    </div>
+  </section>
+
+  <hr />
+
+  <!-- 4. TextArea error state -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">4. TextArea error state — <code>.error:focus</code> + V2 combined selector</goa-text>
+    <goa-text mb="s">
+      Tab into each error text area. Click into each. The <code>:focus-within</code> container
+      pattern should still apply on focus (correct).
+    </goa-text>
+    <goa-text as="h4" mt="s" mb="xs">V1 error</goa-text>
+    <goa-textarea name="v1-error" error="true" version="1" />
+    <goa-text as="h4" mt="m" mb="xs">V2 error</goa-text>
+    <goa-textarea name="v2-error" error="true" version="2" />
+  </section>
+
+  <hr />
+
+  <!-- 5. Button variants -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">5. Button — drop <code>:focus</code> from combined selectors</goa-text>
+    <goa-text mb="s">
+      Click and Tab each variant across V1 and V2. Watch for lingering rings after mouse-up.
+    </goa-text>
+
+    <goa-text as="h4" mt="s" mb="xs">V1 — default</goa-text>
+    <div class="row">
+      <goa-button type="primary" version="1">Primary</goa-button>
+      <goa-button type="secondary" version="1">Secondary</goa-button>
+      <goa-button type="tertiary" version="1">Tertiary</goa-button>
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">V1 — destructive</goa-text>
+    <div class="row">
+      <goa-button type="primary" variant="destructive" version="1">Primary destructive</goa-button>
+      <goa-button type="secondary" variant="destructive" version="1">Secondary destructive</goa-button>
+      <goa-button type="tertiary" variant="destructive" version="1">Tertiary destructive</goa-button>
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">V1 — inverse (on dark bg)</goa-text>
+    <div class="row dark">
+      <goa-button type="primary" variant="inverse" version="1">Primary inverse</goa-button>
+      <goa-button type="secondary" variant="inverse" version="1">Secondary inverse</goa-button>
+      <goa-button type="tertiary" variant="inverse" version="1">Tertiary inverse</goa-button>
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">V2 — default</goa-text>
+    <div class="row">
+      <goa-button type="primary" version="2">Primary</goa-button>
+      <goa-button type="secondary" version="2">Secondary</goa-button>
+      <goa-button type="tertiary" version="2">Tertiary</goa-button>
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">V2 — destructive</goa-text>
+    <div class="row">
+      <goa-button type="primary" variant="destructive" version="2">Primary destructive</goa-button>
+      <goa-button type="secondary" variant="destructive" version="2">Secondary destructive</goa-button>
+      <goa-button type="tertiary" variant="destructive" version="2">Tertiary destructive</goa-button>
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">V2 — inverse (on dark bg)</goa-text>
+    <div class="row dark">
+      <goa-button type="primary" variant="inverse" version="2">Primary inverse</goa-button>
+      <goa-button type="secondary" variant="inverse" version="2">Secondary inverse</goa-button>
+      <goa-button type="tertiary" variant="inverse" version="2">Tertiary inverse</goa-button>
+    </div>
+  </section>
+
+  <hr />
+
+  <!-- 6. Checkbox -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">6. Checkbox — drop <code>:has(:focus)</code> duplicates from V1</goa-text>
+    <goa-text mb="s">
+      V1 had 10 rules pairing <code>:has(:focus-visible)</code> with <code>:has(:focus)</code>.
+      The <code>:focus</code> duplicate fired on mouse click. V2 already correct.
+    </goa-text>
+
+    <goa-text as="h4" mt="s" mb="xs">V1 — normal</goa-text>
+    <div class="row">
+      <goa-checkbox name="v1-a" text="Option A" version="1" />
+      <goa-checkbox name="v1-b" text="Option B" version="1" checked="true" />
+      <goa-checkbox name="v1-c" text="Option C" version="1" />
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">V1 — error</goa-text>
+    <div class="row">
+      <goa-checkbox name="v1-err" text="With error" version="1" error="true" />
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">V2 — normal</goa-text>
+    <div class="row">
+      <goa-checkbox name="v2-a" text="Option A" version="2" />
+      <goa-checkbox name="v2-b" text="Option B" version="2" checked="true" />
+      <goa-checkbox name="v2-c" text="Option C" version="2" />
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">V2 — error</goa-text>
+    <div class="row">
+      <goa-checkbox name="v2-err" text="With error" version="2" error="true" />
+    </div>
+  </section>
+
+  <hr />
+
+  <!-- 7. Link -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">7. Link — <code>::slotted(a:focus-visible)</code></goa-text>
+    <goa-text mb="s">
+      Ring is now on the slotted anchor directly (reliable across shadow DOM).
+      <strong>Trade-off:</strong> ring wraps the anchor text only, not the icons.
+    </goa-text>
+
+    <goa-text as="h4" mt="s" mb="xs">Plain links</goa-text>
+    <div class="row">
+      <goa-link version="2"><a href="#link-a">First link</a></goa-link>
+      <goa-link version="2"><a href="#link-b">Second link</a></goa-link>
+      <goa-link version="2"><a href="#link-c">Third link</a></goa-link>
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">Links with leading icons</goa-text>
+    <div class="row">
+      <goa-link version="2" leadingicon="download"><a href="#link-dl">Download file</a></goa-link>
+      <goa-link version="2" leadingicon="information-circle"><a href="#link-info">Learn more</a></goa-link>
+      <goa-link version="2" leadingicon="open"><a href="#link-ext">Open in new tab</a></goa-link>
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">Links with trailing icons</goa-text>
+    <div class="row">
+      <goa-link version="2" trailingicon="arrow-forward"><a href="#link-next">Continue</a></goa-link>
+      <goa-link version="2" trailingicon="chevron-forward"><a href="#link-more">See more</a></goa-link>
+      <goa-link version="2" trailingicon="open"><a href="#link-ext2">External resource</a></goa-link>
+    </div>
+
+    <goa-text as="h4" mt="m" mb="xs">Links with both icons</goa-text>
+    <div class="row">
+      <goa-link version="2" leadingicon="download" trailingicon="arrow-forward"><a href="#link-both">Download and continue</a></goa-link>
+    </div>
+  </section>
+
+  <hr />
+
+  <!-- 8. Notification -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">8. Notification — <code>::slotted(a:focus)</code> → <code>:focus-visible</code></goa-text>
+    <goa-text mb="s">
+      8 rules (V1 + V2 variants) styled slotted anchors on <code>:focus</code>. Now keyboard only.
+    </goa-text>
+
+    <goa-text as="h4" mt="s" mb="xs">V1 Notifications</goa-text>
+    <goa-notification type="information">
+      Info notification with a <a href="#n-v1-info">link</a> inside.
+    </goa-notification>
+    <goa-notification type="important" mt="s">
+      Important notification with a <a href="#n-v1-imp">link</a> inside.
+    </goa-notification>
+
+    <goa-text as="h4" mt="m" mb="xs">V2 Notifications</goa-text>
+    <goa-notification type="information" importance="high" version="2">
+      Information high with a <a href="#n-v2-info-h">link</a> inside.
+    </goa-notification>
+    <goa-notification type="important" importance="high" version="2" mt="s">
+      Important high with a <a href="#n-v2-imp-h">link</a> inside.
+    </goa-notification>
+    <goa-notification type="emergency" importance="high" version="2" mt="s">
+      Emergency high with a <a href="#n-v2-em-h">link</a> inside.
+    </goa-notification>
+  </section>
+
+  <hr />
+
+  <!-- 9. Tooltip -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">9. Tooltip — <code>.tooltip:focus .tooltip-text</code> → <code>:focus-visible</code></goa-text>
+    <goa-text mb="s">
+      Previously mouse-clicking the tooltip trigger revealed the tooltip. Now hover for mouse,
+      keyboard focus for keyboard (standard tooltip behavior).
+    </goa-text>
+    <div class="row">
+      <goa-tooltip content="Helpful tip goes here" version="2">
+        <goa-button type="secondary" version="2">Hover or Tab me</goa-button>
+      </goa-tooltip>
+    </div>
+  </section>
+
+  <hr />
+
+  <!-- 10. Details -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">10. Details — <code>summary:focus</code> → <code>:focus-visible</code></goa-text>
+    <goa-text mb="s">
+      Previously clicking the summary left a hover-ish style. Now click just toggles open;
+      keyboard focus shows the focused look.
+    </goa-text>
+    <goa-details heading="Click me to expand" version="2">
+      Content inside the details component.
+    </goa-details>
+  </section>
+
+  <hr />
+
+  <!-- 11. DataGrid -->
+  <section>
+    <goa-text as="h2" mt="0" mb="xs">11. DataGrid — realistic table usage</goa-text>
+    <goa-text mb="s">
+      Typical pattern: <code>goa-data-grid</code> wrapping a <code>goa-table</code>. Cells contain
+      badges, buttons, and text. Focus styling is JS-driven via
+      <code>setFocusedStyle</code>. Describe what looks wrong (mouse click leaving an outline?
+      UA default ring on a cell? ring jumping?).
+    </goa-text>
+    <goa-data-grid keyboard-nav="table" keyboard-icon-position="right">
+      <goa-table width="100%" version="2">
+        <thead>
+          <tr data-grid="row">
+            <th data-grid="cell">Name</th>
+            <th data-grid="cell">Role</th>
+            <th data-grid="cell">Status</th>
+            <th data-grid="cell">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-grid="row">
+            <td data-grid="cell">Alice Johnson</td>
+            <td data-grid="cell">Developer</td>
+            <td data-grid="cell"><goa-badge version="2" type="success" content="Active" /></td>
+            <td data-grid="cell"><goa-button version="2" type="tertiary" size="compact">View</goa-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell">Bob Smith</td>
+            <td data-grid="cell">Designer</td>
+            <td data-grid="cell"><goa-badge version="2" type="success" content="Active" /></td>
+            <td data-grid="cell"><goa-button version="2" type="tertiary" size="compact">View</goa-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell">Carol White</td>
+            <td data-grid="cell">Manager</td>
+            <td data-grid="cell"><goa-badge version="2" type="information" content="Away" /></td>
+            <td data-grid="cell"><goa-button version="2" type="tertiary" size="compact">View</goa-button></td>
+          </tr>
+          <tr data-grid="row">
+            <td data-grid="cell">David Brown</td>
+            <td data-grid="cell">Analyst</td>
+            <td data-grid="cell"><goa-badge version="2" type="success" content="Active" /></td>
+            <td data-grid="cell"><goa-button version="2" type="tertiary" size="compact">View</goa-button></td>
+          </tr>
+        </tbody>
+      </goa-table>
+    </goa-data-grid>
+
+    <goa-text as="h4" mt="l" mb="xs">DataGrid around cards (layout mode)</goa-text>
+    <goa-text mb="s">
+      <code>keyboardNav="layout"</code>. Each card is a row, cells include the checkbox, name,
+      badge, stat blocks, and menu button.
+    </goa-text>
+    <goa-data-grid keyboard-nav="layout" keyboard-icon-position="right">
+      <goa-container version="2" mt="m" data-grid="row" maxwidth="100%">
+        <div class="card-row">
+          <goa-checkbox version="2" data-grid="cell-0" name="user-1" />
+          <div class="card-body">
+            <goa-block version="2" direction="row" gap="s" alignment="center">
+              <strong data-grid="cell-1">Mike Zwei</strong>
+              <goa-badge version="2" data-grid="cell-2" type="success" content="Removed" />
+            </goa-block>
+            <div class="card-stats">
+              <goa-block version="2" direction="column" gap="xs" data-grid="cell-4">
+                <strong>Updated</strong>
+                <span>Jun 30, 2022 at 2:30 PM</span>
+              </goa-block>
+              <goa-block version="2" direction="column" gap="xs" data-grid="cell-5">
+                <strong>Email</strong>
+                <span>mike.zwei@gmail.com</span>
+              </goa-block>
+              <goa-block version="2" direction="column" gap="xs" data-grid="cell-6">
+                <strong>Program</strong>
+                <span>Wee Wild Ones Curry</span>
+              </goa-block>
+            </div>
+            <div class="card-stats">
+              <goa-block version="2" direction="column" gap="xs" data-grid="cell-7">
+                <strong>Program ID</strong>
+                <span>74528567</span>
+              </goa-block>
+              <goa-block version="2" direction="column" gap="xs" data-grid="cell-8">
+                <strong>Service access</strong>
+                <span>Claims Adjustments</span>
+              </goa-block>
+            </div>
+          </div>
+          <goa-menu-button version="2" data-grid="cell-3" text="Actions" type="tertiary" size="compact">
+            <goa-menu-action version="2" action="open" text="Open" />
+            <goa-menu-action version="2" action="delete" text="Delete" />
+          </goa-menu-button>
+        </div>
+      </goa-container>
+
+      <goa-container version="2" mt="m" data-grid="row" maxwidth="100%">
+        <div class="card-row">
+          <goa-checkbox version="2" data-grid="cell-0" name="user-2" />
+          <div class="card-body">
+            <goa-block version="2" direction="row" gap="s" alignment="center">
+              <strong data-grid="cell-1">Emma Stroman</strong>
+              <goa-badge version="2" data-grid="cell-2" type="emergency" content="To be removed" />
+            </goa-block>
+            <div class="card-stats">
+              <goa-block version="2" direction="column" gap="xs" data-grid="cell-4">
+                <strong>Updated</strong>
+                <span>Nov 28, 2021 at 1:30 PM</span>
+              </goa-block>
+              <goa-block version="2" direction="column" gap="xs" data-grid="cell-5">
+                <strong>Email</strong>
+                <span>emma.stroman@gmail.com</span>
+              </goa-block>
+              <goa-block version="2" direction="column" gap="xs" data-grid="cell-6">
+                <strong>Program</strong>
+                <span>Fort McMurray</span>
+              </goa-block>
+            </div>
+            <div class="card-stats">
+              <goa-block version="2" direction="column" gap="xs" data-grid="cell-7">
+                <strong>Program ID</strong>
+                <span>74522643</span>
+              </goa-block>
+              <goa-block version="2" direction="column" gap="xs" data-grid="cell-8">
+                <strong>Service access</strong>
+                <span>Claims Adjustments</span>
+              </goa-block>
+            </div>
+          </div>
+          <goa-menu-button version="2" data-grid="cell-3" text="Actions" type="tertiary" size="compact">
+            <goa-menu-action version="2" action="open" text="Open" />
+            <goa-menu-action version="2" action="delete" text="Delete" />
+          </goa-menu-button>
+        </div>
+      </goa-container>
+    </goa-data-grid>
+  </section>
+</div>
+
+<style>
+  .page {
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 72rem;
+    margin: 0 auto;
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--goa-color-greyscale-200);
+    margin: 1rem 0;
+  }
+
+  .row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .row.dark {
+    background-color: var(--goa-color-greyscale-black, #1f1f1f);
+    padding: 1rem;
+    border-radius: 0.25rem;
+  }
+
+  a {
+    color: var(--goa-color-interactive-default);
+  }
+
+  .card-row {
+    display: flex;
+    flex-direction: row;
+    gap: var(--goa-space-m);
+    align-items: flex-start;
+  }
+
+  .card-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--goa-space-m);
+    flex: 1;
+    min-width: 0;
+  }
+
+  .card-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--goa-space-xl);
+  }
+</style>

--- a/libs/angular-components/src/lib/components/table-sort-header/table-sort-header.ts
+++ b/libs/angular-components/src/lib/components/table-sort-header/table-sort-header.ts
@@ -17,6 +17,7 @@ import {
         [attr.name]="name"
         [attr.direction]="direction"
         [attr.sort-order]="sortOrder"
+        [attr.version]="version"
       >
         <ng-content />
       </goa-table-sort-header>
@@ -30,6 +31,7 @@ export class GoabTableSortHeader implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
   isReady = false;
+  version = "2";
   /** Column name identifier for sorting. */
   @Input() name?: string;
   /** Sets the sort direction indicator. @default "none" */

--- a/libs/react-components/specs/datagrid.browser.spec.tsx
+++ b/libs/react-components/specs/datagrid.browser.spec.tsx
@@ -328,8 +328,10 @@ describe("DataGrid", () => {
       const cell1DateStarted = result.container.querySelector('[data-testid="cell-1-dateStarted"]') as HTMLElement;
       expect(cell1DateStarted?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
 
-      // verify td data-testid="cell-1-idNumber" has no more style defined on line 129 (no focus)
-      expect(cell1IdNumber?.style.outline).toBe('');
+      // verify td data-testid="cell-1-idNumber" is back to the suppressed baseline.
+      // Cells carry an inline outline: 'none' to prevent the UA default from showing on
+      // mouse focus; removeFocusedStyle restores that baseline when nav moves away.
+      expect(cell1IdNumber?.style.outline).toBe('none');
 
       // Press Arrow Right
       await userEvent.keyboard("{ArrowRight}");
@@ -470,14 +472,15 @@ describe("DataGrid", () => {
 
       // Wait for components to fully render
       await new Promise(resolve => setTimeout(resolve, 500));
-      // Click on <strong data-grid="cell-1"
+      // Click on <strong data-grid="cell-1"> to establish focus position.
+      // Per issue #3605, mouse click does NOT apply the focus ring — only keyboard
+      // navigation does. The cell stays at its inline baseline of outline: 'none'.
       const cell1 = result.container.querySelector('[data-grid="cell-1"]') as HTMLElement;
       await userEvent.click(cell1);
       await new Promise(resolve => setTimeout(resolve, 100));
+      expect(cell1?.style.outline).toBe('none');
 
-      // Verify that it is highlighted style: outline: 3px...
-      expect(cell1?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
-      // Press Arrow Right
+      // Arrow Right is keyboard input — ring applies on the next cell.
       await userEvent.keyboard("{ArrowRight}");
       await new Promise(resolve => setTimeout(resolve, 100));
 
@@ -485,8 +488,8 @@ describe("DataGrid", () => {
       const cell2 = result.container.querySelector('[data-grid="cell-2"]') as HTMLElement;
       expect(cell2?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
 
-      // verify that data-grid="cell-1" no more highlighted
-      expect(cell1?.style.outline).toBe('');
+      // verify that data-grid="cell-1" is back to the suppressed baseline.
+      expect(cell1?.style.outline).toBe('none');
       // Arrow Right
       await userEvent.keyboard("{ArrowRight}");
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -703,15 +706,14 @@ describe("DataGrid", () => {
       const initialRows = result.container.querySelectorAll('[data-grid="row"]');
       expect(initialRows.length).toBe(2);
 
-      // Click on the first row's name cell to establish focus
+      // Click on the first row's name cell to establish focus position.
+      // Per issue #3605, mouse click establishes focus but does NOT apply the
+      // cell outline — the outline only shows for keyboard-driven focus.
       const firstRowName = result.container.querySelector('[data-testid="name-1"]') as HTMLElement;
       await userEvent.click(firstRowName);
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Verify first row name is highlighted
-      expect(firstRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
-
-      // Navigate to the second row using Arrow Down
+      // Navigate to the second row using Arrow Down — keyboard nav applies the outline.
       await userEvent.keyboard("{ArrowDown}");
       await new Promise(resolve => setTimeout(resolve, 100));
 
@@ -731,14 +733,11 @@ describe("DataGrid", () => {
       const updatedRows = result.container.querySelectorAll('[data-grid="row"]');
       expect(updatedRows.length).toBe(4);
 
-      // Click on first row's name to re-establish focus
+      // Click on first row's name to re-establish focus position (no outline per #3605).
       await userEvent.click(firstRowName);
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Verify first row name is highlighted after re-click
-      expect(firstRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
-
-      // Navigate down through all rows including newly added ones
+      // Navigate down through all rows including newly added ones — keyboard applies outline.
       // Row 1 -> Row 2
       await userEvent.keyboard("{ArrowDown}");
       await new Promise(resolve => setTimeout(resolve, 100));

--- a/libs/react-components/specs/datagrid.browser.spec.tsx
+++ b/libs/react-components/specs/datagrid.browser.spec.tsx
@@ -315,37 +315,38 @@ describe("DataGrid", () => {
       await userEvent.keyboard("{ArrowDown}");
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Verify td data-testid="cell-1-idNumber" has style outline:3px solid var(--goa-color-interactive-focus)
+      // Verify td data-testid="cell-1-idNumber" carries the [data-focused] attribute
       const cell1IdNumber = result.container.querySelector('[data-testid="cell-1-idNumber"]') as HTMLElement;
       expect(cell1IdNumber).toBeTruthy();
-      expect(cell1IdNumber.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(cell1IdNumber.hasAttribute('data-focused')).toBe(true);
 
       // Press Arrow Right
       await userEvent.keyboard("{ArrowRight}");
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Verify td data-testid="cell-1-dateStarted" has style outline:3px solid var(--goa-color-interactive-focus)
+      // Verify td data-testid="cell-1-dateStarted" carries the [data-focused] attribute
       const cell1DateStarted = result.container.querySelector('[data-testid="cell-1-dateStarted"]') as HTMLElement;
-      expect(cell1DateStarted?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(cell1DateStarted?.hasAttribute('data-focused')).toBe(true);
 
-      // verify td data-testid="cell-1-idNumber" has no more style defined on line 129 (no focus)
-      expect(cell1IdNumber?.style.outline).toBe('');
+      // verify td data-testid="cell-1-idNumber" no longer carries [data-focused].
+      // The attribute is removed when nav moves away. Table CSS owns the visual.
+      expect(cell1IdNumber?.hasAttribute('data-focused')).toBe(false);
 
       // Press Arrow Right
       await userEvent.keyboard("{ArrowRight}");
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Verify td data-testid="cell-1-dateSubmitted" has inline style outline 3px...
+      // Verify td data-testid="cell-1-dateSubmitted" carries the [data-focused] attribute
       const cell1DateSubmitted = result.container.querySelector('[data-testid="cell-1-dateSubmitted"]') as HTMLElement;
-      expect(cell1DateSubmitted?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(cell1DateSubmitted?.hasAttribute('data-focused')).toBe(true);
 
       // Press Arrow Right
       await userEvent.keyboard("{ArrowRight}");
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Verify td data-testid="cell-1-status" has inline style outline
+      // Verify td data-testid="cell-1-status" carries the [data-focused] attribute
       const cell1Status = result.container.querySelector('[data-testid="cell-1-status"]') as HTMLElement;
-      expect(cell1Status?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(cell1Status?.hasAttribute('data-focused')).toBe(true);
 
       // Press Arrow Right to move to Actions column (last cell with buttons)
       await userEvent.keyboard("{ArrowRight}");
@@ -433,13 +434,13 @@ describe("DataGrid", () => {
 
       statusCells.forEach(cell => {
         const htmlCell = cell as HTMLElement;
-        if (htmlCell.style.outline?.includes('3px solid')) {
+        if (htmlCell.hasAttribute('data-focused')) {
           focusedStatusCell = htmlCell;
         }
       });
 
       expect(focusedStatusCell).toBeTruthy();
-      expect(focusedStatusCell?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(focusedStatusCell?.hasAttribute('data-focused')).toBe(true);
 
       // Press arrow right to move to Actions column
       await userEvent.keyboard("{ArrowRight}");
@@ -461,7 +462,7 @@ describe("DataGrid", () => {
       // Verify a status cell is still highlighted after deletion
       const remainingStatusCell = result.container.querySelector('td[data-testid*="-status"]') as HTMLElement;
       expect(remainingStatusCell).toBeTruthy();
-      expect(remainingStatusCell?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(remainingStatusCell?.hasAttribute('data-focused')).toBe(true);
     });
 
     it("Using with Container - should navigate with arrow keys", async() => {
@@ -470,23 +471,24 @@ describe("DataGrid", () => {
 
       // Wait for components to fully render
       await new Promise(resolve => setTimeout(resolve, 500));
-      // Click on <strong data-grid="cell-1"
+      // Click on <strong data-grid="cell-1"> to establish focus position.
+      // Per issue #3605, mouse click does NOT apply the focus ring — only keyboard
+      // navigation does. The cell carries no [data-focused] attribute on click.
       const cell1 = result.container.querySelector('[data-grid="cell-1"]') as HTMLElement;
       await userEvent.click(cell1);
       await new Promise(resolve => setTimeout(resolve, 100));
+      expect(cell1?.hasAttribute('data-focused')).toBe(false);
 
-      // Verify that it is highlighted style: outline: 3px...
-      expect(cell1?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
-      // Press Arrow Right
+      // Arrow Right is keyboard input — ring applies on the next cell.
       await userEvent.keyboard("{ArrowRight}");
       await new Promise(resolve => setTimeout(resolve, 100));
 
       // Verify goa-block data-grid="cell-2" highlighted
       const cell2 = result.container.querySelector('[data-grid="cell-2"]') as HTMLElement;
-      expect(cell2?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(cell2?.hasAttribute('data-focused')).toBe(true);
 
-      // verify that data-grid="cell-1" no more highlighted
-      expect(cell1?.style.outline).toBe('');
+      // verify that data-grid="cell-1" no longer carries [data-focused].
+      expect(cell1?.hasAttribute('data-focused')).toBe(false);
       // Arrow Right
       await userEvent.keyboard("{ArrowRight}");
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -505,7 +507,7 @@ describe("DataGrid", () => {
 
       // Verify data-grid="cell-4" highlighted
       const cell4 = result.container.querySelector('[data-grid="cell-4"]') as HTMLElement;
-      expect(cell4?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(cell4?.hasAttribute('data-focused')).toBe(true);
 
       // Arrow Right
       await userEvent.keyboard("{ArrowRight}");
@@ -513,7 +515,7 @@ describe("DataGrid", () => {
 
       // Verify data-grid="cell-5" highlighted
       const cell5 = result.container.querySelector('[data-grid="cell-5"]') as HTMLElement;
-      expect(cell5?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(cell5?.hasAttribute('data-focused')).toBe(true);
 
       // Arrow Right
       await userEvent.keyboard("{ArrowRight}");
@@ -521,7 +523,7 @@ describe("DataGrid", () => {
 
       // Verify data-grid="cell-6" highlighted
       const cell6 = result.container.querySelector('[data-grid="cell-6"]') as HTMLElement;
-      expect(cell6?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(cell6?.hasAttribute('data-focused')).toBe(true);
 
       // Arrow Right
       await userEvent.keyboard("{ArrowRight}");
@@ -529,7 +531,7 @@ describe("DataGrid", () => {
 
       // Verify data-grid="cell-7" highlighted
       const cell7 = result.container.querySelector('[data-grid="cell-7"]') as HTMLElement;
-      expect(cell7?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(cell7?.hasAttribute('data-focused')).toBe(true);
 
       // Arrow Right
       await userEvent.keyboard("{ArrowRight}");
@@ -537,7 +539,7 @@ describe("DataGrid", () => {
 
       // Verify data-grid="cell-8" highlighted
       const cell8 = result.container.querySelector('[data-grid="cell-8"]') as HTMLElement;
-      expect(cell8?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(cell8?.hasAttribute('data-focused')).toBe(true);
       // Arrow right
       await userEvent.keyboard("{ArrowRight}");
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -703,21 +705,20 @@ describe("DataGrid", () => {
       const initialRows = result.container.querySelectorAll('[data-grid="row"]');
       expect(initialRows.length).toBe(2);
 
-      // Click on the first row's name cell to establish focus
+      // Click on the first row's name cell to establish focus position.
+      // Per issue #3605, mouse click establishes focus but does NOT apply the
+      // cell outline — the outline only shows for keyboard-driven focus.
       const firstRowName = result.container.querySelector('[data-testid="name-1"]') as HTMLElement;
       await userEvent.click(firstRowName);
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Verify first row name is highlighted
-      expect(firstRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
-
-      // Navigate to the second row using Arrow Down
+      // Navigate to the second row using Arrow Down — keyboard nav applies the outline.
       await userEvent.keyboard("{ArrowDown}");
       await new Promise(resolve => setTimeout(resolve, 100));
 
       // Verify second row name is highlighted
       const secondRowName = result.container.querySelector('[data-testid="name-2"]') as HTMLElement;
-      expect(secondRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(secondRowName?.hasAttribute('data-focused')).toBe(true);
 
       // Add new rows by clicking the button
       const addRowsBtn = result.container.querySelector('[data-testid="add-rows-btn"]') as HTMLElement;
@@ -731,20 +732,17 @@ describe("DataGrid", () => {
       const updatedRows = result.container.querySelectorAll('[data-grid="row"]');
       expect(updatedRows.length).toBe(4);
 
-      // Click on first row's name to re-establish focus
+      // Click on first row's name to re-establish focus position (no outline per #3605).
       await userEvent.click(firstRowName);
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Verify first row name is highlighted after re-click
-      expect(firstRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
-
-      // Navigate down through all rows including newly added ones
+      // Navigate down through all rows including newly added ones — keyboard applies outline.
       // Row 1 -> Row 2
       await userEvent.keyboard("{ArrowDown}");
       await new Promise(resolve => setTimeout(resolve, 100));
 
       // Verify second row name is highlighted
-      expect(secondRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(secondRowName?.hasAttribute('data-focused')).toBe(true);
 
       // Row 2 -> Row 3 (newly added)
       await userEvent.keyboard("{ArrowDown}");
@@ -754,7 +752,7 @@ describe("DataGrid", () => {
       const thirdRowName = result.container.querySelector('[data-testid="name-3"]') as HTMLElement;
       expect(thirdRowName).toBeTruthy();
       expect(thirdRowName?.textContent).toBe("New User 3");
-      expect(thirdRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(thirdRowName?.hasAttribute('data-focused')).toBe(true);
 
       // Row 3 -> Row 4 (newly added)
       await userEvent.keyboard("{ArrowDown}");
@@ -764,20 +762,20 @@ describe("DataGrid", () => {
       const fourthRowName = result.container.querySelector('[data-testid="name-4"]') as HTMLElement;
       expect(fourthRowName).toBeTruthy();
       expect(fourthRowName?.textContent).toBe("New User 4");
-      expect(fourthRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(fourthRowName?.hasAttribute('data-focused')).toBe(true);
 
       // Navigate back up to verify bidirectional navigation works
       await userEvent.keyboard("{ArrowUp}"); // Row 4 -> Row 3
       await new Promise(resolve => setTimeout(resolve, 100));
-      expect(thirdRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(thirdRowName?.hasAttribute('data-focused')).toBe(true);
 
       await userEvent.keyboard("{ArrowUp}"); // Row 3 -> Row 2
       await new Promise(resolve => setTimeout(resolve, 100));
-      expect(secondRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(secondRowName?.hasAttribute('data-focused')).toBe(true);
 
       await userEvent.keyboard("{ArrowUp}"); // Row 2 -> Row 1
       await new Promise(resolve => setTimeout(resolve, 100));
-      expect(firstRowName?.style.outline).toContain('3px solid var(--goa-color-interactive-focus)');
+      expect(firstRowName?.hasAttribute('data-focused')).toBe(true);
     });
   });
 

--- a/libs/react-components/src/lib/table/table-sort-header.tsx
+++ b/libs/react-components/src/lib/table/table-sort-header.tsx
@@ -10,6 +10,7 @@ interface WCProps {
   name?: string;
   direction?: GoabTableSortDirection;
   "sort-order"?: GoabTableSortOrder;
+  version?: "1" | "2";
 }
 
 declare module "react" {
@@ -46,6 +47,7 @@ export function GoabTableSortHeader({
       name={name}
       direction={direction}
       sort-order={sortOrder}
+      version="2"
       {...rest}
     >
       {children}

--- a/libs/web-components/src/assets/css/components.css
+++ b/libs/web-components/src/assets/css/components.css
@@ -144,6 +144,53 @@ goa-table[version="2"] tfoot td:last-child {
 }
 
 
+/* DataGrid keyboard focus ring on table cells.
+   goa-data-grid signals focus via [data-focused] / [data-focus-corner]
+   attributes so the visual styling lives with the table. The :focus rule
+   suppresses the UA default; the [data-focused] rule overrides it via source
+   order when goa-data-grid promotes the focus to a keyboard-driven state. */
+goa-table td:focus,
+goa-table th:focus {
+  outline: none;
+}
+
+goa-table td[data-focused],
+goa-table th[data-focused] {
+  outline: var(--goa-border-width-l, 0.1875rem) solid var(--goa-color-interactive-focus);
+  /* Inset so the outline stays visible on edge cells inside the table's
+     overflow: hidden container. */
+  outline-offset: -0.1875rem;
+}
+
+goa-table td[data-focus-corner="top-left"],
+goa-table th[data-focus-corner="top-left"] {
+  border-top-left-radius: var(--goa-table-border-radius-container, 1rem);
+}
+goa-table td[data-focus-corner="top-right"],
+goa-table th[data-focus-corner="top-right"] {
+  border-top-right-radius: var(--goa-table-border-radius-container, 1rem);
+}
+goa-table td[data-focus-corner="bottom-left"],
+goa-table th[data-focus-corner="bottom-left"] {
+  border-bottom-left-radius: var(--goa-table-border-radius-container, 1rem);
+}
+goa-table td[data-focus-corner="bottom-right"],
+goa-table th[data-focus-corner="bottom-right"] {
+  border-bottom-right-radius: var(--goa-table-border-radius-container, 1rem);
+}
+
+/* DataGrid keyboard focus ring on layout-mode cells (cards, etc). Outline
+   sits outside the cell with a small gap so it never overlaps content. */
+goa-data-grid [role="gridcell"]:not(td):not(th):focus {
+  outline: none;
+}
+
+goa-data-grid [role="gridcell"]:not(td):not(th)[data-focused] {
+  outline: var(--goa-border-width-l, 0.1875rem) solid var(--goa-color-interactive-focus);
+  outline-offset: 0.125rem;
+}
+
+
 /* Normal Variant Cell Types */
 
 goa-table td.goa-table-cell--text {

--- a/libs/web-components/src/assets/css/reset.css
+++ b/libs/web-components/src/assets/css/reset.css
@@ -67,7 +67,7 @@ a:hover {
   color: var(--goa-color-interactive-hover);
 }
 
-a:focus-visible, a:focus-within, a:focus {
+a:focus-visible {
   outline: 3px solid var(--goa-color-interactive-focus);
   outline-offset: 1px;
 }

--- a/libs/web-components/src/assets/css/reset.css
+++ b/libs/web-components/src/assets/css/reset.css
@@ -67,9 +67,10 @@ a:hover {
   color: var(--goa-color-interactive-hover);
 }
 
-a:focus-visible, a:focus-within, a:focus {
-  outline: 3px solid var(--goa-color-interactive-focus);
-  outline-offset: 1px;
+a:focus-visible {
+  border-radius: var(--goa-border-radius-s);
+  outline: var(--goa-border-width-l) solid var(--goa-color-interactive-focus);
+  outline-offset: var(--goa-space-3xs);
 }
 
 ::placeholder {

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -200,8 +200,7 @@
     transform: translateY(2px);
   }
 
-  button:focus-visible,
-  button:focus {
+  button:focus-visible {
     box-shadow: 0 0 0 var(--goa-border-width-l)
       var(--goa-color-interactive-focus);
   }
@@ -258,7 +257,6 @@
     background-color: var(--goa-button-primary-hover-color-bg);
   }
   button:focus-visible,
-  button:focus,
   button:active {
     border-color: var(--goa-button-primary-hover-border);
     background-color: var(--goa-button-primary-focus-color-bg);
@@ -277,7 +275,6 @@
     background-color: var(--goa-button-secondary-hover-color-bg);
   }
   button.secondary:focus-visible,
-  button.secondary:focus,
   button.secondary:active {
     border: var(--goa-button-secondary-focus-border);
     background-color: var(--goa-button-secondary-focus-color-bg);
@@ -297,7 +294,6 @@
     color: var(--goa-button-tertiary-hover-color-text);
   }
   button.tertiary:focus-visible,
-  button.tertiary:focus,
   button.tertiary:active {
     background-color: var(--goa-button-tertiary-focus-color-bg);
     color: var(--goa-button-tertiary-focus-color-text);
@@ -315,9 +311,7 @@
   }
   .submit.destructive:focus-visible,
   .submit.destructive:active,
-  .submit.destructive:focus,
   .primary.destructive:focus-visible,
-  .primary.destructive:focus,
   .primary.destructive:active {
     background-color: var(--goa-button-primary-destructive-focus-color-bg);
   }
@@ -332,7 +326,6 @@
     border: var(--goa-button-secondary-destructive-hover-border);
   }
   .secondary.destructive:focus-visible,
-  .secondary.destructive:focus,
   .secondary.destructive:active {
     color: var(--goa-button-secondary-destructive-focus-color-text);
     border: var(--goa-button-secondary-destructive-focus-border);
@@ -346,7 +339,6 @@
     color: var(--goa-button-tertiary-destructive-hover-color-text);
   }
   .tertiary.destructive:focus-visible,
-  .tertiary.destructive:focus,
   .tertiary.destructive:active {
     color: var(--goa-button-tertiary-destructive-focus-color-text);
   }
@@ -363,10 +355,8 @@
     color: var(--goa-button-primary-inverse-hover-color-text);
   }
   .submit.inverse:focus-visible,
-  .submit.inverse:focus,
   .submit.inverse:active,
   .primary.inverse:focus-visible,
-  .primary.inverse:focus,
   .primary.inverse:active {
     background-color: var(--goa-button-primary-inverse-focus-color-bg);
   }
@@ -382,7 +372,6 @@
     border: var(--goa-button-secondary-inverse-hover-border);
   }
   .secondary.inverse:focus-visible,
-  .secondary.inverse:focus,
   .secondary.inverse:active {
     color: var(--goa-button-secondary-inverse-focus-color-text);
     border: var(--goa-button-secondary-inverse-focus-border);
@@ -396,7 +385,6 @@
     color: var(--goa-button-tertiary-inverse-hover-color-text);
   }
   .tertiary.inverse:focus-visible,
-  .tertiary.inverse:focus,
   .tertiary.inverse:active {
     color: var(--goa-button-tertiary-inverse-focus-color-text);
   }

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -204,8 +204,7 @@
     transform: translateY(2px);
   }
 
-  button:focus-visible,
-  button:focus {
+  button:focus-visible {
     box-shadow: 0 0 0 var(--goa-border-width-l)
       var(--goa-color-interactive-focus);
   }
@@ -262,7 +261,6 @@
     background-color: var(--goa-button-primary-hover-color-bg);
   }
   button:focus-visible,
-  button:focus,
   button:active {
     border-color: var(--goa-button-primary-hover-border);
     background-color: var(--goa-button-primary-focus-color-bg);
@@ -281,7 +279,6 @@
     background-color: var(--goa-button-secondary-hover-color-bg);
   }
   button.secondary:focus-visible,
-  button.secondary:focus,
   button.secondary:active {
     border: var(--goa-button-secondary-focus-border);
     background-color: var(--goa-button-secondary-focus-color-bg);
@@ -301,7 +298,6 @@
     color: var(--goa-button-tertiary-hover-color-text);
   }
   button.tertiary:focus-visible,
-  button.tertiary:focus,
   button.tertiary:active {
     background-color: var(--goa-button-tertiary-focus-color-bg);
     color: var(--goa-button-tertiary-focus-color-text);
@@ -319,9 +315,7 @@
   }
   .submit.destructive:focus-visible,
   .submit.destructive:active,
-  .submit.destructive:focus,
   .primary.destructive:focus-visible,
-  .primary.destructive:focus,
   .primary.destructive:active {
     background-color: var(--goa-button-primary-destructive-focus-color-bg);
   }
@@ -336,7 +330,6 @@
     border: var(--goa-button-secondary-destructive-hover-border);
   }
   .secondary.destructive:focus-visible,
-  .secondary.destructive:focus,
   .secondary.destructive:active {
     color: var(--goa-button-secondary-destructive-focus-color-text);
     border: var(--goa-button-secondary-destructive-focus-border);
@@ -350,7 +343,6 @@
     color: var(--goa-button-tertiary-destructive-hover-color-text);
   }
   .tertiary.destructive:focus-visible,
-  .tertiary.destructive:focus,
   .tertiary.destructive:active {
     color: var(--goa-button-tertiary-destructive-focus-color-text);
   }
@@ -367,10 +359,8 @@
     color: var(--goa-button-primary-inverse-hover-color-text);
   }
   .submit.inverse:focus-visible,
-  .submit.inverse:focus,
   .submit.inverse:active,
   .primary.inverse:focus-visible,
-  .primary.inverse:focus,
   .primary.inverse:active {
     background-color: var(--goa-button-primary-inverse-focus-color-bg);
   }
@@ -386,7 +376,6 @@
     border: var(--goa-button-secondary-inverse-hover-border);
   }
   .secondary.inverse:focus-visible,
-  .secondary.inverse:focus,
   .secondary.inverse:active {
     color: var(--goa-button-secondary-inverse-focus-color-text);
     border: var(--goa-button-secondary-inverse-focus-border);
@@ -400,7 +389,6 @@
     color: var(--goa-button-tertiary-inverse-hover-color-text);
   }
   .tertiary.inverse:focus-visible,
-  .tertiary.inverse:focus,
   .tertiary.inverse:active {
     color: var(--goa-button-tertiary-inverse-focus-color-text);
   }

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -507,59 +507,49 @@ max-width: ${maxwidth};
   }
 
   /* Focus + Error Container */
-  .error .container:has(:focus-visible),
-  .error .container:has(:focus) {
+  .error .container:has(:focus-visible) {
     outline: none;
     box-shadow: 0 0 0 3px var(--goa-color-interactive-focus);
   }
-  .error .container:has(:focus-visible):hover,
-  .error .container:has(:focus):hover {
+  .error .container:has(:focus-visible):hover {
     outline: none;
     border: var(--goa-checkbox-border-error);
   }
-  .error .container.selected:has(:focus-visible):hover,
-  .error .container.selected:has(:focus):hover {
+  .error .container.selected:has(:focus-visible):hover {
     outline: none;
     border: none;
     background-color: var(--goa-checkbox-color-bg);
   }
-  label:hover.error .container.selected:has(:focus-visible),
-  label:hover.error .container.selected:has(:focus) {
+  label:hover.error .container.selected:has(:focus-visible) {
     outline: none;
     border: var(--goa-checkbox-border-error);
     background-color: var(--goa-checkbox-color-bg);
   }
-  label:hover.error .container:has(:focus-visible),
-  label:hover.error .container:has(:focus) {
+  label:hover.error .container:has(:focus-visible) {
     outline: none;
     border: var(--goa-checkbox-border-error);
   }
 
   /* Focus Container */
-  .container:has(:focus-visible),
-  .container:has(:focus) {
+  .container:has(:focus-visible) {
     outline: none;
     box-shadow: 0 0 0 3px var(--goa-color-interactive-focus);
   }
-  .container:has(:focus-visible):hover,
-  .container:has(:focus):hover {
+  .container:has(:focus-visible):hover {
     outline: none;
     border: var(--goa-checkbox-border);
   }
-  .container.selected:has(:focus-visible):hover,
-  .container.selected:has(:focus):hover {
+  .container.selected:has(:focus-visible):hover {
     outline: none;
     border: none;
     background-color: var(--goa-checkbox-color-bg-checked);
   }
-  label:hover .container.selected:has(:focus-visible),
-  label:hover .container.selected:has(:focus) {
+  label:hover .container.selected:has(:focus-visible) {
     outline: none;
     border: none;
     background-color: var(--goa-checkbox-color-bg-checked);
   }
-  label:hover .container:has(:focus-visible),
-  label:hover .container:has(:focus) {
+  label:hover .container:has(:focus-visible) {
     outline: none;
     border: var(--goa-checkbox-border);
   }

--- a/libs/web-components/src/components/chip/Chip.svelte
+++ b/libs/web-components/src/components/chip/Chip.svelte
@@ -136,7 +136,7 @@
     ); /* acumin font requires this to allow for vertical alignment  */
   }
 
-  .chip:focus {
+  .chip:focus-visible {
     outline: var(--goa-border-width-m) solid var(--goa-color-interactive-focus);
     background-color: var(--goa-color-greyscale-white);
   }

--- a/libs/web-components/src/components/data-grid/DataGrid.svelte
+++ b/libs/web-components/src/components/data-grid/DataGrid.svelte
@@ -46,6 +46,10 @@
   let _bindTimeoutId: any = null; // Track pending grid rebuilds to prevent race conditions
   let _isRebuilding = false; // Flag to prevent navigation during grid rebuild
   let _gridHasFocus = false; // Track if the grid currently has focus (persists through DOM mutations)
+  // Track last input type so cell outline only appears on keyboard-driven focus.
+  // Avoids browser :focus-visible heuristics around the first interaction on a fresh page,
+  // which can match on the first mouse click.
+  let _lastInputType: 'pointer' | 'keyboard' = 'keyboard';
 
   onMount(() => {
     // Delay to allow nested shadow DOMs to fully render before grid setup - menu button is one case vs a lot of nested elements and shadow
@@ -73,6 +77,8 @@
         }
       }
       document.removeEventListener('click', handleOutsideClick);
+      document.removeEventListener('pointerdown', handlePointerdown, true);
+      document.removeEventListener('keydown', handleGlobalKeydown, true);
     };
   })
 
@@ -121,6 +127,9 @@
 
       sortedCells.forEach(cell => {
         cell.setAttribute('role', 'gridcell'); // for screen reader
+        // Suppress the browser UA default focus outline. The grid applies its own
+        // outline via setFocusedStyle() on keyboard-driven focus only.
+        cell.style.outline = 'none';
 
         // Set first cell globally as focusable, others not focusable (so Tab focuses on first cell)
         if (globalCellIndex === 0) {
@@ -158,10 +167,35 @@
 
     // Listen for clicks outside the grid to reset focus indices -> remove focusing style
     document.addEventListener('click', handleOutsideClick);
+
+    // Track last input type globally so cell focus rings only appear on keyboard input.
+    // Capture phase so we record the signal before focus events fire.
+    document.addEventListener('pointerdown', handlePointerdown, true);
+    document.addEventListener('keydown', handleGlobalKeydown, true);
   }
 
-  function handleFocusIn() {
+  function handlePointerdown() {
+    _lastInputType = 'pointer';
+  }
+
+  function handleGlobalKeydown() {
+    _lastInputType = 'keyboard';
+  }
+
+  function handleFocusIn(event: FocusEvent) {
     _gridHasFocus = true;
+    // Apply the cell focus ring only when the cell itself has keyboard-driven focus
+    // AND the cell has no focusable children of its own. When a cell contains an
+    // interactive component (checkbox, button, menu-button), event retargeting in
+    // shadow DOM makes the host appear as the focused element, but the component
+    // already shows its own focus indicator — applying our ring would stack.
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    if (target.getAttribute('role') !== 'gridcell') return;
+    if (_lastInputType !== 'keyboard') return;
+    const cellData = _grid[_focusingRowIndex]?.[_focusingColIndex];
+    if (cellData?.cell === target && cellData.focusables.length > 0) return;
+    setFocusedStyle(target);
   }
 
   function handleFocusOut(event: FocusEvent) {
@@ -386,7 +420,8 @@
 
     const newCell = _grid[row][col]?.cell;
     newCell?.setAttribute('tabindex', '0');
-    setFocusedStyle(newCell);
+    // Outline is applied by handleFocusIn when the cell receives keyboard-driven focus,
+    // so mouse clicks don't leave a ring on the cell.
 
     // Only disable arrow key navigation for input elements
     _navigationDisabled = newCell.matches('input') || newCell.querySelector('input') !== null;
@@ -437,13 +472,40 @@
   function setFocusedStyle(el: HTMLElement) {
     if (!el) return;
     el.style.outline = '3px solid var(--goa-color-interactive-focus)';
+
+    if (keyboardNav === 'table') {
+      // Table mode: inset the outline so it renders inside the cell's box,
+      // otherwise cells on the edges get clipped by the table's overflow.
+      el.style.outlineOffset = '-0.1875rem';
+
+      // Match the table's corner radius on corner cells so the inset outline
+      // follows the rounded table corner instead of looking square.
+      const row = _focusingRowIndex;
+      const col = _focusingColIndex;
+      const lastRow = _grid.length - 1;
+      const lastCol = _grid[row] ? _grid[row].length - 1 : 0;
+      const radius = 'var(--goa-table-border-radius-container, 16px)';
+      if (row === 0 && col === 0) el.style.borderTopLeftRadius = radius;
+      if (row === 0 && col === lastCol) el.style.borderTopRightRadius = radius;
+      if (row === lastRow && col === 0) el.style.borderBottomLeftRadius = radius;
+      if (row === lastRow && col === lastCol) el.style.borderBottomRightRadius = radius;
+    } else {
+      // Layout mode (cards): outline sits outside the cell with a small gap so
+      // it never overlaps content.
+      el.style.outlineOffset = '0.125rem';
+    }
   }
 
   function removeFocusedStyle(el: HTMLElement) {
     if (!el) return;
-    el.style.outline = '';
+    // Back to the suppressed baseline so the UA default doesn't reappear on mouse focus.
+    el.style.outline = 'none';
     el.style.outlineOffset = '';
     el.style.boxShadow = '';
+    el.style.borderTopLeftRadius = '';
+    el.style.borderTopRightRadius = '';
+    el.style.borderBottomLeftRadius = '';
+    el.style.borderBottomRightRadius = '';
   }
 
   function moveUp() {

--- a/libs/web-components/src/components/data-grid/DataGrid.svelte
+++ b/libs/web-components/src/components/data-grid/DataGrid.svelte
@@ -46,6 +46,10 @@
   let _bindTimeoutId: any = null; // Track pending grid rebuilds to prevent race conditions
   let _isRebuilding = false; // Flag to prevent navigation during grid rebuild
   let _gridHasFocus = false; // Track if the grid currently has focus (persists through DOM mutations)
+  // Track last input modality so cell outline only appears on keyboard-driven focus.
+  // Avoids browser :focus-visible heuristics around the first interaction on a fresh page,
+  // which can match on the first mouse click.
+  let _lastInputModality: 'pointer' | 'keyboard' = 'keyboard';
 
   onMount(() => {
     // Delay to allow nested shadow DOMs to fully render before grid setup - menu button is one case vs a lot of nested elements and shadow
@@ -73,6 +77,8 @@
         }
       }
       document.removeEventListener('click', handleOutsideClick);
+      document.removeEventListener('pointerdown', handlePointerdown, true);
+      document.removeEventListener('keydown', handleGlobalKeydown, true);
     };
   })
 
@@ -158,10 +164,35 @@
 
     // Listen for clicks outside the grid to reset focus indices -> remove focusing style
     document.addEventListener('click', handleOutsideClick);
+
+    // Track last input modality globally so cell focus rings only appear on keyboard input.
+    // Capture phase so we record the signal before focus events fire.
+    document.addEventListener('pointerdown', handlePointerdown, true);
+    document.addEventListener('keydown', handleGlobalKeydown, true);
   }
 
-  function handleFocusIn() {
+  function handlePointerdown() {
+    _lastInputModality = 'pointer';
+  }
+
+  function handleGlobalKeydown() {
+    _lastInputModality = 'keyboard';
+  }
+
+  function handleFocusIn(event: FocusEvent) {
     _gridHasFocus = true;
+    // Apply the cell focus ring only when the cell itself has keyboard-driven focus
+    // AND the cell has no focusable children of its own. When a cell contains an
+    // interactive component (checkbox, button, menu-button), event retargeting in
+    // shadow DOM makes the host appear as the focused element, but the component
+    // already shows its own focus indicator — applying our ring would stack.
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+    if (target.getAttribute('role') !== 'gridcell') return;
+    if (_lastInputModality !== 'keyboard') return;
+    const cellData = _grid[_focusingRowIndex]?.[_focusingColIndex];
+    if (cellData?.cell === target && cellData.focusables.length > 0) return;
+    setFocusedStyle(target);
   }
 
   function handleFocusOut(event: FocusEvent) {
@@ -386,7 +417,8 @@
 
     const newCell = _grid[row][col]?.cell;
     newCell?.setAttribute('tabindex', '0');
-    setFocusedStyle(newCell);
+    // Outline is applied by handleFocusIn when the cell receives keyboard-driven focus,
+    // so mouse clicks don't leave a ring on the cell.
 
     // Only disable arrow key navigation for input elements
     _navigationDisabled = newCell.matches('input') || newCell.querySelector('input') !== null;
@@ -436,14 +468,30 @@
 
   function setFocusedStyle(el: HTMLElement) {
     if (!el) return;
-    el.style.outline = '3px solid var(--goa-color-interactive-focus)';
+    // Flip the attribute and let the host component's CSS apply the visual ring.
+    // Table-mode rules (outline + corner radius) live alongside the rest of the
+    // table styles in assets/css/components.css; layout-mode has its own rule.
+    el.setAttribute('data-focused', '');
+
+    if (keyboardNav !== 'table') return;
+
+    // Tag corner cells so Table CSS can round them to follow the container radius.
+    const row = _focusingRowIndex;
+    const col = _focusingColIndex;
+    const lastRow = _grid.length - 1;
+    const lastCol = _grid[row] ? _grid[row].length - 1 : 0;
+    let corner: string | null = null;
+    if (row === 0 && col === 0) corner = 'top-left';
+    else if (row === 0 && col === lastCol) corner = 'top-right';
+    else if (row === lastRow && col === 0) corner = 'bottom-left';
+    else if (row === lastRow && col === lastCol) corner = 'bottom-right';
+    if (corner) el.setAttribute('data-focus-corner', corner);
   }
 
   function removeFocusedStyle(el: HTMLElement) {
     if (!el) return;
-    el.style.outline = '';
-    el.style.outlineOffset = '';
-    el.style.boxShadow = '';
+    el.removeAttribute('data-focused');
+    el.removeAttribute('data-focus-corner');
   }
 
   function moveUp() {

--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -120,7 +120,7 @@
     outline: var(--goa-details-focus-border);
     color: var(--goa-color-interactive-hover);
   }
-  summary:focus,
+  summary:focus-visible,
   summary:active {
     border-radius: var(--goa-details-border-radius);
     color: var(--goa-details-color-text-hover);

--- a/libs/web-components/src/components/filter-chip/FilterChip.svelte
+++ b/libs/web-components/src/components/filter-chip/FilterChip.svelte
@@ -105,7 +105,6 @@
     data-testid={testid}
     class="chip"
     class:error={_error}
-    class:focused={_focused}
     style={calculateMargin(mt, mr, mb, ml)}
     tabindex="0"
     role="button"
@@ -162,8 +161,14 @@
     touch-action: manipulation;
   }
 
-  .chip.focused {
+  .chip:focus-visible {
+    outline: none;
+  }
+
+  .chip:focus-visible .delete-icon {
     outline: var(--goa-border-width-l) solid var(--goa-color-interactive-focus);
+    outline-offset: 0.125rem;
+    border-radius: 50%;
   }
 
   .chip.error {

--- a/libs/web-components/src/components/link/Link.svelte
+++ b/libs/web-components/src/components/link/Link.svelte
@@ -194,18 +194,13 @@
     color: var(--goa-link-color-light-visited, #9D8EBB) !important;
   }
 
-  /* Focus */
-  .link:focus-within {
+  /* Focus — ring on the slotted anchor directly. Container-scoped :focus-within / :has
+     can't reach keyboard-only semantics through the slot boundary reliably, so style
+     the focusable element itself. */
+  .link :global(::slotted(a:focus-visible)) {
     border-radius: var(--goa-link-border-radius-focus, var(--goa-border-radius-s));
     outline: var(--goa-link-border-focus, var(--goa-border-width-l) solid var(--goa-color-interactive-focus));
     outline-offset: var(--goa-link-focus-offset, var(--goa-space-3xs));
-  }
-
-  .link :global(::slotted(a:focus-visible)),
-  .link :global(::slotted(a:focus-within)),
-  .link :global(::slotted(a:focus)) {
-    outline: none !important;
-    outline-offset: 0 !important;
     box-shadow: none !important;
   }
 </style>

--- a/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
+++ b/libs/web-components/src/components/microsite-header/MicrositeHeader.svelte
@@ -161,7 +161,7 @@
     color: var(--goa-microsite-header-color-links-hover);
   }
 
-  a:focus {
+  a:focus-visible {
     outline: var(--goa-microsite-header-link-focus-border);
   }
 

--- a/libs/web-components/src/components/notification/Notification.svelte
+++ b/libs/web-components/src/components/notification/Notification.svelte
@@ -191,11 +191,11 @@
     color: unset !important;
     outline: unset !important;
   }
-  :global(::slotted(a:focus)) {
+  :global(::slotted(a:focus-visible)) {
     outline: auto !important;
     border-radius: var(--goa-border-radius-xs);
   }
-  .notification.important :global(::slotted(a:focus)) {
+  .notification.important :global(::slotted(a:focus-visible)) {
     outline: unset !important;
     box-shadow: 0 0 0 3px var(--goa-color-greyscale-black);
     border-radius: var(--goa-border-radius-xs);
@@ -423,27 +423,27 @@
   }
 
   /* V2 link focus states */
-  .v2 .notification.important.high :global(::slotted(a:focus)) {
+  .v2 .notification.important.high :global(::slotted(a:focus-visible)) {
     box-shadow: var(--goa-notification-banner-important-high-focus-border);
   }
 
-  .v2 .notification.important.low :global(::slotted(a:focus)) {
+  .v2 .notification.important.low :global(::slotted(a:focus-visible)) {
     box-shadow: var(--goa-notification-banner-important-low-focus-border);
   }
 
-  .v2 .notification.information.high :global(::slotted(a:focus)) {
+  .v2 .notification.information.high :global(::slotted(a:focus-visible)) {
     box-shadow: var(--goa-notification-banner-information-high-focus-border);
   }
 
-  .v2 .notification.information.low :global(::slotted(a:focus)) {
+  .v2 .notification.information.low :global(::slotted(a:focus-visible)) {
     box-shadow: var(--goa-notification-banner-information-low-focus-border);
   }
 
-  .v2 .notification.emergency.high :global(::slotted(a:focus)) {
+  .v2 .notification.emergency.high :global(::slotted(a:focus-visible)) {
     box-shadow: var(--goa-notification-banner-emergency-high-focus-border);
   }
 
-  .v2 .notification.emergency.low :global(::slotted(a:focus)) {
+  .v2 .notification.emergency.low :global(::slotted(a:focus-visible)) {
     box-shadow: var(--goa-notification-banner-emergency-low-focus-border);
   }
 </style>

--- a/libs/web-components/src/components/table/TableSortHeader.svelte
+++ b/libs/web-components/src/components/table/TableSortHeader.svelte
@@ -49,16 +49,18 @@
   class:sorted={direction !== "none"}
   class:v2={version === "2"}
 >
-  <slot />
-  <span class="icon-wrapper">
-    <span class="sort-order" class:hidden={!sortOrder || direction === "none"}>{sortOrder}</span>
-    {#if direction === "desc"}
-      <goa-icon type="arrow-down" size="3" />
-    {:else if direction === "asc"}
-      <goa-icon type="arrow-up" size="3" />
-    {:else}
-      <goa-icon type="chevron-expand" size="3" />
-    {/if}
+  <span class="content">
+    <slot />
+    <span class="icon-wrapper">
+      <span class="sort-order" class:hidden={!sortOrder || direction === "none"}>{sortOrder}</span>
+      {#if direction === "desc"}
+        <goa-icon type="arrow-down" size="3" />
+      {:else if direction === "asc"}
+        <goa-icon type="arrow-up" size="3" />
+      {:else}
+        <goa-icon type="chevron-expand" size="3" />
+      {/if}
+    </span>
   </span>
 </button>
 
@@ -85,9 +87,19 @@
       var(--goa-space-s) var(--goa-space-m) var(--goa-space-xs)
     );
     justify-content: var(--header-text-align, flex-start);
-    gap: var(--goa-table-sort-header-gap, var(--goa-space-2xs));
     align-items: flex-end;
     text-align: var(--header-align, left);
+  }
+
+  /* Inline-flex wrapper around label + sort icon. Sizes to its content so the
+     focus ring wraps just the visible button content, not the whole cell.
+     The padding adds breathing room between the content and the focus ring. */
+  .content {
+    display: inline-flex;
+    align-items: flex-end;
+    gap: var(--goa-table-sort-header-gap, var(--goa-space-2xs));
+    padding: var(--goa-space-3xs);
+    border-radius: var(--goa-border-radius-m);
   }
 
   /* Hover state - no background change, only text color */
@@ -102,15 +114,10 @@
     outline: none;
   }
 
-  /* V1: Focus ring on whole button */
-  button:focus-visible {
+  /* Focus ring on the content wrapper (label + sort icon) */
+  button:focus-visible .content {
     box-shadow: 0 0 0 var(--goa-border-width-l)
       var(--goa-color-interactive-focus);
-  }
-
-  /* V2: No focus ring on button, focus ring goes on icon instead */
-  button.v2:focus-visible {
-    box-shadow: none;
   }
 
   /* Icon wrapper - contains the sort icon */
@@ -119,15 +126,6 @@
     align-items: center;
     justify-content: center;
     border-radius: var(--goa-border-radius-m);
-  }
-
-  /* V2: Focus ring on icon when button is focused */
-  button.v2:focus-visible .icon-wrapper {
-    box-shadow: 0 0 0 var(--goa-icon-button-focus-border-width, 2px)
-      var(
-        --goa-icon-button-focus-border-color,
-        var(--goa-color-interactive-focus)
-      );
   }
 
   /* Active sort icon */

--- a/libs/web-components/src/components/text-area/TextArea.svelte
+++ b/libs/web-components/src/components/text-area/TextArea.svelte
@@ -290,7 +290,7 @@
   .error:hover {
     box-shadow: var(--goa-text-area-border-error);
   }
-  .error:focus {
+  .error:focus-visible {
     box-shadow: var(--goa-text-area-border), var(--goa-text-area-border-focus);
   }
   .error:focus-within:hover {
@@ -322,7 +322,6 @@
   .v2.root:focus-within {
     box-shadow: var(--goa-text-area-border-focus);
   }
-  .v2.error:focus,
   .v2.error:focus-within,
   .v2.error:focus-within:hover {
     box-shadow: var(--goa-text-area-border-focus);

--- a/libs/web-components/src/components/tooltip/Tooltip.svelte
+++ b/libs/web-components/src/components/tooltip/Tooltip.svelte
@@ -143,6 +143,16 @@
     }, 500);
   };
 
+  // Mouse click also fires on:focus on a tabindex=0 element, but we only want
+  // to reveal the tooltip on keyboard-driven focus so JS state stays aligned
+  // with the CSS :focus-visible rule that drives opacity.
+  function handleFocus(e: FocusEvent) {
+    const target = e.currentTarget as HTMLElement | null;
+    if (!target?.matches?.(":focus-visible")) return;
+    clearTimeout(_hideTooltipTimeout);
+    showTooltip();
+  }
+
   async function checkAndAdjustPosition() {
     // angular needs time to render the _tooltipEl
     await tick();
@@ -227,10 +237,7 @@
     showTooltip();
   }}
   on:mouseleave={hideTooltip}
-  on:focus={() => {
-    clearTimeout(_hideTooltipTimeout);
-    showTooltip();
-  }}
+  on:focus={handleFocus}
   on:blur={hideTooltip}
   data-testid={testid}
   role="tooltip"
@@ -315,7 +322,7 @@
   }
 
   .tooltip:hover .tooltip-text,
-  .tooltip:focus .tooltip-text {
+  .tooltip:focus-visible .tooltip-text {
     opacity: 1;
   }
 


### PR DESCRIPTION
Fixes #3605

# Before

Mouse click on interactive components left the focus ring visible for mouse users. In some cases the ring rendered without the designed gap/offset because `:focus` fired on the mouse path alongside `:focus-visible`.

# After

Mouse click no longer shows the focus ring. Keyboard Tab and arrow-key navigation show the ring with the correct gap/offset. V1 and V2 paths both behave correctly.

## Components updated

- Button.svelte
- Chip.svelte (V1, deprecated)
- Checkbox.svelte (V1)
- DataGrid.svelte
- Details.svelte
- FilterChip.svelte
- Link.svelte
- MicrositeHeader.svelte
- Notification.svelte
- TextArea.svelte
- Tooltip.svelte
- assets/css/reset.css

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Check out this branch and run `npm run serve:prs:react` (or `:angular` or `:web`).
2. Navigate to `/bugs/3605` (React/Angular) or `/issues/3605` (Web).
3. For each section, press Tab through the interactive elements. A focus ring should appear with the correct gap/offset.
4. Click the same elements with a mouse. No focus ring should remain after the click. Holding mouse down (`:active`) should still show the pressed/focused state on buttons.
5. For DataGrid: use arrow keys inside both the table example and the cards example. Focus ring appears on keyboard nav, not on mouse click. Cells containing interactive components (checkbox, button, menu-button) do not stack our ring on top of the component's native ring.


https://github.com/user-attachments/assets/d6fe2cd1-e431-45a1-86b5-a6a6628fedaa


https://github.com/user-attachments/assets/07a3560d-fdc7-4d42-b090-770606f25214

