### PR TITLE
chore: Remove Netlify deploys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,0 @@
-[build]
-  publish = "dist/docs"
-  command = "npm ci && cd docs && npm ci && cd .. && npm run build:prod"
-
-[build.environment]
-  NODE_VERSION = "22"
-  NPM_FLAGS = "--legacy-peer-deps"


### PR DESCRIPTION
This will remove Netlify from our PR requests, which is currently breaking some of our PR's because it's not working anymore.
