### PR TITLE
fix(#3882): use neutral border token on filled-accent interactive content

### DIFF
--- a/libs/web-components/src/components/container/Container.svelte
+++ b/libs/web-components/src/components/container/Container.svelte
@@ -220,7 +220,7 @@
     color: var(--goa-container-interactive-heading-text-color);
   }
   .goa-container--interactive.accent--filled .content {
-    border: var(--goa-container-interactive-border);
+    border: var(--goa-container-border);
     background-color: var(--goa-container-interactive-bg-color);
   }
 


### PR DESCRIPTION
## What

Follow-up to #3848. That PR pointed the `.goa-container--interactive.accent--filled .content` rule at `--goa-container-interactive-border`, which resolves to brand teal. Every interactive container with `accent="filled"` (the default) is rendering a teal border at rest. Intent is greyscale-200.

Swaps the rule to `--goa-container-border`, the existing neutral token already used by the base `.content` rule for non-filled accents. One-line change. No token changes, no wrapper changes.

## Why not change the token

`--goa-container-interactive-border` stays as is. It is still in legitimate use for the heading element on `accent="thick"` and `accent="thin"`, where teal-on-teal renders as the flush accent bar. Recoloring the token would put a gray outline around that bar.

## Test plan

1. `accent="filled"` interactive container: greyscale-200 border at rest.
2. `accent="thick"` and `accent="thin"`: flush teal accent bar at top, no outline around it.
3. Non-interactive variants unchanged across all accents.

<img width="1405" height="1036" alt="image" src="https://github.com/user-attachments/assets/cdd4130f-104e-437f-815a-3168654b7a7d" />
<img width="1405" height="1036" alt="image" src="https://github.com/user-attachments/assets/6418c67c-60b9-410a-9138-3731e6706e1a" />
