### PR TITLE
feat(#3504): Add "text" type to Button

### DIFF
--- a/apps/prs/angular/src/routes/features/feat3504-text-button/feat3504.component.html
+++ b/apps/prs/angular/src/routes/features/feat3504-text-button/feat3504.component.html
@@ -1,0 +1,160 @@
+<main>
+  <goab-text tag="h1" mt="none">
+    feat(#3504): Add "text" type to Button component
+  </goab-text>
+  <goab-text>Demonstrates the new "text" type button variations. Requires design tokens from <a href="https://github.com/GovAlta/design-tokens/pull/156">GovAlta/design-tokens#156</a>.</goab-text>
+
+  <div style="display: flex; gap: 2rem; flex-direction: column; align-items: flex-start;">
+    <goab-block direction="row" gap="2xl">
+      <div style="display: flex; gap: 1rem; flex-direction: column; align-items: flex-start;">
+        <goab-text tag="h3">Regular button size</goab-text>
+
+        <goab-button type="text">Text Button</goab-button>
+
+        <goab-button type="text" [disabled]="true">
+          Disabled Text Button
+        </goab-button>
+
+        <goab-button type="text" variant="destructive">
+          Destructive Text Button
+        </goab-button>
+
+        <goab-button type="text" variant="destructive" [disabled]="true">
+          Destructive and Disabled Text Button
+        </goab-button>
+
+        <div style="background-color: #000; padding: 0.5rem; display: flex; flex-direction: column; gap: 1rem;">
+          <goab-button type="text" variant="inverse">
+            Inverse Text Button
+          </goab-button>
+
+          <goab-button type="text" variant="inverse" [disabled]="true">
+            Inverse and Disabled Text Button
+          </goab-button>
+        </div>
+
+        <goab-button type="text" variant="dark">
+          Dark Text Button
+        </goab-button>
+
+        <goab-button type="text" variant="dark" [disabled]="true">
+          Dark and Disabled Text Button
+        </goab-button>
+      </div>
+
+      <div style="display: flex; gap: 1rem; flex-direction: column; align-items: flex-start;">
+        <goab-text tag="h3">Regular button size with icons</goab-text>
+
+        <goab-button type="text" leadingIcon="add">
+          Leading Icon
+        </goab-button>
+
+        <goab-button type="text" trailingIcon="arrow-forward">
+          Trailing Icon
+        </goab-button>
+
+        <goab-button type="text" leadingIcon="add" trailingIcon="arrow-forward">
+          Leading and Trailing Icons
+        </goab-button>
+
+        <goab-button type="text" leadingIcon="add" [disabled]="true">
+          Disabled + Leading Icon
+        </goab-button>
+
+        <goab-button type="text" variant="destructive" leadingIcon="trash">
+          Destructive + Leading Icon
+        </goab-button>
+
+        <div style="background-color: #000; padding: 0.5rem; display: flex; flex-direction: column; gap: 1rem;">
+          <goab-button type="text" variant="inverse" leadingIcon="pencil">
+            Inverse + Leading Icon
+          </goab-button>
+        </div>
+
+        <goab-button type="text" variant="dark" leadingIcon="add">
+          Dark + Leading Icon
+        </goab-button>
+      </div>
+    </goab-block>
+
+    <goab-block direction="row" gap="2xl">
+      <div style="display: flex; gap: 1rem; flex-direction: column; align-items: flex-start;">
+        <goab-text tag="h3">Compact button size</goab-text>
+
+        <goab-button type="text" size="compact">
+          Text Button
+        </goab-button>
+
+        <goab-button type="text" size="compact" [disabled]="true">
+          Disabled Text Button
+        </goab-button>
+
+        <goab-button type="text" size="compact" variant="destructive">
+          Destructive Text Button
+        </goab-button>
+
+        <goab-button type="text" size="compact" variant="destructive" [disabled]="true">
+          Destructive and Disabled Text Button
+        </goab-button>
+
+        <div style="background-color: #000; padding: 0.5rem; display: flex; flex-direction: column; gap: 1rem;">
+          <goab-button type="text" size="compact" variant="inverse">
+            Inverse Text Button
+          </goab-button>
+
+          <goab-button type="text" size="compact" variant="inverse" [disabled]="true">
+            Inverse and Disabled Text Button
+          </goab-button>
+        </div>
+
+        <goab-button type="text" size="compact" variant="dark">
+          Dark Text Button
+        </goab-button>
+
+        <goab-button type="text" size="compact" variant="dark" [disabled]="true">
+          Dark and Disabled Text Button
+        </goab-button>
+      </div>
+
+      <div style="display: flex; gap: 1rem; flex-direction: column; align-items: flex-start;">
+        <goab-text tag="h3">Compact button size with icons</goab-text>
+
+        <goab-button type="text" size="compact" leadingIcon="add">
+          Leading Icon
+        </goab-button>
+
+        <goab-button type="text" size="compact" trailingIcon="arrow-forward">
+          Trailing Icon
+        </goab-button>
+
+        <goab-button type="text" size="compact" leadingIcon="add" trailingIcon="arrow-forward">
+          Leading and Trailing Icons
+        </goab-button>
+
+        <goab-button type="text" size="compact" leadingIcon="add" [disabled]="true">
+          Disabled + Leading Icon
+        </goab-button>
+
+        <goab-button type="text" size="compact" variant="destructive" leadingIcon="trash">
+          Destructive + Leading Icon
+        </goab-button>
+
+        <div style="background-color: #000; padding: 0.5rem; display: flex; flex-direction: column; gap: 1rem;">
+          <goab-button type="text" size="compact" variant="inverse" leadingIcon="pencil">
+            Inverse + Leading Icon
+          </goab-button>
+        </div>
+
+        <goab-button type="text" size="compact" variant="dark" leadingIcon="add">
+          Dark + Leading Icon
+        </goab-button>
+      </div>
+    </goab-block>
+    <goab-text tag="h3" mb="none">
+      Invalid states
+    </goab-text>
+    <goab-button type="secondary" variant="dark" size="compact">
+      This non-text button with "dark" variant should cause a console warning
+    </goab-button>
+  </div>
+</main>

--- a/apps/prs/angular/src/routes/features/feat3504-text-button/feat3504.component.ts
+++ b/apps/prs/angular/src/routes/features/feat3504-text-button/feat3504.component.ts
@@ -1,0 +1,11 @@
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { GoabButton, GoabBlock, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat3504-text-button",
+  templateUrl: "./feat3504.component.html",
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [GoabButton, GoabBlock, GoabText],
+})
+export class Feat3504TextButtonComponent {}

--- a/apps/prs/angular/src/routes/features/feat3504-text-button/feat3504.route.json
+++ b/apps/prs/angular/src/routes/features/feat3504-text-button/feat3504.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Text Button Component",
+  "path": "features/3504",
+  "id": "3504",
+  "type": "feature"
+}

--- a/apps/prs/react/src/app/routes/features/feat3504.route.ts
+++ b/apps/prs/react/src/app/routes/features/feat3504.route.ts
@@ -1,0 +1,9 @@
+import { Feat3504TextButtonRoute } from "../../../routes/features/feat3504";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "feature",
+  id: "3504",
+  path: "features/3504",
+  title: "Text Button Component",
+  component: Feat3504TextButtonRoute,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/features/feat3504.tsx
+++ b/apps/prs/react/src/routes/features/feat3504.tsx
@@ -1,0 +1,256 @@
+import { GoabButton, GoabBlock, GoabText } from "@abgov/react-components";
+
+export function Feat3504TextButtonRoute() {
+  return (
+    <main>
+      <GoabText as="h1" mt="none">
+        feat(#3504): Add "text" type to Button component
+      </GoabText>
+      <GoabText>
+        Demonstrates the new "text" type button variations. Requires design tokens from{" "}
+        <a href="https://github.com/GovAlta/design-tokens/pull/156">
+          GovAlta/design-tokens#156
+        </a>
+        .
+      </GoabText>
+
+      <div
+        style={{
+          display: "flex",
+          gap: "2rem",
+          flexDirection: "column",
+          alignItems: "flex-start",
+        }}
+      >
+        <GoabBlock direction="row" gap="2xl" alignment="start">
+          <div
+            style={{
+              display: "flex",
+              gap: "1rem",
+              flexDirection: "column",
+              alignItems: "flex-start",
+            }}
+          >
+            <GoabText as="h3">Regular button size</GoabText>
+
+            <GoabButton type="text">Text Button</GoabButton>
+
+            <GoabButton type="text" disabled={true}>
+              Disabled Text Button
+            </GoabButton>
+
+            <GoabButton type="text" variant="destructive">
+              Destructive Text Button
+            </GoabButton>
+
+            <GoabButton type="text" variant="destructive" disabled={true}>
+              Destructive and Disabled Text Button
+            </GoabButton>
+
+            <div
+              style={{
+                backgroundColor: "#000",
+                padding: "0.5rem",
+                display: "flex",
+                flexDirection: "column",
+                gap: "1rem",
+              }}
+            >
+              <GoabButton type="text" variant="inverse">
+                Inverse Text Button
+              </GoabButton>
+
+              <GoabButton type="text" variant="inverse" disabled={true}>
+                Inverse and Disabled Text Button
+              </GoabButton>
+            </div>
+
+            <GoabButton type="text" variant="dark">
+              Dark Text Button
+            </GoabButton>
+
+            <GoabButton type="text" variant="dark" disabled={true}>
+              Dark and Disabled Text Button
+            </GoabButton>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              gap: "1rem",
+              flexDirection: "column",
+              alignItems: "flex-start",
+            }}
+          >
+            <GoabText as="h3">Regular button size with icons</GoabText>
+
+            <GoabButton type="text" leadingIcon="add">
+              Leading Icon
+            </GoabButton>
+
+            <GoabButton type="text" trailingIcon="arrow-forward">
+              Trailing Icon
+            </GoabButton>
+
+            <GoabButton type="text" leadingIcon="add" trailingIcon="arrow-forward">
+              Leading and Trailing Icons
+            </GoabButton>
+
+            <GoabButton type="text" leadingIcon="add" disabled={true}>
+              Disabled + Leading Icon
+            </GoabButton>
+
+            <GoabButton type="text" variant="destructive" leadingIcon="trash">
+              Destructive + Leading Icon
+            </GoabButton>
+
+            <div
+              style={{
+                backgroundColor: "#000",
+                padding: "0.5rem",
+                display: "flex",
+                flexDirection: "column",
+                gap: "1rem",
+              }}
+            >
+              <GoabButton type="text" variant="inverse" leadingIcon="pencil">
+                Inverse + Leading Icon
+              </GoabButton>
+            </div>
+
+            <GoabButton type="text" variant="dark" leadingIcon="add">
+              Dark + Leading Icon
+            </GoabButton>
+          </div>
+        </GoabBlock>
+
+        <GoabBlock direction="row" gap="2xl" alignment="start">
+          <div
+            style={{
+              display: "flex",
+              gap: "1rem",
+              flexDirection: "column",
+              alignItems: "flex-start",
+            }}
+          >
+            <GoabText as="h3">Compact button size</GoabText>
+
+            <GoabButton type="text" size="compact">
+              Text Button
+            </GoabButton>
+
+            <GoabButton type="text" size="compact" disabled={true}>
+              Disabled Text Button
+            </GoabButton>
+
+            <GoabButton type="text" size="compact" variant="destructive">
+              Destructive Text Button
+            </GoabButton>
+
+            <GoabButton type="text" size="compact" variant="destructive" disabled={true}>
+              Destructive and Disabled Text Button
+            </GoabButton>
+
+            <div
+              style={{
+                backgroundColor: "#000",
+                padding: "0.5rem",
+                display: "flex",
+                flexDirection: "column",
+                gap: "1rem",
+              }}
+            >
+              <GoabButton type="text" size="compact" variant="inverse">
+                Inverse Text Button
+              </GoabButton>
+
+              <GoabButton type="text" size="compact" variant="inverse" disabled={true}>
+                Inverse and Disabled Text Button
+              </GoabButton>
+            </div>
+
+            <GoabButton type="text" size="compact" variant="dark">
+              Dark Text Button
+            </GoabButton>
+
+            <GoabButton type="text" size="compact" variant="dark" disabled={true}>
+              Dark and Disabled Text Button
+            </GoabButton>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              gap: "1rem",
+              flexDirection: "column",
+              alignItems: "flex-start",
+            }}
+          >
+            <GoabText as="h3">Compact button size with icons</GoabText>
+
+            <GoabButton type="text" size="compact" leadingIcon="add">
+              Leading Icon
+            </GoabButton>
+
+            <GoabButton type="text" size="compact" trailingIcon="arrow-forward">
+              Trailing Icon
+            </GoabButton>
+
+            <GoabButton
+              type="text"
+              size="compact"
+              leadingIcon="add"
+              trailingIcon="arrow-forward"
+            >
+              Leading and Trailing Icons
+            </GoabButton>
+
+            <GoabButton type="text" size="compact" leadingIcon="add" disabled={true}>
+              Disabled + Leading Icon
+            </GoabButton>
+
+            <GoabButton
+              type="text"
+              size="compact"
+              variant="destructive"
+              leadingIcon="trash"
+            >
+              Destructive + Leading Icon
+            </GoabButton>
+
+            <div
+              style={{
+                backgroundColor: "#000",
+                padding: "0.5rem",
+                display: "flex",
+                flexDirection: "column",
+                gap: "1rem",
+              }}
+            >
+              <GoabButton
+                type="text"
+                size="compact"
+                variant="inverse"
+                leadingIcon="pencil"
+              >
+                Inverse + Leading Icon
+              </GoabButton>
+            </div>
+
+            <GoabButton type="text" size="compact" variant="dark" leadingIcon="add">
+              Dark + Leading Icon
+            </GoabButton>
+          </div>
+        </GoabBlock>
+        <GoabText as="h3" mb="none">
+          Invalid states
+        </GoabText>
+        <GoabButton type="secondary" variant="dark" size="compact">
+          This non-text button with "dark" variant should cause a console warning
+        </GoabButton>
+      </div>
+    </main>
+  );
+}
+
+export default Feat3504TextButtonRoute;

--- a/docs/generated/component-apis/button.json
+++ b/docs/generated/component-apis/button.json
@@ -4,18 +4,19 @@
   "props": [
     {
       "name": "type",
-      "type": "\"primary\" | \"submit\" | \"secondary\" | \"tertiary\" | \"start\"",
+      "type": "\"primary\" | \"submit\" | \"secondary\" | \"tertiary\" | \"start\" | \"text\"",
       "typeLabel": "GoabButtonType",
       "values": [
         "primary",
         "submit",
         "secondary",
         "tertiary",
-        "start"
+        "start",
+        "text"
       ],
       "required": false,
       "default": "primary",
-      "description": "Sets the visual style of the button. Use \"primary\" for main actions, \"secondary\" for alternative actions, \"tertiary\" for low-emphasis actions, and \"start\" for prominent call-to-action buttons."
+      "description": "Sets the visual style of the button. Use \"primary\" for main actions, \"secondary\" for alternative actions, \"tertiary\" for low-emphasis actions, \"start\" for prominent call-to-action buttons, and \"text\" for text-only buttons."
     },
     {
       "name": "size",
@@ -31,16 +32,17 @@
     },
     {
       "name": "variant",
-      "type": "\"normal\" | \"destructive\" | \"inverse\"",
+      "type": "\"normal\" | \"destructive\" | \"inverse\" | \"dark\"",
       "typeLabel": "GoabButtonVariant",
       "values": [
         "normal",
         "destructive",
-        "inverse"
+        "inverse",
+        "dark"
       ],
       "required": false,
       "default": "normal",
-      "description": "Sets the color variant for semantic meaning. Use \"destructive\" for delete or irreversible actions, \"inverse\" for dark backgrounds."
+      "description": "Sets the color variant for semantic meaning. Use \"destructive\" for delete or irreversible actions, \"inverse\" for light-colored text on dark backgrounds, and \"dark\" for dark text color on text buttons only. Note: \"dark\" has no effect on non-text button types."
     },
     {
       "name": "disabled",

--- a/docs/generated/component-apis/link-button.json
+++ b/docs/generated/component-apis/link-button.json
@@ -11,7 +11,8 @@
       ],
       "required": false,
       "default": "interactive",
-      "description": "Sets the color theme. 'interactive' for blue, 'light' for white on dark backgrounds."
+      "description": "@deprecated Use GoabButton instead. Sets the color theme. 'interactive' for blue, 'light' for white on dark backgrounds.",
+      "deprecated": true
     },
     {
       "name": "leadingIcon",
@@ -19,7 +20,8 @@
       "typeLabel": "GoAIconType",
       "required": true,
       "default": null,
-      "description": "Icon displayed before the button text."
+      "description": "@deprecated Use GoabButton instead. Icon displayed before the button text.",
+      "deprecated": true
     },
     {
       "name": "trailingIcon",
@@ -27,7 +29,24 @@
       "typeLabel": "GoAIconType",
       "required": true,
       "default": null,
-      "description": "Icon displayed after the button text."
+      "description": "@deprecated Use GoabButton instead. Icon displayed after the button text.",
+      "deprecated": true
+    },
+    {
+      "name": "disabled",
+      "type": "boolean",
+      "required": false,
+      "default": "false",
+      "description": "@deprecated Use GoabButton instead. When true, prevents user interaction and applies disabled styling.",
+      "deprecated": true
+    },
+    {
+      "name": "testId",
+      "type": "string",
+      "required": false,
+      "default": "",
+      "description": "@deprecated Use GoabButton instead. Sets a data-testid attribute for automated testing.",
+      "deprecated": true
     },
     {
       "name": "mt",
@@ -35,7 +54,8 @@
       "typeLabel": "Spacing",
       "required": false,
       "default": null,
-      "description": "Top margin."
+      "description": "@deprecated Use GoabButton instead. Top margin.",
+      "deprecated": true
     },
     {
       "name": "mr",
@@ -43,7 +63,8 @@
       "typeLabel": "Spacing",
       "required": false,
       "default": null,
-      "description": "Right margin."
+      "description": "@deprecated Use GoabButton instead. Right margin.",
+      "deprecated": true
     },
     {
       "name": "mb",
@@ -51,7 +72,8 @@
       "typeLabel": "Spacing",
       "required": false,
       "default": null,
-      "description": "Bottom margin."
+      "description": "@deprecated Use GoabButton instead. Bottom margin.",
+      "deprecated": true
     },
     {
       "name": "ml",
@@ -59,7 +81,8 @@
       "typeLabel": "Spacing",
       "required": false,
       "default": null,
-      "description": "Left margin."
+      "description": "@deprecated Use GoabButton instead. Left margin.",
+      "deprecated": true
     }
   ],
   "events": [

--- a/docs/public/search-index.json
+++ b/docs/public/search-index.json
@@ -440,16 +440,6 @@
   },
   {
     "type": "component",
-    "id": "link-button",
-    "name": "Link Button",
-    "description": "Button styled as a link for secondary actions.",
-    "status": "stable",
-    "category": "inputs-and-actions",
-    "tags": [],
-    "slug": "link-button"
-  },
-  {
-    "type": "component",
     "id": "link",
     "name": "Link",
     "description": "Wraps an anchor element to add icons or margins.",

--- a/docs/src/content/components/button.mdx
+++ b/docs/src/content/components/button.mdx
@@ -10,7 +10,6 @@ tags:
 relatedComponents:
   - button-group
   - icon-button
-  - link-button
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=57138-300030
 githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3AButton
 webComponentTag: goa-button

--- a/docs/src/content/components/link-button.mdx
+++ b/docs/src/content/components/link-button.mdx
@@ -1,8 +1,9 @@
 ---
 name: Link Button
 description: Button styled as a link for secondary actions.
-status: stable
+status: deprecated
 category: inputs-and-actions
+hidden: true
 relatedComponents:
   - button
   - link

--- a/libs/angular-components/src/lib/components/button/button.ts
+++ b/libs/angular-components/src/lib/components/button/button.ts
@@ -53,11 +53,11 @@ import { GoabBaseComponent } from "../base.component";
 export class GoabButton extends GoabBaseComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
 
-  /** Sets the visual style of the button. Use "primary" for main actions, "secondary" for alternative actions, "tertiary" for low-emphasis actions, and "start" for prominent call-to-action buttons. @default "primary" */
+  /** Sets the visual style of the button. Use "primary" for main actions, "secondary" for alternative actions, "tertiary" for low-emphasis actions, "start" for prominent call-to-action buttons, and "text" for text-only buttons. @default "primary" */
   @Input() type?: GoabButtonType = "primary";
   /** Sets the size of the button. Use "compact" for inline actions or space-constrained layouts. @default "normal" */
   @Input() size?: GoabButtonSize;
-  /** Sets the color variant for semantic meaning. Use "destructive" for delete or irreversible actions, "inverse" for dark backgrounds. @default "normal" */
+  /** Sets the color variant for semantic meaning. Use "destructive" for delete or irreversible actions, "inverse" for light-colored text on dark backgrounds, and "dark" for dark text color on text buttons only. Note: "dark" has no effect on non-text button types. @default "normal" */
   @Input() variant?: GoabButtonVariant;
   /** Sets the disabled state. When true, prevents user interaction and applies disabled styling. */
   @Input({ transform: booleanAttribute }) disabled?: boolean;

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -247,10 +247,16 @@ export type GoabCalloutAriaLive = "off" | "polite" | "assertive";
 export type GoabCalloutIconTheme = "outline" | "filled";
 
 // Button
-export type GoabButtonType = "primary" | "submit" | "secondary" | "tertiary" | "start";
+export type GoabButtonType =
+  | "primary"
+  | "submit"
+  | "secondary"
+  | "tertiary"
+  | "start"
+  | "text";
 
 export type GoabButtonSize = "compact" | "normal";
-export type GoabButtonVariant = "normal" | "destructive" | "inverse";
+export type GoabButtonVariant = "normal" | "destructive" | "inverse" | "dark";
 
 // Button group
 export type GoabButtonGroupAlignment = "start" | "end" | "center";

--- a/libs/react-components/src/lib/button/button.tsx
+++ b/libs/react-components/src/lib/button/button.tsx
@@ -37,11 +37,11 @@ declare module "react" {
 }
 
 export interface GoabButtonProps extends Margins, DataAttributes {
-  /** Sets the visual style of the button. Use "primary" for main actions, "secondary" for alternative actions, "tertiary" for low-emphasis actions, and "start" for prominent call-to-action buttons. @default "primary" */
+  /** Sets the visual style of the button. Use "primary" for main actions, "secondary" for alternative actions, "tertiary" for low-emphasis actions, "start" for prominent call-to-action buttons, and "text" for text-only buttons. @default "primary" */
   type?: GoabButtonType;
   /** Controls the size of the button. Use "compact" for inline actions or space-constrained layouts. @default "normal" */
   size?: GoabButtonSize;
-  /** Sets the color variant for semantic meaning. Use "destructive" for delete or irreversible actions, "inverse" for dark backgrounds. @default "normal" */
+  /** Sets the color variant for semantic meaning. Use "destructive" for delete or irreversible actions, "inverse" for light-colored text on dark backgrounds, and "dark" for dark text color on text buttons only. Note: "dark" has no effect on non-text button types. @default "normal" */
   variant?: GoabButtonVariant;
   /** When true, prevents user interaction and applies disabled styling. */
   disabled?: boolean;

--- a/libs/react-components/src/lib/link-button/link-button.tsx
+++ b/libs/react-components/src/lib/link-button/link-button.tsx
@@ -18,8 +18,11 @@ declare module "react" {
 }
 
 interface GoALinkButtonProps extends Margins, DataAttributes {
+  /** @deprecated Use GoabButton instead. Sets the type of button. */
   type?: GoabLinkButtonType;
+  /** @deprecated Use GoabButton instead. Icon displayed before the button text. */
   leadingIcon?: GoabIconType;
+  /** @deprecated Use GoabButton instead. Icon displayed after the button text. */
   trailingIcon?: GoabIconType;
   children: ReactNode;
 }

--- a/libs/web-components/src/components/button/Button.spec.ts
+++ b/libs/web-components/src/components/button/Button.spec.ts
@@ -56,7 +56,7 @@ describe("GoAButtonComponent", () => {
   });
 
   describe("type", () => {
-    ["primary", "secondary", "tertiary", "start"].forEach((type) => {
+    ["primary", "secondary", "tertiary", "start", "text"].forEach((type) => {
       it(`should render ${type} type`, async () => {
         const baseElement = render(GoAButton, { type });
         const button = await baseElement.findByRole("button");
@@ -68,7 +68,7 @@ describe("GoAButtonComponent", () => {
   });
 
   describe("variant", () => {
-    ["normal", "destructive"].forEach((variant) => {
+    ["normal", "destructive", "inverse", "dark"].forEach((variant) => {
       it(`should render ${variant} variant`, async () => {
         const baseElement = render(GoAButton, { variant });
         const button = await baseElement.findByRole("button");

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -19,7 +19,7 @@
   // Validators
   const [Types, validateType] = typeValidator(
     "Button type",
-    ["primary", "submit", "secondary", "tertiary", "start"],
+    ["primary", "submit", "secondary", "tertiary", "start", "text"],
     { required: true, deprecated: ["submit"] },
   );
   const [Sizes, validateSize] = typeValidator(
@@ -29,7 +29,7 @@
   );
   const [Variants, validateVariant] = typeValidator(
     "Button variant",
-    ["normal", "destructive", "inverse"],
+    ["normal", "destructive", "inverse", "dark"],
     { required: true },
   );
   const [Versions, validateVersion] = typeValidator(
@@ -44,13 +44,13 @@
   type Variant = (typeof Variants)[number];
   type Version = (typeof Versions)[number];
 
-  /** Sets the visual style of the button. Use "primary" for main actions, "secondary" for alternative actions, "tertiary" for low-emphasis actions, and "start" for prominent call-to-action buttons. */
+  /** Sets the visual style of the button. Use "primary" for main actions, "secondary" for alternative actions, "tertiary" for low-emphasis actions, "start" for prominent call-to-action buttons, and "text" for text-only buttons. */
   export let type: ButtonType = "primary";
 
   /** Controls the size of the button. Use "compact" for inline actions or space-constrained layouts. */
   export let size: Size = "normal";
 
-  /** Sets the color variant for semantic meaning. Use "destructive" for delete or irreversible actions, "inverse" for dark backgrounds. */
+  /** Sets the color variant for semantic meaning. Use "destructive" for delete or irreversible actions, "inverse" for light-colored text on dark backgrounds, and "dark" for dark text color on text buttons only. Note: "dark" has no effect on non-text button types. */
   export let variant: Variant = "normal";
 
   /** When true, prevents user interaction and applies disabled styling. */
@@ -108,6 +108,10 @@
     validateSize(size);
     validateVariant(variant);
     validateVersion(version);
+
+    if (variant === "dark" && type !== "text") {
+      console.warn(`[GoabButton] The "dark" variant only applies to type="text". It has no effect on type="${type}".`);
+    }
   });
 
   // =========
@@ -463,5 +467,78 @@
 
   button.v2 .text {
     padding-bottom: 0;
+  }
+
+  /* Text */
+  button.v2.text {
+    border: none;
+    background-color: transparent;
+    color: var(--goa-button-text-color-text);
+    text-decoration: var(--goa-button-text-text-decoration);
+    padding: var(--goa-button-text-padding);
+    height: auto;
+    font: var(--goa-button-text-font);
+    letter-spacing: var(--goa-button-text-letter-spacing);
+    border-radius: var(--goa-button-text-border-radius);
+  }
+  button.v2.text:hover {
+    color: var(--goa-button-text-hover-color-text);
+    background-color: transparent;
+  }
+  button.v2.text:focus-visible {
+    color: var(--goa-button-text-focus-color-text);
+    background-color: transparent;
+  }
+  button.v2.text:focus:not(:focus-visible) {
+    box-shadow: none;
+  }
+
+  button.v2.text.compact {
+    font: var(--goa-button-text-compact-font);
+    letter-spacing: var(--goa-button-text-compact-letter-spacing);
+  }
+
+  /* Destructive Text */
+  button.v2.text.destructive {
+    color: var(--goa-button-text-destructive-color-text);
+  }
+  button.v2.text.destructive:hover {
+    color: var(--goa-button-text-destructive-hover-color-text);
+  }
+  button.v2.text.destructive:focus-visible {
+    color: var(--goa-button-text-destructive-focus-color-text);
+  }
+
+  /* Inverse Text */
+  button.v2.text.inverse {
+    color: var(--goa-button-text-inverse-color-text);
+  }
+  button.v2.text.inverse:hover {
+    color: var(--goa-button-text-inverse-hover-color-text);
+  }
+  button.v2.text.inverse:focus-visible {
+    color: var(--goa-button-text-inverse-focus-color-text);
+  }
+
+  /* Dark Text */
+  button.v2.text.dark {
+    color: var(--goa-button-text-dark-color-text);
+  }
+  button.v2.text.dark:hover {
+    color: var(--goa-button-text-dark-hover-color-text);
+  }
+  button.v2.text.dark:focus-visible {
+    color: var(--goa-button-text-dark-focus-color-text);
+  }
+
+  /* Disabled Text */
+
+  button.v2.text:disabled {
+    color: var(--goa-button-text-disabled-color-text);
+    text-decoration: var(--goa-button-text-disabled-text-decoration);
+  }
+  button.v2.text.compact:disabled {
+    color: var(--goa-button-text-compact-disabled-color-text);
+    text-decoration: var(--goa-button-text-compact-disabled-text-decoration);
   }
 </style>

--- a/libs/web-components/src/components/link-button/LinkButton.svelte
+++ b/libs/web-components/src/components/link-button/LinkButton.svelte
@@ -10,32 +10,42 @@
 />
 
 <script lang="ts">
+  import { onMount } from "svelte";
+
   import { calculateMargin, Spacing } from "../../common/styling";
   import { dispatch } from "../../common/utils";
   import { GoAIconType } from "../icon/Icon.svelte";
 
-  /** Sets the color theme. 'interactive' for blue, 'light' for white on dark backgrounds. */
+  /** @deprecated Use GoabButton instead. Sets the color theme. 'interactive' for blue, 'light' for white on dark backgrounds. */
   export let color: "interactive" | "light" = "interactive";
-  /** Icon displayed before the button text. */
+  /** @deprecated Use GoabButton instead. Icon displayed before the button text. */
   export let leadingicon: GoAIconType;
-  /** Icon displayed after the button text. */
+  /** @deprecated Use GoabButton instead. Icon displayed after the button text. */
   export let trailingicon: GoAIconType;
+  /** @deprecated Use GoabButton instead. When true, prevents user interaction and applies disabled styling. */
   export let disabled: boolean = false;
+  /** @deprecated Use GoabButton instead. Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
-  /** Top margin. */
+  /** @deprecated Use GoabButton instead. Top margin. */
   export let mt: Spacing = null;
-  /** Right margin. */
+  /** @deprecated Use GoabButton instead. Right margin. */
   export let mr: Spacing = null;
-  /** Bottom margin. */
+  /** @deprecated Use GoabButton instead. Bottom margin. */
   export let mb: Spacing = null;
-  /** Left margin. */
+  /** @deprecated Use GoabButton instead. Left margin. */
   export let ml: Spacing = null;
-  /** Action identifier passed in click events for event delegation patterns. */
+  /** @deprecated Use GoabButton instead. Action identifier passed in click events for event delegation patterns. */
   export let action: string = "";
-  /** Single argument value passed with the action in click events. */
+  /** @deprecated Use GoabButton instead. Single argument value passed with the action in click events. */
   export let actionArg: string = "";
-  /** Multiple argument values passed with the action in click events. */
+  /** @deprecated Use GoabButton instead. Multiple argument values passed with the action in click events. */
   export let actionArgs: Record<string, unknown> = {};
+
+  onMount(() => {
+    console.warn(
+      "GoabLinkButton is deprecated and will be removed in a future release. Use GoabButton instead.",
+    );
+  });
 
   let _el: HTMLButtonElement;
 


### PR DESCRIPTION
This PR adds a new "Text" type to the Button component. It aligns with the current [Figma components](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library?node-id=27335-578956&t=ltZeOwai8iGP3k9C-1). It requires the new tokens from https://github.com/GovAlta/design-tokens/pull/156.

It includes the following changes:
- Works with existing states: disabled, destructive, and inverse
- Works with leading and trailing icons
- Adds "dark" variant
  - Works only with "text" type
  - Shows a console warning when "dark" is used with another type
- Adds "deprecated" warning to `LinkButton` in console and JSDocs
- Includes a design token for "text decoration" to remove the underline, if needed

### Decisions

- The ticket had differing opinions on the underline so I chose the following approach:
  - Always show an underline
  - Use a design token so teams can remove the underline
  - Don't add a property for the underline

- I kept the 100% width for text buttons on a mobile breakpoint.

Let me know if you have any questions or comments about these decisions.

### Screenshots

<img width="815" height="892" alt="image" src="https://github.com/user-attachments/assets/bc5e39a9-8929-406f-b53c-c2a486039624" />

<br/>

<img width="728" height="350" alt="focus-states" src="https://github.com/user-attachments/assets/2501f26a-aad5-4bb5-a132-66aa99cd0063" />

