### PR TITLE
chore(#3903): drop unused frontmatter fields from component and example schemas

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,10 +88,6 @@ category: inputs-and-actions # determines nav section
 tags: [action, submit]
 relatedComponents: [button-group, icon-button]
 figmaUrl: https://www.figma.com/...
-githubUrl: https://github.com/...
-webComponentTag: goa-button
-reactClassName: GoabButton
-angularSelector: goab-button
 hidden: true # optional — hide from nav (used for subcomponents, deprecated, internal)
 subcomponent: true # optional — show API on parent component page
 ---
@@ -261,7 +257,6 @@ status: stable
 category: structure-and-navigation
 relatedComponents:
   - tab # <-- this is how the parent discovers the subcomponent
-webComponentTag: goa-tabs
 ---
 ```
 
@@ -277,7 +272,6 @@ hidden: true # not shown in nav
 subcomponent: true # API appears on parent page
 relatedComponents:
   - tabs
-webComponentTag: goa-tab
 ---
 ```
 

--- a/docs/src/components/ComponentsGrid.tsx
+++ b/docs/src/components/ComponentsGrid.tsx
@@ -49,9 +49,6 @@ export interface Component {
       | "utilities";
     tags?: string[];
     relatedComponents?: string[];
-    webComponentTag?: string;
-    reactClassName?: string;
-    angularSelector?: string;
   };
 }
 

--- a/docs/src/content/components/accordion.mdx
+++ b/docs/src/content/components/accordion.mdx
@@ -12,8 +12,4 @@ tags:
 relatedComponents:
   - details
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=15932-570754
-githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aopen%20label%3AAccordion
-webComponentTag: goa-accordion
-reactClassName: GoabAccordion
-angularSelector: goab-accordion
 ---

--- a/docs/src/content/components/app-header-menu.mdx
+++ b/docs/src/content/components/app-header-menu.mdx
@@ -7,7 +7,4 @@ hidden: true
 subcomponent: true
 relatedComponents:
   - app-header
-webComponentTag: goa-app-header-menu
-reactClassName: GoabAppHeaderMenu
-angularSelector: goab-app-header-menu
 ---

--- a/docs/src/content/components/app-header.mdx
+++ b/docs/src/content/components/app-header.mdx
@@ -19,8 +19,4 @@ relatedComponents:
   - app-header-menu
   - microsite-header
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=58757-186832
-githubUrl: https://github.com/GovAlta/ui-components/labels/Header
-webComponentTag: goa-app-header
-reactClassName: GoabAppHeader
-angularSelector: goab-app-header
 ---

--- a/docs/src/content/components/badge.mdx
+++ b/docs/src/content/components/badge.mdx
@@ -14,8 +14,4 @@ relatedComponents:
   - chip
   - callout
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-153280
-githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22Badge%22
-webComponentTag: goa-badge
-reactClassName: GoabBadge
-angularSelector: goab-badge
 ---

--- a/docs/src/content/components/block.mdx
+++ b/docs/src/content/components/block.mdx
@@ -8,8 +8,4 @@ tags:
 relatedComponents:
   - container
   - page-block
-githubUrl: https://github.com/GovAlta/ui-components/labels/Block
-webComponentTag: goa-block
-reactClassName: GoabBlock
-angularSelector: goab-block
 ---

--- a/docs/src/content/components/button-group.mdx
+++ b/docs/src/content/components/button-group.mdx
@@ -10,8 +10,4 @@ tags:
 relatedComponents:
   - button
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=13541-388737
-githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22Button%20group%22
-webComponentTag: goa-button-group
-reactClassName: GoabButtonGroup
-angularSelector: goab-button-group
 ---

--- a/docs/src/content/components/button.mdx
+++ b/docs/src/content/components/button.mdx
@@ -11,8 +11,4 @@ relatedComponents:
   - button-group
   - icon-button
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=57138-300030
-githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3AButton
-webComponentTag: goa-button
-reactClassName: GoabButton
-angularSelector: goab-button
 ---

--- a/docs/src/content/components/calendar.mdx
+++ b/docs/src/content/components/calendar.mdx
@@ -6,7 +6,4 @@ category: utilities
 hidden: true
 relatedComponents:
   - date-picker
-webComponentTag: goa-calendar
-reactClassName: GoabCalendar
-angularSelector: goab-calendar
 ---

--- a/docs/src/content/components/callout.mdx
+++ b/docs/src/content/components/callout.mdx
@@ -11,8 +11,4 @@ relatedComponents:
   - notification
   - badge
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-453927
-githubUrl: https://github.com/GovAlta/ui-components/labels/Callout
-webComponentTag: goa-callout
-reactClassName: GoabCallout
-angularSelector: goab-callout
 ---

--- a/docs/src/content/components/checkbox-list.mdx
+++ b/docs/src/content/components/checkbox-list.mdx
@@ -11,7 +11,4 @@ relatedComponents:
   - checkbox
   - form-item
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-469340
-webComponentTag: goa-checkbox-list
-reactClassName: GoabCheckboxList
-angularSelector: goab-checkbox-list
 ---

--- a/docs/src/content/components/checkbox.mdx
+++ b/docs/src/content/components/checkbox.mdx
@@ -13,8 +13,4 @@ relatedComponents:
   - form-item
   - radio-group
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-469737
-githubUrl: https://github.com/GovAlta/ui-components/labels/Checkbox
-webComponentTag: goa-checkbox
-reactClassName: GoabCheckbox
-angularSelector: goab-checkbox
 ---

--- a/docs/src/content/components/chip.mdx
+++ b/docs/src/content/components/chip.mdx
@@ -7,7 +7,4 @@ hidden: true
 relatedComponents:
   - filter-chip
   - badge
-webComponentTag: goa-chip
-reactClassName: GoabChip
-angularSelector: goab-chip
 ---

--- a/docs/src/content/components/circular-progress.mdx
+++ b/docs/src/content/components/circular-progress.mdx
@@ -15,8 +15,4 @@ relatedComponents:
   - linear-progress
   - spinner
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=633-12563
-githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22Progress%20indicator%22
-webComponentTag: goa-circular-progress
-reactClassName: GoabCircularProgress
-angularSelector: goab-circular-progress
 ---

--- a/docs/src/content/components/container.mdx
+++ b/docs/src/content/components/container.mdx
@@ -13,8 +13,4 @@ relatedComponents:
   - block
   - grid
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=1791-19104
-githubUrl: https://github.com/GovAlta/ui-components/labels/Container
-webComponentTag: goa-container
-reactClassName: GoabContainer
-angularSelector: goab-container
 ---

--- a/docs/src/content/components/data-grid.mdx
+++ b/docs/src/content/components/data-grid.mdx
@@ -13,7 +13,4 @@ tags:
 relatedComponents:
   - table
   - pagination
-webComponentTag: goa-data-grid
-reactClassName: GoabDataGrid
-angularSelector: goab-data-grid
 ---

--- a/docs/src/content/components/date-picker.mdx
+++ b/docs/src/content/components/date-picker.mdx
@@ -14,8 +14,4 @@ relatedComponents:
   - input
   - calendar
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=61102-130736
-githubUrl: https://github.com/GovAlta/ui-components/labels/Date%20picker
-webComponentTag: goa-date-picker
-reactClassName: GoabDatePicker
-angularSelector: goab-date-picker
 ---

--- a/docs/src/content/components/details.mdx
+++ b/docs/src/content/components/details.mdx
@@ -24,8 +24,4 @@ tags:
 relatedComponents:
   - accordion
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=15932-569233
-githubUrl: https://github.com/GovAlta/ui-components/labels/Accordion %2B Detail
-webComponentTag: goa-details
-reactClassName: GoabDetails
-angularSelector: goab-details
 ---

--- a/docs/src/content/components/divider.mdx
+++ b/docs/src/content/components/divider.mdx
@@ -10,8 +10,4 @@ tags:
 relatedComponents:
   - spacer
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=550-5137
-githubUrl: https://github.com/GovAlta/ui-components/labels/Divider
-webComponentTag: goa-divider
-reactClassName: GoabDivider
-angularSelector: goab-divider
 ---

--- a/docs/src/content/components/drawer.mdx
+++ b/docs/src/content/components/drawer.mdx
@@ -13,8 +13,4 @@ relatedComponents:
   - modal
   - push-drawer
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=60158-687174
-githubUrl: https://github.com/GovAlta/ui-components/labels/Drawer
-webComponentTag: goa-drawer
-reactClassName: GoabDrawer
-angularSelector: goab-drawer
 ---

--- a/docs/src/content/components/dropdown.mdx
+++ b/docs/src/content/components/dropdown.mdx
@@ -11,8 +11,4 @@ relatedComponents:
   - form-item
   - input
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=28478-241608
-githubUrl: https://github.com/GovAlta/ui-components/labels/Dropdown
-webComponentTag: goa-dropdown
-reactClassName: GoabDropdown
-angularSelector: goab-dropdown
 ---

--- a/docs/src/content/components/file-upload-card.mdx
+++ b/docs/src/content/components/file-upload-card.mdx
@@ -7,7 +7,4 @@ hidden: true
 subcomponent: true
 relatedComponents:
   - file-upload-input
-webComponentTag: goa-file-upload-card
-reactClassName: GoabFileUploadCard
-angularSelector: goab-file-upload-card
 ---

--- a/docs/src/content/components/file-upload-input.mdx
+++ b/docs/src/content/components/file-upload-input.mdx
@@ -12,8 +12,4 @@ relatedComponents:
   - file-upload-card
   - form-item
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=14458-398119
-githubUrl: https://github.com/GovAlta/ui-components/labels/File%20uploader
-webComponentTag: goa-file-upload-input
-reactClassName: GoabFileUploadInput
-angularSelector: goab-file-upload-input
 ---

--- a/docs/src/content/components/filter-chip.mdx
+++ b/docs/src/content/components/filter-chip.mdx
@@ -9,8 +9,4 @@ tags:
 relatedComponents:
   - chip
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-516598
-githubUrl: https://github.com/GovAlta/ui-components/labels/Filter%20chip
-webComponentTag: goa-filter-chip
-reactClassName: GoabFilterChip
-angularSelector: goab-filter-chip
 ---

--- a/docs/src/content/components/focus-trap.mdx
+++ b/docs/src/content/components/focus-trap.mdx
@@ -5,7 +5,4 @@ status: stable
 category: utilities
 hidden: true
 
-webComponentTag: goa-focus-trap
-reactClassName: GoabFocusTrap
-angularSelector: goab-focus-trap
 ---

--- a/docs/src/content/components/footer-meta-section.mdx
+++ b/docs/src/content/components/footer-meta-section.mdx
@@ -7,7 +7,4 @@ hidden: true
 subcomponent: true
 relatedComponents:
   - footer
-webComponentTag: goa-footer-meta-section
-reactClassName: GoabFooterMetaSection
-angularSelector: goab-footer-meta-section
 ---

--- a/docs/src/content/components/footer-nav-section.mdx
+++ b/docs/src/content/components/footer-nav-section.mdx
@@ -8,7 +8,4 @@ subcomponent: true
 relatedComponents:
   - footer
   - link
-webComponentTag: goa-footer-nav-section
-reactClassName: GoabFooterNavSection
-angularSelector: goab-footer-nav-section
 ---

--- a/docs/src/content/components/footer.mdx
+++ b/docs/src/content/components/footer.mdx
@@ -10,8 +10,4 @@ relatedComponents:
   - footer-meta-section
   - footer-nav-section
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=5652-228863
-githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22Footer%22
-webComponentTag: goa-footer
-reactClassName: GoabFooter
-angularSelector: goab-footer
 ---

--- a/docs/src/content/components/form-item.mdx
+++ b/docs/src/content/components/form-item.mdx
@@ -17,8 +17,4 @@ relatedComponents:
   - radio-group
   - text-area
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-535065
-githubUrl: https://github.com/GovAlta/ui-components/labels/Form%20item
-webComponentTag: goa-form-item
-reactClassName: GoabFormItem
-angularSelector: goab-form-item
 ---

--- a/docs/src/content/components/form-step.mdx
+++ b/docs/src/content/components/form-step.mdx
@@ -7,7 +7,4 @@ hidden: true
 subcomponent: true
 relatedComponents:
   - form-stepper
-webComponentTag: goa-form-step
-reactClassName: GoabFormStep
-angularSelector: goab-form-step
 ---

--- a/docs/src/content/components/form-stepper.mdx
+++ b/docs/src/content/components/form-stepper.mdx
@@ -15,8 +15,4 @@ relatedComponents:
   - form-step
   - form
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=27335-606356
-githubUrl: https://github.com/GovAlta/ui-components/labels/Form%20stepper
-webComponentTag: goa-form-stepper
-reactClassName: GoabFormStepper
-angularSelector: goab-form-stepper
 ---

--- a/docs/src/content/components/form.mdx
+++ b/docs/src/content/components/form.mdx
@@ -6,7 +6,4 @@ category: inputs-and-actions
 relatedComponents:
   - form-item
   - form-stepper
-webComponentTag: goa-form
-reactClassName: GoabForm
-angularSelector: goab-form
 ---

--- a/docs/src/content/components/grid.mdx
+++ b/docs/src/content/components/grid.mdx
@@ -8,8 +8,4 @@ tags:
 relatedComponents:
   - container
   - spacer
-githubUrl: https://github.com/GovAlta/ui-components/labels/Grid
-webComponentTag: goa-grid
-reactClassName: GoabGrid
-angularSelector: goab-grid
 ---

--- a/docs/src/content/components/hero-banner.mdx
+++ b/docs/src/content/components/hero-banner.mdx
@@ -8,8 +8,4 @@ tags:
   - hero panel
   - structure and navigation
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=633-10280
-githubUrl: https://github.com/GovAlta/ui-components/labels/Hero banner
-webComponentTag: goa-hero-banner
-reactClassName: GoabHeroBanner
-angularSelector: goab-hero-banner
 ---

--- a/docs/src/content/components/icon-button.mdx
+++ b/docs/src/content/components/icon-button.mdx
@@ -11,8 +11,4 @@ relatedComponents:
   - button
   - icon
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56969-757260
-githubUrl: https://github.com/GovAlta/ui-components/labels/Icon%20button
-webComponentTag: goa-icon-button
-reactClassName: GoabIconButton
-angularSelector: goab-icon-button
 ---

--- a/docs/src/content/components/icon.mdx
+++ b/docs/src/content/components/icon.mdx
@@ -8,8 +8,4 @@ tags:
 relatedComponents:
   - icon-button
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=24019-474002
-githubUrl: https://github.com/GovAlta/ui-components/labels/Icons
-webComponentTag: goa-icon
-reactClassName: GoabIcon
-angularSelector: goab-icon
 ---

--- a/docs/src/content/components/input.mdx
+++ b/docs/src/content/components/input.mdx
@@ -14,10 +14,6 @@ relatedComponents:
   - text-area
   - dropdown
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56970-136310
-githubUrl: https://github.com/GovAlta/ui-components/labels/Input
-webComponentTag: goa-input
-reactClassName: GoabInput
-angularSelector: goab-input
 ---
 
 Capture text input from users in forms.

--- a/docs/src/content/components/linear-progress.mdx
+++ b/docs/src/content/components/linear-progress.mdx
@@ -14,8 +14,4 @@ relatedComponents:
   - circular-progress
   - spinner
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=14458-398386
-githubUrl: https://github.com/GovAlta/ui-components/issues?q=sort%3Aupdated-desc+is%3Aopen+label%3A%22Linear+progress+indicator%22
-webComponentTag: goa-linear-progress
-reactClassName: GoabLinearProgress
-angularSelector: goab-linear-progress
 ---

--- a/docs/src/content/components/link-button.mdx
+++ b/docs/src/content/components/link-button.mdx
@@ -7,7 +7,4 @@ hidden: true
 relatedComponents:
   - button
   - link
-webComponentTag: goa-link-button
-reactClassName: GoabLinkButton
-angularSelector: goab-link-button
 ---

--- a/docs/src/content/components/link.mdx
+++ b/docs/src/content/components/link.mdx
@@ -9,8 +9,4 @@ tags:
 relatedComponents:
   - link-button
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56970-352878
-githubUrl: https://github.com/GovAlta/ui-components/issues?q=is%3Aissue+is%3Aopen+label%3A%22Link%22
-webComponentTag: goa-link
-reactClassName: GoabLink
-angularSelector: goab-link
 ---

--- a/docs/src/content/components/menu-action.mdx
+++ b/docs/src/content/components/menu-action.mdx
@@ -7,5 +7,4 @@ hidden: true
 subcomponent: true
 relatedComponents:
   - menu-button
-webComponentTag: goa-menu-action
 ---

--- a/docs/src/content/components/menu-button.mdx
+++ b/docs/src/content/components/menu-button.mdx
@@ -11,8 +11,4 @@ relatedComponents:
   - menu-action
   - popover
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=57138-308450
-githubUrl: https://github.com/GovAlta/ui-components/labels/Multi%20action%20button
-webComponentTag: goa-menu-button
-reactClassName: GoabMenuButton
-angularSelector: goab-menu-button
 ---

--- a/docs/src/content/components/microsite-header.mdx
+++ b/docs/src/content/components/microsite-header.mdx
@@ -17,8 +17,4 @@ tags:
   - structure and navigation
 relatedComponents:
   - app-header
-githubUrl: https://github.com/GovAlta/ui-components/labels/Microsite%20header
-webComponentTag: goa-microsite-header
-reactClassName: GoabMicrositeHeader
-angularSelector: goab-microsite-header
 ---

--- a/docs/src/content/components/modal.mdx
+++ b/docs/src/content/components/modal.mdx
@@ -12,8 +12,4 @@ tags:
 relatedComponents:
   - drawer
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56970-444330
-githubUrl: https://github.com/GovAlta/ui-components/labels/Modal
-webComponentTag: goa-modal
-reactClassName: GoabModal
-angularSelector: goab-modal
 ---

--- a/docs/src/content/components/notification.mdx
+++ b/docs/src/content/components/notification.mdx
@@ -11,8 +11,4 @@ relatedComponents:
   - callout
   - temporary-notification
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56970-485993
-githubUrl: https://github.com/GovAlta/ui-components/labels/Notification%20banner
-webComponentTag: goa-notification
-reactClassName: GoabNotification
-angularSelector: goab-notification
 ---

--- a/docs/src/content/components/page-block.mdx
+++ b/docs/src/content/components/page-block.mdx
@@ -6,7 +6,4 @@ category: content-layout
 relatedComponents:
   - block
   - container
-webComponentTag: goa-page-block
-reactClassName: GoabPageBlock
-angularSelector: goab-page-block
 ---

--- a/docs/src/content/components/pages.mdx
+++ b/docs/src/content/components/pages.mdx
@@ -5,7 +5,4 @@ status: stable
 category: structure-and-navigation
 hidden: true
 
-webComponentTag: goa-pages
-reactClassName: GoabPages
-angularSelector: goab-pages
 ---

--- a/docs/src/content/components/pagination.mdx
+++ b/docs/src/content/components/pagination.mdx
@@ -11,8 +11,4 @@ relatedComponents:
   - data-grid
   - table
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=26318-193264
-githubUrl: https://github.com/GovAlta/ui-components/labels/Pagination
-webComponentTag: goa-pagination
-reactClassName: GoabPagination
-angularSelector: goab-pagination
 ---

--- a/docs/src/content/components/popover.mdx
+++ b/docs/src/content/components/popover.mdx
@@ -10,8 +10,4 @@ relatedComponents:
   - tooltip
   - menu-button
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=32486-707969
-githubUrl: https://github.com/GovAlta/ui-components/labels/Popover
-webComponentTag: goa-popover
-reactClassName: GoabPopover
-angularSelector: goab-popover
 ---

--- a/docs/src/content/components/push-drawer.mdx
+++ b/docs/src/content/components/push-drawer.mdx
@@ -12,8 +12,4 @@ tags:
 relatedComponents:
   - drawer
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=60151-367783
-githubUrl: https://github.com/GovAlta/ui-components/labels/Push%20Drawer
-webComponentTag: goa-push-drawer
-reactClassName: GoabPushDrawer
-angularSelector: goab-push-drawer
 ---

--- a/docs/src/content/components/radio-group.mdx
+++ b/docs/src/content/components/radio-group.mdx
@@ -13,8 +13,4 @@ relatedComponents:
   - form-item
   - checkbox
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=56970-509527
-githubUrl: https://github.com/GovAlta/ui-components/labels/Radio
-webComponentTag: goa-radio-group
-reactClassName: GoabRadioGroup
-angularSelector: goab-radio-group
 ---

--- a/docs/src/content/components/radio-item.mdx
+++ b/docs/src/content/components/radio-item.mdx
@@ -7,7 +7,4 @@ hidden: true
 subcomponent: true
 relatedComponents:
   - radio-group
-webComponentTag: goa-radio-item
-reactClassName: GoabRadioItem
-angularSelector: goab-radio-item
 ---

--- a/docs/src/content/components/scrollable.mdx
+++ b/docs/src/content/components/scrollable.mdx
@@ -5,7 +5,4 @@ status: stable
 category: utilities
 hidden: true
 
-webComponentTag: goa-scrollable
-reactClassName: GoabScrollable
-angularSelector: goab-scrollable
 ---

--- a/docs/src/content/components/side-menu-group.mdx
+++ b/docs/src/content/components/side-menu-group.mdx
@@ -8,7 +8,4 @@ subcomponent: true
 relatedComponents:
   - side-menu
   - side-menu-heading
-webComponentTag: goa-side-menu-group
-reactClassName: GoabSideMenuGroup
-angularSelector: goab-side-menu-group
 ---

--- a/docs/src/content/components/side-menu-heading.mdx
+++ b/docs/src/content/components/side-menu-heading.mdx
@@ -8,7 +8,4 @@ subcomponent: true
 relatedComponents:
   - side-menu
   - side-menu-group
-webComponentTag: goa-side-menu-heading
-reactClassName: GoabSideMenuHeading
-angularSelector: goab-side-menu-heading
 ---

--- a/docs/src/content/components/side-menu.mdx
+++ b/docs/src/content/components/side-menu.mdx
@@ -13,8 +13,4 @@ relatedComponents:
   - side-menu-heading
   - work-side-menu
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=58780-485596
-githubUrl: https://github.com/GovAlta/ui-components/labels/Side%20menu
-webComponentTag: goa-side-menu
-reactClassName: GoabSideMenu
-angularSelector: goab-side-menu
 ---

--- a/docs/src/content/components/skeleton.mdx
+++ b/docs/src/content/components/skeleton.mdx
@@ -6,8 +6,4 @@ category: feedback-and-alerts
 tags:
   - content layout
   - loading
-githubUrl: https://github.com/GovAlta/ui-components/labels/Skeleton%20loading
-webComponentTag: goa-skeleton
-reactClassName: GoabSkeleton
-angularSelector: goab-skeleton
 ---

--- a/docs/src/content/components/spacer.mdx
+++ b/docs/src/content/components/spacer.mdx
@@ -13,8 +13,4 @@ relatedComponents:
   - divider
   - grid
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=21567-616073
-githubUrl: https://github.com/GovAlta/ui-components/labels/Spacer
-webComponentTag: goa-spacer
-reactClassName: GoabSpacer
-angularSelector: goab-spacer
 ---

--- a/docs/src/content/components/spinner.mdx
+++ b/docs/src/content/components/spinner.mdx
@@ -7,7 +7,4 @@ hidden: true
 relatedComponents:
   - circular-progress
   - linear-progress
-webComponentTag: goa-spinner
-reactClassName: GoabSpinner
-angularSelector: goab-spinner
 ---

--- a/docs/src/content/components/tab.mdx
+++ b/docs/src/content/components/tab.mdx
@@ -7,7 +7,4 @@ hidden: true
 subcomponent: true
 relatedComponents:
   - tabs
-webComponentTag: goa-tab
-reactClassName: GoabTab
-angularSelector: goab-tab
 ---

--- a/docs/src/content/components/table.mdx
+++ b/docs/src/content/components/table.mdx
@@ -12,8 +12,4 @@ relatedComponents:
   - data-grid
   - pagination
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=27343-613386
-githubUrl: https://github.com/GovAlta/ui-components/labels/Table
-webComponentTag: goa-table
-reactClassName: GoabTable
-angularSelector: goab-table
 ---

--- a/docs/src/content/components/tabs.mdx
+++ b/docs/src/content/components/tabs.mdx
@@ -10,8 +10,4 @@ tags:
 relatedComponents:
   - tab
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=25293-550667
-githubUrl: https://github.com/GovAlta/ui-components/labels/Tabs
-webComponentTag: goa-tabs
-reactClassName: GoabTabs
-angularSelector: goab-tabs
 ---

--- a/docs/src/content/components/temporary-notification.mdx
+++ b/docs/src/content/components/temporary-notification.mdx
@@ -10,8 +10,4 @@ tags:
 relatedComponents:
   - notification
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=33183-290309
-githubUrl: https://github.com/GovAlta/ui-components/labels/Temporary%20notification
-webComponentTag: goa-temporary-notification
-reactClassName: GoabTemporaryNotification
-angularSelector: goab-temporary-notification
 ---

--- a/docs/src/content/components/text-area.mdx
+++ b/docs/src/content/components/text-area.mdx
@@ -14,8 +14,4 @@ relatedComponents:
   - form-item
   - input
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=12711-380735
-githubUrl: https://github.com/GovAlta/ui-components/labels/Text%20area
-webComponentTag: goa-text-area
-reactClassName: GoabTextArea
-angularSelector: goab-text-area
 ---

--- a/docs/src/content/components/text.mdx
+++ b/docs/src/content/components/text.mdx
@@ -8,8 +8,4 @@ tags:
   - body
   - copy
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=21567-615910
-githubUrl: https://github.com/GovAlta/ui-components/labels/Text
-webComponentTag: goa-text
-reactClassName: GoabText
-angularSelector: goab-text
 ---

--- a/docs/src/content/components/tooltip.mdx
+++ b/docs/src/content/components/tooltip.mdx
@@ -8,8 +8,4 @@ tags:
 relatedComponents:
   - popover
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=21932-557085
-githubUrl: https://github.com/GovAlta/ui-components/labels/Tooltip
-webComponentTag: goa-tooltip
-reactClassName: GoabTooltip
-angularSelector: goab-tooltip
 ---

--- a/docs/src/content/components/work-side-menu-group.mdx
+++ b/docs/src/content/components/work-side-menu-group.mdx
@@ -7,5 +7,4 @@ hidden: true
 subcomponent: true
 relatedComponents:
   - work-side-menu
-webComponentTag: goa-work-side-menu-group
 ---

--- a/docs/src/content/components/work-side-menu-item.mdx
+++ b/docs/src/content/components/work-side-menu-item.mdx
@@ -7,5 +7,4 @@ hidden: true
 subcomponent: true
 relatedComponents:
   - work-side-menu
-webComponentTag: goa-work-side-menu-item
 ---

--- a/docs/src/content/components/work-side-menu.mdx
+++ b/docs/src/content/components/work-side-menu.mdx
@@ -8,7 +8,4 @@ relatedComponents:
   - work-side-menu-group
   - work-side-menu-item
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=57622-159377
-webComponentTag: goa-work-side-menu
-reactClassName: GoabWorkSideMenu
-angularSelector: goab-work-side-menu
 ---

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -29,12 +29,6 @@ const components = defineCollection({
 
     // External links
     figmaUrl: z.string().url().optional(),
-    githubUrl: z.string().optional(),
-
-    // Framework identifiers (for cross-referencing)
-    webComponentTag: z.string().optional(),
-    reactClassName: z.string().optional(),
-    angularSelector: z.string().optional(),
 
     // Visibility
     hidden: z.boolean().optional(), // Hide from navigation and public views
@@ -147,9 +141,6 @@ const examples = defineCollection({
 
     // Preview image (optional)
     previewImage: z.string().optional(),
-
-    // Shared CSS file reference (relative to _shared folder)
-    styles: z.string().optional(),
 
     // Display options
     fullWidth: z.boolean().optional(), // Remove side padding in preview (for callouts, notifications)


### PR DESCRIPTION
# Before (the change)

Component MDX frontmatter and the docs schemas carry four fields that nothing in the docs site reads:

- `webComponentTag`, `reactClassName`, `angularSelector` on components. Added speculatively in Dec 2025 for a "cross-referencing" feature that was never built. 8 of 68 components had drifted to wrong values.
- `githubUrl` on components. The docs site computes the URL from `data.name` directly. Stored values were inconsistent (three URL shapes in the wild, including `details.mdx` pointing at a different component's label).
- `styles` on examples. Pure dead schema. 0 of 85 example MDX files populate it.

# After (the change)

All four fields removed from the schemas, plus all populated values stripped from the MDX corpus. Dead TypeScript references in `ComponentsGrid.tsx` cleaned up. Docs site behaviour unchanged: GitHub issues link on each component page still renders, computed from `data.name`.

Diff stat: 71 files, 0 insertions, 259 deletions.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests (N/A: schema and content cleanup, no behaviour change)
- [ ] I have tested the functionality in both React and Angular (N/A: no component changes)

## Steps needed to test

1. Pull the branch and run `npm run build:docs` (or `cd docs && npm run build`)
2. Confirm a clean build with no errors
3. Open any component page (e.g. button, footer, table) and verify the GitHub issues link in the page still resolves to the correct label-filtered issue list
4. Spot-check `docs/src/content/config.ts` and `docs/src/components/ComponentsGrid.tsx` to confirm the dead schema and type fields are gone