### PR TITLE
fix(#3602): FileUploadInput error state to match FileUploadCard

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3602/bug3602.component.html
+++ b/apps/prs/angular/src/routes/bugs/3602/bug3602.component.html
@@ -1,0 +1,39 @@
+<h1>3602 FileUploadInput and FileUploadCard Improvements</h1>
+
+<goab-form-item label="Small file (100KB limit)">
+  <goab-file-upload-input
+    maxFileSize="100KB"
+    (onSelectFile)="onSmallFileSelect($event)"
+  ></goab-file-upload-input>
+</goab-form-item>
+
+<div style="padding-top: 0.75rem; padding-bottom: 2rem">
+  @for (f of smallFiles; track f.id) {
+    <goab-file-upload-card
+      [filename]="f.filename"
+      [size]="f.size"
+      [type]="f.type"
+      [progress]="f.progress"
+      (onDelete)="onSmallFileDelete($event, f.id)"
+    ></goab-file-upload-card>
+  }
+</div>
+
+<goab-form-item label="Large file (50MB limit)">
+  <goab-file-upload-input
+    maxFileSize="50MB"
+    (onSelectFile)="onLargeFileSelect($event)"
+  ></goab-file-upload-input>
+</goab-form-item>
+
+<div style="padding-top: 0.75rem; padding-bottom: 2rem">
+  @for (f of largeFiles; track f.id) {
+    <goab-file-upload-card
+      [filename]="f.filename"
+      [size]="f.size"
+      [type]="f.type"
+      [progress]="f.progress"
+      (onDelete)="onLargeFileDelete($event, f.id)"
+    ></goab-file-upload-card>
+  }
+</div>

--- a/apps/prs/angular/src/routes/bugs/3602/bug3602.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3602/bug3602.component.ts
@@ -1,0 +1,76 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  GoabFileUploadInputOnSelectFileDetail,
+  GoabFileUploadOnDeleteDetail,
+} from "@abgov/ui-components-common";
+import {
+  GoabFileUploadCard,
+  GoabFileUploadInput,
+  GoabFormItem,
+} from "@abgov/angular-components";
+
+type UploadedFile = {
+  id: string;
+  filename: string;
+  size: number;
+  type?: string;
+  progress: number;
+};
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3602",
+  templateUrl: "./bug3602.component.html",
+  imports: [CommonModule, GoabFileUploadInput, GoabFileUploadCard, GoabFormItem],
+})
+export class Bug3602Component {
+  smallFiles: UploadedFile[] = [];
+  largeFiles: UploadedFile[] = [];
+
+  onSmallFileSelect(detail: GoabFileUploadInputOnSelectFileDetail) {
+    const file = detail.file;
+    this.smallFiles = [
+      ...this.smallFiles,
+      {
+        id: `${file.name}-${Date.now()}`,
+        filename: file.name,
+        size: file.size,
+        type: file.type,
+        progress: -1,
+      },
+    ];
+  }
+
+  onLargeFileSelect(detail: GoabFileUploadInputOnSelectFileDetail) {
+    const file = detail.file;
+    this.largeFiles = [
+      ...this.largeFiles,
+      {
+        id: `${file.name}-${Date.now()}`,
+        filename: file.name,
+        size: file.size,
+        type: file.type,
+        progress: -1,
+      },
+    ];
+  }
+
+  private removeFirstMatchingFile(files: UploadedFile[], id: string): UploadedFile[] {
+    const index = files.findIndex((f) => f.id === id);
+    if (index === -1) {
+      return files;
+    }
+    return [...files.slice(0, index), ...files.slice(index + 1)];
+  }
+
+  onSmallFileDelete(detail: GoabFileUploadOnDeleteDetail, id: string) {
+    console.log("Deleting file with id:", id);
+    this.smallFiles = this.removeFirstMatchingFile(this.smallFiles, id);
+  }
+
+  onLargeFileDelete(detail: GoabFileUploadOnDeleteDetail, id: string) {
+    console.log("Deleting file with id:", id);
+    this.largeFiles = this.removeFirstMatchingFile(this.largeFiles, id);
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3602/bug3602.route.json
+++ b/apps/prs/angular/src/routes/bugs/3602/bug3602.route.json
@@ -1,0 +1,6 @@
+{
+    "title": "FileUploadInput and FileUploadCard Improvements",
+    "path": "bugs/3602",
+    "id": "3602",
+    "type": "bug"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3602.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3602.route.ts
@@ -1,0 +1,9 @@
+import { Bug3602Route } from "../../../routes/bugs/bug3602";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "bug",
+  id: "3602",
+  path: "bugs/3602",
+  title: "FileUploadInput and FileUploadCard Improvements",
+  component: Bug3602Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3602.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3602.tsx
@@ -1,0 +1,81 @@
+import { useState, type Dispatch, type SetStateAction } from "react";
+import { GoabFileUploadInputOnSelectFileDetail } from "@abgov/ui-components-common";
+import {
+  GoabFileUploadCard,
+  GoabFileUploadInput,
+  GoabFormItem,
+} from "@abgov/react-components";
+
+type UploadedFile = {
+  id: string;
+  filename: string;
+  size: number;
+  type?: string;
+  progress: number;
+};
+
+export function Bug3602Route() {
+  const [smallFiles, setSmallFiles] = useState<UploadedFile[]>([]);
+  const [largeFiles, setLargeFiles] = useState<UploadedFile[]>([]);
+
+  function handleFileChange(
+    detail: GoabFileUploadInputOnSelectFileDetail,
+    setFiles: Dispatch<SetStateAction<UploadedFile[]>>,
+  ) {
+    const file = detail.file;
+    setFiles((prev) => [
+      ...prev,
+      {
+        id: `${file.name}-${Date.now()}`,
+        filename: file.name,
+        size: file.size,
+        type: file.type,
+        progress: -1,
+      },
+    ]);
+  }
+
+  return (
+    <>
+      <h1>3602 FileUploadInput and FileUploadCard Improvements</h1>
+      <div>
+        <GoabFormItem label="Small file (100KB limit)">
+          <GoabFileUploadInput
+            maxFileSize="100KB"
+            onSelectFile={(detail) => handleFileChange(detail, setSmallFiles)}
+          />
+        </GoabFormItem>
+        <div style={{ paddingTop: "0.75rem", paddingBottom: "2rem" }}>
+          {smallFiles.map((f) => (
+            <GoabFileUploadCard
+              key={f.id}
+              filename={f.filename}
+              size={f.size}
+              type={f.type}
+              progress={f.progress}
+              onDelete={() => setSmallFiles((prev) => prev.filter((item) => item.id !== f.id))}
+            />
+          ))}
+        </div>
+        <GoabFormItem label="Large file (50MB limit)">
+          <GoabFileUploadInput
+            maxFileSize="50MB"
+            onSelectFile={(detail) => handleFileChange(detail, setLargeFiles)}
+          />
+        </GoabFormItem>
+        <div style={{ paddingTop: "0.75rem", paddingBottom: "2rem" }}>
+          {largeFiles.map((f) => (
+            <GoabFileUploadCard
+              key={f.id}
+              filename={f.filename}
+              size={f.size}
+              type={f.type}
+              progress={f.progress}
+              onDelete={() => setLargeFiles((prev) => prev.filter((item) => item.id !== f.id))}
+            />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
+++ b/libs/web-components/src/components/file-upload-input/FileUploadInput.svelte
@@ -6,6 +6,8 @@
   type Variant = "dragdrop" | "button";
   type Issue = {
     filename: string;
+    size: number;
+    filetype: string;
     error: string;
   };
   type FileSizeUnit = "B" | "KB" | "MB" | "GB";
@@ -41,7 +43,15 @@
         [..._fileInput.files].forEach((file) => {
           const error = validate(file);
           if (error) {
-            issues = [{ filename: file.name, error }, ...issues];
+            issues = [
+              {
+                filename: file.name,
+                size: file.size,
+                filetype: file.type,
+                error,
+              },
+              ...issues,
+            ];
             return;
           }
           dispatch(file);
@@ -135,7 +145,15 @@
           if (file) {
             const error = validate(file);
             if (error) {
-              issues = [{ filename: file.name, error }, ...issues];
+              issues = [
+                {
+                  filename: file.name,
+                  size: file.size,
+                  filetype: file.type,
+                  error,
+                },
+                ...issues,
+              ];
               return;
             }
             dispatch(file);
@@ -147,7 +165,15 @@
       [...e.dataTransfer?.files].forEach((file) => {
         const error = validate(file);
         if (error) {
-          issues = [{ filename: file.name, error }, ...issues];
+          issues = [
+            {
+              filename: file.name,
+              size: file.size,
+              filetype: file.type,
+              error,
+            },
+            ...issues,
+          ];
           return;
         }
         dispatch(file);
@@ -251,14 +277,18 @@
 
 {#if issues.length}
   <div class="issues">
-    {#each issues as issue}
-      <div class="issue">
-        {issue.filename}
-        <div class="error" data-testid="error">
-          <goa-icon type="warning" size="small" theme="filled" />
-          {issue.error}
-        </div>
-      </div>
+    {#each issues as issue, i (issue)}
+      <goa-file-upload-card
+        data-testid={testid ? `${testid}-issue-${i}` : undefined}
+        on:_delete={() => {
+          issues = issues.filter((currentIssue) => currentIssue !== issue);
+        }}
+        filename={issue.filename}
+        size={issue.size}
+        type={issue.filetype}
+        error={issue.error}
+        {version}
+      />
     {/each}
   </div>
 {/if}
@@ -345,18 +375,7 @@
 
   /* issues */
   .issues {
-    border-bottom: 1px solid var(--goa-color-greyscale-200);
-    margin: 1rem 0;
-  }
-  .issue {
-    margin-bottom: 1rem;
-  }
-  .error {
-    color: var(--goa-color-interactive-error);
-    font-size: 0.9em;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    margin: 0.75rem 0 0 0;
   }
 
   @container self (--mobile) {

--- a/libs/web-components/src/components/file-upload-input/file-upload-input.spec.ts
+++ b/libs/web-components/src/components/file-upload-input/file-upload-input.spec.ts
@@ -38,7 +38,10 @@ describe("File selection", () => {
     const file = new File([new ArrayBuffer(1e6)], "file.jpg", {
       type: "image/jpg",
     });
-    const { queryByTestId } = render(FileUploadInput, { maxfilesize: "100KB" });
+    const { queryByTestId } = render(FileUploadInput, {
+      testid: "upload",
+      maxfilesize: "100KB",
+    });
     const input = queryByTestId("input") as HTMLInputElement;
 
     expect(input).toBeTruthy();
@@ -46,7 +49,9 @@ describe("File selection", () => {
 
     await tick();
     await waitFor(() => {
-      expect(queryByTestId("error")?.innerHTML).toContain("100KB");
+      const card = queryByTestId("upload-issue-0");
+      expect(queryByTestId("upload-issue-0")).toBeTruthy();
+      expect(card?.getAttribute("error")).toContain("100KB");
     });
   });
 
@@ -54,13 +59,16 @@ describe("File selection", () => {
     const file = new File([new ArrayBuffer(1e6)], "file.jpg", {
       type: "image/jpg",
     });
-    const { queryByTestId } = render(FileUploadInput, { accept: "image/*" });
+    const { queryByTestId } = render(FileUploadInput, {
+      testid: "upload",
+      accept: "image/*",
+    });
     const input = queryByTestId("input") as HTMLInputElement;
 
     fireEvent.change(input, { target: { files: [file] } });
 
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeFalsy();
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
     });
   });
 
@@ -68,13 +76,16 @@ describe("File selection", () => {
     const file = new File([new ArrayBuffer(1e6)], "file.jpg", {
       type: "image/jpg",
     });
-    const { queryByTestId } = render(FileUploadInput, { accept: ".gif, .jpg" });
+    const { queryByTestId } = render(FileUploadInput, {
+      testid: "upload",
+      accept: ".gif, .jpg",
+    });
     const input = queryByTestId("input") as HTMLInputElement;
 
     fireEvent.change(input, { target: { files: [file] } });
 
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeFalsy();
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
     });
   });
 
@@ -83,13 +94,16 @@ describe("File selection", () => {
       type: "image/jpg",
     });
 
-    const { queryByTestId } = render(FileUploadInput, { accept: ".bmp,.png" });
+    const { queryByTestId } = render(FileUploadInput, {
+      testid: "upload",
+      accept: ".bmp,.png",
+    });
     const input = queryByTestId("input") as HTMLInputElement;
 
     fireEvent.change(input, { target: { files: [file] } });
 
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeTruthy();
+      expect(queryByTestId("upload-issue-0")).toBeTruthy();
     });
   });
 
@@ -99,13 +113,14 @@ describe("File selection", () => {
     });
     const { queryByTestId } = render(FileUploadInput, {
       accept: "application/*",
+      testid: "upload",
     });
     const input = queryByTestId("input") as HTMLInputElement;
 
     fireEvent.change(input, { target: { files: [file] } });
 
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeTruthy();
+      expect(queryByTestId("upload-issue-0")).toBeTruthy();
     });
   });
 
@@ -118,30 +133,31 @@ describe("File selection", () => {
     });
 
     const { queryByTestId, rerender } = render(FileUploadInput, {
+      testid: "upload",
       accept: ".PDF",
     });
     const input = queryByTestId("input") as HTMLInputElement;
 
     fireEvent.change(input, { target: { files: [fileLowercase] } });
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeFalsy();
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
     });
 
     fireEvent.change(input, { target: { files: [fileUppercase] } });
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeFalsy();
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
     });
 
     rerender({ accept: ".pdf" });
 
     fireEvent.change(input, { target: { files: [fileLowercase] } });
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeFalsy();
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
     });
 
     fireEvent.change(input, { target: { files: [fileUppercase] } });
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeFalsy();
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
     });
   });
 
@@ -153,30 +169,58 @@ describe("File selection", () => {
       type: "IMAGE/JPEG",
     });
     const { queryByTestId, rerender } = render(FileUploadInput, {
+      testid: "upload",
       accept: "image/jpeg",
     });
     const input = queryByTestId("input") as HTMLInputElement;
 
     fireEvent.change(input, { target: { files: [fileLowercase] } });
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeFalsy();
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
     });
 
     fireEvent.change(input, { target: { files: [fileUppercase] } });
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeFalsy();
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
     });
 
     rerender({ accept: "IMAGE/JPEG" });
 
     fireEvent.change(input, { target: { files: [fileLowercase] } });
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeFalsy();
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
     });
 
     fireEvent.change(input, { target: { files: [fileUppercase] } });
     await waitFor(() => {
-      expect(queryByTestId("error")).toBeFalsy();
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
+    });
+  });
+
+  it("dismisses an issue when the delete event is triggered", async () => {
+    const file = new File([new ArrayBuffer(1e6)], "file.jpg", {
+      type: "image/jpg",
+    });
+    const { queryByTestId } = render(FileUploadInput, {
+      testid: "upload",
+      maxfilesize: "100KB",
+    });
+    const input = queryByTestId("input") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(queryByTestId("upload-issue-0")).toBeTruthy();
+    });
+
+    const issueCard = queryByTestId("upload-issue-0")!;
+    fireEvent(
+      issueCard,
+      new CustomEvent("_delete", { bubbles: true, composed: true }),
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId("upload-issue-0")).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
This is a reopened/rebased version of https://github.com/GovAlta/ui-components/pull/3842

# Before (the change)

<img width="1195" height="304" alt="image" src="https://github.com/user-attachments/assets/0ec49e8b-3e05-44b3-a5ce-2f13e76cd93b" />

File upload errors were listed in a unique state, which could cause them to not be visible when used in conjunction with the `FileUploadCards`.

# After (the change)

File upload errors are listed in the same format as FileUploadCard.

<img width="1174" height="312" alt="image" src="https://github.com/user-attachments/assets/8d757efb-cc25-4ac3-8e5c-a8b00c29277e" />

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
