### PR TITLE
chore(#3923): add experimental Vue support to docs

### DIFF
--- a/docs/src/components/CodeSnippet.tsx
+++ b/docs/src/components/CodeSnippet.tsx
@@ -58,7 +58,7 @@ interface CodeSnippetProps {
 const FRAMEWORK_LABELS: Record<Framework, string> = {
   react: "React",
   angular: "Angular",
-  webComponents: "Web Components",
+  webComponents: "Vue / Web Components",
 };
 
 // ============================================================================

--- a/docs/src/pages/get-started/developers/setup.astro
+++ b/docs/src/pages/get-started/developers/setup.astro
@@ -108,6 +108,74 @@ npm i @abgov/design-tokens</code></pre>
 
   <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
 
+  <div style="display: flex; gap: 1rem; align-items: baseline;">
+    <h2 id="vue">Vue UI components</h2>
+    <goa-badge version="2" type="important" emphasis="subtle" content="Experimental"
+    ></goa-badge>
+  </div>
+  <goa-callout version="2" type="information" emphasis="low" mb="m">
+    <goa-text version="2" size="body-m" mt="2xs" mb="none">Supported versions: 3</goa-text
+    >
+  </goa-callout>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Vue 3 consumes the Government of Alberta web components directly. No Vue-specific
+    wrapper package is required.
+  </goa-text>
+
+  <h3 id="vue-step-1">1. Add dependencies</h3>
+  <pre><code>npm i @abgov/web-components
+npm i @abgov/design-tokens</code></pre>
+
+  <h3 id="vue-step-2">2. Link ionicons in index.html</h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Add the following in the <code>head</code> element:
+  </goa-text>
+  <pre><code>&lt;script type="module" src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.esm.js"&gt;&lt;/script&gt;
+&lt;script nomodule src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.js"&gt;&lt;/script&gt;</code></pre>
+
+  <h3 id="vue-step-3">
+    3. Configure your Vue build tool and import the web components in src/main.ts
+  </h3>
+  <goa-text version="2" size="body-m" mt="none" mb="m">
+    Vite is shown below. Tell the Vue compiler to treat <code>goa-*</code> tags as custom elements,
+    then register the components:
+  </goa-text>
+  <pre><code>// vite.config.ts
+import &#123; defineConfig &#125; from "vite";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig(&#123;
+  plugins: [
+    vue(&#123;
+      template: &#123;
+        compilerOptions: &#123;
+          isCustomElement: (tag) =&gt; tag.startsWith("goa-"),
+        &#125;,
+      &#125;,
+    &#125;),
+  ],
+&#125;);</code></pre>
+  <pre><code>// src/main.ts
+import "@abgov/web-components";</code></pre>
+
+  <h3 id="vue-step-4">4. Add the styles in src/assets/main.css</h3>
+  <pre><code>@import "@abgov/web-components/index.css";
+@import "@abgov/design-tokens/dist/tokens.css";</code></pre>
+
+  <h4>Notes</h4>
+  <ul>
+    <li>
+      Pass booleans as <code>"true"</code> /
+      <code>"false"</code> strings.
+    </li>
+    <li>
+      Listen for events using their underscore-prefixed names (e.g. <code>@_change</code
+      >).
+    </li>
+  </ul>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
   <h2 id="web-components">Web components</h2>
   <goa-text version="2" size="body-m" mt="none" mb="m">
     This library contains web components from the Government of Alberta.

--- a/docs/src/pages/get-started/developers/technologies.astro
+++ b/docs/src/pages/get-started/developers/technologies.astro
@@ -1,13 +1,13 @@
 ---
-import { withBase } from '@/lib/base-url';
+import { withBase } from "@/lib/base-url";
 /**
  * Get Started - Developers - Technologies
  *
  * Overview of Design System technologies: Web Components, Svelte, Angular, React.
  * Content from Confluence (Brief 87).
  */
-import DropInCallout from '../../../components/DropInCallout.astro';
-import DocumentationPageLayout from '../../../layouts/DocumentationPageLayout.astro';
+import DropInCallout from "../../../components/DropInCallout.astro";
+import DocumentationPageLayout from "../../../layouts/DocumentationPageLayout.astro";
 ---
 
 <DocumentationPageLayout
@@ -20,48 +20,80 @@ import DocumentationPageLayout from '../../../layouts/DocumentationPageLayout.as
     An overview of the technologies used in the Design System.
   </goa-text>
 
-  <goa-text as="h2" id="how-technologies-fit-together" version="2" size="heading-m">How the technologies fit together</goa-text>
+  <goa-text as="h2" id="how-technologies-fit-together" version="2" size="heading-m"
+    >How the technologies fit together</goa-text
+  >
   <p>
-    The Design System is built on Web Components. Most component functionality lives in the core Web
-    Components layer. Angular and React wrappers sit on top of that layer to make the components easier
-    to use in those frameworks.
+    The Design System is built on Web Components. Most component functionality lives in
+    the core Web Components layer. Angular and React wrappers sit on top of that layer to
+    make the components easier to use in those frameworks.
   </p>
   <p>
-    We use Svelte to author the components that are compiled to custom elements. You can use the Design
-    System through the core Web Components or through Angular and React wrappers.
+    We use Svelte to author the components that are compiled to custom elements. You can
+    use the Design System through the core Web Components or through Angular and React
+    wrappers.
   </p>
-  <img src={withBase(`/images/technologies.svg`)} alt="Diagram showing the technology layers: Svelte compiles to Web Components, which are wrapped by Angular and React" style="width: 100%; max-width: 700px; margin: var(--goa-space-l) 0;" />
-  <goa-text as="h2" id="web-components" version="2" size="heading-m">Web Components</goa-text>
+  <img
+    src={withBase(`/images/technologies.svg`)}
+    alt="Diagram showing the technology layers: Svelte compiles to Web Components, which are wrapped by Angular and React"
+    style="width: 100%; max-width: 700px; margin: var(--goa-space-l) 0;"
+  />
+  <goa-text as="h2" id="web-components" version="2" size="heading-m"
+    >Web Components</goa-text
+  >
   <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Components" target="_blank">Web Components</a>
-    are a set of standard web technologies that allow you to create reusable custom elements. Each component
-    includes its own structure, styling, and behaviour. This keeps it independent from the rest of your code.
+    <a
+      href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Components"
+      target="_blank">Web Components</a
+    >
+    are a set of standard web technologies that allow you to create reusable custom elements.
+    Each component includes its own structure, styling, and behaviour. This keeps it independent
+    from the rest of your code.
   </p>
   <p>
-    In the Design System, Web Components are the core library. They are framework-agnostic, so teams
-    can use them in different front-end environments.
+    In the Design System, Web Components are the core library. They are
+    framework-agnostic, so teams can use them in different front-end environments.
   </p>
 
   <goa-text version="2" size="heading-xs">Benefits of using Web Components</goa-text>
   <ul>
-    <li><strong>Reuse:</strong> Build once and use across pages, applications, and frameworks</li>
-    <li><strong>Browser support:</strong> Work in modern browsers without additional libraries</li>
-    <li><strong>Maintenance:</strong> Modular and self-contained structure simplifies updates</li>
-    <li><strong>Encapsulation:</strong> Structure, style, and behaviour remain isolated from other page elements</li>
-    <li><strong>Reliability:</strong> Code is not spread across HTML and JS files, thereby avoiding inconsistencies</li>
-    <li><strong>Flexibility:</strong> Use inline, import, or compile components as needed</li>
-    <li><strong>Composability:</strong> Combine components or integrate them with other components</li>
+    <li>
+      <strong>Reuse:</strong> Build once and use across pages, applications, and frameworks
+    </li>
+    <li>
+      <strong>Browser support:</strong> Work in modern browsers without additional libraries
+    </li>
+    <li>
+      <strong>Maintenance:</strong> Modular and self-contained structure simplifies updates
+    </li>
+    <li>
+      <strong>Encapsulation:</strong> Structure, style, and behaviour remain isolated from other
+      page elements
+    </li>
+    <li>
+      <strong>Reliability:</strong> Code is not spread across HTML and JS files, thereby avoiding
+      inconsistencies
+    </li>
+    <li>
+      <strong>Flexibility:</strong> Use inline, import, or compile components as needed
+    </li>
+    <li>
+      <strong>Composability:</strong> Combine components or integrate them with other components
+    </li>
   </ul>
 
   <goa-callout version="2" type="important" emphasis="low" mb="m">
-    <goa-text version="2" size="body-m" mt="2xs" mb="none">Do not use Web Components directly unless there is a specific reason to do so. Using wrappers provides
-    type checking and developer helpers that are not available when working with the core Web Components alone.</goa-text>
+    <goa-text version="2" size="body-m" mt="2xs" mb="none"
+      >Do not use Web Components directly unless there is a specific reason to do so.
+      Using wrappers provides type checking and developer helpers that are not available
+      when working with the core Web Components alone.</goa-text
+    >
   </goa-callout>
   <goa-text as="h2" id="svelte" version="2" size="heading-m">Svelte</goa-text>
   <p>
-    <a href="https://svelte.dev/" target="_blank">Svelte</a> is the framework used to generate the
-    Design System Web Components. Svelte combines JavaScript (logic), HTML (structure), and CSS (style)
-    within a single file. It compiles these into efficient, reusable components.
+    <a href="https://svelte.dev/" target="_blank">Svelte</a> is the framework used to generate
+    the Design System Web Components. Svelte combines JavaScript (logic), HTML (structure),
+    and CSS (style) within a single file. It compiles these into efficient, reusable components.
   </p>
   <goa-text version="2" size="heading-xs">Why Svelte</goa-text>
   <p>We use Svelte to:</p>
@@ -73,39 +105,86 @@ import DocumentationPageLayout from '../../../layouts/DocumentationPageLayout.as
   <goa-text as="h2" id="angular" version="2" size="heading-m">Angular</goa-text>
 
   <goa-callout version="2" type="information" emphasis="low" mb="m">
-    <goa-text version="2" size="body-m" mt="2xs" mb="none">Supported versions: 18, 19, 20, 21</goa-text>
+    <goa-text version="2" size="body-m" mt="2xs" mb="none"
+      >Supported versions: 18, 19, 20, 21</goa-text
+    >
   </goa-callout>
 
   <p>
-    <a href="https://angular.dev/" target="_blank">Angular</a> is a TypeScript-based framework for building
-    web applications. The Design System supports Angular through Angular wrappers around the core Web Components.
+    <a href="https://angular.dev/" target="_blank">Angular</a> is a TypeScript-based framework
+    for building web applications. The Design System supports Angular through Angular wrappers
+    around the core Web Components.
   </p>
 
-  <goa-text version="2" size="heading-xs">How Web Components and Angular work together</goa-text>
+  <goa-text version="2" size="heading-xs"
+    >How Web Components and Angular work together</goa-text
+  >
   <p>Angular wrappers are created around the Web Components. These wrappers:</p>
   <ul>
     <li>Manage component properties and events</li>
     <li>Support form binding (Reactive and Template-driven)</li>
     <li>Allow integration within Angular applications</li>
   </ul>
-  <p>The Angular application interacts with the wrapper, which renders the underlying Web Component.</p>
+  <p>
+    The Angular application interacts with the wrapper, which renders the underlying Web
+    Component.
+  </p>
   <goa-text as="h2" id="react" version="2" size="heading-m">React</goa-text>
 
   <goa-callout version="2" type="information" emphasis="low" mb="m">
-    <goa-text version="2" size="body-m" mt="2xs" mb="none">Supported versions: 17, 18, 19</goa-text>
+    <goa-text version="2" size="body-m" mt="2xs" mb="none"
+      >Supported versions: 17, 18, 19</goa-text
+    >
   </goa-callout>
 
   <p>
-    <a href="https://react.dev/" target="_blank">React</a> is an open-source JavaScript library used to
-    build user interfaces from reusable components.
+    <a href="https://react.dev/" target="_blank">React</a> is an open-source JavaScript library
+    used to build user interfaces from reusable components.
   </p>
 
-  <goa-text version="2" size="heading-xs">How Web Components and React work together</goa-text>
+  <goa-text version="2" size="heading-xs"
+    >How Web Components and React work together</goa-text
+  >
   <p>React wrappers are created around the Web Components. These wrappers:</p>
   <ul>
     <li>Manage properties and events</li>
     <li>Enable integration within React applications</li>
   </ul>
-  <p>The React application interacts with the wrapper, which renders the underlying Web Component.</p>
+  <p>
+    The React application interacts with the wrapper, which renders the underlying Web
+    Component.
+  </p>
+
+  <div style="display: flex; gap: 1rem; align-items: baseline;">
+    <goa-text as="h2" id="vue" version="2" size="heading-m">Vue</goa-text>
+    <goa-badge version="2" type="important" emphasis="subtle" content="Experimental"
+    ></goa-badge>
+  </div>
+
+  <goa-callout version="2" type="information" emphasis="low" mb="m">
+    <goa-text version="2" size="body-m" mt="2xs" mb="none">Supported versions: 3</goa-text
+    >
+  </goa-callout>
+
+  <p>
+    <a href="https://vuejs.org/" target="_blank">Vue</a> is a progressive JavaScript framework
+    for building user interfaces. The Design System supports Vue by using the core Web Components
+    directly.
+  </p>
+
+  <goa-text version="2" size="heading-xs"
+    >How Web Components and Vue work together</goa-text
+  >
+  <p>
+    Vue applications use the core Web Components directly. Teams can configure Vue to
+    recognize <code>goa-*</code> tags as custom elements. This approach:
+  </p>
+  <ul>
+    <li>Uses the same core components as other frameworks</li>
+    <li>Avoids wrapper-specific dependencies</li>
+    <li>Supports integration in Vue component templates</li>
+  </ul>
+  <p>The Vue application renders the underlying Web Component directly.</p>
+
   <DropInCallout />
 </DocumentationPageLayout>


### PR DESCRIPTION
This PR adds initial "Vue support" to our docs with the following changes:
- Adds a setup guide for Vue
- Adds "Vue" to the frameworks switcher

<img width="608" height="132" alt="image" src="https://github.com/user-attachments/assets/cb1b56d7-0fa2-4b68-bedf-01842eb0b27d" />

<hr/>

<img width="748" height="378" alt="image" src="https://github.com/user-attachments/assets/b51e6450-aba4-47f3-a64e-bce5b697a8a5" />

<hr/>

<img width="767" height="527" alt="image" src="https://github.com/user-attachments/assets/6b2f5cfe-a601-4359-b79b-79e415c35309" />
