### PR TITLE
chore(#3877): update Designing with the updated design system page

### DIFF
--- a/docs/public/search-index.json
+++ b/docs/public/search-index.json
@@ -2800,8 +2800,8 @@
   {
     "type": "page",
     "id": "designers/designing-with-ds",
-    "title": "Designing with Design System 2.0",
-    "description": "How to start new designs and update existing projects to Design System 2.0",
+    "title": "Designing with the updated design system",
+    "description": "How to start using the updated design system in your designs",
     "status": "published",
     "category": "get started",
     "tags": [

--- a/docs/src/content/get-started/designers/designing-with-ds.mdx
+++ b/docs/src/content/get-started/designers/designing-with-ds.mdx
@@ -13,7 +13,7 @@ import DropInCallout from "../../../components/DropInCallout.astro";
 <goa-text size="body-l" mt="none" mb="2xl">How to start using the updated design system in your designs.</goa-text>
 <goa-text as="h2" id="starting-a-new-design" size="heading-m" style={{ marginTop: "var(--goa-space-xl)" }}>Starting a new design</goa-text>
 <p>
-  Use <a href="https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-BETA-Component-library?node-id=58855-81995" target="_blank">updated design system templates</a> as your starting point. Templates package layout, navigation, spacing, and
+  Use <goa-link trailingicon="open"><a href="https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-BETA-Component-library?node-id=58855-81995" target="_blank">updated design system templates</a></goa-link> as your starting point. Templates package layout, navigation, spacing, and
   example content that you can adapt to your service. Some templates are built for specific service types —
   for example, public-facing forms and workspace applications. Others are general-purpose
   starting points you can use across many kinds of pages and flows.
@@ -24,7 +24,7 @@ import DropInCallout from "../../../components/DropInCallout.astro";
 
 <goa-text size="heading-xs">Library swap</goa-text>
 <p>
-  Use a <a href="https://help.figma.com/hc/en-us/articles/4404856784663-Swap-style-and-component-libraries" target="_blank">library swap</a> if
+  Use a <goa-link trailingicon="open"><a href="https://help.figma.com/hc/en-us/articles/4404856784663-Swap-style-and-component-libraries" target="_blank">library swap</a></goa-link> if
   your goal is to convert most of the file to the updated design system in one pass.
 </p>
 <ul>

--- a/docs/src/content/get-started/designers/designing-with-ds.mdx
+++ b/docs/src/content/get-started/designers/designing-with-ds.mdx
@@ -1,63 +1,56 @@
 ---
 id: designers/designing-with-ds
-title: Designing with Design System 2.0
-description: How to start new designs and update existing projects to Design System 2.0
+title: Designing with the updated design system
+description: How to start using the updated design system in your designs
 section: designers
 order: 2
 status: published
 ---
+import { withBase } from "@/lib/base-url";
 import DropInCallout from "../../../components/DropInCallout.astro";
 
-<goa-text size="heading-xl" mt="none" mb="m">Designing with Design System 2.0</goa-text>
-<goa-text size="body-l" mt="none" mb="2xl">What's new in DS 2.0 and how to start using it in your designs.</goa-text>
-<p>
-  The Digital Design and Delivery (DDD) Design System has evolved to better support how service teams
-  design and build digital government services. Design System 2.0 includes an updated design
-  language, new tokens, refreshed components, and ready-to-use templates.
-</p>
+<goa-text size="heading-xl" mt="none" mb="m">Designing with the updated design system</goa-text>
+<goa-text size="body-l" mt="none" mb="2xl">How to start using the updated design system in your designs.</goa-text>
 <goa-text as="h2" id="starting-a-new-design" size="heading-m" style={{ marginTop: "var(--goa-space-xl)" }}>Starting a new design</goa-text>
 <p>
-  Use <a href="https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-BETA-Component-library?node-id=58855-81995" target="_blank">DS 2.0 templates</a> as your starting point. Templates package layout, navigation, spacing, and
-  example content that you can adapt to your service. Some templates are built for specific service types
-  (for example, public-facing forms and workspace applications), and others are more general-purpose
+  Use <a href="https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-BETA-Component-library?node-id=58855-81995" target="_blank">updated design system templates</a> as your starting point. Templates package layout, navigation, spacing, and
+  example content that you can adapt to your service. Some templates are built for specific service types —
+  for example, public-facing forms and workspace applications. Others are general-purpose
   starting points you can use across many kinds of pages and flows.
 </p>
 
-<goa-text as="h2" id="starting-from-an-existing-design" size="heading-m">Starting from an existing design</goa-text>
+<goa-text as="h2" id="starting-from-an-existing-design" size="heading-m">Updating an existing design file</goa-text>
+<p>Choose one of two approaches depending on how much control you need over the process.</p>
 
 <goa-text size="heading-xs">Library swap</goa-text>
 <p>
   Use a <a href="https://help.figma.com/hc/en-us/articles/4404856784663-Swap-style-and-component-libraries" target="_blank">library swap</a> if
-  your goal is to convert most of the file to DS 2.0 in one pass.
+  your goal is to convert most of the file to the updated design system in one pass.
 </p>
 <ul>
   <li>Make a copy of your file before you start.</li>
-  <li>Expect mixed results. Some screens may need cleanup after the swap.</li>
+  <li>Expect mixed results — some screens may need cleanup after the swap.</li>
 </ul>
 
 <goa-text size="heading-xs">Manual rebuild</goa-text>
-<p>Use a manual rebuild if you need more control.</p>
+<p>Use a manual rebuild if you need more control over the process.</p>
 <ul>
   <li>Rebuild your highest value screens first.</li>
-  <li>Consider using DS 2.0 templates as a base to speed things up.</li>
-</ul>
-<goa-text as="h2" id="update-existing-project" size="heading-m">Update an existing project to the new design library</goa-text>
-
-<goa-text size="heading-xs">Approach 1: Developer-first</goa-text>
-<p>Use this approach in most cases.</p>
-<ol>
-  <li>A developer creates a new branch and completes the upgrade steps.</li>
-  <li>The team runs the upgraded application to see what changed.</li>
-  <li>Designers review the upgraded screens and identify what needs design updates.</li>
-</ol>
-<p>When reviewing the upgraded branch, watch for:</p>
-<ul>
-  <li>Spacing and layout rhythm</li>
-  <li>Typography scale and weight usage</li>
-  <li>Dense or constrained screens (these often have the highest risk during an update)</li>
+  <li>Use updated design system templates as a base to speed things up.</li>
 </ul>
 
-<goa-text size="heading-xs">Approach 2: Design-first</goa-text>
+<goa-text as="h2" id="update-existing-project" size="heading-m">Updating an existing product</goa-text>
+<p>Choose your approach based on whether design or development work is leading the update.</p>
+
+<goa-text size="heading-xs">Developer-first approach</goa-text>
+<p>
+  Use this approach in most cases. A developer creates a branch and runs the update so your team
+  can see what changed in the real product before committing to design work. Designers then review
+  the updated screens and identify what needs follow-up.
+</p>
+<p>See <a href={withBase(`/get-started/developers/updating-your-product`)}>Updating your product</a> for the full steps.</p>
+
+<goa-text size="heading-xs">Design-first approach</goa-text>
 <p>Use this approach when you want design work to move ahead of development work.</p>
 <ol>
   <li>Identify custom elements that support your users' needs.</li>
@@ -66,6 +59,6 @@ import DropInCallout from "../../../components/DropInCallout.astro";
 </ol>
 
 <goa-callout version="2" type="important" emphasis="low" heading="Start with the developer-first approach" mt="l" mb="l">
-  <goa-text size="body-m" mt="2xs" mb="none">In most cases, start with the developer-first approach. It helps you quickly see what changed in your real product, so you can focus design effort where it matters most.</goa-text>
+  <goa-text size="body-m" mt="2xs" mb="none">Use this approach in most cases. It helps you focus design effort on what actually changed in your product rather than redesigning based on assumptions.</goa-text>
 </goa-callout>
 <DropInCallout />


### PR DESCRIPTION
## Summary

- Removes all references to "Design System 2.0" and "DS 2.0" from the page
- Updates page title and subtitle to match the revised naming
- Slims down the developer-first section and links out to the new [Updating your product](#3920) page
- Updates section titles and content to match the revised copy in the issue
- Applies writing guide standards throughout

## Changes

- `docs/src/content/get-started/designers/designing-with-ds.mdx` — content update
- Nav label is derived from the page `title` frontmatter field — no separate nav file change needed

## Test plan

- [ ] Page loads at `/get-started/designers/designing-with-ds`
- [ ] Nav label reads "Designing with the updated design system" (no DS 2.0 references anywhere on the page or in the nav)
- [ ] "Updating your product" links to `/get-started/developers/updating-your-product`
- [ ] Both Figma template and library swap links open correctly in a new tab
- [ ] Important callout and DropInCallout render correctly at the bottom of the page

Fixes #3877

🤖 Generated with [Claude Code](https://claude.com/claude-code)