### PR TITLE
feat(#3814): Add trailingSlot to Work Side Menu Item

### DIFF
--- a/apps/prs/angular/src/routes/features/feat3814/feat3814.component.css
+++ b/apps/prs/angular/src/routes/features/feat3814/feat3814.component.css
@@ -1,0 +1,19 @@
+:host {
+  display: block;
+}
+
+.search-menu-badge {
+  color: var(--goa-color-greyscale-600);
+  height: 1.25rem;
+  min-width: 1.25rem;
+  line-height: 1;
+  text-align: center;
+  font-size: var(--goa-font-size-2);
+  background-color: var(--goa-color-greyscale-100);
+  border: 1px solid var(--goa-color-greyscale-200);
+  border-radius: var(--goa-border-radius-s);
+  padding: var(--goa-space-3xs) var(--goa-space-xs);
+  display: inline-block;
+  vertical-align: top;
+    margin-top: var(--goa-space-3xs);
+}

--- a/apps/prs/angular/src/routes/features/feat3814/feat3814.component.html
+++ b/apps/prs/angular/src/routes/features/feat3814/feat3814.component.html
@@ -1,0 +1,47 @@
+<div style="display: flex; flex-direction: column; gap: var(--goa-spacing-l)">
+  <goab-text tag="h1">Feature 3814: Work Side Menu trailingContent slot</goab-text>
+
+  <goab-text>
+    This page demonstrates the new trailingContent slot on Work Side Menu Item.
+    The first item shows a keyboard shortcut hint and the second item shows a badge.
+  </goab-text>
+
+  <goab-container>
+    <div style="height: 420px; overflow: hidden">
+      <goab-work-side-menu
+        heading="Feature 3814 Demo"
+        url="/"
+        [open]="true"
+        [primaryContent]="primaryTemplate"
+      ></goab-work-side-menu>
+    </div>
+  </goab-container>
+</div>
+
+<ng-template #primaryTemplate>
+  <goab-work-side-menu-item
+    label="Search"
+    icon="search"
+    url="/features/3814/search"
+    [trailingContent]="shortcutTemplate"
+  ></goab-work-side-menu-item>
+  <goab-work-side-menu-item
+    label="Notifications"
+    icon="notifications"
+    url="/features/3814/notifications"
+    [trailingContent]="badgeTemplate"
+  ></goab-work-side-menu-item>
+  <goab-work-side-menu-item
+    label="Reports"
+    icon="document"
+    url="/features/3814/reports"
+  ></goab-work-side-menu-item>
+</ng-template>
+
+<ng-template #shortcutTemplate>
+  <span class="search-menu-badge">Ctrl K</span>
+</ng-template>
+
+<ng-template #badgeTemplate>
+  <goab-badge type="success" content="3" [icon]="false"></goab-badge>
+</ng-template>

--- a/apps/prs/angular/src/routes/features/feat3814/feat3814.component.ts
+++ b/apps/prs/angular/src/routes/features/feat3814/feat3814.component.ts
@@ -1,0 +1,17 @@
+import { Component } from "@angular/core";
+import {
+  GoabBadge,
+  GoabContainer,
+  GoabText,
+  GoabWorkSideMenu,
+  GoabWorkSideMenuItem,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat3814",
+  templateUrl: "./feat3814.component.html",
+  styleUrls: ["./feat3814.component.css"],
+  imports: [GoabBadge, GoabContainer, GoabText, GoabWorkSideMenu, GoabWorkSideMenuItem],
+})
+export class Feat3814Component {}

--- a/apps/prs/angular/src/routes/features/feat3814/feat3814.route.json
+++ b/apps/prs/angular/src/routes/features/feat3814/feat3814.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Work Side Menu Trailing Slot",
+  "path": "features/3814",
+  "id": "3814",
+  "type": "feature"
+}

--- a/apps/prs/react/src/app/routes/features/feat3814.route.ts
+++ b/apps/prs/react/src/app/routes/features/feat3814.route.ts
@@ -1,0 +1,10 @@
+import { Feat3814Route } from "../../../routes/features/feat3814";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "feature",
+  id: "3814",
+  path: "features/3814",
+  title: "Work Side Menu Trailing Slot",
+  component: Feat3814Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/features/feat3814.tsx
+++ b/apps/prs/react/src/routes/features/feat3814.tsx
@@ -1,0 +1,75 @@
+import {
+  GoabBadge,
+  GoabContainer,
+  GoabText,
+  GoabWorkSideMenu,
+  GoabWorkSideMenuItem,
+} from "@abgov/react-components";
+
+export function Feat3814Route() {
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: "var(--goa-spacing-l)" }}
+    >
+      <GoabText as="h1" size="heading-xl">
+        Feature 3814: Work Side Menu trailingContent slot
+      </GoabText>
+
+      <GoabText as="p" size="body-m">
+        This page demonstrates the new trailingContent slot on Work Side Menu Item. The
+        first item shows a keyboard shortcut hint and the second item shows a badge.
+      </GoabText>
+
+      <GoabContainer>
+        <div style={{ height: "420px", overflow: "hidden" }}>
+          <GoabWorkSideMenu
+            heading="Feature 3814 Demo"
+            url="/"
+            open={true}
+            primaryContent={
+              <>
+                <GoabWorkSideMenuItem
+                  label="Search"
+                  icon="search"
+                  url="/features/3814/search"
+                  trailingContent={
+                    <span
+                      style={{
+                        color: "var(--goa-color-greyscale-600)",
+                        minWidth: "var(--goa-spacing-5)",
+                        lineHeight: "1",
+                        fontSize: "var(--goa-font-size-2)",
+                        backgroundColor: "var(--goa-color-greyscale-100)",
+                        border: "1px solid var(--goa-color-greyscale-200)",
+                        borderRadius: "var(--goa-border-radius-s)",
+                        padding: "var(--goa-space-3xs) var(--goa-space-xs)",
+                        display: "inline-block",
+                        verticalAlign: "top",
+                        marginTop: "var(--goa-space-3xs)",
+                      }}
+                    >
+                      Ctrl K
+                    </span>
+                  }
+                />
+                <GoabWorkSideMenuItem
+                  label="Notifications"
+                  icon="notifications"
+                  url="/features/3814/notifications"
+                  trailingContent={<GoabBadge type="success" content="3" icon={false} />}
+                />
+                <GoabWorkSideMenuItem
+                  label="Reports"
+                  icon="document"
+                  url="/features/3814/reports"
+                />
+              </>
+            }
+          />
+        </div>
+      </GoabContainer>
+    </div>
+  );
+}
+
+export default Feat3814Route;

--- a/docs/generated/component-apis/work-side-menu-item.json
+++ b/docs/generated/component-apis/work-side-menu-item.json
@@ -5,13 +5,6 @@
     "react": {
       "props": [
         {
-          "name": "badge",
-          "type": "string",
-          "required": false,
-          "default": null,
-          "description": "Badge text displayed alongside the menu item (e.g., notification count)."
-        },
-        {
           "name": "current",
           "type": "boolean",
           "required": false,
@@ -45,13 +38,6 @@
           "required": false,
           "default": null,
           "description": "Sets a data-testid attribute for automated testing."
-        },
-        {
-          "name": "type",
-          "type": "GoabWorkSideMenuItemType",
-          "required": false,
-          "default": "normal",
-          "description": "Sets the visual style of the badge. Use \"emergency\" for urgent items, \"success\" for positive status."
         },
         {
           "name": "url",
@@ -68,18 +54,17 @@
           "type": "ReactNode",
           "description": "Content rendered inside the popover panel attached to this menu item.",
           "required": false
+        },
+        {
+          "name": "trailingContent",
+          "type": "ReactNode",
+          "description": "Content rendered after the label in the trailing area of the menu item.",
+          "required": false
         }
       ]
     },
     "angular": {
       "props": [
-        {
-          "name": "badge",
-          "type": "string",
-          "required": false,
-          "default": null,
-          "description": "Badge text displayed alongside the menu item (e.g., notification count)."
-        },
         {
           "name": "current",
           "type": "boolean",
@@ -116,13 +101,6 @@
           "description": "Sets a data-testid attribute for automated testing."
         },
         {
-          "name": "type",
-          "type": "GoabWorkSideMenuItemType",
-          "required": false,
-          "default": "normal",
-          "description": "Sets the visual style of the badge. Use \"emergency\" for urgent items, \"success\" for positive status."
-        },
-        {
           "name": "url",
           "type": "string",
           "required": false,
@@ -137,18 +115,17 @@
           "type": "TemplateRef",
           "description": "Content rendered inside the popover panel attached to this menu item.",
           "required": false
+        },
+        {
+          "name": "trailingContent",
+          "type": "TemplateRef",
+          "description": "Content rendered after the label in the trailing area of the menu item.",
+          "required": false
         }
       ]
     },
     "webComponents": {
       "props": [
-        {
-          "name": "badge",
-          "type": "string",
-          "required": false,
-          "default": "",
-          "description": "Badge text displayed alongside the menu item (e.g., notification count)."
-        },
         {
           "name": "current",
           "type": "boolean",
@@ -186,18 +163,6 @@
           "description": "Sets a data-testid attribute for automated testing."
         },
         {
-          "name": "type",
-          "type": "\"normal\" | \"emergency\" | \"success\"",
-          "values": [
-            "normal",
-            "emergency",
-            "success"
-          ],
-          "required": false,
-          "default": "normal",
-          "description": "Sets the visual style of the badge. Use \"emergency\" for urgent items, \"success\" for positive status."
-        },
-        {
           "name": "url",
           "type": "string",
           "required": false,
@@ -210,6 +175,11 @@
         {
           "name": "popoverContent",
           "description": "Content rendered inside the popover panel attached to this menu item.",
+          "required": false
+        },
+        {
+          "name": "trailingContent",
+          "description": "Content rendered after the label in the trailing area of the menu item.",
           "required": false
         }
       ]

--- a/docs/src/scripts/extract-api.ts
+++ b/docs/src/scripts/extract-api.ts
@@ -2186,8 +2186,10 @@ function mergeItemArray<T extends { name: string; description: string }>(
   });
 
   // Preserve items from existing that are absent in the new extraction
+  // (but skip deprecated entries — they are intentionally excluded)
   for (const existingItem of existing) {
     if (!nextNames.has(existingItem.name)) {
+      if ((existingItem as Record<string, unknown>).deprecated) continue;
       console.warn(
         `  Preserved manually-added entry "${existingItem.name}" in ${context} (not found in extraction — check source)`,
       );

--- a/libs/angular-components/src/lib/components/work-side-menu-item/work-side-menu-item.spec.ts
+++ b/libs/angular-components/src/lib/components/work-side-menu-item/work-side-menu-item.spec.ts
@@ -51,6 +51,26 @@ class TestWorkSideMenuItemWithPopoverComponent {
   url = "/popover";
 }
 
+@Component({
+  standalone: true,
+  imports: [GoabWorkSideMenuItem],
+  template: `
+    <goab-work-side-menu-item
+      [label]="label"
+      [url]="url"
+      [trailingContent]="trailingTpl"
+    >
+    </goab-work-side-menu-item>
+    <ng-template #trailingTpl>
+      <div class="trailing-test-content">2</div>
+    </ng-template>
+  `,
+})
+class TestWorkSideMenuItemWithTrailingContentComponent {
+  label = "Trailing item";
+  url = "/trailing";
+}
+
 describe("GoabWorkSideMenuItem", () => {
   it("should render and set the props correctly", fakeAsync(() => {
     TestBed.configureTestingModule({
@@ -95,5 +115,27 @@ describe("GoabWorkSideMenuItem", () => {
     );
     expect(popoverContent).toBeTruthy();
     expect(popoverContent.nativeElement.textContent).toBe("Popover content here");
+  }));
+
+  it("should render trailing content into the trailingContent slot", fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestWorkSideMenuItemWithTrailingContentComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestWorkSideMenuItemWithTrailingContentComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const slotDiv = fixture.debugElement.query(
+      By.css('[slot="trailingContent"]'),
+    );
+    expect(slotDiv).toBeTruthy();
+
+    const trailingContent = fixture.debugElement.query(
+      By.css(".trailing-test-content"),
+    );
+    expect(trailingContent).toBeTruthy();
+    expect(trailingContent.nativeElement.textContent).toBe("2");
   }));
 });

--- a/libs/angular-components/src/lib/components/work-side-menu-item/work-side-menu-item.ts
+++ b/libs/angular-components/src/lib/components/work-side-menu-item/work-side-menu-item.ts
@@ -31,6 +31,11 @@ import { NgTemplateOutlet } from "@angular/common";
             <ng-container [ngTemplateOutlet]="popoverContent"></ng-container>
           </div>
         }
+        @if (trailingContent) {
+          <div slot="trailingContent">
+            <ng-container [ngTemplateOutlet]="trailingContent"></ng-container>
+          </div>
+        }
         <ng-content />
       </goa-work-side-menu-item>
     }
@@ -45,7 +50,7 @@ export class GoabWorkSideMenuItem implements OnInit {
   @Input({ required: true }) label!: string;
   /** The URL the menu item links to. Optional — when absent, renders as a button instead of a link. */
   @Input() url?: string;
-  /** Badge text displayed alongside the menu item (e.g., notification count). */
+  /** @deprecated Use trailingContent instead. Badge text displayed alongside the menu item (e.g., notification count). */
   @Input() badge?: string;
   /** When true, indicates this is the currently active menu item. */
   @Input() current?: boolean;
@@ -55,10 +60,12 @@ export class GoabWorkSideMenuItem implements OnInit {
   @Input() icon?: string;
   /** Sets a data-testid attribute for automated testing. */
   @Input() testId?: string;
-  /** Sets the visual style of the badge. Use "emergency" for urgent items, "success" for positive status. @default "normal" */
+  /** @deprecated Use trailingContent instead. Sets the visual style of the badge. Use "emergency" for urgent items, "success" for positive status. @default "normal" */
   @Input() type?: GoabWorkSideMenuItemType = "normal";
   /** Template reference for the popover content slot. */
   @Input() popoverContent!: TemplateRef<any>;
+  /** Template reference for the trailing content slot. */
+  @Input() trailingContent!: TemplateRef<any>;
 
   isReady = false;
 

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -1337,6 +1337,7 @@ export type GoabDrawerSizeUnit = "px" | "rem" | "ch" | "vh" | "vw" | "%";
 export type GoabDrawerSize = `${number}${GoabDrawerSizeUnit}` | undefined;
 
 // Work side menu
+/** @deprecated Use trailingContent with explicit badge components for indicator styling. */
 export type GoabWorkSideMenuItemType = "normal" | "emergency" | "success";
 
 // Work side notification

--- a/libs/react-components/specs/work-side-menu.browser.spec.tsx
+++ b/libs/react-components/specs/work-side-menu.browser.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from "vitest-browser-react";
 import { useState } from "react";
-import { GoabButton } from "../src";
+import { GoabBadge, GoabButton } from "../src";
 import { GoabWorkSideMenu, GoabWorkSideMenuItem, GoabWorkSideMenuGroup } from "../src";
 import { expect, describe, it, vi } from "vitest";
 import { page } from "@vitest/browser/context";
@@ -22,6 +22,7 @@ describe("WorkSideMenu", () => {
                 url="#item1"
                 label="Item 1"
                 testId="primary-menu-item"
+                trailingContent={<div data-testid="trailing-content">Trailing</div>}
               />
             }
             secondaryContent={
@@ -51,11 +52,15 @@ describe("WorkSideMenu", () => {
         const primarySlot = result.baseElement.querySelector("[slot='primary']");
         const primaryMenuItem = result.getByTestId("primary-menu-item");
         const primaryLink = primaryMenuItem.element().querySelector("a");
+        const primaryTrailing = result.getByTestId("trailing-content");
 
         expect(primarySlot).toBeTruthy();
         expect(primaryLink?.getAttribute("href")).toBe("#item1");
         expect(primaryLink?.textContent).toContain("Item 1");
         expect(primaryLink?.role).toBe("menuitem");
+
+        expect(primaryTrailing).toBeTruthy();
+        expect(primaryTrailing.element().textContent).toBe("Trailing");
 
         const secondarySlot = result.baseElement.querySelector("[slot='secondary']");
         const secondaryMenuItem = result.getByTestId("secondary-menu-item");

--- a/libs/react-components/src/lib/work-side-menu-item/work-side-menu-item.spec.tsx
+++ b/libs/react-components/src/lib/work-side-menu-item/work-side-menu-item.spec.tsx
@@ -57,4 +57,19 @@ describe("WorkSideMenuItem", () => {
     const slotDiv = menuItem?.querySelector('[slot="popoverContent"]');
     expect(slotDiv).toBeNull();
   });
+
+  it("should render trailingContent slot", () => {
+    const { baseElement } = render(
+      <WorkSideMenuItem
+        label="Notifications"
+        trailingContent={<span data-testid="trailing">2</span>}
+      />,
+    );
+    const menuItem = baseElement.querySelector("goa-work-side-menu-item");
+    expect(menuItem).toBeTruthy();
+
+    const trailingSlot = menuItem?.querySelector('[slot="trailingContent"]');
+    expect(trailingSlot).toBeTruthy();
+    expect(trailingSlot?.textContent).toBe("2");
+  });
 });

--- a/libs/react-components/src/lib/work-side-menu-item/work-side-menu-item.tsx
+++ b/libs/react-components/src/lib/work-side-menu-item/work-side-menu-item.tsx
@@ -25,7 +25,7 @@ export interface GoabWorkSideMenuItemProps {
   label: string;
   /** The URL the menu item links to. When absent, renders as a button instead of a link. */
   url?: string;
-  /** Badge text displayed alongside the menu item (e.g., notification count). */
+  /** @deprecated Use trailingContent instead. Badge text displayed alongside the menu item (e.g., notification count). */
   badge?: string;
   /** When true, indicates this is the currently active menu item. */
   current?: boolean;
@@ -35,12 +35,14 @@ export interface GoabWorkSideMenuItemProps {
   icon?: string;
   /** Sets a data-testid attribute for automated testing. */
   testId?: string;
-  /** Sets the visual style of the badge. Use "emergency" for urgent items, "success" for positive status. @default "normal" */
+  /** @deprecated Use trailingContent instead. Sets the visual style of the badge. Use "emergency" for urgent items, "success" for positive status. @default "normal" */
   type?: GoabWorkSideMenuItemType;
   /** Content rendered inside the menu item. */
   children?: React.ReactNode;
   /** Content rendered inside the popover panel attached to this menu item. */
   popoverContent?: React.ReactNode;
+  /** Content rendered after the label in the trailing area of the menu item. */
+  trailingContent?: React.ReactNode;
 }
 
 /** Individual menu item within the work side menu. */
@@ -57,6 +59,7 @@ export function GoabWorkSideMenuItem(props: GoabWorkSideMenuItemProps): JSX.Elem
       type={props.type}
     >
       {props.popoverContent && <div slot="popoverContent">{props.popoverContent}</div>}
+      {props.trailingContent && <div slot="trailingContent">{props.trailingContent}</div>}
       {props.children}
     </goa-work-side-menu-item>
   );

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.spec.ts
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.spec.ts
@@ -29,6 +29,18 @@ describe("WorkSideMenuItem", () => {
     expect(badge).toBeTruthy();
   });
 
+  it("renders badge for backward compatibility", async () => {
+    const { container } = render(GoAWorkSideMenuItem, {
+      label: "Foo",
+      url: "#",
+      badge: "2",
+      type: "success",
+    });
+
+    const badge = container.querySelector("goa-badge.badge");
+    expect(badge).toBeTruthy();
+  });
+
   describe("click events", () => {
     it("should dispatch _navigate event with url on click", async () => {
       const onNavigate = vi.fn();

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte
@@ -18,7 +18,7 @@
   export let url: string = "";
 
   // optional
-  /** Badge text displayed alongside the menu item (e.g., notification count). */
+  /** @deprecated Use trailingContent instead. Badge text displayed alongside the menu item (e.g., notification count). */
   export let badge: string = "";
   /** When true, indicates this is the currently active menu item. */
   export let current: boolean = false;
@@ -28,7 +28,7 @@
   export let icon: GoAIconType | undefined = undefined;
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
-  /** Sets the visual style of the badge. Use "emergency" for urgent items, "success" for positive status. */
+  /** @deprecated Use trailingContent instead. Sets the visual style of the badge. Use "emergency" for urgent items, "success" for positive status. */
   export let type: WorkSideMenuItemType = "normal";
 
   // *******
@@ -52,6 +52,7 @@
   $: _alwaysVisible =
     !isNaN(parseInt(badge)) && parseInt(badge) > 0 && parseInt(badge) < 10;
   $: _hasPopoverContent = $$slots.popoverContent;
+  $: _hasTrailingContent = $$slots.trailingContent;
   $: _badgeType = type === "emergency" ? "emergency" : "success";
 
   // *****
@@ -260,6 +261,11 @@
         <div class="menu-item-label">
           {label}
         </div>
+        {#if _hasTrailingContent}
+          <div class="trailing-content-slot">
+            <slot name="trailingContent" />
+          </div>
+        {/if}
         {#if badge}
           <goa-badge
             class="badge"
@@ -310,6 +316,11 @@
           <div class="menu-item-label">
             {label}
           </div>
+          {#if _hasTrailingContent}
+            <div class="trailing-content-slot">
+              <slot name="trailingContent" />
+            </div>
+          {/if}
           {#if badge}
             <goa-badge
               class="badge"
@@ -348,6 +359,11 @@
       <div class="menu-item-label">
         {label}
       </div>
+      {#if _hasTrailingContent}
+        <div class="trailing-content-slot">
+          <slot name="trailingContent" />
+        </div>
+      {/if}
       {#if badge}
         <goa-badge
           class="badge"
@@ -451,10 +467,6 @@
       var(--goa-typography-body-s)
     );
     animation: delayText 100ms;
-  }
-
-  .trailing-content-slot {
-    display: flex;
   }
 
   /* Current item */


### PR DESCRIPTION
This PR adds a `trailingContent` slot to the Work Side Menu item and soft deprecates the previous "badge" property.

<img width="428" height="260" alt="image" src="https://github.com/user-attachments/assets/29930f2f-6045-4c2c-b8e8-df7e030043d8" />
