### PR TITLE
fix(#3932):  fix tooltip position on Work Side Menu

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3932/bug3932.component.html
+++ b/apps/prs/angular/src/routes/bugs/3932/bug3932.component.html
@@ -1,0 +1,50 @@
+<div style="--goa-work-side-menu-height: 500px">
+  <goab-block gap="m" direction="column">
+    <goab-text tag="h1" mt="m">Bug #3932: Work Side Menu tooltips</goab-text>
+    <goab-text tag="span">
+      This page renders a closed Work Side Menu so tooltip behavior can be tested
+      manually.
+    </goab-text>
+    <goab-text tag="span">
+      Move between multiple items and confirm each tooltip appears in the correct
+      position and shows the matching label.
+    </goab-text>
+
+    <goab-work-side-menu
+      heading="Bug 3932"
+      url="#"
+      [open]="false"
+      [primaryContent]="primaryContentTpl"
+      [secondaryContent]="secondaryContentTpl"
+    >
+    </goab-work-side-menu>
+  </goab-block>
+</div>
+
+<ng-template #primaryContentTpl>
+  <goab-work-side-menu-item icon="home" label="Dashboard" url="#dashboard">
+  </goab-work-side-menu-item>
+  <goab-work-side-menu-item icon="search" label="Search" url="#search">
+  </goab-work-side-menu-item>
+  <goab-work-side-menu-item icon="document" label="Reports" url="#reports">
+  </goab-work-side-menu-item>
+  <goab-work-side-menu-group heading="Applications" icon="folder" [open]="true">
+    <goab-work-side-menu-item label="New applications" url="#new-applications">
+    </goab-work-side-menu-item>
+    <goab-work-side-menu-item label="In progress" url="#in-progress">
+    </goab-work-side-menu-item>
+    <goab-work-side-menu-item label="Approved" url="#approved">
+    </goab-work-side-menu-item>
+  </goab-work-side-menu-group>
+</ng-template>
+
+<ng-template #secondaryContentTpl>
+  <goab-work-side-menu-item icon="help-circle" label="Get support" url="#support">
+  </goab-work-side-menu-item>
+  <goab-work-side-menu-item
+    icon="information-circle"
+    label="Release notes"
+    url="#release-notes"
+  >
+  </goab-work-side-menu-item>
+</ng-template>

--- a/apps/prs/angular/src/routes/bugs/3932/bug3932.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3932/bug3932.component.ts
@@ -1,0 +1,22 @@
+import { Component } from "@angular/core";
+import {
+  GoabBlock,
+  GoabText,
+  GoabWorkSideMenu,
+  GoabWorkSideMenuGroup,
+  GoabWorkSideMenuItem,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3932",
+  templateUrl: "./bug3932.component.html",
+  imports: [
+    GoabBlock,
+    GoabText,
+    GoabWorkSideMenu,
+    GoabWorkSideMenuGroup,
+    GoabWorkSideMenuItem,
+  ],
+})
+export class Bug3932Component {}

--- a/apps/prs/angular/src/routes/bugs/3932/bug3932.route.json
+++ b/apps/prs/angular/src/routes/bugs/3932/bug3932.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3932",
+  "path": "bugs/3932",
+  "title": "Work Side Menu tooltips"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3932.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3932.route.ts
@@ -1,0 +1,10 @@
+import Bug3932Route from "../../../routes/bugs/bug3932";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3932",
+  path: "bugs/3932",
+  title: "Work Side Menu tooltips",
+  component: Bug3932Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3932.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3932.tsx
@@ -1,0 +1,62 @@
+import {
+  GoabBlock,
+  GoabText,
+  GoabWorkSideMenu,
+  GoabWorkSideMenuGroup,
+  GoabWorkSideMenuItem,
+} from "@abgov/react-components";
+
+export function Bug3932Route() {
+  const menuHeight = { "--goa-work-side-menu-height": "500px" } as React.CSSProperties;
+  return (
+    <div style={menuHeight}>
+      <GoabBlock gap="m" direction="column">
+        <GoabText tag="h1" mt="m">
+          Bug #3932: Work Side Menu tooltips
+        </GoabText>
+        <GoabText tag="span">
+          This page renders a closed Work Side Menu so tooltip behavior can be tested
+          manually.
+        </GoabText>
+        <GoabText tag="span">
+          Move between multiple items and confirm each tooltip appears in the correct
+          position and shows the matching label.
+        </GoabText>
+
+        <GoabWorkSideMenu
+          heading="Bug 3932"
+          url="#"
+          open={false}
+          primaryContent={
+            <>
+              <GoabWorkSideMenuItem icon="home" label="Dashboard" url="#dashboard" />
+              <GoabWorkSideMenuItem icon="search" label="Search" url="#search" />
+              <GoabWorkSideMenuItem icon="document" label="Reports" url="#reports" />
+              <GoabWorkSideMenuGroup heading="Applications" icon="folder" open={true}>
+                <GoabWorkSideMenuItem label="New applications" url="#new-applications" />
+                <GoabWorkSideMenuItem label="In progress" url="#in-progress" />
+                <GoabWorkSideMenuItem label="Approved" url="#approved" />
+              </GoabWorkSideMenuGroup>
+            </>
+          }
+          secondaryContent={
+            <>
+              <GoabWorkSideMenuItem
+                icon="help-circle"
+                label="Get support"
+                url="#support"
+              />
+              <GoabWorkSideMenuItem
+                icon="information-circle"
+                label="Release notes"
+                url="#release-notes"
+              />
+            </>
+          }
+        />
+      </GoabBlock>
+    </div>
+  );
+}
+
+export default Bug3932Route;

--- a/libs/react-components/specs/work-side-menu.browser.spec.tsx
+++ b/libs/react-components/specs/work-side-menu.browser.spec.tsx
@@ -110,6 +110,173 @@ describe("WorkSideMenu", () => {
       expect(menu.element().classList.contains("closed")).toBeFalsy();
     });
 
+    it("should show and hide tooltip for item", async () => {
+      await page.viewport(1024, 768);
+
+      const Component = () => {
+        return (
+          <GoabWorkSideMenu
+            heading="Test Heading"
+            url="https://example.com/"
+            testId="menu"
+            primaryContent={
+              <GoabWorkSideMenuItem
+                icon="search"
+                label="Search"
+                url="/search"
+                testId="hover-item"
+              />
+            }
+            open={false}
+          />
+        );
+      };
+
+      const result = render(<Component />);
+      const menu = result.getByTestId("menu");
+      const menuItem = result.getByTestId("hover-item");
+
+      vi.useFakeTimers();
+      try {
+        await menuItem.hover();
+        await vi.advanceTimersByTimeAsync(300);
+
+        await vi.waitFor(() => {
+          const tooltipEl = menu
+            .element()
+            .querySelector(".tooltip") as HTMLElement | null;
+          expect(tooltipEl).toBeTruthy();
+          expect(tooltipEl?.classList.contains("show")).toBe(true);
+          expect(tooltipEl?.textContent?.trim()).toBe("Search");
+          expect(tooltipEl?.style.left).not.toBe("");
+          expect(tooltipEl?.style.top).not.toBe("");
+        });
+
+        await menuItem.unhover();
+        await vi.advanceTimersByTimeAsync(300);
+
+        await vi.waitFor(() => {
+          const tooltipEl = menu
+            .element()
+            .querySelector(".tooltip") as HTMLElement | null;
+          expect(tooltipEl).toBeTruthy();
+          expect(tooltipEl?.classList.contains("show")).toBe(false);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should show and hide tooltip for group", async () => {
+      await page.viewport(1024, 768);
+
+      const Component = () => {
+        return (
+          <GoabWorkSideMenu
+            heading="Test Heading"
+            url="https://example.com/"
+            testId="menu"
+            primaryContent={
+              <GoabWorkSideMenuGroup
+                heading="Applications"
+                icon="documents"
+                testId="hover-group"
+              >
+                <GoabWorkSideMenuItem label="In progress" url="/in-progress" />
+              </GoabWorkSideMenuGroup>
+            }
+            open={false}
+          />
+        );
+      };
+
+      const result = render(<Component />);
+      const menu = result.getByTestId("menu");
+      const group = result.getByTestId("hover-group");
+
+      vi.useFakeTimers();
+      try {
+        await group.hover();
+        await vi.advanceTimersByTimeAsync(300);
+
+        await vi.waitFor(() => {
+          const tooltipEl = menu
+            .element()
+            .querySelector(".tooltip") as HTMLElement | null;
+          expect(tooltipEl).toBeTruthy();
+          expect(tooltipEl?.classList.contains("show")).toBe(true);
+          expect(tooltipEl?.textContent?.trim()).toBe("Applications");
+          expect(tooltipEl?.style.left).not.toBe("");
+          expect(tooltipEl?.style.top).not.toBe("");
+        });
+
+        await group.unhover();
+        await vi.advanceTimersByTimeAsync(300);
+
+        await vi.waitFor(() => {
+          const tooltipEl = menu
+            .element()
+            .querySelector(".tooltip") as HTMLElement | null;
+          expect(tooltipEl).toBeTruthy();
+          expect(tooltipEl?.classList.contains("show")).toBe(false);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should show and hide tooltip for toggle button", async () => {
+      await page.viewport(1024, 768);
+
+      const Component = () => {
+        return (
+          <GoabWorkSideMenu
+            heading="Test Heading"
+            url="https://example.com/"
+            testId="work-side-menu"
+            primaryContent={
+              <GoabWorkSideMenuItem icon="search" label="Search" url="/search" />
+            }
+            open={false}
+          />
+        );
+      };
+
+      const result = render(<Component />);
+      const menu = result.getByTestId("work-side-menu");
+      const toggle = result.getByTestId("toggle-menu");
+
+      vi.useFakeTimers();
+      try {
+        await toggle.hover();
+        await vi.advanceTimersByTimeAsync(300);
+
+        await vi.waitFor(() => {
+          const tooltipEl = menu
+            .element()
+            .querySelector(".tooltip") as HTMLElement | null;
+          expect(tooltipEl).toBeTruthy();
+          expect(tooltipEl?.classList.contains("show")).toBe(true);
+          expect(tooltipEl?.textContent?.trim()).toBe("Expand menu");
+          expect(tooltipEl?.style.left).not.toBe("");
+          expect(tooltipEl?.style.top).not.toBe("");
+        });
+
+        await toggle.unhover();
+        await vi.advanceTimersByTimeAsync(300);
+
+        await vi.waitFor(() => {
+          const tooltipEl = menu
+            .element()
+            .querySelector(".tooltip") as HTMLElement | null;
+          expect(tooltipEl).toBeTruthy();
+          expect(tooltipEl?.classList.contains("show")).toBe(false);
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("should call onNavigate and prevent default navigation when menu item is clicked", async () => {
       await page.viewport(1024, 768);
       const onNavigate = vi.fn();

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenu.svelte
@@ -375,7 +375,7 @@
     data-testid="work-side-menu-background"
     on:click={handleToggleClick}
   />
-  <div class="container">
+  <div class="container" bind:this={_containerEl}>
     <header class="top-section">
       {#if url}
         <a href={url} class="header" role="menuitem" data-testid="url">
@@ -458,7 +458,10 @@
           class="toggle-button"
           data-testid="toggle-menu"
           on:click={handleToggleClick}
+          on:mouseenter={handleToggleHover}
+          on:mouseleave={handleMouseLeave}
           aria-label={open ? "Collapse menu" : "Expand menu"}
+          bind:this={_toggleButtonEl}
         >
           <goa-icon
             size="small"


### PR DESCRIPTION
This PR fixes two regressions to restore the tooltip for the Work Side Menu on items and the toggle button. It also adds browser tests to guard against future Work Side Menu tooltip regressions.