### PR TITLE
feat(#1233): implement a MultiselectDropdown component by combining popover and checkboxlist

### DIFF
--- a/apps/prs/angular/src/routes/docs/dropdown-multiselect/dropdown-multiselect.component.html
+++ b/apps/prs/angular/src/routes/docs/dropdown-multiselect/dropdown-multiselect.component.html
@@ -1,0 +1,151 @@
+<h2>Dropdown Multiselect</h2>
+
+<h3>Reactive forms (FormControl)</h3>
+
+<form [formGroup]="form">
+  <goab-form-item label="Select fruits" mb="l">
+    <goab-dropdown-multiselect name="fruits" formControlName="fruits" width="320px">
+      <goab-dropdown-item value="apple" label="Apple"></goab-dropdown-item>
+      <goab-dropdown-item value="banana" label="Banana"></goab-dropdown-item>
+      <goab-dropdown-item value="orange" label="Orange"></goab-dropdown-item>
+      <goab-dropdown-item value="pear" label="Pear"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>
+
+<h3>Simple dropdown multiselect with options</h3>
+
+<h4>Dropdown multiselect with placeholder text when no selection</h4>
+
+<form [formGroup]="form">
+  <goab-form-item label="Select services" mb="l">
+    <goab-dropdown-multiselect
+      name="services"
+      width="320px"
+      placeholder="Select one or more services"
+      formControlName="services"
+    >
+      <goab-dropdown-item value="health" label="Health benefits"></goab-dropdown-item>
+      <goab-dropdown-item value="income" label="Income support"></goab-dropdown-item>
+      <goab-dropdown-item value="housing" label="Housing support"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>
+
+<h3>Label Formatting</h3>
+
+<goab-form-item label="Select fruits" mb="l">
+  <goab-dropdown-multiselect name="fruits" width="320px" [labelFormat]="'count'">
+    <goab-dropdown-item value="apple" label="Apple"></goab-dropdown-item>
+    <goab-dropdown-item value="banana" label="Banana"></goab-dropdown-item>
+    <goab-dropdown-item value="orange" label="Orange"></goab-dropdown-item>
+    <goab-dropdown-item value="pear" label="Pear"></goab-dropdown-item>
+  </goab-dropdown-multiselect>
+</goab-form-item>
+
+<h3>With custom placeholder</h3>
+
+<form [formGroup]="form">
+  <goab-form-item label="Select services" mb="l">
+    <goab-dropdown-multiselect
+      name="services"
+      width="320px"
+      placeholder="Select one or more services"
+      formControlName="services"
+    >
+      <goab-dropdown-item value="health" label="Health benefits"></goab-dropdown-item>
+      <goab-dropdown-item value="income" label="Income support"></goab-dropdown-item>
+      <goab-dropdown-item value="housing" label="Housing support"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>
+
+<h3>Filterable</h3>
+
+<form [formGroup]="form">
+  <goab-form-item label="Which cities have you visited?" mb="l">
+    <goab-dropdown-multiselect
+      name="cities"
+      [filterable]="true"
+      maxHeight="400px"
+      width="320px"
+      formControlName="cities"
+    >
+      <goab-dropdown-item value="calgary" label="Calgary"></goab-dropdown-item>
+      <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+      <goab-dropdown-item value="red-deer" label="Red Deer"></goab-dropdown-item>
+      <goab-dropdown-item value="lethbridge" label="Lethbridge"></goab-dropdown-item>
+      <goab-dropdown-item value="medicine-hat" label="Medicine Hat"></goab-dropdown-item>
+      <goab-dropdown-item
+        value="grande-prairie"
+        label="Grande Prairie"
+      ></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>
+
+<h3>With select all</h3>
+
+<form [formGroup]="form">
+  <goab-form-item label="Select departments" mb="l">
+    <goab-dropdown-multiselect
+      name="departments"
+      [showSelectAll]="true"
+      formControlName="departments"
+      width="320px"
+    >
+      <goab-dropdown-item value="health" label="Health"></goab-dropdown-item>
+      <goab-dropdown-item value="education" label="Education"></goab-dropdown-item>
+      <goab-dropdown-item
+        value="transportation"
+        label="Transportation"
+      ></goab-dropdown-item>
+      <goab-dropdown-item value="justice" label="Justice"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>
+
+<h3>Sizes and states</h3>
+
+<form [formGroup]="form">
+  <goab-form-item label="Default size" mb="l">
+    <goab-dropdown-multiselect
+      name="sizeDefault"
+      formControlName="sizeDefault"
+      width="320px"
+    >
+      <goab-dropdown-item value="draft" label="Draft"></goab-dropdown-item>
+      <goab-dropdown-item value="review" label="In review"></goab-dropdown-item>
+      <goab-dropdown-item value="approved" label="Approved"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+  <goab-form-item label="Compact size" mb="l">
+    <goab-dropdown-multiselect
+      name="sizeCompact"
+      size="compact"
+      formControlName="sizeCompact"
+      width="320px"
+    >
+      <goab-dropdown-item value="draft" label="Draft"></goab-dropdown-item>
+      <goab-dropdown-item value="review" label="In review"></goab-dropdown-item>
+      <goab-dropdown-item value="approved" label="Approved"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+  <goab-form-item label="Disabled" mb="l">
+    <goab-dropdown-multiselect name="disabled" formControlName="disabled" width="320px">
+      <goab-dropdown-item value="opt1" label="Option 1"></goab-dropdown-item>
+      <goab-dropdown-item value="opt2" label="Option 2"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+  <goab-form-item label="With error" error="Please select at least one option" mb="l">
+    <goab-dropdown-multiselect
+      name="error"
+      [error]="true"
+      formControlName="errorValue"
+      width="320px"
+    >
+      <goab-dropdown-item value="opt1" label="Option 1"></goab-dropdown-item>
+      <goab-dropdown-item value="opt2" label="Option 2"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>

--- a/apps/prs/angular/src/routes/docs/dropdown-multiselect/dropdown-multiselect.component.ts
+++ b/apps/prs/angular/src/routes/docs/dropdown-multiselect/dropdown-multiselect.component.ts
@@ -1,0 +1,39 @@
+import {
+  GoabDropdownItem,
+  GoabDropdownMultiselect,
+  GoabFormItem,
+} from "@abgov/angular-components";
+import { CommonModule } from "@angular/common";
+import { Component, inject } from "@angular/core";
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from "@angular/forms";
+
+@Component({
+  standalone: true,
+  selector: "abgov-docs-dropdown-multiselect",
+  templateUrl: "./dropdown-multiselect.component.html",
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    GoabDropdownItem,
+    GoabDropdownMultiselect,
+    GoabFormItem,
+  ],
+})
+export class DocsDropdownMultiselectComponent {
+  form!: FormGroup;
+  private fb = inject(FormBuilder);
+
+  constructor() {
+    this.form = this.fb.group({
+      fruits: [[] as string[]],
+      services: [[] as string[]],
+      cities: [[] as string[]],
+      departments: [[] as string[]],
+      sizeDefault: [[] as string[]],
+      sizeCompact: [[] as string[]],
+      disabled: [{ value: [] as string[], disabled: true }],
+      errorValue: [[] as string[]],
+    });
+  }
+}

--- a/apps/prs/angular/src/routes/docs/dropdown-multiselect/dropdown-multiselect.route.json
+++ b/apps/prs/angular/src/routes/docs/dropdown-multiselect/dropdown-multiselect.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "docs",
+  "id": "dropdown-multiselect",
+  "path": "docs/dropdown-multiselect",
+  "title": "Dropdown Multiselect"
+}

--- a/apps/prs/angular/src/routes/features/feat1233/feat1233.component.html
+++ b/apps/prs/angular/src/routes/features/feat1233/feat1233.component.html
@@ -1,0 +1,623 @@
+<main>
+  <goab-text tag="h1" mt="none">feat(#1233): DropdownMultiselect component</goab-text>
+  <goab-text>
+    A dropdown component that presents a CheckboxList for multiple selection. The trigger
+    displays a comma-separated summary of selected labels with ellipsis overflow.
+    Keyboard: ArrowDown/Enter/Space opens, Escape and Tab close.
+  </goab-text>
+
+  <goab-block direction="column" gap="xl">
+    <section>
+      <goab-text tag="h2">Basic usage</goab-text>
+      <goab-text
+        >Select items from the list. The trigger label updates as you select.</goab-text
+      >
+      <div style="max-width: 400px">
+        <goab-form-item label="Favourite fruit">
+          <goab-dropdown-multiselect
+            name="fruit-basic"
+            placeholder="Select fruit"
+            [value]="selected1"
+            (onChange)="onSelected1Change($event)"
+            testId="basic-multiselect"
+          >
+            <goab-dropdown-item value="apple" label="Apple" />
+            <goab-dropdown-item value="banana" label="Banana" />
+            <goab-dropdown-item value="cherry" label="Cherry" />
+            <goab-dropdown-item value="date" label="Date" />
+            <goab-dropdown-item value="elderberry" label="Elderberry" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+        <goab-text
+          >Selected: {{ selected1.length ? selected1.join(", ") : "(none)" }}</goab-text
+        >
+        <goab-button type="secondary" size="compact" mt="s" (onClick)="resetBasic()">
+          Reset
+        </goab-button>
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Filterable</goab-text>
+      <goab-text>
+        Type in the trigger to filter options. Only options whose label starts with the
+        typed string are shown. Previously checked options remain selected even when
+        hidden. The filter clears when the dropdown closes.
+      </goab-text>
+      <div style="max-width: 400px">
+        <goab-form-item label="City (filterable)">
+          <goab-dropdown-multiselect
+            name="cities-filterable"
+            placeholder="Select cities"
+            [filterable]="true"
+            [value]="selectedFilterable"
+            (onChange)="onFilterableChange($event)"
+            testId="filterable-multiselect"
+          >
+            <goab-dropdown-item value="ab-aird" label="Airdrie" />
+            <goab-dropdown-item value="ab-beau" label="Beaumont" />
+            <goab-dropdown-item value="ab-broo" label="Brooks" />
+            <goab-dropdown-item value="ab-calg" label="Calgary" />
+            <goab-dropdown-item value="ab-camr" label="Camrose" />
+            <goab-dropdown-item value="ab-canr" label="Canmore" />
+            <goab-dropdown-item value="ab-ches" label="Chestermere" />
+            <goab-dropdown-item value="ab-coch" label="Cochrane" />
+            <goab-dropdown-item value="ab-cold" label="Cold Lake" />
+            <goab-dropdown-item value="ab-edmo" label="Edmonton" />
+            <goab-dropdown-item value="ab-fort" label="Fort Saskatchewan" />
+            <goab-dropdown-item value="ab-ftmy" label="Fort MacKay" />
+            <goab-dropdown-item value="ab-ftmc" label="Fort McMurray" />
+            <goab-dropdown-item value="ab-grca" label="Grande Cache" />
+            <goab-dropdown-item value="ab-gran" label="Grande Prairie" />
+            <goab-dropdown-item value="ab-laco" label="Lacombe" />
+            <goab-dropdown-item value="ab-lalu" label="Lake Louise" />
+            <goab-dropdown-item value="ab-ledu" label="Leduc" />
+            <goab-dropdown-item value="ab-leth" label="Lethbridge" />
+            <goab-dropdown-item value="ab-lloy" label="Lloydminster" />
+            <goab-dropdown-item value="ab-medi" label="Medicine Hat" />
+            <goab-dropdown-item value="ab-ponp" label="Ponoka" />
+            <goab-dropdown-item value="ab-rddr" label="Red Deer" />
+            <goab-dropdown-item value="ab-shpa" label="Sherwood Park" />
+            <goab-dropdown-item value="ab-slvl" label="Slave Lake" />
+            <goab-dropdown-item value="ab-smok" label="Smoky Lake" />
+            <goab-dropdown-item value="ab-spru" label="Spruce Grove" />
+            <goab-dropdown-item value="ab-sprv" label="Spruce Valley" />
+            <goab-dropdown-item value="ab-spfd" label="Sprucefield" />
+            <goab-dropdown-item value="ab-stal" label="St. Albert" />
+            <goab-dropdown-item value="ab-sttl" label="Stettler" />
+            <goab-dropdown-item value="ab-sylv" label="Sylvan Lake" />
+            <goab-dropdown-item value="ab-weta" label="Wetaskiwin" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+        <goab-text
+          >Selected:
+          {{
+            selectedFilterable.length ? selectedFilterable.join(", ") : "(none)"
+          }}</goab-text
+        >
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Filterable with Select All</goab-text>
+      <goab-text>
+        Type in the trigger to filter options. Only options whose label starts with the
+        typed string are shown. Previously checked options remain selected even when
+        hidden. The filter clears when the dropdown closes.
+      </goab-text>
+      <div style="max-width: 400px">
+        <goab-form-item label="City (filterable with select all)">
+          <goab-dropdown-multiselect
+            name="cities-filterable"
+            placeholder="Select cities"
+            [filterable]="true"
+            [showSelectAll]="true"
+            [value]="selectedFilterable"
+            (onChange)="onFilterableChange($event)"
+            testId="filterable-multiselect"
+          >
+            <goab-dropdown-item value="ab-aird" label="Airdrie" />
+            <goab-dropdown-item value="ab-beau" label="Beaumont" />
+            <goab-dropdown-item value="ab-broo" label="Brooks" />
+            <goab-dropdown-item value="ab-calg" label="Calgary" />
+            <goab-dropdown-item value="ab-camr" label="Camrose" />
+            <goab-dropdown-item value="ab-canr" label="Canmore" />
+            <goab-dropdown-item value="ab-ches" label="Chestermere" />
+            <goab-dropdown-item value="ab-coch" label="Cochrane" />
+            <goab-dropdown-item value="ab-cold" label="Cold Lake" />
+            <goab-dropdown-item value="ab-edmo" label="Edmonton" />
+            <goab-dropdown-item value="ab-fort" label="Fort Saskatchewan" />
+            <goab-dropdown-item value="ab-ftmy" label="Fort MacKay" />
+            <goab-dropdown-item value="ab-ftmc" label="Fort McMurray" />
+            <goab-dropdown-item value="ab-grca" label="Grande Cache" />
+            <goab-dropdown-item value="ab-gran" label="Grande Prairie" />
+            <goab-dropdown-item value="ab-laco" label="Lacombe" />
+            <goab-dropdown-item value="ab-lalu" label="Lake Louise" />
+            <goab-dropdown-item value="ab-ledu" label="Leduc" />
+            <goab-dropdown-item value="ab-leth" label="Lethbridge" />
+            <goab-dropdown-item value="ab-lloy" label="Lloydminster" />
+            <goab-dropdown-item value="ab-medi" label="Medicine Hat" />
+            <goab-dropdown-item value="ab-ponp" label="Ponoka" />
+            <goab-dropdown-item value="ab-rddr" label="Red Deer" />
+            <goab-dropdown-item value="ab-shpa" label="Sherwood Park" />
+            <goab-dropdown-item value="ab-slvl" label="Slave Lake" />
+            <goab-dropdown-item value="ab-smok" label="Smoky Lake" />
+            <goab-dropdown-item value="ab-spru" label="Spruce Grove" />
+            <goab-dropdown-item value="ab-sprv" label="Spruce Valley" />
+            <goab-dropdown-item value="ab-spfd" label="Sprucefield" />
+            <goab-dropdown-item value="ab-stal" label="St. Albert" />
+            <goab-dropdown-item value="ab-sttl" label="Stettler" />
+            <goab-dropdown-item value="ab-sylv" label="Sylvan Lake" />
+            <goab-dropdown-item value="ab-weta" label="Wetaskiwin" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+        <goab-text
+          >Selected:
+          {{
+            selectedFilterable.length ? selectedFilterable.join(", ") : "(none)"
+          }}</goab-text
+        >
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Basic usage — Reactive form (FormControl)</goab-text>
+      <goab-text>Bound with formControlName inside a FormGroup.</goab-text>
+      <div style="max-width: 400px">
+        <form [formGroup]="form">
+          <goab-form-item label="Favourite fruit">
+            <goab-dropdown-multiselect
+              name="fruit-reactive"
+              placeholder="Select fruit"
+              formControlName="fruitsReactive"
+              testId="reactive-multiselect"
+            >
+              <goab-dropdown-item value="apple" label="Apple" />
+              <goab-dropdown-item value="banana" label="Banana" />
+              <goab-dropdown-item value="cherry" label="Cherry" />
+              <goab-dropdown-item value="date" label="Date" />
+              <goab-dropdown-item value="elderberry" label="Elderberry" />
+            </goab-dropdown-multiselect>
+          </goab-form-item>
+        </form>
+        <goab-text
+          >FormControl value: {{ form.get("fruitsReactive")?.value | json }}</goab-text
+        >
+        <goab-button type="secondary" size="compact" mt="s" (onClick)="resetReactive()">
+          Reset
+        </goab-button>
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Basic usage — Template-driven (ngModel)</goab-text>
+      <goab-text>Two-way bound with [(ngModel)].</goab-text>
+      <div style="max-width: 400px">
+        <goab-form-item label="Favourite fruit">
+          <goab-dropdown-multiselect
+            name="fruit-ngmodel"
+            placeholder="Select fruit"
+            [(ngModel)]="fruitsNgModel"
+            [ngModelOptions]="{ standalone: true }"
+            testId="ngmodel-multiselect"
+          >
+            <goab-dropdown-item value="apple" label="Apple" />
+            <goab-dropdown-item value="banana" label="Banana" />
+            <goab-dropdown-item value="cherry" label="Cherry" />
+            <goab-dropdown-item value="date" label="Date" />
+            <goab-dropdown-item value="elderberry" label="Elderberry" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+        <goab-text>ngModel value: {{ fruitsNgModel | json }}</goab-text>
+        <goab-button type="secondary" size="compact" mt="s" (onClick)="resetNgModel()">
+          Reset
+        </goab-button>
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Ellipsis overflow</goab-text>
+      <goab-text>
+        When the selected labels exceed the trigger width, they truncate with an ellipsis.
+      </goab-text>
+      <div style="max-width: 250px">
+        <goab-dropdown-multiselect
+          name="nine-nine-characters"
+          placeholder="Best Brooklyn Nine-Nine characters"
+          [value]="brooklyn99Selected"
+          (onChange)="onBrooklyn99Change($event)"
+          testId="overflow-multiselect"
+        >
+          <goab-dropdown-item value="Andy Samberg" label="Jake Peralta" />
+          <goab-dropdown-item value="Stephanie Beatriz" label="Rosa Diaz" />
+          <goab-dropdown-item value="Terry Crews" label="Terry Jeffords" />
+          <goab-dropdown-item value="Melissa Fumero" label="Amy Santiago" />
+          <goab-dropdown-item value="Joe Lo Truglio" label="Charles Boyle" />
+          <goab-dropdown-item value="Chelsea Peretti" label="Gina Linetti" />
+          <goab-dropdown-item value="Andre Braugher" label="Raymond Holt" />
+          <goab-dropdown-item value="Michael Hitchcock" label="Dirk Blocker" />
+          <goab-dropdown-item value="Joel McKinnon Miller" label="Norm Scully" />
+        </goab-dropdown-multiselect>
+      </div>
+      <goab-text
+        >Selected:
+        {{
+          brooklyn99Selected.length ? brooklyn99Selected.join(", ") : "(none)"
+        }}</goab-text
+      >
+    </section>
+
+    <section>
+      <goab-text tag="h2">Truncate label</goab-text>
+      <goab-text>
+        When the selected labels exceed the trigger width, they truncate with an "n
+        selected" label.
+      </goab-text>
+      <div style="max-width: 250px">
+        <goab-dropdown-multiselect
+          name="nine-nine-characters"
+          placeholder="Best Brooklyn Nine-Nine characters"
+          [value]="brooklyn99Selected"
+          (onChange)="onBrooklyn99Change($event)"
+          testId="overflow-multiselect"
+          labelFormat="count"
+        >
+          <goab-dropdown-item value="Andy Samberg" label="Jake Peralta" />
+          <goab-dropdown-item value="Stephanie Beatriz" label="Rosa Diaz" />
+          <goab-dropdown-item value="Terry Crews" label="Terry Jeffords" />
+          <goab-dropdown-item value="Melissa Fumero" label="Amy Santiago" />
+          <goab-dropdown-item value="Joe Lo Truglio" label="Charles Boyle" />
+          <goab-dropdown-item value="Chelsea Peretti" label="Gina Linetti" />
+          <goab-dropdown-item value="Andre Braugher" label="Raymond Holt" />
+          <goab-dropdown-item value="Michael Hitchcock" label="Dirk Blocker" />
+          <goab-dropdown-item value="Joel McKinnon Miller" label="Norm Scully" />
+        </goab-dropdown-multiselect>
+      </div>
+    </section>
+    <section>
+      <goab-text tag="h2">Controlled (pre-selected value)</goab-text>
+      <goab-text tag="p">(and leadingIcon)</goab-text>
+      <div style="max-width: 400px">
+        <goab-dropdown-multiselect
+          name="fruit-controlled"
+          placeholder="Select fruit"
+          leadingIcon="airplane"
+          [value]="selected2"
+          (onChange)="onSelected2Change($event)"
+          testId="controlled-multiselect"
+        >
+          <goab-dropdown-item value="apple" label="Apple" />
+          <goab-dropdown-item value="banana" label="Banana" />
+          <goab-dropdown-item value="cherry" label="Cherry" />
+        </goab-dropdown-multiselect>
+        <goab-text
+          >Selected: {{ selected2.length ? selected2.join(", ") : "(none)" }}</goab-text
+        >
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Controlled — Reactive form (FormControl)</goab-text>
+      <goab-text>Pre-seeded with ["apple", "banana"] via the FormControl.</goab-text>
+      <div style="max-width: 400px">
+        <form [formGroup]="form">
+          <goab-form-item label="Favourite fruit">
+            <goab-dropdown-multiselect
+              name="fruit-controlled-reactive"
+              placeholder="Select fruit"
+              formControlName="fruitsControlledReactive"
+              testId="controlled-reactive-multiselect"
+            >
+              <goab-dropdown-item value="apple" label="Apple" />
+              <goab-dropdown-item value="banana" label="Banana" />
+              <goab-dropdown-item value="cherry" label="Cherry" />
+            </goab-dropdown-multiselect>
+          </goab-form-item>
+        </form>
+        <goab-text
+          >FormControl value:
+          {{ form.get("fruitsControlledReactive")?.value | json }}</goab-text
+        >
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Controlled — Template-driven (ngModel)</goab-text>
+      <goab-text>Pre-seeded with ["apple", "banana"] via [(ngModel)].</goab-text>
+      <div style="max-width: 400px">
+        <goab-form-item label="Favourite fruit">
+          <goab-dropdown-multiselect
+            name="fruit-controlled-ngmodel"
+            placeholder="Select fruit"
+            [(ngModel)]="fruitsControlledNgModel"
+            [ngModelOptions]="{ standalone: true }"
+            testId="controlled-ngmodel-multiselect"
+          >
+            <goab-dropdown-item value="apple" label="Apple" />
+            <goab-dropdown-item value="banana" label="Banana" />
+            <goab-dropdown-item value="cherry" label="Cherry" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+        <goab-text>ngModel value: {{ fruitsControlledNgModel | json }}</goab-text>
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Disabled state</goab-text>
+      <div style="max-width: 400px">
+        <goab-dropdown-multiselect
+          name="fruit-disabled"
+          placeholder="Select fruit"
+          [disabled]="true"
+          [value]="['apple']"
+          testId="disabled-multiselect"
+        >
+          <goab-dropdown-item value="apple" label="Apple" />
+          <goab-dropdown-item value="banana" label="Banana" />
+        </goab-dropdown-multiselect>
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Error state</goab-text>
+      <div style="max-width: 400px">
+        <goab-form-item
+          label="Required selection"
+          error="Please select at least one option."
+        >
+          <goab-dropdown-multiselect
+            name="fruit-error"
+            placeholder="Select fruit"
+            [error]="true"
+            testId="error-multiselect"
+          >
+            <goab-dropdown-item value="apple" label="Apple" />
+            <goab-dropdown-item value="banana" label="Banana" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Show Select All</goab-text>
+      <goab-text>
+        The selectAll prop adds a "Select All" checkbox above the list. Checking it
+        selects every option. Unchecking clears all. It shows as indeterminate when some
+        (but not all) options are selected.
+      </goab-text>
+      <div style="max-width: 400px">
+        <goab-form-item label="Favourite fruit">
+          <goab-dropdown-multiselect
+            name="fruit-select-all"
+            placeholder="Select fruit"
+            [showSelectAll]="true"
+            [filterable]="true"
+            [value]="selectedSelectAll"
+            (onChange)="onSelectAllChange($event)"
+            testId="select-all-multiselect"
+          >
+            <goab-dropdown-item value="apple" label="Apple" />
+            <goab-dropdown-item value="banana" label="Banana" />
+            <goab-dropdown-item value="cherry" label="Cherry" />
+            <goab-dropdown-item value="date" label="Date" />
+            <goab-dropdown-item value="elderberry" label="Elderberry" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+        <goab-text
+          >Selected:
+          {{
+            selectedSelectAll.length ? selectedSelectAll.join(", ") : "(none)"
+          }}</goab-text
+        >
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Compact size</goab-text>
+      <div style="max-width: 400px">
+        <goab-dropdown-multiselect
+          name="fruit-compact"
+          placeholder="Select fruit"
+          size="compact"
+          testId="compact-multiselect"
+        >
+          <goab-dropdown-item value="apple" label="Apple" />
+          <goab-dropdown-item value="banana" label="Banana" />
+          <goab-dropdown-item value="cherry" label="Cherry" />
+        </goab-dropdown-multiselect>
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Percentage width (fill parent)</goab-text>
+      <goab-text>
+        With a percentage width the component sizes relative to its parent container (the
+        dashed box below is 600px wide). The popover panel should match the rendered
+        trigger width. Note: the parent must be block level (no inline goab-block wrapper)
+        or the percentage collapses to the trigger min-content.
+      </goab-text>
+      <div style="width: 600px; max-width: 100%; padding: 1rem; border: 1px dashed #888">
+        <goab-form-item label="100% of parent" mb="m">
+          <goab-dropdown-multiselect
+            name="fruit-width-full"
+            placeholder="Select fruit"
+            width="100%"
+            testId="width-full-multiselect"
+          >
+            <goab-dropdown-item value="apple" label="Apple" />
+            <goab-dropdown-item value="banana" label="Banana" />
+            <goab-dropdown-item value="cherry" label="Cherry" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+        <goab-form-item label="50% of parent">
+          <goab-dropdown-multiselect
+            name="fruit-width-half"
+            placeholder="Select fruit"
+            width="50%"
+            testId="width-half-multiselect"
+          >
+            <goab-dropdown-item value="apple" label="Apple" />
+            <goab-dropdown-item value="banana" label="Banana" />
+            <goab-dropdown-item value="cherry" label="Cherry" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Dynamic options (async load)</goab-text>
+      <goab-text>
+        Options usually come from an API, not a static list. Here the options load after a
+        3 second delay. Open the dropdown before they load to see the empty state, then
+        watch the list populate. Use the buttons to add or remove options at runtime.
+      </goab-text>
+      <div style="max-width: 400px">
+        <goab-button-group alignment="start">
+          <goab-button type="secondary" (onClick)="addOption()">Add option</goab-button>
+          <goab-button type="secondary" (onClick)="removeLastOption()"
+            >Remove last option</goab-button
+          >
+        </goab-button-group>
+        <goab-form-item label="Fruit (loaded async)" mt="s">
+          <goab-dropdown-multiselect
+            name="fruit-async"
+            [placeholder]="asyncLoading ? 'Loading options...' : 'Select fruit'"
+            [value]="selectedAsync"
+            (onChange)="selectedAsync = $event.value"
+            testId="async-multiselect"
+          >
+            @for (o of asyncOptions; track o.value) {
+              <goab-dropdown-item [value]="o.value" [label]="o.label" />
+            }
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+        <goab-text
+          >Selected:
+          {{ selectedAsync.length ? selectedAsync.join(", ") : "(none)" }}</goab-text
+        >
+      </div>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Filterable inside a modal</goab-text>
+      <goab-text>
+        Verifies that the filter input inside a modal receives focus, typing filters
+        options correctly, and that the popover renders above the modal overlay.
+      </goab-text>
+      <ng-template #filterableModalActions>
+        <goab-button-group alignment="end">
+          <goab-button type="secondary" (onClick)="filterableModalOpen = false"
+            >Cancel</goab-button
+          >
+          <goab-button type="primary" (onClick)="filterableModalOpen = false"
+            >Confirm</goab-button
+          >
+        </goab-button-group>
+      </ng-template>
+      <goab-button type="secondary" (onClick)="filterableModalOpen = true"
+        >Open modal</goab-button
+      >
+      <goab-modal
+        [open]="filterableModalOpen"
+        heading="Select provinces"
+        [actions]="filterableModalActions"
+        [closable]="true"
+        (onClose)="filterableModalOpen = false"
+      >
+        <goab-form-item label="Province or territory">
+          <goab-dropdown-multiselect
+            name="provinces-in-modal"
+            placeholder="Select provinces"
+            [filterable]="true"
+            [value]="selectedFilterableInModal"
+            (onChange)="selectedFilterableInModal = $event.value"
+            testId="filterable-modal-multiselect"
+          >
+            <goab-dropdown-item value="ab" label="Alberta" />
+            <goab-dropdown-item value="bc" label="British Columbia" />
+            <goab-dropdown-item value="mb" label="Manitoba" />
+            <goab-dropdown-item value="nb" label="New Brunswick" />
+            <goab-dropdown-item value="nl" label="Newfoundland and Labrador" />
+            <goab-dropdown-item value="ns" label="Nova Scotia" />
+            <goab-dropdown-item value="on" label="Ontario" />
+            <goab-dropdown-item value="pe" label="Prince Edward Island" />
+            <goab-dropdown-item value="qc" label="Quebec" />
+            <goab-dropdown-item value="sk" label="Saskatchewan" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+        <goab-text
+          >Selected:
+          {{
+            selectedFilterableInModal.length
+              ? selectedFilterableInModal.join(", ")
+              : "(none)"
+          }}</goab-text
+        >
+      </goab-modal>
+    </section>
+
+    <section>
+      <goab-text tag="h2">Inside a modal</goab-text>
+      <goab-text>
+        Verifies the dropdown popover renders above the modal and that opening or
+        interacting with the dropdown does not close the modal.
+      </goab-text>
+      <ng-template #modalActions>
+        <goab-button-group alignment="end">
+          <goab-button type="secondary" (onClick)="modalOpen = false">Cancel</goab-button>
+          <goab-button type="primary" (onClick)="modalOpen = false">Confirm</goab-button>
+        </goab-button-group>
+      </ng-template>
+      <goab-button type="secondary" (onClick)="modalOpen = true">Open modal</goab-button>
+      <goab-modal
+        [open]="modalOpen"
+        heading="Select your fruit"
+        [actions]="modalActions"
+        [closable]="true"
+        (onClose)="modalOpen = false"
+      >
+        <goab-form-item label="Favourite fruit">
+          <goab-dropdown-multiselect
+            name="fruit-in-modal"
+            placeholder="Select fruit"
+            [value]="selectedInModal"
+            (onChange)="selectedInModal = $event.value"
+            testId="modal-multiselect"
+          >
+            <goab-dropdown-item value="apple" label="Apple" />
+            <goab-dropdown-item value="banana" label="Banana" />
+            <goab-dropdown-item value="cherry" label="Cherry" />
+            <goab-dropdown-item value="date" label="Date" />
+            <goab-dropdown-item value="elderberry" label="Elderberry" />
+          </goab-dropdown-multiselect>
+        </goab-form-item>
+        <goab-text
+          >Selected:
+          {{ selectedInModal.length ? selectedInModal.join(", ") : "(none)" }}</goab-text
+        >
+      </goab-modal>
+    </section>
+
+    <section>
+      <goab-text tag="h2">MaxHeight Test</goab-text>
+      <goab-text>
+        Make a long list of items to test the maxHeight of the dropdown. The dropdown
+        should scroll when the list exceeds the maxHeight.
+      </goab-text>
+      <goab-form-item label="Favourite fruit">
+        <goab-dropdown-multiselect
+          name="maxheight"
+          placeholder="Pick some numbers"
+          [value]="selectedInModal"
+          (onChange)="selectedInModal = $event.value"
+          testId="modal-maxheight"
+          maxHeight="500px"
+        >
+          @for (o of maxHeightOptions; track o.value) {
+            <goab-dropdown-item [value]="o.value" [label]="o.label" />
+          }
+        </goab-dropdown-multiselect>
+      </goab-form-item>
+    </section>
+  </goab-block>
+</main>

--- a/apps/prs/angular/src/routes/features/feat1233/feat1233.component.ts
+++ b/apps/prs/angular/src/routes/features/feat1233/feat1233.component.ts
@@ -1,0 +1,121 @@
+import { Component, CUSTOM_ELEMENTS_SCHEMA, inject, OnInit } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { FormBuilder, FormsModule, ReactiveFormsModule } from "@angular/forms";
+import {
+  GoabBlock,
+  GoabButton,
+  GoabButtonGroup,
+  GoabDropdownItem,
+  GoabDropdownMultiselect,
+  GoabFormItem,
+  GoabModal,
+  GoabText,
+} from "@abgov/angular-components";
+import { GoabDropdownMultiselectOnChangeDetail } from "@abgov/ui-components-common";
+
+const FRUIT_POOL = [
+  { value: "apple", label: "Apple" },
+  { value: "banana", label: "Banana" },
+  { value: "cherry", label: "Cherry" },
+  { value: "date", label: "Date" },
+  { value: "elderberry", label: "Elderberry" },
+  { value: "fig", label: "Fig" },
+];
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat1233",
+  templateUrl: "./feat1233.component.html",
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    GoabBlock,
+    GoabButton,
+    GoabButtonGroup,
+    GoabDropdownItem,
+    GoabDropdownMultiselect,
+    GoabFormItem,
+    GoabModal,
+    GoabText,
+  ],
+})
+export class Feat1233Component implements OnInit {
+  private fb = inject(FormBuilder);
+  form = this.fb.group({
+    fruitsReactive: [[] as string[]],
+    fruitsControlledReactive: [["apple", "banana"] as string[]],
+  });
+  fruitsNgModel: string[] = [];
+  fruitsControlledNgModel: string[] = ["apple", "banana"];
+  selected1: string[] = [];
+  selected2: string[] = ["apple", "banana"];
+  selectedFilterable: string[] = [];
+  selectedSelectAll: string[] = [];
+  brooklyn99Selected: string[] = [
+    "Andy Samberg",
+    "Stephanie Beatriz",
+    "Terry Crews",
+    "Andre Braugher",
+  ];
+  asyncOptions: { value: string; label: string }[] = [];
+  asyncLoading = true;
+  selectedAsync: string[] = [];
+  modalOpen = false;
+  selectedInModal: string[] = [];
+  filterableModalOpen = false;
+  selectedFilterableInModal: string[] = [];
+  maxHeightOptions = Array.from({ length: 100 }, (_, i) => ({ value: `fruit-${i}`, label: `Fruit ${i}` }));
+
+  ngOnInit(): void {
+    // Simulate options arriving from an API after a delay.
+    setTimeout(() => {
+      this.asyncOptions = FRUIT_POOL.slice(0, 3);
+      this.asyncLoading = false;
+    }, 3000);
+  }
+
+  addOption() {
+    const next = FRUIT_POOL[this.asyncOptions.length];
+    if (next) {
+      this.asyncOptions = [...this.asyncOptions, next];
+    }
+  }
+
+  removeLastOption() {
+    this.asyncOptions = this.asyncOptions.slice(0, -1);
+  }
+
+  onSelected1Change(detail: GoabDropdownMultiselectOnChangeDetail) {
+    this.selected1 = detail.value;
+  }
+
+  onSelected2Change(detail: GoabDropdownMultiselectOnChangeDetail) {
+    this.selected2 = detail.value;
+  }
+
+  onFilterableChange(detail: GoabDropdownMultiselectOnChangeDetail) {
+    this.selectedFilterable = detail.value;
+  }
+
+  onBrooklyn99Change(detail: GoabDropdownMultiselectOnChangeDetail) {
+    this.brooklyn99Selected = detail.value;
+  }
+
+  onSelectAllChange(detail: GoabDropdownMultiselectOnChangeDetail) {
+    this.selectedSelectAll = detail.value;
+  }
+
+  resetBasic() {
+    this.selected1 = [];
+  }
+
+  resetReactive() {
+    this.form.get("fruitsReactive")?.setValue([]);
+  }
+
+  resetNgModel() {
+    this.fruitsNgModel = [];
+  }
+}

--- a/apps/prs/angular/src/routes/features/feat1233/feat1233.route.json
+++ b/apps/prs/angular/src/routes/features/feat1233/feat1233.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "DropdownMultiselect Component",
+  "path": "features/1233",
+  "id": "1233",
+  "type": "feature"
+}

--- a/apps/prs/react/src/app/routes/docs/dropdown-multiselect.route.ts
+++ b/apps/prs/react/src/app/routes/docs/dropdown-multiselect.route.ts
@@ -1,0 +1,10 @@
+import { DocsDropdownMultiselectRoute } from "../../../routes/docs/dropdown-multiselect/dropdown-multiselect";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "docs",
+  id: "dropdown-multiselect",
+  path: "docs/dropdown-multiselect",
+  title: "Dropdown Multiselect",
+  component: DocsDropdownMultiselectRoute,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/app/routes/features/feat1233.route.ts
+++ b/apps/prs/react/src/app/routes/features/feat1233.route.ts
@@ -1,0 +1,9 @@
+import { Feat1233DropdownMultiselectRoute } from "../../../routes/features/feat1233";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "feature",
+  id: "1233",
+  path: "features/1233",
+  title: "DropdownMultiselect Component",
+  component: Feat1233DropdownMultiselectRoute,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/docs/dropdown-multiselect/dropdown-multiselect.tsx
+++ b/apps/prs/react/src/routes/docs/dropdown-multiselect/dropdown-multiselect.tsx
@@ -1,0 +1,129 @@
+import {
+  GoabDropdownItem,
+  GoabDropdownMultiselect,
+  GoabFormItem,
+} from "@abgov/react-components";
+import { useState } from "react";
+
+export function DocsDropdownMultiselectRoute() {
+  const [fruits, setFruits] = useState<string[]>([]);
+  const [services, setServices] = useState<string[]>([]);
+
+  return (
+    <div>
+      <h2>Dropdown</h2>
+
+      <h3>Basic example</h3>
+
+      <GoabFormItem label="Select fruits" mb="l">
+        <GoabDropdownMultiselect
+          name="fruits"
+          width="320px"
+          value={fruits}
+          onChange={(detail) => setFruits(detail.value)}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+          <GoabDropdownItem value="orange" label="Orange" />
+          <GoabDropdownItem value="pear" label="Pear" />
+        </GoabDropdownMultiselect>
+      </GoabFormItem>
+
+      <h3>Dropdown multiselect with placeholder text when no selection</h3>
+
+      <GoabFormItem label="Select services" mb="l">
+        <GoabDropdownMultiselect
+          name="services"
+          width="320px"
+          placeholder="Select one or more services"
+          value={services}
+          onChange={(detail) => setServices(detail.value)}
+        >
+          <GoabDropdownItem value="health" label="Health benefits" />
+          <GoabDropdownItem value="income" label="Income support" />
+          <GoabDropdownItem value="housing" label="Housing support" />
+        </GoabDropdownMultiselect>
+      </GoabFormItem>
+
+      <h3>With count label</h3>
+
+      <GoabFormItem label="Select fruits" mb="l">
+        <GoabDropdownMultiselect name="fruits" width="320px" labelFormat="count">
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+          <GoabDropdownItem value="orange" label="Orange" />
+          <GoabDropdownItem value="pear" label="Pear" />
+        </GoabDropdownMultiselect>
+      </GoabFormItem>
+
+      <h3>With list label</h3>
+
+      <GoabFormItem label="Select fruits" mb="l">
+        <GoabDropdownMultiselect name="fruits" width="320px" labelFormat="list">
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+          <GoabDropdownItem value="orange" label="Orange" />
+          <GoabDropdownItem value="pear" label="Pear" />
+        </GoabDropdownMultiselect>
+      </GoabFormItem>
+
+      <h3>Dropdown multiselect with search/filter capability</h3>
+
+      <GoabFormItem label="Which cities have you visited?" mb="l">
+        <GoabDropdownMultiselect
+          name="cities"
+          filterable={true}
+          maxHeight="400px"
+          width="320px"
+        >
+          <GoabDropdownItem value="calgary" label="Calgary" />
+          <GoabDropdownItem value="edmonton" label="Edmonton" />
+          <GoabDropdownItem value="red-deer" label="Red Deer" />
+          <GoabDropdownItem value="lethbridge" label="Lethbridge" />
+          <GoabDropdownItem value="medicine-hat" label="Medicine Hat" />
+          <GoabDropdownItem value="grande-prairie" label="Grande Prairie" />
+        </GoabDropdownMultiselect>
+      </GoabFormItem>
+
+      <h3>With select all</h3>
+
+      <GoabFormItem label="Select departments" mb="l">
+        <GoabDropdownMultiselect name="departments" showSelectAll={true} width="320px">
+          <GoabDropdownItem value="health" label="Health" />
+          <GoabDropdownItem value="education" label="Education" />
+          <GoabDropdownItem value="transportation" label="Transportation" />
+          <GoabDropdownItem value="justice" label="Justice" />
+        </GoabDropdownMultiselect>
+      </GoabFormItem>
+
+      <h3>Sizes and states</h3>
+
+      <GoabFormItem label="Default size" mb="l">
+        <GoabDropdownMultiselect name="sizeDefault" width="320px">
+          <GoabDropdownItem value="draft" label="Draft" />
+          <GoabDropdownItem value="review" label="In review" />
+          <GoabDropdownItem value="approved" label="Approved" />
+        </GoabDropdownMultiselect>
+      </GoabFormItem>
+      <GoabFormItem label="Compact size" mb="l">
+        <GoabDropdownMultiselect name="sizeCompact" size="compact" width="320px">
+          <GoabDropdownItem value="draft" label="Draft" />
+          <GoabDropdownItem value="review" label="In review" />
+          <GoabDropdownItem value="approved" label="Approved" />
+        </GoabDropdownMultiselect>
+      </GoabFormItem>
+      <GoabFormItem label="Disabled" mb="l">
+        <GoabDropdownMultiselect name="disabled" disabled width="320px">
+          <GoabDropdownItem value="opt1" label="Option 1" />
+          <GoabDropdownItem value="opt2" label="Option 2" />
+        </GoabDropdownMultiselect>
+      </GoabFormItem>
+      <GoabFormItem label="With error" error="Please select at least one option" mb="l">
+        <GoabDropdownMultiselect name="error" error width="320px">
+          <GoabDropdownItem value="opt1" label="Option 1" />
+          <GoabDropdownItem value="opt2" label="Option 2" />
+        </GoabDropdownMultiselect>
+      </GoabFormItem>
+    </div>
+  );
+}

--- a/apps/prs/react/src/routes/features/feat1233.tsx
+++ b/apps/prs/react/src/routes/features/feat1233.tsx
@@ -1,0 +1,608 @@
+import { useEffect, useState } from "react";
+import {
+  GoabBlock,
+  GoabButton,
+  GoabButtonGroup,
+  GoabDropdownItem,
+  GoabDropdownMultiselect,
+  GoabFormItem,
+  GoabModal,
+  GoabText,
+} from "@abgov/react-components";
+
+const FRUIT_POOL = [
+  { value: "apple", label: "Apple" },
+  { value: "banana", label: "Banana" },
+  { value: "cherry", label: "Cherry" },
+  { value: "date", label: "Date" },
+  { value: "elderberry", label: "Elderberry" },
+  { value: "fig", label: "Fig" },
+];
+
+export function Feat1233DropdownMultiselectRoute() {
+  const [selected1, setSelected1] = useState<string[]>([]);
+  const [selected2, setSelected2] = useState<string[]>(["apple", "banana"]);
+  const [brooklyn99Selected, setBrooklyn99Selected] = useState<string[]>([
+    "Andy Samberg",
+    "Stephanie Beatriz",
+    "Terry Crews",
+    "Andre Braugher",
+  ]);
+  const [selectedFilterable, setSelectedFilterable] = useState<string[]>([]);
+  const [selectedSelectAll, setSelectedSelectAll] = useState<string[]>([]);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selectedInModal, setSelectedInModal] = useState<string[]>([]);
+  const [filterableModalOpen, setFilterableModalOpen] = useState(false);
+  const [selectedFilterableInModal, setSelectedFilterableInModal] = useState<string[]>(
+    [],
+  );
+  const [asyncOptions, setAsyncOptions] = useState<{ value: string; label: string }[]>(
+    [],
+  );
+  const [asyncLoading, setAsyncLoading] = useState(true);
+  const [selectedAsync, setSelectedAsync] = useState<string[]>([]);
+
+  // Simulate options arriving from an API after a delay.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setAsyncOptions(FRUIT_POOL.slice(0, 3));
+      setAsyncLoading(false);
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const addOption = () => {
+    setAsyncOptions((prev) => {
+      const next = FRUIT_POOL[prev.length];
+      return next ? [...prev, next] : prev;
+    });
+  };
+
+  const removeLastOption = () => {
+    setAsyncOptions((prev) => prev.slice(0, -1));
+  };
+
+  const onBrooklyn99Change = (e: { value: string[] }) => {
+    setBrooklyn99Selected(e.value);
+  };
+
+  return (
+    <main>
+      <GoabText tag="h1" mt="none">
+        feat(#1233): DropdownMultiselect component
+      </GoabText>
+      <GoabText>
+        A dropdown component that presents a CheckboxList for multiple selection. The
+        trigger displays a comma-separated summary of selected labels with ellipsis
+        overflow. Keyboard: ArrowDown/Enter/Space opens, Escape and Tab close.
+      </GoabText>
+
+      <GoabBlock direction="column" gap="xl">
+        <section>
+          <GoabText tag="h2">Basic usage</GoabText>
+          <GoabText>
+            Select items from the list. The trigger label updates as you select.
+          </GoabText>
+          <div style={{ maxWidth: "400px" }}>
+            <GoabFormItem label="Favourite fruit">
+              <GoabDropdownMultiselect
+                name="fruit-basic"
+                placeholder="Select fruit"
+                value={selected1}
+                onChange={(e) => setSelected1(e.value)}
+                testId="basic-multiselect"
+              >
+                <GoabDropdownItem value="apple" label="Apple" />
+                <GoabDropdownItem value="banana" label="Banana" />
+                <GoabDropdownItem value="cherry" label="Cherry" />
+                <GoabDropdownItem value="date" label="Date" />
+                <GoabDropdownItem value="elderberry" label="Elderberry" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+            <GoabText>Selected: {selected1.join(", ") || "(none)"}</GoabText>
+          </div>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Filterable</GoabText>
+          <GoabText>
+            Type in the trigger to filter options. Only options whose label starts with
+            the typed string are shown. Previously checked options remain selected even
+            when hidden. The filter clears when the dropdown closes.
+          </GoabText>
+          <div style={{ maxWidth: "400px" }}>
+            <GoabFormItem label="City (filterable)">
+              <GoabDropdownMultiselect
+                name="cities-filterable"
+                placeholder="Select cities"
+                filterable={true}
+                value={selectedFilterable}
+                onChange={(e) => setSelectedFilterable(e.value)}
+                testId="filterable-multiselect"
+              >
+                <GoabDropdownItem value="ab-aird" label="Airdrie" />
+                <GoabDropdownItem value="ab-beau" label="Beaumont" />
+                <GoabDropdownItem value="ab-broo" label="Brooks" />
+                <GoabDropdownItem value="ab-calg" label="Calgary" />
+                <GoabDropdownItem value="ab-camr" label="Camrose" />
+                <GoabDropdownItem value="ab-canr" label="Canmore" />
+                <GoabDropdownItem value="ab-ches" label="Chestermere" />
+                <GoabDropdownItem value="ab-coch" label="Cochrane" />
+                <GoabDropdownItem value="ab-cold" label="Cold Lake" />
+                <GoabDropdownItem value="ab-edmo" label="Edmonton" />
+                <GoabDropdownItem value="ab-fort" label="Fort Saskatchewan" />
+                <GoabDropdownItem value="ab-ftmy" label="Fort MacKay" />
+                <GoabDropdownItem value="ab-ftmc" label="Fort McMurray" />
+                <GoabDropdownItem value="ab-grca" label="Grande Cache" />
+                <GoabDropdownItem value="ab-gran" label="Grande Prairie" />
+                <GoabDropdownItem value="ab-lalu" label="Lake Louise" />
+                <GoabDropdownItem value="ab-laco" label="Lacombe" />
+                <GoabDropdownItem value="ab-ledu" label="Leduc" />
+                <GoabDropdownItem value="ab-leth" label="Lethbridge" />
+                <GoabDropdownItem value="ab-lloy" label="Lloydminster" />
+                <GoabDropdownItem value="ab-medi" label="Medicine Hat" />
+                <GoabDropdownItem value="ab-ponp" label="Ponoka" />
+                <GoabDropdownItem value="ab-rddr" label="Red Deer" />
+                <GoabDropdownItem value="ab-shpa" label="Sherwood Park" />
+                <GoabDropdownItem value="ab-slvl" label="Slave Lake" />
+                <GoabDropdownItem value="ab-smok" label="Smoky Lake" />
+                <GoabDropdownItem value="ab-spru" label="Spruce Grove" />
+                <GoabDropdownItem value="ab-sprv" label="Spruce Valley" />
+                <GoabDropdownItem value="ab-spfd" label="Sprucefield" />
+                <GoabDropdownItem value="ab-stal" label="St. Albert" />
+                <GoabDropdownItem value="ab-sttl" label="Stettler" />
+                <GoabDropdownItem value="ab-sylv" label="Sylvan Lake" />
+                <GoabDropdownItem value="ab-weta" label="Wetaskiwin" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+            <GoabText>Selected: {selectedFilterable.join(", ") || "(none)"}</GoabText>
+          </div>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Filterable with Select All</GoabText>
+          <GoabText>
+            Type in the trigger to filter options. Only options whose label starts with
+            the typed string are shown. Previously checked options remain selected even
+            when hidden. The filter clears when the dropdown closes.
+          </GoabText>
+          <div style={{ maxWidth: "400px" }}>
+            <GoabFormItem label="City (filterable with select all)">
+              <GoabDropdownMultiselect
+                name="cities-filterable"
+                placeholder="Select cities"
+                filterable={true}
+                showSelectAll={true}
+                value={selectedFilterable}
+                onChange={(e) => setSelectedFilterable(e.value)}
+                testId="filterable-multiselect"
+              >
+                <GoabDropdownItem value="ab-aird" label="Airdrie" />
+                <GoabDropdownItem value="ab-beau" label="Beaumont" />
+                <GoabDropdownItem value="ab-broo" label="Brooks" />
+                <GoabDropdownItem value="ab-calg" label="Calgary" />
+                <GoabDropdownItem value="ab-camr" label="Camrose" />
+                <GoabDropdownItem value="ab-canr" label="Canmore" />
+                <GoabDropdownItem value="ab-ches" label="Chestermere" />
+                <GoabDropdownItem value="ab-coch" label="Cochrane" />
+                <GoabDropdownItem value="ab-cold" label="Cold Lake" />
+                <GoabDropdownItem value="ab-edmo" label="Edmonton" />
+                <GoabDropdownItem value="ab-fort" label="Fort Saskatchewan" />
+                <GoabDropdownItem value="ab-ftmy" label="Fort MacKay" />
+                <GoabDropdownItem value="ab-ftmc" label="Fort McMurray" />
+                <GoabDropdownItem value="ab-grca" label="Grande Cache" />
+                <GoabDropdownItem value="ab-gran" label="Grande Prairie" />
+                <GoabDropdownItem value="ab-lalu" label="Lake Louise" />
+                <GoabDropdownItem value="ab-laco" label="Lacombe" />
+                <GoabDropdownItem value="ab-ledu" label="Leduc" />
+                <GoabDropdownItem value="ab-leth" label="Lethbridge" />
+                <GoabDropdownItem value="ab-lloy" label="Lloydminster" />
+                <GoabDropdownItem value="ab-medi" label="Medicine Hat" />
+                <GoabDropdownItem value="ab-ponp" label="Ponoka" />
+                <GoabDropdownItem value="ab-rddr" label="Red Deer" />
+                <GoabDropdownItem value="ab-shpa" label="Sherwood Park" />
+                <GoabDropdownItem value="ab-slvl" label="Slave Lake" />
+                <GoabDropdownItem value="ab-smok" label="Smoky Lake" />
+                <GoabDropdownItem value="ab-spru" label="Spruce Grove" />
+                <GoabDropdownItem value="ab-sprv" label="Spruce Valley" />
+                <GoabDropdownItem value="ab-spfd" label="Sprucefield" />
+                <GoabDropdownItem value="ab-stal" label="St. Albert" />
+                <GoabDropdownItem value="ab-sttl" label="Stettler" />
+                <GoabDropdownItem value="ab-sylv" label="Sylvan Lake" />
+                <GoabDropdownItem value="ab-weta" label="Wetaskiwin" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+            <GoabText>Selected: {selectedFilterable.join(", ") || "(none)"}</GoabText>
+          </div>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Ellipsis overflow</GoabText>
+          <GoabText>
+            When the selected labels exceed the trigger width, they truncate with an
+            ellipsis.
+          </GoabText>
+          <div style={{ maxWidth: "250px" }}>
+            <GoabDropdownMultiselect
+              name="nine-nine-characters"
+              placeholder="Best Brooklyn Nine-Nine characters"
+              value={brooklyn99Selected}
+              onChange={onBrooklyn99Change}
+              testId="overflow-multiselect"
+            >
+              <GoabDropdownItem value="Andy Samberg" label="Jake Peralta" />
+              <GoabDropdownItem value="Stephanie Beatriz" label="Rosa Diaz" />
+              <GoabDropdownItem value="Terry Crews" label="Terry Jeffords" />
+              <GoabDropdownItem value="Melissa Fumero" label="Amy Santiago" />
+              <GoabDropdownItem value="Joe Lo Truglio" label="Charles Boyle" />
+              <GoabDropdownItem value="Chelsea Peretti" label="Gina Linetti" />
+              <GoabDropdownItem value="Andre Braugher" label="Raymond Holt" />
+              <GoabDropdownItem value="Michael Hitchcock" label="Dirk Blocker" />
+              <GoabDropdownItem value="Joel McKinnon Miller" label="Norm Scully" />
+            </GoabDropdownMultiselect>
+          </div>
+          <GoabText>Selected: {brooklyn99Selected.join(", ") || "(none)"}</GoabText>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Count labelFormal</GoabText>
+          <GoabText>
+            When the selected labels exceed the trigger width, they truncate with an "n
+            selected" label.
+          </GoabText>
+          <div style={{ maxWidth: "250px" }}>
+            <GoabDropdownMultiselect
+              name="nine-nine-characters"
+              placeholder="Best Brooklyn Nine-Nine characters"
+              value={brooklyn99Selected}
+              labelFormat="count"
+              onChange={onBrooklyn99Change}
+              testId="overflow-multiselect"
+            >
+              <GoabDropdownItem value="Andy Samberg" label="Jake Peralta" />
+              <GoabDropdownItem value="Stephanie Beatriz" label="Rosa Diaz" />
+              <GoabDropdownItem value="Terry Crews" label="Terry Jeffords" />
+              <GoabDropdownItem value="Melissa Fumero" label="Amy Santiago" />
+              <GoabDropdownItem value="Joe Lo Truglio" label="Charles Boyle" />
+              <GoabDropdownItem value="Chelsea Peretti" label="Gina Linetti" />
+              <GoabDropdownItem value="Andre Braugher" label="Raymond Holt" />
+              <GoabDropdownItem value="Michael Hitchcock" label="Dirk Blocker" />
+              <GoabDropdownItem value="Joel McKinnon Miller" label="Norm Scully" />
+            </GoabDropdownMultiselect>
+          </div>
+        </section>
+        <section>
+          <GoabText tag="h2">Controlled (pre-selected value)</GoabText>
+          <GoabText tag="p">(and leadingIcon)</GoabText>
+          <div style={{ maxWidth: "400px" }}>
+            <GoabDropdownMultiselect
+              name="fruit-controlled"
+              placeholder="Select fruit"
+              leadingIcon="airplane"
+              value={selected2}
+              onChange={(e) => setSelected2(e.value)}
+              testId="controlled-multiselect"
+            >
+              <GoabDropdownItem value="apple" label="Apple" />
+              <GoabDropdownItem value="banana" label="Banana" />
+              <GoabDropdownItem value="cherry" label="Cherry" />
+            </GoabDropdownMultiselect>
+            <GoabText>Selected: {selected2.join(", ") || "(none)"}</GoabText>
+          </div>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Disabled state</GoabText>
+          <div style={{ maxWidth: "400px" }}>
+            <GoabDropdownMultiselect
+              name="fruit-disabled"
+              placeholder="Select fruit"
+              disabled={true}
+              value={["apple"]}
+              testId="disabled-multiselect"
+            >
+              <GoabDropdownItem value="apple" label="Apple" />
+              <GoabDropdownItem value="banana" label="Banana" />
+            </GoabDropdownMultiselect>
+          </div>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Error state</GoabText>
+          <div style={{ maxWidth: "400px" }}>
+            <GoabFormItem
+              label="Required selection"
+              error="Please select at least one option."
+            >
+              <GoabDropdownMultiselect
+                name="fruit-error"
+                placeholder="Select fruit"
+                error={true}
+                testId="error-multiselect"
+              >
+                <GoabDropdownItem value="apple" label="Apple" />
+                <GoabDropdownItem value="banana" label="Banana" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+          </div>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Show Select All</GoabText>
+          <GoabText>
+            The selectAll prop adds a "Select All" checkbox above the list. Checking it
+            selects every option. Unchecking clears all. It shows as indeterminate when
+            some (but not all) options are selected.
+          </GoabText>
+          <div style={{ maxWidth: "400px" }}>
+            <GoabFormItem label="Favourite fruit">
+              <GoabDropdownMultiselect
+                name="fruit-select-all"
+                placeholder="Select fruit"
+                showSelectAll={true}
+                filterable={true}
+                value={selectedSelectAll}
+                onChange={(e) => setSelectedSelectAll(e.value)}
+                testId="select-all-multiselect"
+              >
+                <GoabDropdownItem value="apple" label="Apple" />
+                <GoabDropdownItem value="banana" label="Banana" />
+                <GoabDropdownItem value="cherry" label="Cherry" />
+                <GoabDropdownItem value="date" label="Date" />
+                <GoabDropdownItem value="elderberry" label="Elderberry" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+            <GoabText>Selected: {selectedSelectAll.join(", ") || "(none)"}</GoabText>
+          </div>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Compact size</GoabText>
+          <div style={{ maxWidth: "400px" }}>
+            <GoabDropdownMultiselect
+              name="fruit-compact"
+              placeholder="Select fruit"
+              size="compact"
+              testId="compact-multiselect"
+            >
+              <GoabDropdownItem value="apple" label="Apple" />
+              <GoabDropdownItem value="banana" label="Banana" />
+              <GoabDropdownItem value="cherry" label="Cherry" />
+            </GoabDropdownMultiselect>
+          </div>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Fixed width</GoabText>
+          <GoabText>
+            The width prop sets a fixed width on both the trigger and the popover panel,
+            instead of relying on a wrapper. The open panel should match the trigger width
+            exactly.
+          </GoabText>
+          <GoabBlock direction="column" gap="m">
+            <GoabFormItem label="Narrow (240px)">
+              <GoabDropdownMultiselect
+                name="fruit-width-narrow"
+                placeholder="Select fruit"
+                width="240px"
+                testId="width-narrow-multiselect"
+              >
+                <GoabDropdownItem value="apple" label="Apple" />
+                <GoabDropdownItem value="banana" label="Banana" />
+                <GoabDropdownItem value="elderberry" label="Elderberry (a long label)" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+            <GoabFormItem label="Wide (480px)">
+              <GoabDropdownMultiselect
+                name="fruit-width-wide"
+                placeholder="Select fruit"
+                width="480px"
+                testId="width-wide-multiselect"
+              >
+                <GoabDropdownItem value="apple" label="Apple" />
+                <GoabDropdownItem value="banana" label="Banana" />
+                <GoabDropdownItem value="cherry" label="Cherry" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+          </GoabBlock>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Percentage width (fill parent)</GoabText>
+          <GoabText>
+            With a percentage width the component sizes relative to its parent container
+            (the dashed box below is 600px wide). The popover panel, measured in pixels
+            from the trigger, should still match the rendered trigger width. Resize the
+            window to confirm both track the parent.
+          </GoabText>
+          <div
+            style={{
+              width: "600px",
+              maxWidth: "100%",
+              padding: "1rem",
+              border: "1px dashed #888",
+            }}
+          >
+            <GoabFormItem label="100% of parent" mb="m">
+              <GoabDropdownMultiselect
+                name="fruit-width-full"
+                placeholder="Select fruit"
+                width="100%"
+                testId="width-full-multiselect"
+              >
+                <GoabDropdownItem value="apple" label="Apple" />
+                <GoabDropdownItem value="banana" label="Banana" />
+                <GoabDropdownItem value="cherry" label="Cherry" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+            <GoabFormItem label="50% of parent">
+              <GoabDropdownMultiselect
+                name="fruit-width-half"
+                placeholder="Select fruit"
+                width="50%"
+                testId="width-half-multiselect"
+              >
+                <GoabDropdownItem value="apple" label="Apple" />
+                <GoabDropdownItem value="banana" label="Banana" />
+                <GoabDropdownItem value="cherry" label="Cherry" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+          </div>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Dynamic options (async load)</GoabText>
+          <GoabText>
+            Options usually come from an API, not a static list. Here the options load
+            after a 3 second delay. Open the dropdown before they load to see the empty
+            state, then watch the list populate. Use the buttons to add or remove options
+            at runtime.
+          </GoabText>
+          <div style={{ maxWidth: "400px" }}>
+            <GoabButtonGroup alignment="start">
+              <GoabButton type="secondary" onClick={addOption}>
+                Add option
+              </GoabButton>
+              <GoabButton type="secondary" onClick={removeLastOption}>
+                Remove last option
+              </GoabButton>
+            </GoabButtonGroup>
+            <GoabFormItem label="Fruit (loaded async)" mt="s">
+              <GoabDropdownMultiselect
+                name="fruit-async"
+                placeholder={asyncLoading ? "Loading options..." : "Select fruit"}
+                value={selectedAsync}
+                onChange={(e) => setSelectedAsync(e.value)}
+                testId="async-multiselect"
+              >
+                {asyncOptions.map((o) => (
+                  <GoabDropdownItem key={o.value} value={o.value} label={o.label} />
+                ))}
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+            <GoabText>Selected: {selectedAsync.join(", ") || "(none)"}</GoabText>
+          </div>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Filterable inside a modal</GoabText>
+          <GoabText>
+            Verifies that the filter input inside a modal receives focus, typing filters
+            options correctly, and that the popover renders above the modal overlay.
+          </GoabText>
+          <GoabButton type="secondary" onClick={() => setFilterableModalOpen(true)}>
+            Open modal
+          </GoabButton>
+          <GoabModal
+            open={filterableModalOpen}
+            heading="Select provinces"
+            onClose={() => setFilterableModalOpen(false)}
+            actions={
+              <GoabButtonGroup alignment="end">
+                <GoabButton
+                  type="secondary"
+                  onClick={() => setFilterableModalOpen(false)}
+                >
+                  Cancel
+                </GoabButton>
+                <GoabButton type="primary" onClick={() => setFilterableModalOpen(false)}>
+                  Confirm
+                </GoabButton>
+              </GoabButtonGroup>
+            }
+          >
+            <GoabFormItem label="Province or territory">
+              <GoabDropdownMultiselect
+                name="provinces-in-modal"
+                placeholder="Select provinces"
+                filterable={true}
+                value={selectedFilterableInModal}
+                onChange={(e) => setSelectedFilterableInModal(e.value)}
+                testId="filterable-modal-multiselect"
+              >
+                <GoabDropdownItem value="ab" label="Alberta" />
+                <GoabDropdownItem value="bc" label="British Columbia" />
+                <GoabDropdownItem value="mb" label="Manitoba" />
+                <GoabDropdownItem value="nb" label="New Brunswick" />
+                <GoabDropdownItem value="nl" label="Newfoundland and Labrador" />
+                <GoabDropdownItem value="ns" label="Nova Scotia" />
+                <GoabDropdownItem value="on" label="Ontario" />
+                <GoabDropdownItem value="pe" label="Prince Edward Island" />
+                <GoabDropdownItem value="qc" label="Quebec" />
+                <GoabDropdownItem value="sk" label="Saskatchewan" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+            <GoabText>
+              Selected: {selectedFilterableInModal.join(", ") || "(none)"}
+            </GoabText>
+          </GoabModal>
+        </section>
+
+        <section>
+          <GoabText tag="h2">Inside a modal</GoabText>
+          <GoabText>
+            Verifies the dropdown popover renders above the modal and that opening or
+            interacting with the dropdown does not close the modal.
+          </GoabText>
+          <GoabButton type="secondary" onClick={() => setModalOpen(true)}>
+            Open modal
+          </GoabButton>
+          <GoabModal
+            open={modalOpen}
+            heading="Select your fruit"
+            onClose={() => setModalOpen(false)}
+            actions={
+              <GoabButtonGroup alignment="end">
+                <GoabButton type="secondary" onClick={() => setModalOpen(false)}>
+                  Cancel
+                </GoabButton>
+                <GoabButton type="primary" onClick={() => setModalOpen(false)}>
+                  Confirm
+                </GoabButton>
+              </GoabButtonGroup>
+            }
+          >
+            <GoabFormItem label="Favourite fruit">
+              <GoabDropdownMultiselect
+                name="fruit-in-modal"
+                placeholder="Select fruit"
+                value={selectedInModal}
+                onChange={(e) => setSelectedInModal(e.value)}
+                testId="modal-multiselect"
+              >
+                <GoabDropdownItem value="apple" label="Apple" />
+                <GoabDropdownItem value="banana" label="Banana" />
+                <GoabDropdownItem value="cherry" label="Cherry" />
+                <GoabDropdownItem value="date" label="Date" />
+                <GoabDropdownItem value="elderberry" label="Elderberry" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+            <GoabText>Selected: {selectedInModal.join(", ") || "(none)"}</GoabText>
+          </GoabModal>
+        </section>
+
+        <section>
+          <GoabText tag="h2">MaxHeight Test</GoabText>
+          <GoabText>
+            Make a long list of items to test the maxHeight of the dropdown. The dropdown
+            should scroll when the list exceeds the maxHeight.
+          </GoabText>
+          <GoabFormItem label="Favourite fruit">
+            <GoabDropdownMultiselect
+              name="maxheight"
+              placeholder="Pick some numbers"
+              value={selectedInModal}
+              onChange={(e) => setSelectedInModal(e.value)}
+              testId="modal-maxheight"
+              maxHeight="500px"
+            >
+              {[...Array(100).keys()].map((i) => (
+                <GoabDropdownItem key={i} value={`fruit-${i}`} label={`Fruit ${i}`} />
+              ))}
+            </GoabDropdownMultiselect>
+          </GoabFormItem>
+        </section>
+      </GoabBlock>
+    </main>
+  );
+}

--- a/docs/generated/component-apis/dropdown-multiselect.json
+++ b/docs/generated/component-apis/dropdown-multiselect.json
@@ -1,0 +1,470 @@
+{
+  "componentSlug": "dropdown-multiselect",
+  "extractedFrom": "libs/web-components/src/components/dropdown-multiselect/DropdownMultiselect.svelte",
+  "frameworks": {
+    "react": {
+      "props": [
+        {
+          "name": "ariaLabel",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Provides an accessible label when no visible label is associated."
+        },
+        {
+          "name": "ariaLabelledBy",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "References an external element that labels this component."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Disables the component."
+        },
+        {
+          "name": "error",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Shows an error state."
+        },
+        {
+          "name": "filterable",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": "Enables filtering of options by typing in the trigger."
+        },
+        {
+          "name": "labelFormat",
+          "type": "GoabDropdownMultiselectLabelFormatOptions",
+          "required": false,
+          "default": "list",
+          "description": "The display label format of the closed dropdown. When 'count' the display label shows only \"n items\" in the label, when 'list' it shows a comma separated list of selected item labels."
+        },
+        {
+          "name": "leadingIcon",
+          "type": "GoabIconType",
+          "required": false,
+          "default": null,
+          "description": "Icon shown to the left of the dropdown input."
+        },
+        {
+          "name": "maxHeight",
+          "type": "string",
+          "required": false,
+          "default": "276px",
+          "description": "Sets the maximum height of the dropdown content area."
+        },
+        {
+          "name": "mb",
+          "type": "Spacing",
+          "required": false,
+          "default": null,
+          "description": ""
+        },
+        {
+          "name": "ml",
+          "type": "Spacing",
+          "required": false,
+          "default": null,
+          "description": ""
+        },
+        {
+          "name": "mr",
+          "type": "Spacing",
+          "required": false,
+          "default": null,
+          "description": ""
+        },
+        {
+          "name": "mt",
+          "type": "Spacing",
+          "required": false,
+          "default": null,
+          "description": ""
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Identifier for the group. Used in change events."
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Text shown when nothing is selected."
+        },
+        {
+          "name": "showSelectAll",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Shows a \"Select All\" checkbox at the top of the options list."
+        },
+        {
+          "name": "size",
+          "type": "GoabDropdownMultiselectSize",
+          "required": false,
+          "default": "default",
+          "description": "Sets the size variant."
+        },
+        {
+          "name": "testId",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Sets a data-testid attribute for automated testing."
+        },
+        {
+          "name": "value",
+          "type": "string[]",
+          "required": false,
+          "default": null,
+          "description": "Array of currently selected checkbox value."
+        },
+        {
+          "name": "width",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Sets a fixed width for the component and popover panel."
+        }
+      ],
+      "events": [
+        {
+          "name": "onChange",
+          "type": "(detail: GoabDropdownMultiselectOnChangeDetail) => void",
+          "description": "Callback fired when the selected value change.",
+          "frameworks": [
+            "react"
+          ]
+        }
+      ],
+      "slots": []
+    },
+    "angular": {
+      "props": [
+        {
+          "name": "ariaLabel",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Provides an accessible label when no visible label is associated."
+        },
+        {
+          "name": "ariaLabelledBy",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "References an external element that labels this component."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": "Sets the disabled state for the control."
+        },
+        {
+          "name": "error",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": "Sets the error state for the control."
+        },
+        {
+          "name": "filterable",
+          "type": "boolean",
+          "required": false,
+          "default": null,
+          "description": "Enables filtering of options by typing in the trigger."
+        },
+        {
+          "name": "id",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Sets the id attribute of the underlying web component."
+        },
+        {
+          "name": "labelFormat",
+          "type": "GoabDropdownMultiselectLabelFormatOptions",
+          "required": false,
+          "default": "list",
+          "description": "The display label format of the closed dropdown. When 'count' the display label shows only \"n items\" in the label, when 'list' it shows a comma separated list of selected item labels."
+        },
+        {
+          "name": "leadingIcon",
+          "type": "GoabIconType",
+          "required": false,
+          "default": null,
+          "description": "Icon shown to the left of the dropdown input."
+        },
+        {
+          "name": "maxHeight",
+          "type": "string",
+          "required": false,
+          "default": "276px",
+          "description": "Sets the maximum height of the dropdown content area."
+        },
+        {
+          "name": "mb",
+          "type": "Spacing",
+          "required": false,
+          "default": null,
+          "description": "Sets the bottom margin spacing token."
+        },
+        {
+          "name": "ml",
+          "type": "Spacing",
+          "required": false,
+          "default": null,
+          "description": "Sets the left margin spacing token."
+        },
+        {
+          "name": "mr",
+          "type": "Spacing",
+          "required": false,
+          "default": null,
+          "description": "Sets the right margin spacing token."
+        },
+        {
+          "name": "mt",
+          "type": "Spacing",
+          "required": false,
+          "default": null,
+          "description": "Sets the top margin spacing token."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Identifier for the group. Used in change events."
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Text shown when nothing is selected."
+        },
+        {
+          "name": "showSelectAll",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Shows a \"Select All\" checkbox at the top of the options list."
+        },
+        {
+          "name": "size",
+          "type": "GoabDropdownMultiselectSize",
+          "required": false,
+          "default": "default",
+          "description": "Sets the size variant."
+        },
+        {
+          "name": "testId",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Sets the data-testid attribute for automated testing."
+        },
+        {
+          "name": "value",
+          "type": "string[]",
+          "required": false,
+          "default": null,
+          "description": "Array of currently selected checkbox values."
+        },
+        {
+          "name": "width",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Sets a fixed width for the component and popover panel."
+        }
+      ],
+      "events": [
+        {
+          "name": "onChange",
+          "type": "(event: GoabDropdownMultiselectOnChangeDetail) => void",
+          "description": "Emits when the selected value change.",
+          "frameworks": [
+            "angular"
+          ]
+        }
+      ],
+      "slots": []
+    },
+    "webComponents": {
+      "props": [
+        {
+          "name": "aria-label",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "Provides an accessible label when no visible label is associated."
+        },
+        {
+          "name": "aria-labelledby",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "References an external element that labels this component."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Disables the component. @default false"
+        },
+        {
+          "name": "error",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Shows an error state. @default false"
+        },
+        {
+          "name": "filterable",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Enables filtering of options by typing in the trigger."
+        },
+        {
+          "name": "label-format",
+          "type": "\"count\" | \"list\"",
+          "values": [
+            "count",
+            "list"
+          ],
+          "required": false,
+          "default": "list",
+          "description": "The display label format of the closed dropdown. When 'count' the display label shows only \"n items\" in the label, when 'list' it shows a comma separated list of selected item labels. @default \"list\""
+        },
+        {
+          "name": "leading-icon",
+          "type": "GoabIconType",
+          "typeLabel": "GoabIconType",
+          "required": false,
+          "default": null,
+          "description": "Icon shown to the left of the dropdown input. When \"filterable\" is true this can only be \"search\"."
+        },
+        {
+          "name": "max-height",
+          "type": "string",
+          "required": false,
+          "default": "276px",
+          "description": "Sets the maximum height of the dropdown content area. @default \"276px\""
+        },
+        {
+          "name": "mb",
+          "type": "Spacing",
+          "typeLabel": "Spacing",
+          "required": false,
+          "default": null,
+          "description": "Bottom margin."
+        },
+        {
+          "name": "ml",
+          "type": "Spacing",
+          "typeLabel": "Spacing",
+          "required": false,
+          "default": null,
+          "description": "Left margin."
+        },
+        {
+          "name": "mr",
+          "type": "Spacing",
+          "typeLabel": "Spacing",
+          "required": false,
+          "default": null,
+          "description": "Right margin."
+        },
+        {
+          "name": "mt",
+          "type": "Spacing",
+          "typeLabel": "Spacing",
+          "required": false,
+          "default": null,
+          "description": "Top margin."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": true,
+          "default": null,
+          "description": "Identifier for the group. Used in change events."
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "Text shown when nothing is selected."
+        },
+        {
+          "name": "show-select-all",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Shows a \"Select All\" checkbox at the top of the options list. @default false"
+        },
+        {
+          "name": "size",
+          "type": "\"default\" | \"compact\"",
+          "values": [
+            "default",
+            "compact"
+          ],
+          "required": false,
+          "default": "default",
+          "description": "Sets the size variant."
+        },
+        {
+          "name": "testid",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "Sets a data-testid attribute for automated testing."
+        },
+        {
+          "name": "value",
+          "type": "string[]",
+          "required": false,
+          "default": "[]",
+          "description": "Array of currently selected checkbox values."
+        },
+        {
+          "name": "width",
+          "type": "string",
+          "required": false,
+          "default": "",
+          "description": "Sets a fixed width for the component and popover panel."
+        }
+      ],
+      "events": [
+        {
+          "name": "_change",
+          "type": "CustomEvent<{ name: string; value: string[]; labels: string[] }>",
+          "description": "",
+          "frameworks": [
+            "webComponents"
+          ]
+        }
+      ],
+      "slots": []
+    }
+  }
+}

--- a/docs/public/search-index.json
+++ b/docs/public/search-index.json
@@ -264,6 +264,20 @@
   },
   {
     "type": "component",
+    "id": "dropdown-multiselect",
+    "name": "Dropdown multiselect",
+    "description": "Present a list of options to the user to select multiple values from.",
+    "status": "stable",
+    "category": "inputs-and-actions",
+    "tags": [
+      "inputs and actions",
+      "select",
+      "multiple select dropdown"
+    ],
+    "slug": "dropdown-multiselect"
+  },
+  {
+    "type": "component",
     "id": "dropdown",
     "name": "Dropdown",
     "description": "Present a list of options to the user to select from.",

--- a/docs/src/content/components/dropdown-multiselect.mdx
+++ b/docs/src/content/components/dropdown-multiselect.mdx
@@ -1,0 +1,15 @@
+---
+name: Dropdown multiselect
+description: Present a list of options to the user to select multiple values from.
+status: stable
+category: inputs-and-actions
+tags:
+  - inputs and actions
+  - select
+  - multiple select dropdown
+relatedComponents:
+  - checkbox-list
+  - dropdown-item
+  - form-item
+figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=28478-241608
+---

--- a/docs/src/data/configurations/dropdown-multiselect.ts
+++ b/docs/src/data/configurations/dropdown-multiselect.ts
@@ -1,0 +1,576 @@
+/**
+ * DropdownMultiselect Component Configurations
+ *
+ * Shows various Dropdown Multiselect use cases wrapped in FormItem.
+ * Note: Dropdown Multiselect should be wrapped in FormItem for proper labeling.
+ */
+
+import type { ComponentConfigurations } from "./types";
+
+export const dropdownMultiselectConfigurations: ComponentConfigurations = {
+  componentSlug: "dropdown-multiselect",
+  componentName: "Dropdown multiselect",
+  defaultConfigurationId: "basic",
+
+  configurations: [
+    {
+      id: "basic",
+      name: "Basic example",
+      description: "Simple dropdown multiselect with options",
+      code: {
+        react: `const [fruits, setFruits] = useState<string[]>([]);
+
+<GoabFormItem label="Select fruits">
+  <GoabDropdownMultiselect
+    name="fruits"
+    width="320px"
+    value={fruits}
+    onChange={(detail) => setFruits(detail.value)}
+  >
+    <GoabDropdownItem value="apple" label="Apple" />
+    <GoabDropdownItem value="banana" label="Banana" />
+    <GoabDropdownItem value="orange" label="Orange" />
+    <GoabDropdownItem value="pear" label="Pear" />
+  </GoabDropdownMultiselect>
+</GoabFormItem>`,
+        angular: [
+          {
+            title: "Reactive forms (FormControl)",
+            ts: `export class SomeOtherComponent {
+  form!: FormGroup;
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      fruits: [[] as string[]],
+    });
+  }
+}`,
+            template: `<form [formGroup]="form">
+  <goab-form-item label="Select fruits">
+    <goab-dropdown-multiselect name="fruits" formControlName="fruits" width="320px">
+      <goab-dropdown-item value="apple" label="Apple"></goab-dropdown-item>
+      <goab-dropdown-item value="banana" label="Banana"></goab-dropdown-item>
+      <goab-dropdown-item value="orange" label="Orange"></goab-dropdown-item>
+      <goab-dropdown-item value="pear" label="Pear"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>`,
+          },
+          {
+            title: "Template driven (ngModel)",
+            ts: `export class SomeOtherComponent {
+  fruits: string[] = [];
+
+  dropdownOnChange(event: GoabDropdownMultiselectOnChangeDetail) {
+    this.fruits = event.value;
+  }
+}`,
+            template: `<form>
+  <goab-form-item label="Select fruits">
+    <goab-dropdown-multiselect
+      name="fruits"
+      width="320px"
+      [(ngModel)]="fruits"
+      (onChange)="dropdownOnChange($event)"
+    >
+      <goab-dropdown-item value="apple" label="Apple"></goab-dropdown-item>
+      <goab-dropdown-item value="banana" label="Banana"></goab-dropdown-item>
+      <goab-dropdown-item value="orange" label="Orange"></goab-dropdown-item>
+      <goab-dropdown-item value="pear" label="Pear"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>`,
+          },
+        ],
+        webComponents: `<goa-form-item label="Select fruits">
+  <goa-dropdown-multiselect name="fruits" width="320px">
+    <goa-dropdown-item value="apple" label="Apple"></goa-dropdown-item>
+    <goa-dropdown-item value="banana" label="Banana"></goa-dropdown-item>
+    <goa-dropdown-item value="orange" label="Orange"></goa-dropdown-item>
+    <goa-dropdown-item value="pear" label="Pear"></goa-dropdown-item>
+  </goa-dropdown-multiselect>
+</goa-form-item>`,
+      },
+    },
+    {
+      id: "with-custom-placeholder",
+      name: "With custom placeholder",
+      description: "Dropdown multiselect with placeholder text when no selection",
+      code: {
+        react: `const [services, setServices] = useState<string[]>([]);
+
+<GoabFormItem label="Select services">
+  <GoabDropdownMultiselect
+    name="services"
+    width="320px"
+    placeholder="Select one or more services"
+    value={services}
+    onChange={(detail) => setServices(detail.value)}
+  >
+    <GoabDropdownItem value="health" label="Health benefits" />
+    <GoabDropdownItem value="income" label="Income support" />
+    <GoabDropdownItem value="housing" label="Housing support" />
+  </GoabDropdownMultiselect>
+</GoabFormItem>`,
+        angular: [
+          {
+            title: "Reactive forms (FormControl)",
+            ts: `export class SomeOtherComponent {
+  form!: FormGroup;
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      services: [[] as string[]],
+    });
+  }
+}`,
+            template: `<form [formGroup]="form">
+  <goab-form-item label="Select services">
+    <goab-dropdown-multiselect
+      name="services"
+      width="320px"
+      placeholder="Select one or more services"
+      formControlName="services"
+    >
+      <goab-dropdown-item value="health" label="Health benefits"></goab-dropdown-item>
+      <goab-dropdown-item value="income" label="Income support"></goab-dropdown-item>
+      <goab-dropdown-item value="housing" label="Housing support"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>`,
+          },
+          {
+            title: "Template driven (ngModel)",
+            ts: `export class SomeOtherComponent {
+  services: string[] = [];
+
+  dropdownOnChange(event: GoabDropdownMultiselectOnChangeDetail) {
+    this.services = event.value;
+  }
+}`,
+            template: `<form>
+  <goab-form-item label="Select services">
+    <goab-dropdown-multiselect
+      name="services"
+      width="320px"
+      placeholder="Select one or more services"
+      [(ngModel)]="services"
+      (onChange)="dropdownOnChange($event)"
+    >
+      <goab-dropdown-item value="health" label="Health benefits"></goab-dropdown-item>
+      <goab-dropdown-item value="income" label="Income support"></goab-dropdown-item>
+      <goab-dropdown-item value="housing" label="Housing support"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>`,
+          },
+        ],
+        webComponents: `<goa-form-item label="Select services">
+  <goa-dropdown-multiselect
+    name="services"
+    width="320px"
+    placeholder="Select one or more services"
+  >
+    <goa-dropdown-item value="health" label="Health benefits"></goa-dropdown-item>
+    <goa-dropdown-item value="income" label="Income support"></goa-dropdown-item>
+    <goa-dropdown-item value="housing" label="Housing support"></goa-dropdown-item>
+  </goa-dropdown-multiselect>
+</goa-form-item>`,
+      },
+    },
+    {
+      id: "label-format",
+      name: "Label Formatting",
+      description:
+        "When labelFormat='count' the label shows a count 'n items' instead of listing selected options.",
+      code: {
+        react: `<GoabFormItem label="Select fruits">
+  <GoabDropdownMultiselect
+    name="fruits"
+    labelFormat="count"
+    width="320px"
+  >
+    <GoabDropdownItem value="apple" label="Apple" />
+    <GoabDropdownItem value="banana" label="Banana" />
+    <GoabDropdownItem value="orange" label="Orange" />
+    <GoabDropdownItem value="pear" label="Pear" />
+  </GoabDropdownMultiselect>
+</GoabFormItem>`,
+        angular: `<goab-form-item label="Select fruits">
+  <goab-dropdown-multiselect
+    name="fruits"
+    width="320px"
+    [labelFormat]="'count'"
+  >
+    <goab-dropdown-item value="apple" label="Apple"></goab-dropdown-item>
+    <goab-dropdown-item value="banana" label="Banana"></goab-dropdown-item>
+    <goab-dropdown-item value="orange" label="Orange"></goab-dropdown-item>
+    <goab-dropdown-item value="pear" label="Pear"></goab-dropdown-item>
+  </goab-dropdown-multiselect>
+</goab-form-item>`,
+        webComponents: `<goa-form-item label="Select fruits">
+  <goa-dropdown-multiselect
+    name="fruits"
+    label-format="count"
+    width="320px"
+  >
+    <goa-dropdown-item value="apple" label="Apple"></goa-dropdown-item>
+    <goa-dropdown-item value="banana" label="Banana"></goa-dropdown-item>
+    <goa-dropdown-item value="orange" label="Orange"></goa-dropdown-item>
+    <goa-dropdown-item value="pear" label="Pear"></goa-dropdown-item>
+  </goa-dropdown-multiselect>
+</goa-form-item>`,
+      },
+    },
+    {
+      id: "filterable",
+      name: "Filterable",
+      description: "Dropdown multiselect with search/filter capability",
+      code: {
+        react: `<GoabFormItem label="Which cities have you visited?">
+  <GoabDropdownMultiselect
+    name="cities"
+    filterable={true}
+    maxHeight="400px"
+    width="320px"
+  >
+    <GoabDropdownItem value="calgary" label="Calgary" />
+    <GoabDropdownItem value="edmonton" label="Edmonton" />
+    <GoabDropdownItem value="red-deer" label="Red Deer" />
+    <GoabDropdownItem value="lethbridge" label="Lethbridge" />
+    <GoabDropdownItem value="medicine-hat" label="Medicine Hat" />
+    <GoabDropdownItem value="grande-prairie" label="Grande Prairie" />
+  </GoabDropdownMultiselect>
+</GoabFormItem>`,
+        angular: [
+          {
+            title: "Reactive forms (FormControl)",
+            ts: `export class SomeOtherComponent {
+  form!: FormGroup;
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      cities: [[] as string[]],
+    });
+  }
+}`,
+            template: `<form [formGroup]="form">
+  <goab-form-item label="Which cities have you visited?">
+    <goab-dropdown-multiselect
+      name="cities"
+      [filterable]="true"
+      maxHeight="400px"
+      width="320px"
+      formControlName="cities"
+    >
+      <goab-dropdown-item value="calgary" label="Calgary"></goab-dropdown-item>
+      <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+      <goab-dropdown-item value="red-deer" label="Red Deer"></goab-dropdown-item>
+      <goab-dropdown-item value="lethbridge" label="Lethbridge"></goab-dropdown-item>
+      <goab-dropdown-item value="medicine-hat" label="Medicine Hat"></goab-dropdown-item>
+      <goab-dropdown-item value="grande-prairie" label="Grande Prairie"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>`,
+          },
+          {
+            title: "Template driven (ngModel)",
+            ts: `export class SomeOtherComponent {
+  cities: string[] = [];
+
+  dropdownOnChange(event: GoabDropdownMultiselectOnChangeDetail) {
+    this.cities = event.value;
+  }
+}`,
+            template: `<form>
+  <goab-form-item label="Which cities have you visited?">
+    <goab-dropdown-multiselect
+      name="cities"
+      [filterable]="true"
+      maxHeight="400px"
+      width="320px"
+      [(ngModel)]="cities"
+      (onChange)="dropdownOnChange($event)"
+    >
+      <goab-dropdown-item value="calgary" label="Calgary"></goab-dropdown-item>
+      <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+      <goab-dropdown-item value="red-deer" label="Red Deer"></goab-dropdown-item>
+      <goab-dropdown-item value="lethbridge" label="Lethbridge"></goab-dropdown-item>
+      <goab-dropdown-item value="medicine-hat" label="Medicine Hat"></goab-dropdown-item>
+      <goab-dropdown-item value="grande-prairie" label="Grande Prairie"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>`,
+          },
+        ],
+        webComponents: `<goa-form-item label="Which cities have you visited?">
+  <goa-dropdown-multiselect
+    name="cities"
+    filterable="true"
+    maxheight="400px"
+    width="320px"
+  >
+    <goa-dropdown-item value="calgary" label="Calgary"></goa-dropdown-item>
+    <goa-dropdown-item value="edmonton" label="Edmonton"></goa-dropdown-item>
+    <goa-dropdown-item value="red-deer" label="Red Deer"></goa-dropdown-item>
+    <goa-dropdown-item value="lethbridge" label="Lethbridge"></goa-dropdown-item>
+    <goa-dropdown-item value="medicine-hat" label="Medicine Hat"></goa-dropdown-item>
+    <goa-dropdown-item value="grande-prairie" label="Grande Prairie"></goa-dropdown-item>
+  </goa-dropdown-multiselect>
+</goa-form-item>`,
+      },
+    },
+    {
+      id: "select-all",
+      name: "With select all",
+      description: 'Shows a "Select all" option at the top of the list',
+      code: {
+        react: `<GoabFormItem label="Select departments">
+  <GoabDropdownMultiselect
+    name="departments"
+    showSelectAll={true}
+    width="320px"
+  >
+    <GoabDropdownItem value="health" label="Health" />
+    <GoabDropdownItem value="education" label="Education" />
+    <GoabDropdownItem value="transportation" label="Transportation" />
+    <GoabDropdownItem value="justice" label="Justice" />
+  </GoabDropdownMultiselect>
+</GoabFormItem>`,
+        angular: [
+          {
+            title: "Reactive forms (FormControl)",
+            ts: `export class SomeOtherComponent {
+  form!: FormGroup;
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      departments: [[] as string[]],
+    });
+  }
+}`,
+            template: `<form [formGroup]="form">
+  <goab-form-item label="Select departments">
+    <goab-dropdown-multiselect
+      name="departments"
+      [showSelectAll]="true"
+      formControlName="departments"
+      width="320px"
+    >
+      <goab-dropdown-item value="health" label="Health"></goab-dropdown-item>
+      <goab-dropdown-item value="education" label="Education"></goab-dropdown-item>
+      <goab-dropdown-item value="transportation" label="Transportation"></goab-dropdown-item>
+      <goab-dropdown-item value="justice" label="Justice"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>`,
+          },
+          {
+            title: "Template driven (ngModel)",
+            ts: `export class SomeOtherComponent {
+  departments: string[] = [];
+
+  dropdownOnChange(event: GoabDropdownMultiselectOnChangeDetail) {
+    this.departments = event.value;
+  }
+}`,
+            template: `<form>
+  <goab-form-item label="Select departments">
+    <goab-dropdown-multiselect
+      name="departments"
+      [showSelectAll]="true"
+      [(ngModel)]="departments"
+      (onChange)="dropdownOnChange($event)"
+      width="320px"
+    >
+      <goab-dropdown-item value="health" label="Health"></goab-dropdown-item>
+      <goab-dropdown-item value="education" label="Education"></goab-dropdown-item>
+      <goab-dropdown-item value="transportation" label="Transportation"></goab-dropdown-item>
+      <goab-dropdown-item value="justice" label="Justice"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>`,
+          },
+        ],
+        webComponents: `<goa-form-item label="Select departments">
+  <goa-dropdown-multiselect name="departments" show-select-all="true" width="320px">
+    <goa-dropdown-item value="health" label="Health"></goa-dropdown-item>
+    <goa-dropdown-item value="education" label="Education"></goa-dropdown-item>
+    <goa-dropdown-item value="transportation" label="Transportation"></goa-dropdown-item>
+    <goa-dropdown-item value="justice" label="Justice"></goa-dropdown-item>
+  </goa-dropdown-multiselect>
+</goa-form-item>`,
+      },
+    },
+    {
+      id: "sizes-and-states",
+      name: "Sizes and states",
+      description: "Default and compact sizes with disabled and error states",
+      code: {
+        react: `<GoabFormItem label="Default size">
+  <GoabDropdownMultiselect name="sizeDefault" width="320px">
+    <GoabDropdownItem value="draft" label="Draft" />
+    <GoabDropdownItem value="review" label="In review" />
+    <GoabDropdownItem value="approved" label="Approved" />
+  </GoabDropdownMultiselect>
+</GoabFormItem>
+<GoabFormItem label="Compact size">
+  <GoabDropdownMultiselect name="sizeCompact" size="compact" width="320px">
+    <GoabDropdownItem value="draft" label="Draft" />
+    <GoabDropdownItem value="review" label="In review" />
+    <GoabDropdownItem value="approved" label="Approved" />
+  </GoabDropdownMultiselect>
+</GoabFormItem>
+<GoabFormItem label="Disabled">
+  <GoabDropdownMultiselect name="disabled" disabled width="320px">
+    <GoabDropdownItem value="opt1" label="Option 1" />
+    <GoabDropdownItem value="opt2" label="Option 2" />
+  </GoabDropdownMultiselect>
+</GoabFormItem>
+<GoabFormItem label="With error" error="Please select at least one option">
+  <GoabDropdownMultiselect name="error" error width="320px">
+    <GoabDropdownItem value="opt1" label="Option 1" />
+    <GoabDropdownItem value="opt2" label="Option 2" />
+  </GoabDropdownMultiselect>
+</GoabFormItem>`,
+        angular: [
+          {
+            title: "Reactive forms (FormControl)",
+            ts: `export class SomeOtherComponent {
+  form!: FormGroup;
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      sizeDefault: [[] as string[]],
+      sizeCompact: [[] as string[]],
+      disabled: [{ value: [] as string[], disabled: true }],
+      errorValue: [[] as string[]],
+    });
+  }
+}`,
+            template: `<form [formGroup]="form">
+  <goab-form-item label="Default size">
+    <goab-dropdown-multiselect name="sizeDefault" formControlName="sizeDefault" width="320px">
+      <goab-dropdown-item value="draft" label="Draft"></goab-dropdown-item>
+      <goab-dropdown-item value="review" label="In review"></goab-dropdown-item>
+      <goab-dropdown-item value="approved" label="Approved"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+  <goab-form-item label="Compact size">
+    <goab-dropdown-multiselect
+      name="sizeCompact"
+      size="compact"
+      formControlName="sizeCompact"
+      width="320px"
+    >
+      <goab-dropdown-item value="draft" label="Draft"></goab-dropdown-item>
+      <goab-dropdown-item value="review" label="In review"></goab-dropdown-item>
+      <goab-dropdown-item value="approved" label="Approved"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+  <goab-form-item label="Disabled">
+    <goab-dropdown-multiselect name="disabled" formControlName="disabled" width="320px">
+      <goab-dropdown-item value="opt1" label="Option 1"></goab-dropdown-item>
+      <goab-dropdown-item value="opt2" label="Option 2"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+  <goab-form-item label="With error" error="Please select at least one option">
+    <goab-dropdown-multiselect
+      name="error"
+      [error]="true"
+      formControlName="errorValue"
+      width="320px"
+    >
+      <goab-dropdown-item value="opt1" label="Option 1"></goab-dropdown-item>
+      <goab-dropdown-item value="opt2" label="Option 2"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>`,
+          },
+          {
+            title: "Template driven (ngModel)",
+            ts: `export class SomeOtherComponent {
+  sizeDefault: string[] = [];
+  sizeCompact: string[] = [];
+  disabledValue: string[] = [];
+  errorValue: string[] = [];
+
+  dropdownOnChange(event: GoabDropdownMultiselectOnChangeDetail) {
+    this.errorValue = event.value;
+  }
+}`,
+            template: `<form>
+  <goab-form-item label="Default size">
+    <goab-dropdown-multiselect
+      name="sizeDefault"
+      [(ngModel)]="sizeDefault"
+      width="320px"
+    >
+      <goab-dropdown-item value="draft" label="Draft"></goab-dropdown-item>
+      <goab-dropdown-item value="review" label="In review"></goab-dropdown-item>
+      <goab-dropdown-item value="approved" label="Approved"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+  <goab-form-item label="Compact size">
+    <goab-dropdown-multiselect
+      name="sizeCompact"
+      size="compact"
+      [(ngModel)]="sizeCompact"
+      width="320px"
+    >
+      <goab-dropdown-item value="draft" label="Draft"></goab-dropdown-item>
+      <goab-dropdown-item value="review" label="In review"></goab-dropdown-item>
+      <goab-dropdown-item value="approved" label="Approved"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+  <goab-form-item label="Disabled">
+    <goab-dropdown-multiselect
+      name="disabled"
+      [disabled]="true"
+      [(ngModel)]="disabledValue"
+      width="320px"
+    >
+      <goab-dropdown-item value="opt1" label="Option 1"></goab-dropdown-item>
+      <goab-dropdown-item value="opt2" label="Option 2"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+  <goab-form-item label="With error" error="Please select at least one option">
+    <goab-dropdown-multiselect
+      name="error"
+      [error]="true"
+      [(ngModel)]="errorValue"
+      (onChange)="dropdownOnChange($event)"
+      width="320px"
+    >
+      <goab-dropdown-item value="opt1" label="Option 1"></goab-dropdown-item>
+      <goab-dropdown-item value="opt2" label="Option 2"></goab-dropdown-item>
+    </goab-dropdown-multiselect>
+  </goab-form-item>
+</form>`,
+          },
+        ],
+        webComponents: `<goa-form-item label="Default size">
+  <goa-dropdown-multiselect name="sizeDefault" width="320px">
+    <goa-dropdown-item value="draft" label="Draft"></goa-dropdown-item>
+    <goa-dropdown-item value="review" label="In review"></goa-dropdown-item>
+    <goa-dropdown-item value="approved" label="Approved"></goa-dropdown-item>
+  </goa-dropdown-multiselect>
+</goa-form-item>
+<goa-form-item label="Compact size">
+  <goa-dropdown-multiselect name="sizeCompact" size="compact" width="320px">
+    <goa-dropdown-item value="draft" label="Draft"></goa-dropdown-item>
+    <goa-dropdown-item value="review" label="In review"></goa-dropdown-item>
+    <goa-dropdown-item value="approved" label="Approved"></goa-dropdown-item>
+  </goa-dropdown-multiselect>
+</goa-form-item>
+<goa-form-item label="Disabled">
+  <goa-dropdown-multiselect name="disabled" disabled width="320px">
+    <goa-dropdown-item value="opt1" label="Option 1"></goa-dropdown-item>
+    <goa-dropdown-item value="opt2" label="Option 2"></goa-dropdown-item>
+  </goa-dropdown-multiselect>
+</goa-form-item>
+<goa-form-item label="With error" error="Please select at least one option">
+  <goa-dropdown-multiselect name="error" error width="320px">
+    <goa-dropdown-item value="opt1" label="Option 1"></goa-dropdown-item>
+    <goa-dropdown-item value="opt2" label="Option 2"></goa-dropdown-item>
+  </goa-dropdown-multiselect>
+</goa-form-item>`,
+      },
+    },
+  ],
+};

--- a/docs/src/data/configurations/index.ts
+++ b/docs/src/data/configurations/index.ts
@@ -11,6 +11,7 @@ export * from "./types";
 export { buttonConfigurations } from "./button";
 export { inputConfigurations } from "./input";
 export { dropdownConfigurations } from "./dropdown";
+export { dropdownMultiselectConfigurations } from "./dropdown-multiselect";
 export { checkboxConfigurations } from "./checkbox";
 export { checkboxListConfigurations } from "./checkbox-list";
 export { radioGroupConfigurations } from "./radio-group";
@@ -88,6 +89,7 @@ import type { ComponentConfigurations, ConfigurationRegistry } from "./types";
 import { buttonConfigurations } from "./button";
 import { inputConfigurations } from "./input";
 import { dropdownConfigurations } from "./dropdown";
+import { dropdownMultiselectConfigurations } from "./dropdown-multiselect";
 import { checkboxConfigurations } from "./checkbox";
 import { checkboxListConfigurations } from "./checkbox-list";
 import { radioGroupConfigurations } from "./radio-group";
@@ -159,6 +161,7 @@ export const configurationRegistry: ConfigurationRegistry = {
   button: buttonConfigurations,
   input: inputConfigurations,
   dropdown: dropdownConfigurations,
+  "dropdown-multiselect": dropdownMultiselectConfigurations,
   checkbox: checkboxConfigurations,
   "checkbox-list": checkboxListConfigurations,
   "radio-group": radioGroupConfigurations,

--- a/libs/angular-components/src/lib/components/dropdown-multiselect/dropdown-multiselect.spec.ts
+++ b/libs/angular-components/src/lib/components/dropdown-multiselect/dropdown-multiselect.spec.ts
@@ -1,0 +1,176 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { GoabDropdownMultiselect } from "./dropdown-multiselect";
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { fireEvent } from "@testing-library/dom";
+import { By } from "@angular/platform-browser";
+import { GoabDropdownMultiselectSize, Spacing } from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  imports: [GoabDropdownMultiselect],
+  template: `
+    <goab-dropdown-multiselect
+      [name]="name"
+      [value]="value"
+      [placeholder]="placeholder"
+      [disabled]="disabled"
+      [error]="error"
+      [testId]="testId"
+      [maxHeight]="maxHeight"
+      [width]="width"
+      [size]="size"
+      [ariaLabel]="ariaLabel"
+      [ariaLabelledBy]="ariaLabelledBy"
+      [showSelectAll]="showSelectAll"
+      [mt]="mt"
+      [mb]="mb"
+      [ml]="ml"
+      [mr]="mr"
+      (onChange)="onChangeFn($event)"
+    >
+    </goab-dropdown-multiselect>
+  `,
+})
+class TestDropdownMultiselectComponent {
+  name?: string;
+  value?: string[];
+  placeholder?: string;
+  disabled?: boolean;
+  error?: boolean;
+  testId?: string;
+  maxHeight?: string;
+  width?: string;
+  size?: GoabDropdownMultiselectSize;
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
+  showSelectAll?: boolean;
+  mt?: Spacing;
+  mb?: Spacing;
+  ml?: Spacing;
+  mr?: Spacing;
+
+  onChangeFn(_detail: unknown) {
+    /* do nothing */
+  }
+}
+
+describe("GoabDropdownMultiselect", () => {
+  let fixture: ComponentFixture<TestDropdownMultiselectComponent>;
+  let component: TestDropdownMultiselectComponent;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestDropdownMultiselectComponent, GoabDropdownMultiselect],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestDropdownMultiselectComponent);
+    component = fixture.componentInstance;
+
+    component.name = "fruit";
+    component.value = ["apple"];
+    component.placeholder = "Select fruit";
+    component.disabled = false;
+    component.error = false;
+    component.testId = "testId";
+    component.maxHeight = "300px";
+    component.width = "400px";
+    component.size = "compact";
+    component.ariaLabel = "Choose fruit";
+    component.ariaLabelledBy = "fruit-label";
+    component.mt = "s";
+    component.mr = "m";
+    component.mb = "l";
+    component.ml = "xl";
+    component.showSelectAll = true;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+  }));
+
+  it("should render properties", () => {
+    const el = fixture.debugElement.query(
+      By.css("goa-dropdown-multiselect"),
+    ).nativeElement;
+
+    expect(el.getAttribute("name")).toBe("fruit");
+    expect(el.getAttribute("placeholder")).toBe("Select fruit");
+    expect(el.getAttribute("max-height")).toBe("300px");
+    expect(el.getAttribute("width")).toBe("400px");
+    expect(el.getAttribute("size")).toBe("compact");
+    expect(el.getAttribute("aria-label")).toBe("Choose fruit");
+    expect(el.getAttribute("aria-labelledby")).toBe("fruit-label");
+    expect(el.getAttribute("testid")).toBe("testId");
+    expect(el.getAttribute("show-select-all")).toBe("true");
+    expect(el.getAttribute("mt")).toBe("s");
+    expect(el.getAttribute("mr")).toBe("m");
+    expect(el.getAttribute("mb")).toBe("l");
+    expect(el.getAttribute("ml")).toBe("xl");
+  });
+
+  it("should not set disabled attribute when false", () => {
+    const el = fixture.debugElement.query(
+      By.css("goa-dropdown-multiselect"),
+    ).nativeElement;
+    expect(el.getAttribute("disabled")).toBeNull();
+  });
+
+  it("should set disabled attribute when true", fakeAsync(() => {
+    component.disabled = true;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const el = fixture.debugElement.query(
+      By.css("goa-dropdown-multiselect"),
+    ).nativeElement;
+    expect(el.getAttribute("disabled")).toBe("true");
+  }));
+
+  it("should not set error attribute when false", () => {
+    const el = fixture.debugElement.query(
+      By.css("goa-dropdown-multiselect"),
+    ).nativeElement;
+    expect(el.getAttribute("error")).toBeNull();
+  });
+
+  it("should set error attribute when true", fakeAsync(() => {
+    component.error = true;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const el = fixture.debugElement.query(
+      By.css("goa-dropdown-multiselect"),
+    ).nativeElement;
+    expect(el.getAttribute("error")).toBe("true");
+  }));
+
+  it("should emit onChange when _change event fires", fakeAsync(() => {
+    const spy = jest.spyOn(component, "onChangeFn");
+    const el = fixture.debugElement.query(
+      By.css("goa-dropdown-multiselect"),
+    ).nativeElement;
+
+    fireEvent(
+      el,
+      new CustomEvent("_change", {
+        detail: {
+          name: "fruit",
+          value: ["apple", "banana"],
+          labels: ["Apple", "Banana"],
+        },
+        bubbles: true,
+      }),
+    );
+
+    tick();
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const detail = spy.mock.calls[0][0] as any;
+    expect(detail.name).toBe("fruit");
+    expect(detail.value).toEqual(["apple", "banana"]);
+    expect(detail.labels).toEqual(["Apple", "Banana"]);
+  }));
+});

--- a/libs/angular-components/src/lib/components/dropdown-multiselect/dropdown-multiselect.ts
+++ b/libs/angular-components/src/lib/components/dropdown-multiselect/dropdown-multiselect.ts
@@ -1,0 +1,114 @@
+import {
+  GoabDropdownMultiselectLabelFormatOptions,
+  GoabDropdownMultiselectOnChangeDetail,
+  GoabDropdownMultiselectSize,
+  GoabIconType,
+} from "@abgov/ui-components-common";
+import {
+  ChangeDetectorRef,
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  EventEmitter,
+  inject,
+  Input,
+  OnInit,
+  Output,
+  booleanAttribute,
+  forwardRef,
+} from "@angular/core";
+import { NG_VALUE_ACCESSOR } from "@angular/forms";
+import { GoabControlValueAccessor } from "../base.component";
+
+@Component({
+  standalone: true,
+  selector: "goab-dropdown-multiselect",
+  template: `@if (isReady) {
+    <goa-dropdown-multiselect
+      [attr.name]="name"
+      [value]="value"
+      [attr.placeholder]="placeholder"
+      [attr.disabled]="disabled ? 'true' : undefined"
+      [attr.error]="error ? 'true' : undefined"
+      [attr.filterable]="filterable"
+      [attr.leading-icon]="leadingIcon"
+      [attr.testid]="testId"
+      [attr.aria-label]="ariaLabel"
+      [attr.aria-labelledby]="ariaLabelledBy"
+      [attr.max-height]="maxHeight"
+      [attr.width]="width"
+      [attr.size]="size"
+      [attr.label-format]="labelFormat ? labelFormat : undefined"
+      [attr.show-select-all]="showSelectAll ? 'true' : undefined"
+      [attr.mt]="mt"
+      [attr.mb]="mb"
+      [attr.ml]="ml"
+      [attr.mr]="mr"
+      (_change)="_onChange($event)"
+    >
+      <ng-content />
+    </goa-dropdown-multiselect>
+  }`,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      multi: true,
+      useExisting: forwardRef(() => GoabDropdownMultiselect),
+    },
+  ],
+})
+/** A dropdown that presents a list of checkboxes for multiple selection. */
+export class GoabDropdownMultiselect extends GoabControlValueAccessor implements OnInit {
+  private cdr = inject(ChangeDetectorRef);
+
+  isReady = false;
+
+  /** @required Identifier for the group. Used in change events. */
+  @Input({ required: true }) name!: string;
+  /** Array of currently selected checkbox values. */
+  @Input() override value?: string[];
+  /** Text shown when nothing is selected. */
+  @Input() placeholder?: string;
+  /** Enables filtering of options by typing in the trigger. */
+  @Input({ transform: booleanAttribute }) filterable?: boolean;
+  /** Icon shown to the left of the dropdown input. */
+  @Input() leadingIcon?: GoabIconType;
+  /** Provides an accessible label when no visible label is associated. */
+  @Input() ariaLabel?: string;
+  /** References an external element that labels this component. */
+  @Input() ariaLabelledBy?: string;
+  /** Sets the maximum height of the dropdown content area. @default "276px" */
+  @Input() maxHeight?: string;
+  /** Sets a fixed width for the component and popover panel. */
+  @Input() width?: string;
+  /** Sets the size variant. @default "default" */
+  @Input() size?: GoabDropdownMultiselectSize = "default";
+  /** The display label format of the closed dropdown. When 'count' the display label shows only "n items" in the label, when 'list' it shows a comma separated list of selected item labels. @default "list" */
+  @Input() labelFormat?: GoabDropdownMultiselectLabelFormatOptions;
+  /** Shows a "Select All" checkbox at the top of the options list. @default false */
+  @Input({ transform: booleanAttribute }) showSelectAll?: boolean;
+  /** Emits when the selected value change. */
+  @Output() onChange = new EventEmitter<GoabDropdownMultiselectOnChangeDetail>();
+
+  ngOnInit(): void {
+    setTimeout(() => {
+      this.isReady = true;
+      this.cdr.detectChanges();
+    });
+  }
+
+  _onChange(e: Event) {
+    const detail = {
+      ...(e as CustomEvent<GoabDropdownMultiselectOnChangeDetail>).detail,
+      event: e,
+    };
+    this.onChange.emit(detail);
+    this.markAsTouched();
+    this.value = [...(detail.value || [])];
+    this.fcChange?.([...(detail.value || [])]);
+  }
+
+  override writeValue(value: string[] | null): void {
+    this.value = Array.isArray(value) ? [...value] : [];
+  }
+}

--- a/libs/angular-components/src/lib/components/index.ts
+++ b/libs/angular-components/src/lib/components/index.ts
@@ -22,6 +22,7 @@ export * from "./divider/divider";
 export * from "./drawer/drawer";
 export * from "./dropdown/dropdown";
 export * from "./dropdown-item/dropdown-item";
+export * from "./dropdown-multiselect/dropdown-multiselect";
 export * from "./file-upload-card/file-upload-card";
 export * from "./file-upload-input/file-upload-input";
 export * from "./filter-chip/filter-chip";

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -1497,3 +1497,25 @@ export interface GoabWorkspaceLayoutOnScrollStateChangeDetail {
   /** The originating DOM event. */
   event: Event;
 }
+export type GoabDropdownMultiselectSize = "default" | "compact";
+
+/**
+ * Provides details when a dropdown multiselect value changes.
+ */
+export type GoabDropdownMultiselectOnChangeDetail = {
+  /** The group name. */
+  name: string;
+  /** The selected values. */
+  value: string[];
+  /** The display labels for each selected value. */
+  labels: string[];
+  /** The originating DOM event. */
+  event: Event;
+};
+
+/**
+ * Label formatting options:
+ * - list: Displays the selected items as a comma-separated list.
+ * - count: Displays the number of selected items.
+ */
+export type GoabDropdownMultiselectLabelFormatOptions = "list" | "count";

--- a/libs/react-components/specs/dropdown-multiselect.browser.spec.tsx
+++ b/libs/react-components/specs/dropdown-multiselect.browser.spec.tsx
@@ -1,0 +1,695 @@
+import { render } from "vitest-browser-react";
+import { GoabDropdownMultiselect, GoabDropdownItem } from "../src";
+import { expect, describe, it, vi } from "vitest";
+import { userEvent } from "@vitest/browser/context";
+import { useState } from "react";
+
+/**
+ * The checkbox-list testid lands on a div inside the goa-checkbox-list shadow DOM.
+ * The goa-checkbox elements are light-DOM children of the host, so resolve to it.
+ */
+function checkboxListHost(checkboxListShadowDiv: HTMLElement): HTMLElement {
+  return (checkboxListShadowDiv.getRootNode() as ShadowRoot).host as HTMLElement;
+}
+
+/** Svelte sets name as a property on the custom element rather than an attribute. */
+function checkboxName(cb: Element): string {
+  return (cb as { name?: string }).name || cb.getAttribute("name") || "";
+}
+
+/** The goa-checkbox elements currently rendered inside the checkbox list. */
+function renderedCheckboxes(checkboxListShadowDiv: HTMLElement): HTMLElement[] {
+  return Array.from(
+    checkboxListHost(checkboxListShadowDiv).querySelectorAll("goa-checkbox"),
+  );
+}
+
+/** Names of the goa-checkbox elements currently rendered inside the checkbox list. */
+function renderedCheckboxNames(checkboxListShadowDiv: HTMLElement): string[] {
+  return renderedCheckboxes(checkboxListShadowDiv).map(checkboxName);
+}
+
+describe("DropdownMultiselect", () => {
+  it("should not open the popover when disabled", async () => {
+    const Component = () => {
+      return (
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          disabled={true}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+        </GoabDropdownMultiselect>
+      );
+    };
+
+    const { getByTestId } = render(<Component />);
+    const host = getByTestId("dropdown-multiselect");
+
+    await userEvent.click(host);
+
+    await vi.waitFor(() => {
+      const checkboxListDiv = getByTestId("dropdown-multiselect-checkbox-list");
+      expect(checkboxListDiv).not.toBeVisible();
+    });
+  });
+
+  it("should open the popover when enabled", async () => {
+    const Component = () => {
+      return (
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+        </GoabDropdownMultiselect>
+      );
+    };
+
+    const { getByTestId } = render(<Component />);
+    const host = getByTestId("dropdown-multiselect");
+
+    await userEvent.click(host);
+
+    await vi.waitFor(() => {
+      const checkboxListDiv = getByTestId("dropdown-multiselect-checkbox-list");
+      expect(checkboxListDiv).toBeVisible();
+    });
+  });
+
+  it("should open the popover when the trigger receives focus via keyboard tab", async () => {
+    const Component = () => (
+      <>
+        <button data-testid="before">Before</button>
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+        </GoabDropdownMultiselect>
+      </>
+    );
+
+    const { getByTestId } = render(<Component />);
+    const before = getByTestId("before");
+
+    before.element().focus();
+    await userEvent.tab();
+
+    await vi.waitFor(() => {
+      const checkboxListDiv = getByTestId("dropdown-multiselect-checkbox-list");
+      expect(checkboxListDiv).toBeVisible();
+    });
+  });
+
+  it("should not open the popover on tab when disabled", async () => {
+    const Component = () => (
+      <>
+        <button data-testid="before">Before</button>
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          disabled={true}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+        </GoabDropdownMultiselect>
+      </>
+    );
+
+    const { getByTestId } = render(<Component />);
+    const before = getByTestId("before");
+
+    before.element().focus();
+    await userEvent.tab();
+
+    await vi.waitFor(() => {
+      const checkboxListDiv = getByTestId("dropdown-multiselect-checkbox-list");
+      expect(checkboxListDiv).not.toBeVisible();
+    });
+  });
+
+  it("should not reopen the popover when focus returns to the trigger after closing with Escape", async () => {
+    const Component = () => (
+      <GoabDropdownMultiselect
+        name="fruit"
+        testId="dropdown-multiselect"
+        placeholder="Select fruit"
+      >
+        <GoabDropdownItem value="apple" label="Apple" />
+        <GoabDropdownItem value="banana" label="Banana" />
+      </GoabDropdownMultiselect>
+    );
+
+    const { getByTestId } = render(<Component />);
+    const host = getByTestId("dropdown-multiselect");
+
+    await userEvent.click(host);
+
+    await vi.waitFor(() => {
+      expect(getByTestId("dropdown-multiselect-checkbox-list")).toBeVisible();
+    });
+
+    await userEvent.keyboard("{Escape}");
+
+    await vi.waitFor(() => {
+      const checkboxListDiv = getByTestId("dropdown-multiselect-checkbox-list");
+      expect(checkboxListDiv).not.toBeVisible();
+    });
+  });
+
+  it("should focus the filter input when tabbing to a filterable trigger", async () => {
+    const Component = () => (
+      <>
+        <button data-testid="before">Before</button>
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          filterable={true}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+        </GoabDropdownMultiselect>
+      </>
+    );
+
+    const { getByTestId } = render(<Component />);
+    const before = getByTestId("before");
+
+    before.element().focus();
+    await userEvent.tab();
+
+    const filterInput = await vi.waitFor(() =>
+      getByTestId("dropdown-multiselect-filter-input"),
+    );
+    const filterInputEl = filterInput.element() as HTMLInputElement;
+    const host = (filterInputEl.getRootNode() as ShadowRoot).host as HTMLElement;
+
+    await vi.waitFor(() => {
+      expect(host.shadowRoot?.activeElement).toBe(filterInputEl);
+    });
+  });
+
+  it("should build a checkbox for each dropdown item", async () => {
+    const Component = () => (
+      <GoabDropdownMultiselect
+        name="fruit"
+        testId="dropdown-multiselect"
+        placeholder="Select fruit"
+      >
+        <GoabDropdownItem value="apple" label="Apple" />
+        <GoabDropdownItem value="banana" label="Banana" />
+        <GoabDropdownItem value="cherry" label="Cherry" />
+      </GoabDropdownMultiselect>
+    );
+
+    const { getByTestId } = render(<Component />);
+    const host = getByTestId("dropdown-multiselect");
+
+    await userEvent.click(host);
+
+    const checkboxList = getByTestId("dropdown-multiselect-checkbox-list");
+    await vi.waitFor(() => {
+      expect(renderedCheckboxNames(checkboxList.element() as HTMLElement)).toEqual([
+        "apple",
+        "banana",
+        "cherry",
+      ]);
+    });
+  });
+
+  describe("filtering", () => {
+    it("should show a filter input when filterable and open", async () => {
+      const Component = () => (
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          filterable={true}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+        </GoabDropdownMultiselect>
+      );
+
+      const { getByTestId } = render(<Component />);
+      const host = getByTestId("dropdown-multiselect");
+
+      await userEvent.click(host);
+
+      await vi.waitFor(() => {
+        const filterInput = getByTestId("dropdown-multiselect-filter-input");
+
+        expect(filterInput).toBeVisible();
+      });
+    });
+
+    it("should not show a filter input when filterable is not set", async () => {
+      const Component = () => (
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+        </GoabDropdownMultiselect>
+      );
+
+      const { getByTestId, container } = render(<Component />);
+      const host = getByTestId("dropdown-multiselect");
+
+      await userEvent.click(host);
+
+      await vi.waitFor(() => {
+        const checkboxListDiv = getByTestId("dropdown-multiselect-checkbox-list");
+        expect(checkboxListDiv).toBeVisible();
+      });
+
+      expect(
+        container.querySelector("[data-testid='dropdown-multiselect-filter-input']"),
+      ).toBeNull();
+    });
+
+    it("should only render matching checkboxes when typing", async () => {
+      const Component = () => (
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          filterable={true}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+          <GoabDropdownItem value="cherry" label="Cherry" />
+        </GoabDropdownMultiselect>
+      );
+
+      const { getByTestId } = render(<Component />);
+      const host = getByTestId("dropdown-multiselect");
+
+      await userEvent.click(host);
+
+      const filterInput = await vi.waitFor(() =>
+        getByTestId("dropdown-multiselect-filter-input"),
+      );
+      const checkboxList = getByTestId("dropdown-multiselect-checkbox-list");
+
+      await userEvent.type(filterInput, "b");
+
+      await vi.waitFor(() => {
+        expect(renderedCheckboxNames(checkboxList.element() as HTMLElement)).toEqual([
+          "banana",
+        ]);
+      });
+    });
+
+    it("should filter case-insensitively", async () => {
+      const Component = () => (
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          filterable={true}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+        </GoabDropdownMultiselect>
+      );
+
+      const { getByTestId } = render(<Component />);
+      const host = getByTestId("dropdown-multiselect");
+
+      await userEvent.click(host);
+
+      const filterInput = await vi.waitFor(() =>
+        getByTestId("dropdown-multiselect-filter-input"),
+      );
+      const checkboxList = getByTestId("dropdown-multiselect-checkbox-list");
+
+      await userEvent.type(filterInput, "A");
+
+      await vi.waitFor(() => {
+        expect(renderedCheckboxNames(checkboxList.element() as HTMLElement)).toEqual([
+          "apple",
+        ]);
+      });
+    });
+
+    it("should filter using the item's filter prop", async () => {
+      const Component = () => (
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          filterable={true}
+        >
+          <GoabDropdownItem value="apple" label="Apple" filter="red fruit" />
+          <GoabDropdownItem value="banana" label="Banana" filter="yellow fruit" />
+        </GoabDropdownMultiselect>
+      );
+
+      const { getByTestId } = render(<Component />);
+      const host = getByTestId("dropdown-multiselect");
+
+      await userEvent.click(host);
+
+      const filterInput = await vi.waitFor(() =>
+        getByTestId("dropdown-multiselect-filter-input"),
+      );
+      const checkboxList = getByTestId("dropdown-multiselect-checkbox-list");
+
+      await userEvent.type(filterInput, "yellow");
+
+      await vi.waitFor(() => {
+        expect(renderedCheckboxNames(checkboxList.element() as HTMLElement)).toEqual([
+          "banana",
+        ]);
+      });
+    });
+
+    it("should keep checked items selected when they are hidden by the filter", async () => {
+      const Component = () => {
+        const [value, setValues] = useState<string[]>([]);
+        return (
+          <>
+            <span data-testid="selected">{value.join(",")}</span>
+            <GoabDropdownMultiselect
+              name="fruit"
+              testId="dropdown-multiselect"
+              placeholder="Select fruit"
+              filterable={true}
+              value={value}
+              onChange={(e) => setValues(e.value)}
+            >
+              <GoabDropdownItem value="apple" label="Apple" />
+              <GoabDropdownItem value="banana" label="Banana" />
+            </GoabDropdownMultiselect>
+          </>
+        );
+      };
+
+      const { getByTestId } = render(<Component />);
+      const host = getByTestId("dropdown-multiselect");
+
+      await userEvent.click(host);
+
+      const checkboxList = getByTestId("dropdown-multiselect-checkbox-list");
+      await vi.waitFor(() => {
+        expect(renderedCheckboxNames(checkboxList.element() as HTMLElement)).toContain(
+          "banana",
+        );
+      });
+
+      const bananaCheckbox = renderedCheckboxes(
+        checkboxList.element() as HTMLElement,
+      ).find((cb) => checkboxName(cb) === "banana") as HTMLElement & {
+        shadowRoot?: ShadowRoot;
+      };
+      const bananaLabel = bananaCheckbox.shadowRoot?.querySelector(
+        "label",
+      ) as HTMLElement;
+      await userEvent.click(bananaLabel);
+
+      await vi.waitFor(() => {
+        expect(getByTestId("selected").element().textContent).toBe("banana");
+      });
+
+      const filterInput = await vi.waitFor(() =>
+        getByTestId("dropdown-multiselect-filter-input"),
+      );
+
+      await userEvent.type(filterInput, "a");
+
+      await vi.waitFor(() => {
+        expect(
+          renderedCheckboxNames(checkboxList.element() as HTMLElement),
+        ).not.toContain("banana");
+      });
+
+      expect(getByTestId("selected").element().textContent).toBe("banana");
+    });
+
+    it("should restore all checkboxes when the filter is cleared", async () => {
+      const Component = () => (
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          filterable={true}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+        </GoabDropdownMultiselect>
+      );
+
+      const { getByTestId } = render(<Component />);
+      const host = getByTestId("dropdown-multiselect");
+
+      await userEvent.click(host);
+
+      const filterInput = await vi.waitFor(() =>
+        getByTestId("dropdown-multiselect-filter-input"),
+      );
+      const checkboxList = getByTestId("dropdown-multiselect-checkbox-list");
+
+      await userEvent.type(filterInput, "b");
+
+      await vi.waitFor(() => {
+        expect(renderedCheckboxNames(checkboxList.element() as HTMLElement)).toEqual([
+          "banana",
+        ]);
+      });
+
+      await userEvent.clear(filterInput);
+
+      await vi.waitFor(() => {
+        expect(renderedCheckboxNames(checkboxList.element() as HTMLElement)).toEqual([
+          "apple",
+          "banana",
+        ]);
+      });
+    });
+
+    it("should clear the filter when the dropdown closes", async () => {
+      const Component = () => (
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          filterable={true}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+        </GoabDropdownMultiselect>
+      );
+
+      const { getByTestId } = render(<Component />);
+      const trigger = getByTestId("dropdown-multiselect-trigger");
+
+      await userEvent.click(trigger);
+
+      const filterInputBefore = await vi.waitFor(() =>
+        getByTestId("dropdown-multiselect-filter-input"),
+      );
+
+      await userEvent.type(filterInputBefore, "b");
+
+      await userEvent.keyboard("{Escape}");
+
+      await vi.waitFor(() => {
+        const input = trigger
+          .element()
+          .querySelector("[data-testid='dropdown-multiselect-filter-input']");
+        expect(input).toBeNull();
+      });
+
+      await userEvent.click(trigger);
+
+      const reopenedFilter = await vi.waitFor(() =>
+        trigger
+          .element()
+          .querySelector("[data-testid='dropdown-multiselect-filter-input']"),
+      );
+      expect((reopenedFilter as HTMLInputElement).value).toBe("");
+    });
+  });
+
+  describe("labelFormat", () => {
+    function getTriggerText(host: { element(): Element }): string {
+      const span = (host.element() as HTMLElement).querySelector(".value-display");
+      return span?.textContent?.trim() ?? "";
+    }
+
+    it("should show comma-separated labels when labelFormat is not set", async () => {
+      const { getByTestId } = render(
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          value={["apple", "banana"]}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+          <GoabDropdownItem value="cherry" label="Cherry" />
+        </GoabDropdownMultiselect>,
+      );
+
+      const host = getByTestId("dropdown-multiselect");
+      await vi.waitFor(() => {
+        expect(getTriggerText(host)).toBe("Apple, Banana");
+      });
+    });
+
+    it("should show the single item label when labelFormat is 'count' and one item is selected", async () => {
+      const { getByTestId } = render(
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          labelFormat="count"
+          value={["apple"]}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+          <GoabDropdownItem value="cherry" label="Cherry" />
+        </GoabDropdownMultiselect>,
+      );
+
+      const host = getByTestId("dropdown-multiselect");
+      await vi.waitFor(() => {
+        expect(getTriggerText(host)).toBe("Apple");
+      });
+    });
+
+    it("should show 'N items' when labelFormat is 'count' and multiple items are selected", async () => {
+      const { getByTestId } = render(
+        <GoabDropdownMultiselect
+          name="fruit"
+          testId="dropdown-multiselect"
+          placeholder="Select fruit"
+          labelFormat="count"
+          value={["apple", "banana", "cherry"]}
+        >
+          <GoabDropdownItem value="apple" label="Apple" />
+          <GoabDropdownItem value="banana" label="Banana" />
+          <GoabDropdownItem value="cherry" label="Cherry" />
+        </GoabDropdownMultiselect>,
+      );
+
+      const host = getByTestId("dropdown-multiselect");
+      await vi.waitFor(() => {
+        expect(getTriggerText(host)).toBe("3 items");
+      });
+    });
+
+    it("should switch from single label to 'N items' as second item is selected", async () => {
+      const Component = () => {
+        const [value, setValues] = useState<string[]>([]);
+        return (
+          <GoabDropdownMultiselect
+            name="fruit"
+            testId="dropdown-multiselect"
+            placeholder="Select fruit"
+            labelFormat="count"
+            value={value}
+            onChange={(e) => setValues(e.value)}
+          >
+            <GoabDropdownItem value="apple" label="Apple" />
+            <GoabDropdownItem value="banana" label="Banana" />
+          </GoabDropdownMultiselect>
+        );
+      };
+
+      const { getByTestId } = render(<Component />);
+      const host = getByTestId("dropdown-multiselect");
+
+      await userEvent.click(host);
+
+      const checkboxList = getByTestId("dropdown-multiselect-checkbox-list");
+      await vi.waitFor(() => {
+        expect(renderedCheckboxNames(checkboxList.element() as HTMLElement)).toContain(
+          "apple",
+        );
+      });
+
+      const appleCheckbox = renderedCheckboxes(
+        checkboxList.element() as HTMLElement,
+      ).find((cb) => checkboxName(cb) === "apple") as HTMLElement & {
+        shadowRoot?: ShadowRoot;
+      };
+      await userEvent.click(
+        appleCheckbox.shadowRoot?.querySelector("label") as HTMLElement,
+      );
+
+      await vi.waitFor(() => {
+        expect(getTriggerText(host)).toBe("Apple");
+      });
+
+      const bananaCheckbox = renderedCheckboxes(
+        checkboxList.element() as HTMLElement,
+      ).find((cb) => checkboxName(cb) === "banana") as HTMLElement & {
+        shadowRoot?: ShadowRoot;
+      };
+      await userEvent.click(
+        bananaCheckbox.shadowRoot?.querySelector("label") as HTMLElement,
+      );
+
+      await vi.waitFor(() => {
+        expect(getTriggerText(host)).toBe("2 items");
+      });
+    });
+  });
+
+  it("filter with select all should only select filtered items", async () => {
+    const Component = () => {
+      return (
+        <GoabDropdownMultiselect
+          name="stuff-and-things"
+          testId="dropdown-multiselect"
+          placeholder="Select Stuff and/or things"
+          filterable={true}
+          showSelectAll={true}
+        >
+          <GoabDropdownItem value="Stuff1" label="Stuff1" />
+          <GoabDropdownItem value="Thing1" label="Thing1" />
+          <GoabDropdownItem value="Stuff2" label="Stuff2" />
+          <GoabDropdownItem value="Thing2" label="Thing2" />
+          <GoabDropdownItem value="Stuff3" label="Stuff3" />
+          <GoabDropdownItem value="Thing3" label="Thing3" />
+        </GoabDropdownMultiselect>
+      );
+    };
+
+    const { getByTestId } = render(<Component />);
+    const host = getByTestId("dropdown-multiselect");
+
+    await userEvent.click(host);
+
+    const filterInput = await vi.waitFor(() =>
+      getByTestId("dropdown-multiselect-filter-input"),
+    );
+
+    await userEvent.type(filterInput, "Stuff");
+
+    const selectAllCheckbox = getByTestId("dropdown-multiselect-select-all");
+    await userEvent.click(selectAllCheckbox);
+
+    await vi.waitFor(() => {
+      const checkboxList = getByTestId("dropdown-multiselect-checkbox-list");
+      expect(renderedCheckboxNames(checkboxList.element() as HTMLElement)).toEqual([
+        "Stuff1",
+        "Stuff2",
+        "Stuff3",
+      ]);
+    });
+  });
+});

--- a/libs/react-components/src/index.ts
+++ b/libs/react-components/src/index.ts
@@ -20,6 +20,7 @@ export * from "./lib/divider/divider";
 export * from "./lib/drawer/drawer";
 export * from "./lib/dropdown/dropdown";
 export * from "./lib/dropdown/dropdown-item";
+export * from "./lib/dropdown-multiselect/dropdown-multiselect";
 export * from "./lib/file-upload-card/file-upload-card";
 export * from "./lib/file-upload-input/file-upload-input";
 export * from "./lib/footer/footer";

--- a/libs/react-components/src/lib/dropdown-multiselect/dropdown-multiselect.spec.tsx
+++ b/libs/react-components/src/lib/dropdown-multiselect/dropdown-multiselect.spec.tsx
@@ -1,0 +1,99 @@
+import { render } from "@testing-library/react";
+import { fireEvent } from "@testing-library/dom";
+import GoabDropdownMultiselect, {
+  GoabDropdownMultiselectProps,
+} from "./dropdown-multiselect";
+import { GoabDropdownItem } from "../dropdown/dropdown-item";
+import { describe, it, expect, vi } from "vitest";
+import { GoabDropdownMultiselectOnChangeDetail } from "@abgov/ui-components-common";
+
+describe("GoabDropdownMultiselect", () => {
+  it("should render with required props", () => {
+    render(<GoabDropdownMultiselect name="fruit" />);
+
+    const el = document.querySelector("goa-dropdown-multiselect");
+    expect(el?.getAttribute("name")).toBe("fruit");
+    expect(el?.getAttribute("disabled")).toBeNull();
+    expect(el?.getAttribute("error")).toBeNull();
+  });
+
+  it("should render with all props", () => {
+    const props: GoabDropdownMultiselectProps = {
+      name: "fruit",
+      value: ["apple", "banana"],
+      placeholder: "Select fruit",
+      disabled: true,
+      error: true,
+      testId: "test-multiselect",
+      ariaLabel: "Choose fruit",
+      ariaLabelledBy: "fruit-label",
+      maxHeight: "300px",
+      width: "400px",
+      size: "compact",
+      labelFormat: "count",
+      showSelectAll: true,
+      mt: "s",
+      mr: "m",
+      mb: "l",
+      ml: "xl",
+    };
+
+    render(<GoabDropdownMultiselect {...props} />);
+
+    const el = document.querySelector("goa-dropdown-multiselect");
+    expect(el?.getAttribute("name")).toBe("fruit");
+    expect(el?.getAttribute("placeholder")).toBe("Select fruit");
+    expect(el?.getAttribute("disabled")).toBe("true");
+    expect(el?.getAttribute("error")).toBe("true");
+    expect(el?.getAttribute("testid")).toBe("test-multiselect");
+    expect(el?.getAttribute("aria-label")).toBe("Choose fruit");
+    expect(el?.getAttribute("aria-labelledby")).toBe("fruit-label");
+    expect(el?.getAttribute("max-height")).toBe("300px");
+    expect(el?.getAttribute("width")).toBe("400px");
+    expect(el?.getAttribute("size")).toBe("compact");
+    expect(el?.getAttribute("label-format")).toBe("count");
+    expect(el?.getAttribute("show-select-all")).toBe("true");
+    expect(el?.getAttribute("mt")).toBe("s");
+    expect(el?.getAttribute("mr")).toBe("m");
+    expect(el?.getAttribute("mb")).toBe("l");
+    expect(el?.getAttribute("ml")).toBe("xl");
+  });
+
+  it("should not set disabled or error attributes when false", () => {
+    render(<GoabDropdownMultiselect name="fruit" disabled={false} error={false} />);
+
+    const el = document.querySelector("goa-dropdown-multiselect");
+    expect(el?.getAttribute("disabled")).toBeNull();
+    expect(el?.getAttribute("error")).toBeNull();
+  });
+
+  it("should fire onChange callback on _change event", () => {
+    const onChange = vi.fn();
+    render(<GoabDropdownMultiselect name="fruit" onChange={onChange} />);
+
+    const el = document.querySelector("goa-dropdown-multiselect") as HTMLElement;
+    const detail: Omit<GoabDropdownMultiselectOnChangeDetail, "event"> = {
+      name: "fruit",
+      value: ["apple"],
+      labels: ["Apple"],
+    };
+
+    fireEvent(el, new CustomEvent("_change", { detail, bubbles: true }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].name).toBe("fruit");
+    expect(onChange.mock.calls[0][0].value).toEqual(["apple"]);
+    expect(onChange.mock.calls[0][0].labels).toEqual(["Apple"]);
+  });
+
+  it("should render children", () => {
+    render(
+      <GoabDropdownMultiselect name="fruit">
+        <GoabDropdownItem value="apple" label="Apple" />
+      </GoabDropdownMultiselect>,
+    );
+
+    const child = document.querySelector("goa-dropdown-item");
+    expect(child).toBeTruthy();
+  });
+});

--- a/libs/react-components/src/lib/dropdown-multiselect/dropdown-multiselect.tsx
+++ b/libs/react-components/src/lib/dropdown-multiselect/dropdown-multiselect.tsx
@@ -1,0 +1,145 @@
+import {
+  GoabDropdownMultiselectLabelFormatOptions,
+  GoabDropdownMultiselectOnChangeDetail,
+  GoabDropdownMultiselectSize,
+  GoabIconType,
+  Margins,
+} from "@abgov/ui-components-common";
+import { useEffect, useRef, type JSX } from "react";
+
+interface WCProps extends Margins {
+  ref: React.RefObject<HTMLElement | null>;
+  name: string;
+  value?: string[];
+  placeholder?: string;
+  disabled?: string;
+  error?: string;
+  filterable?: string;
+  "leading-icon"?: string;
+  testid?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  "max-height"?: string;
+  width?: string;
+  size?: GoabDropdownMultiselectSize;
+  "label-format"?: string;
+  "show-select-all"?: string;
+}
+
+declare module "react" {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      "goa-dropdown-multiselect": WCProps & React.HTMLAttributes<HTMLElement>;
+    }
+  }
+}
+
+export interface GoabDropdownMultiselectProps extends Margins {
+  /** @required Identifier for the group. Used in change events. */
+  name: string;
+  /** Array of currently selected checkbox value. */
+  value?: string[];
+  /** Text shown when nothing is selected. */
+  placeholder?: string;
+  /** Enables filtering of options by typing in the trigger. */
+  filterable?: boolean;
+  /** Icon shown to the left of the dropdown input. */
+  leadingIcon?: GoabIconType;
+  /** Disables the component.  @default false */
+  disabled?: boolean;
+  /** Shows an error state.  @default false */
+  error?: boolean;
+  /** Sets a data-testid attribute for automated testing. */
+  testId?: string;
+  /** Provides an accessible label when no visible label is associated. */
+  ariaLabel?: string;
+  /** References an external element that labels this component. */
+  ariaLabelledBy?: string;
+  /** Sets the maximum height of the dropdown content area. @default "276px" */
+  maxHeight?: string;
+  /** Sets a fixed width for the component and popover panel. */
+  width?: string;
+  /** Sets the size variant. @default "default" */
+  size?: GoabDropdownMultiselectSize;
+  /** The display label format of the closed dropdown. When 'count' the display label shows only "n items" in the label, when 'list' it shows a comma separated list of selected item labels. @default "list" */
+  labelFormat?: GoabDropdownMultiselectLabelFormatOptions;
+  /** Shows a "Select All" checkbox at the top of the options list. @default false */
+  showSelectAll?: boolean;
+  /** Dropdown items rendered inside the component (GoabDropdownItem elements). */
+  children?: React.ReactNode;
+  /** Callback fired when the selected value change. */
+  onChange?: (detail: GoabDropdownMultiselectOnChangeDetail) => void;
+}
+
+/** A dropdown that presents a list of checkboxes for multiple selection. */
+export function GoabDropdownMultiselect({
+  name,
+  value = [],
+  placeholder,
+  disabled,
+  error,
+  filterable,
+  leadingIcon,
+  showSelectAll,
+  testId,
+  ariaLabel,
+  ariaLabelledBy,
+  maxHeight,
+  width,
+  size = "default",
+  labelFormat,
+  children,
+  onChange,
+  mt,
+  mr,
+  mb,
+  ml,
+}: GoabDropdownMultiselectProps): JSX.Element {
+  const el = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!el.current) return;
+
+    const current = el.current;
+    const listener = (e: Event) => {
+      const detail = (e as CustomEvent<GoabDropdownMultiselectOnChangeDetail>).detail;
+      onChange?.({ ...detail, event: e });
+    };
+
+    current.addEventListener("_change", listener);
+
+    return () => {
+      current.removeEventListener("_change", listener);
+    };
+  }, [onChange]);
+
+  return (
+    <goa-dropdown-multiselect
+      ref={el}
+      name={name}
+      value={value}
+      placeholder={placeholder}
+      disabled={disabled ? "true" : undefined}
+      error={error ? "true" : undefined}
+      filterable={filterable ? "true" : undefined}
+      leading-icon={leadingIcon}
+      testid={testId}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      max-height={maxHeight}
+      width={width}
+      size={size}
+      label-format={labelFormat ? labelFormat : undefined}
+      show-select-all={showSelectAll ? "true" : undefined}
+      mt={mt}
+      mr={mr}
+      mb={mb}
+      ml={ml}
+    >
+      {children}
+    </goa-dropdown-multiselect>
+  );
+}
+
+export default GoabDropdownMultiselect;

--- a/libs/web-components/src/common/filtering.ts
+++ b/libs/web-components/src/common/filtering.ts
@@ -1,0 +1,32 @@
+export type FilterOption = {
+  label: string;
+  value: string;
+  filter: string;
+};
+
+// Match against the filter text and the text the user sees, which is the
+// label, or the value when no label is set. Both are searched so that adding
+// a filter supplies extra search terms rather than replacing the visible text.
+export function isFilterMatch(
+  option: FilterOption,
+  filter: string,
+  partialMatch = true,
+) {
+  // empty string matches all
+  if (filter.length === 0) return true;
+
+  const targets = [option.filter, option.label || option.value].filter(
+    (target) => target !== "",
+  );
+  filter = filter.toLowerCase().trim();
+
+  return targets.some((target) => {
+    const value = target.toLowerCase();
+
+    if (!partialMatch) {
+      return value === filter;
+    }
+
+    return value.startsWith(filter) || value.includes(" " + filter);
+  });
+}

--- a/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
+++ b/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
@@ -283,7 +283,10 @@
    */
   function onChildCheckboxMount(detail: FormFieldMountRelayDetail) {
     const checkboxElement = (detail.el.getRootNode() as any)?.host;
-    if (!checkboxElement || checkboxElement.tagName.toLowerCase() !== "goa-checkbox") {
+    if (
+      !checkboxElement ||
+      checkboxElement.tagName.toLowerCase() !== "goa-checkbox"
+    ) {
       return;
     }
 
@@ -308,7 +311,15 @@
       const detail = customEvent.detail;
       e.stopPropagation();
 
-      if (detail && detail.value !== undefined) {
+      // Only react to real user check changes. Parent-to-child sync events
+      // from Checkbox.onSetValue dispatch _change without a `checked` field,
+      // and treating those as user actions creates a feedback loop that
+      // wipes out the selection.
+      if (
+        detail &&
+        detail.value !== undefined &&
+        typeof detail.checked === "boolean"
+      ) {
         handleChildCheckboxChange(detail);
       }
     });
@@ -439,7 +450,12 @@
   data-testid={testid}
   on:focus={onFocus}
 >
-  <div bind:this={_slotEl} class="checkbox-container" class:v2={version === "2"} class:compact={size === "compact"}>
+  <div
+    bind:this={_slotEl}
+    class="checkbox-container"
+    class:v2={version === "2"}
+    class:compact={size === "compact"}
+  >
     <slot />
   </div>
 </div>

--- a/libs/web-components/src/components/dropdown-multiselect/DropdownMultiselect.spec.ts
+++ b/libs/web-components/src/components/dropdown-multiselect/DropdownMultiselect.spec.ts
@@ -1,0 +1,430 @@
+import { cleanup, render, waitFor, fireEvent } from "@testing-library/svelte";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { tick } from "svelte";
+import DropdownMultiselect from "./DropdownMultiselect.svelte";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("GoADropdownMultiselect", () => {
+  const defaultProps = {
+    name: "fruit",
+    testid: "dropdown-multiselect",
+    placeholder: "Select fruit",
+  };
+
+  describe("Rendering", () => {
+    it("should render with default props", async () => {
+      const { queryByTestId } = render(DropdownMultiselect, defaultProps);
+      const root = queryByTestId("dropdown-multiselect");
+      expect(root).toBeTruthy();
+    });
+
+    it("should show placeholder when no values selected", async () => {
+      const { container } = render(DropdownMultiselect, defaultProps);
+      const placeholder = container.querySelector(".placeholder");
+      expect(placeholder).toBeTruthy();
+      expect(placeholder?.textContent?.trim()).toBe("Select fruit");
+    });
+
+    it("should not show placeholder when values are selected", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        value: ["apple"],
+      });
+      const placeholder = container.querySelector(".placeholder");
+      expect(placeholder).toBeNull();
+    });
+
+    it("should show comma-separated display text for selected values", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        value: ["apple", "banana"],
+      });
+      const valueDisplay = container.querySelector(".value-display");
+      expect(valueDisplay?.textContent?.trim()).toBe("apple, banana");
+    });
+  });
+
+  describe("ARIA attributes", () => {
+    it("should render trigger with combobox role", async () => {
+      const { container } = render(DropdownMultiselect, defaultProps);
+      const trigger = container.querySelector(".trigger");
+      expect(trigger?.getAttribute("role")).toBe("combobox");
+    });
+
+    it("should set aria-haspopup to dialog", async () => {
+      const { container } = render(DropdownMultiselect, defaultProps);
+      const trigger = container.querySelector(".trigger");
+      expect(trigger?.getAttribute("aria-haspopup")).toBe("dialog");
+    });
+
+    it("should set aria-expanded to false when closed", async () => {
+      const { container } = render(DropdownMultiselect, defaultProps);
+      const trigger = container.querySelector(".trigger");
+      expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("should apply aria-label", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        ariaLabel: "Select fruits",
+      });
+      const trigger = container.querySelector(".trigger");
+      expect(trigger?.getAttribute("aria-label")).toBe("Select fruits");
+    });
+  });
+
+  describe("Disabled state", () => {
+    it("should apply disabled class when disabled", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        disabled: "true",
+      });
+      const trigger = container.querySelector(".trigger");
+      expect(trigger?.classList.contains("disabled")).toBe(true);
+    });
+
+    it("should set tabindex to -1 when disabled", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        disabled: "true",
+      });
+      const trigger = container.querySelector(".trigger");
+      expect(trigger?.getAttribute("tabindex")).toBe("-1");
+    });
+
+    it("should set aria-disabled when disabled", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        disabled: "true",
+      });
+      const trigger = container.querySelector(".trigger");
+      expect(trigger?.getAttribute("aria-disabled")).toBe("true");
+    });
+  });
+
+  describe("Error state", () => {
+    it("should apply error class when error is true", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        error: "true",
+      });
+      const trigger = container.querySelector(".trigger");
+      expect(trigger?.classList.contains("error")).toBe(true);
+    });
+  });
+
+  describe("Size", () => {
+    it("should apply compact class when size is compact", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        size: "compact",
+      });
+      const trigger = container.querySelector(".trigger");
+      expect(trigger?.classList.contains("compact")).toBe(true);
+    });
+  });
+
+  describe("Margins", () => {
+    it("should apply margin styles", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        mt: "m",
+        mb: "l",
+      });
+      const root = container.querySelector(".root") as HTMLElement;
+      expect(root?.getAttribute("style")).toContain("margin-top");
+    });
+  });
+
+  describe("Keyboard interaction", () => {
+    it("should set aria-expanded to true on ArrowDown keydown", async () => {
+      const { container } = render(DropdownMultiselect, defaultProps);
+      const trigger = container.querySelector(".trigger") as HTMLElement;
+
+      await fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+      await waitFor(() => {
+        expect(trigger.getAttribute("aria-expanded")).toBe("true");
+      });
+    });
+
+    it("should set aria-expanded to true on Enter keydown", async () => {
+      const { container } = render(DropdownMultiselect, defaultProps);
+      const trigger = container.querySelector(".trigger") as HTMLElement;
+
+      await fireEvent.keyDown(trigger, { key: "Enter" });
+
+      await waitFor(() => {
+        expect(trigger.getAttribute("aria-expanded")).toBe("true");
+      });
+    });
+
+    it("should set aria-expanded to true on Space keydown", async () => {
+      const { container } = render(DropdownMultiselect, defaultProps);
+      const trigger = container.querySelector(".trigger") as HTMLElement;
+
+      await fireEvent.keyDown(trigger, { key: " " });
+
+      await waitFor(() => {
+        expect(trigger.getAttribute("aria-expanded")).toBe("true");
+      });
+    });
+
+    it("should not open when disabled and ArrowDown pressed", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        disabled: "true",
+      });
+      const trigger = container.querySelector(".trigger") as HTMLElement;
+
+      await fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+      await waitFor(() => {
+        expect(trigger.getAttribute("aria-expanded")).toBe("false");
+      });
+    });
+  });
+
+  describe("Select All", () => {
+    // Simulate goa-dropdown-item mount relay so _options gets populated.
+    // Must await: onMount has an `await tick()` before addRelayListener, so we
+    // need one tick to pass before the listener is registered.
+    async function addOption(
+      rootEl: HTMLElement,
+      value: string,
+      label: string,
+    ) {
+      await tick();
+      rootEl.dispatchEvent(
+        new CustomEvent("msg", {
+          detail: {
+            action: "dropdown-item:mounted",
+            data: {
+              el: document.createElement("span"),
+              value,
+              label,
+              mountType: "append",
+            },
+          },
+        }),
+      );
+    }
+
+    it("should not render Select All checkbox by default", async () => {
+      const { container } = render(DropdownMultiselect, defaultProps);
+      const selectAll = container.querySelector(
+        "goa-checkbox[name='select-all']",
+      );
+      expect(selectAll).toBeNull();
+    });
+
+    it("should not render Select All when no options exist", async () => {
+      const { container } = render(DropdownMultiselect, {
+        ...defaultProps,
+        showSelectAll: "true",
+      });
+      const selectAll = container.querySelector(
+        "goa-checkbox[name='select-all']",
+      );
+      expect(selectAll).toBeNull();
+    });
+
+    it("should render Select All checkbox when selectall=true and options exist", async () => {
+      const { container, queryByTestId } = render(DropdownMultiselect, {
+        ...defaultProps,
+        showSelectAll: "true",
+      });
+      const rootEl = queryByTestId("dropdown-multiselect") as HTMLElement;
+      await addOption(rootEl, "apple", "Apple");
+      await addOption(rootEl, "banana", "Banana");
+
+      await waitFor(() => {
+        const selectAll = container.querySelector(
+          "goa-checkbox[name='select-all']",
+        );
+        expect(selectAll).not.toBeNull();
+      });
+    });
+
+    it("should render a divider after Select All when options exist", async () => {
+      const { container, queryByTestId } = render(DropdownMultiselect, {
+        ...defaultProps,
+        showSelectAll: "true",
+      });
+      const rootEl = queryByTestId("dropdown-multiselect") as HTMLElement;
+      await addOption(rootEl, "apple", "Apple");
+
+      await waitFor(() => {
+        const divider = container.querySelector("hr.select-all-divider");
+        expect(divider).not.toBeNull();
+      });
+    });
+
+    it("should dispatch _change with all values when Select All is checked", async () => {
+      const { container, queryByTestId } = render(DropdownMultiselect, {
+        ...defaultProps,
+        showSelectAll: "true",
+      });
+      const rootEl = queryByTestId("dropdown-multiselect") as HTMLElement;
+      const handler = vi.fn();
+      rootEl.addEventListener("_change", handler);
+
+      await addOption(rootEl, "apple", "Apple");
+      await addOption(rootEl, "banana", "Banana");
+
+      let selectAll: Element | null = null;
+      await waitFor(() => {
+        selectAll = container.querySelector("goa-checkbox[name='select-all']");
+        expect(selectAll).not.toBeNull();
+      });
+
+      selectAll!.dispatchEvent(
+        new CustomEvent("_change", {
+          detail: { name: selectAll, checked: true, value: selectAll },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(handler).toHaveBeenCalledTimes(1);
+        const detail = (handler.mock.calls[0][0] as CustomEvent).detail;
+        expect(detail.value).toEqual(["apple", "banana"]);
+      });
+    });
+
+    it("should dispatch _change with empty values when Select All is unchecked", async () => {
+      const { container, queryByTestId } = render(DropdownMultiselect, {
+        ...defaultProps,
+        showSelectAll: "true",
+        value: ["apple", "banana"],
+      });
+      const rootEl = queryByTestId("dropdown-multiselect") as HTMLElement;
+      const handler = vi.fn();
+      rootEl.addEventListener("_change", handler);
+
+      await addOption(rootEl, "apple", "Apple");
+      await addOption(rootEl, "banana", "Banana");
+
+      let selectAll: Element | null = null;
+      await waitFor(() => {
+        selectAll = container.querySelector("goa-checkbox[name='select-all']");
+        expect(selectAll).not.toBeNull();
+      });
+
+      selectAll!.dispatchEvent(
+        new CustomEvent("_change", {
+          detail: { name: selectAll, checked: false, value: "" },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(handler).toHaveBeenCalledTimes(1);
+        const detail = (handler.mock.calls[0][0] as CustomEvent).detail;
+        expect(detail.value).toEqual([]);
+      });
+    });
+
+    it("should set checked=true on Select All when all options are selected", async () => {
+      const { queryByTestId } = render(DropdownMultiselect, {
+        ...defaultProps,
+        showSelectAll: "true",
+        value: ["apple", "banana"],
+      });
+      const rootEl = queryByTestId("dropdown-multiselect") as HTMLElement;
+      await addOption(rootEl, "apple", "Apple");
+      await addOption(rootEl, "banana", "Banana");
+
+      await waitFor(() => {
+        const selectAll = queryByTestId(
+          "dropdown-multiselect-select-all",
+        ) as HTMLElement;
+        expect(selectAll?.getAttribute("checked")).toBe("true");
+        expect(selectAll?.getAttribute("indeterminate")).toBe("false");
+      });
+    });
+
+    it("should set indeterminate=true on Select All when some options are selected", async () => {
+      const { queryByTestId } = render(DropdownMultiselect, {
+        ...defaultProps,
+        showSelectAll: "true",
+        value: ["apple"],
+      });
+      const rootEl = queryByTestId("dropdown-multiselect") as HTMLElement;
+      await addOption(rootEl, "apple", "Apple");
+      await addOption(rootEl, "banana", "Banana");
+
+      await waitFor(() => {
+        const selectAll = queryByTestId(
+          "dropdown-multiselect-select-all",
+        ) as HTMLElement;
+        expect(selectAll?.getAttribute("checked")).toBe("false");
+        expect(selectAll?.getAttribute("indeterminate")).toBe("true");
+      });
+    });
+
+    it("should set checked=false and indeterminate=false on Select All when no options are selected", async () => {
+      const { queryByTestId } = render(DropdownMultiselect, {
+        ...defaultProps,
+        showSelectAll: "true",
+        value: [],
+      });
+      const rootEl = queryByTestId("dropdown-multiselect") as HTMLElement;
+      await addOption(rootEl, "apple", "Apple");
+      await addOption(rootEl, "banana", "Banana");
+
+      await waitFor(() => {
+        const selectAll = queryByTestId(
+          "dropdown-multiselect-select-all",
+        ) as HTMLElement;
+        expect(selectAll?.getAttribute("checked")).toBe("false");
+        expect(selectAll?.getAttribute("indeterminate")).toBe("false");
+      });
+    });
+  });
+
+  describe("Change event", () => {
+    it("should dispatch _change event when checkbox list changes", async () => {
+      const { container } = render(DropdownMultiselect, defaultProps);
+      const root = container.querySelector(
+        "[data-testid='dropdown-multiselect']",
+      ) as HTMLElement;
+      const handler = vi.fn();
+      root.addEventListener("_change", handler);
+
+      // A dropdown item relays its registration, which populates the options
+      // and causes the internal checkbox list to render.
+      const item = document.createElement("goa-dropdown-item");
+      item.setAttribute("value", "apple");
+      item.setAttribute("label", "Apple");
+      root.appendChild(item);
+
+      let checkboxList: Element | null = null;
+      await waitFor(() => {
+        checkboxList = container.querySelector("goa-checkbox-list");
+        expect(checkboxList).not.toBeNull();
+      });
+
+      checkboxList!.dispatchEvent(
+        new CustomEvent("_change", {
+          detail: { name: "fruit", value: ["apple"] },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(handler).toHaveBeenCalledTimes(1);
+        const detail = (handler.mock.calls[0][0] as CustomEvent).detail;
+        expect(detail.name).toBe("fruit");
+        expect(detail.value).toEqual(["apple"]);
+      });
+    });
+  });
+});

--- a/libs/web-components/src/components/dropdown-multiselect/DropdownMultiselect.svelte
+++ b/libs/web-components/src/components/dropdown-multiselect/DropdownMultiselect.svelte
@@ -1,0 +1,831 @@
+<svelte:options
+  customElement={{
+    tag: "goa-dropdown-multiselect",
+    props: {
+      labelFormat: {
+        type: "String",
+        attribute: "label-format",
+        reflect: true,
+      },
+      filterable: {
+        type: "Boolean",
+        attribute: "filterable",
+        reflect: true,
+      },
+      showSelectAll: {
+        type: "Boolean",
+        attribute: "show-select-all",
+        reflect: true,
+      },
+      leadingIcon: {
+        type: "String",
+        attribute: "leading-icon",
+        reflect: true,
+      },
+      ariaLabel: {
+        type: "String",
+        attribute: "aria-label",
+        reflect: true,
+      },
+      ariaLabelledBy: {
+        type: "String",
+        attribute: "aria-labelledby",
+        reflect: true,
+      },
+      maxHeight: {
+        type: "String",
+        attribute: "max-height",
+        reflect: true,
+      },
+    },
+  }}
+/>
+
+<script lang="ts">
+  import { onDestroy, onMount, tick } from "svelte";
+  import type { Spacing } from "../../common/styling";
+  import { calculateMargin } from "../../common/styling";
+  import {
+    dispatch,
+    ensureSlotExists,
+    findFirstFocusableNode,
+    fromBoolean,
+    generateRandomId,
+    receive,
+    relay,
+    style,
+    styles,
+    toBoolean,
+    typeValidator,
+    validateRequired,
+  } from "../../common/utils";
+  import { isFilterMatch } from "../../common/filtering";
+  import type {
+    DropdownItemMountedRelayDetail,
+    DropdownItemDestroyRelayDetail,
+    Option,
+  } from "../dropdown/DropdownItem.svelte";
+  import {
+    DropdownItemMountedMsg,
+    DropdownItemDestroyMsg,
+  } from "../dropdown/DropdownItem.svelte";
+  import { GoAIconType } from "../icon/Icon.svelte";
+  import {
+    FieldsetErrorRelayDetail,
+    FieldsetResetErrorsMsg,
+    FieldsetResetFieldsMsg,
+    FieldsetSetErrorMsg,
+    FieldsetSetValueMsg,
+    FieldsetSetValueRelayDetail,
+  } from "../../types/relay-types";
+
+  const [Size, validateSize] = typeValidator("Size", ["default", "compact"]);
+  const [LabelFormat, validateLabelFormat] = typeValidator("LabelFormat", [
+    "count",
+    "list",
+  ]);
+  function validateLeadingIcon() {
+    if (filterable && leadingIcon) {
+      throw new Error(
+        "Invalid leadingIcon: when filterable is true the leading icon will only be 'search'.",
+      );
+    }
+  }
+
+  /** @required Identifier for the group. Used in change events. */
+  export let name: string;
+  /** Array of currently selected checkbox values. */
+  export let value: string[] = [];
+  /** Text shown when nothing is selected. */
+  export let placeholder: string = "";
+  /** Enables filtering of options by typing in the trigger. */
+  export let filterable: boolean = false;
+  /** Icon shown to the left of the dropdown input. When "filterable" is true this can only be "search". */
+  export let leadingIcon: GoAIconType | null = null;
+  /** Disables the component. @default false */
+  export let disabled: boolean = false;
+  /** Shows an error state. @default false */
+  export let error: boolean = false;
+  /** Sets a data-testid attribute for automated testing. */
+  export let testid: string = "";
+  /** Provides an accessible label when no visible label is associated. */
+  export let ariaLabel: string = "";
+  /** References an external element that labels this component. */
+  export let ariaLabelledBy: string = "";
+  /** Sets the maximum height of the dropdown content area. @default "276px" */
+  export let maxHeight: string = "276px";
+  /** Sets a fixed width for the component and popover panel. */
+  export let width: string = "";
+  /** Sets the size variant. */
+  export let size: "default" | "compact" = "default";
+  /** The display label format of the closed dropdown. When 'count' the display label shows only "n items" in the label, when 'list' it shows a comma separated list of selected item labels. @default "list" */
+  export let labelFormat: "count" | "list" = "list";
+  /** Shows a "Select All" checkbox at the top of the options list. @default false */
+  export let showSelectAll: boolean = false;
+  /** Top margin. */
+  export let mt: Spacing = null;
+  /** Right margin. */
+  export let mr: Spacing = null;
+  /** Bottom margin. */
+  export let mb: Spacing = null;
+  /** Left margin. */
+  export let ml: Spacing = null;
+
+  // Private state
+  let _rootEl: HTMLElement;
+  let _triggerEl: HTMLElement;
+  let _popoverEl: HTMLElement;
+  let _checkboxListEl: HTMLElement;
+  let _isOpen = false;
+  let _options: Option[] = [];
+  let _popoverWidth = "";
+  let _resizeObserver: ResizeObserver | null = null;
+  const _contentId = `goa-dropdown-multiselect-content-${generateRandomId()}`;
+  let _filterText = "";
+  let _filterInputEl: HTMLInputElement | undefined;
+  let _selectAllEl: HTMLElement | undefined;
+  let _focusedIndex = -1;
+  let _isTriggerMouseDown = false;
+  let _skipNextTriggerFocusOpen = false;
+  let _prevError = error;
+
+  // Reactive
+  $: value = Array.isArray(value) ? value : [];
+  $: _hasValue = value.length > 0;
+  // Select All is indeterminate if only some, not all visible selected
+  $: _someVisibleSelected =
+    !_allVisibleSelected &&
+    _visibleOptions.some((vo) => value.includes(vo.value));
+  // All Visible selected if there are visible options and all are selected
+  $: _allVisibleSelected =
+    _visibleOptions.length > 0 &&
+    _visibleOptions.every((vo) => value.includes(vo.value));
+  $: _labelMap = Object.fromEntries(
+    _options.map((o) => [o.value, o.label || o.value]),
+  );
+  $: _displayText = calculateDisplayText(value, _labelMap);
+  // Filter the options based on _filterText if filterable is true
+  $: _visibleOptions =
+    filterable && _filterText.trim()
+      ? _options.filter((o) => isFilterMatch(o, _filterText))
+      : _options;
+
+  // When the error state changes, dispatch error::change to notify the fieldset
+  $: {
+    if (error !== _prevError) {
+      dispatch(_rootEl, "error::change", { isError: error }, { bubbles: true });
+      _prevError = error;
+    }
+  }
+
+  onMount(async () => {
+    await tick();
+    validateSize(size);
+    validateLabelFormat(labelFormat);
+    validateLeadingIcon();
+    validateRequired("DropdownMultiselect", { name });
+
+    ensureSlotExists(_rootEl);
+    addRelayListener();
+    updatePopoverWidth();
+
+    if (_rootEl && typeof ResizeObserver !== "undefined") {
+      _resizeObserver = new ResizeObserver(updatePopoverWidth);
+      _resizeObserver.observe(_rootEl);
+    }
+
+    _popoverEl?.addEventListener("_open", handlePopoverOpen);
+    _popoverEl?.addEventListener("_close", handlePopoverClose);
+  });
+
+  onDestroy(() => {
+    _resizeObserver?.disconnect();
+  });
+
+  function calculateDisplayText(
+    values: string[],
+    labelMap: Record<string, string>,
+  ) {
+    if (labelFormat === "count" && values.length > 1) {
+      return `${values.length} items`;
+    }
+
+    return values.map((v) => labelMap[v] || v).join(", ");
+  }
+
+  function updatePopoverWidth() {
+    if (_rootEl) {
+      _popoverWidth = `${_rootEl.offsetWidth}px`;
+    }
+  }
+
+  function addRelayListener() {
+    receive(_rootEl, (action, data) => {
+      switch (action) {
+        case FieldsetSetValueMsg:
+          onSetValue(data as FieldsetSetValueRelayDetail);
+          break;
+        case FieldsetSetErrorMsg:
+          setError(data as FieldsetErrorRelayDetail);
+          break;
+        case FieldsetResetErrorsMsg:
+          error = false;
+          break;
+        case FieldsetResetFieldsMsg:
+          onSetValue({ name, value: "" });
+          break;
+        case DropdownItemMountedMsg:
+          onChildMounted(data as DropdownItemMountedRelayDetail);
+          break;
+        case DropdownItemDestroyMsg:
+          onChildDestroyed(data as DropdownItemDestroyRelayDetail);
+          break;
+      }
+    });
+  }
+
+  function onChildMounted(detail: DropdownItemMountedRelayDetail) {
+    switch (detail.mountType) {
+      case "prepend":
+        _options = [detail, ..._options];
+        break;
+      case "append":
+      case "reset":
+        _options = [..._options, detail];
+        break;
+    }
+    relay(detail.el, "dropdown:bind", { el: _rootEl });
+  }
+
+  function onChildDestroyed(detail: DropdownItemDestroyRelayDetail) {
+    _options = _options.filter((o) => o.value !== detail.value);
+
+    // If the value was selected, remove it from the value array and dispatch a change event
+    if (value.includes(detail.value)) {
+      value = value.filter((v) => v !== detail.value);
+      dispatch(
+        _rootEl,
+        "_change",
+        { name, value, labels: value.map((v) => _labelMap[v] || v) },
+        { bubbles: true },
+      );
+    }
+  }
+
+  function setError(detail: FieldsetErrorRelayDetail) {
+    error = toBoolean(detail.error);
+  }
+
+  function onSetValue(detail: FieldsetSetValueRelayDetail) {
+    value = Array.from(detail.value.toString());
+    dispatch(
+      _rootEl,
+      "_change",
+      { name, value, labels: value.map((v) => _labelMap[v] || v) },
+      { bubbles: true },
+    );
+  }
+
+  function handlePopoverOpen() {
+    _isOpen = true;
+    // goa-focus-trap with the popover auto-focuses the first focusable element
+    // in its slot via its own setTimeout(0) once open. tick() waits for the DOM
+    // update (so the filter input exists), then scheduling our own setTimeout(0)
+    // queues it after the focus trap's, so this focus call runs last and wins.
+    if (filterable) {
+      tick().then(() => setTimeout(focusFilterTextbox, 0));
+    }
+  }
+
+  function handlePopoverClose() {
+    _isOpen = false;
+    if (filterable) {
+      _filterText = "";
+    }
+    focusTriggerWithoutOpening();
+  }
+
+  // Moving focus back to the trigger after closing must not reopen the popover.
+  function focusTriggerWithoutOpening() {
+    _skipNextTriggerFocusOpen = true;
+    _triggerEl?.focus();
+    // .focus() is a no-op when the trigger is already the active element, in which case
+    // no focus event fires to consume the flag above, so clear it on the next tick.
+    setTimeout(() => {
+      _skipNextTriggerFocusOpen = false;
+    }, 0);
+  }
+
+  function handleTriggerMouseDown() {
+    _isTriggerMouseDown = true;
+    setTimeout(() => {
+      _isTriggerMouseDown = false;
+    }, 0);
+  }
+
+  // Opens the popover when the trigger is focused via keyboard tab, not mouse click
+  // (click already opens it through goa-popover's own click handling).
+  function handleTriggerFocus() {
+    if (_isTriggerMouseDown) {
+      _isTriggerMouseDown = false;
+      return;
+    }
+    if (_skipNextTriggerFocusOpen) {
+      _skipNextTriggerFocusOpen = false;
+      return;
+    }
+    if (disabled || _isOpen) return;
+
+    dispatch(_rootEl, "help-text::announce", undefined, { bubbles: true });
+    _isOpen = true;
+  }
+
+  function getCheckboxList(): HTMLElement[] {
+    const listItems = Array.from(
+      _checkboxListEl?.querySelectorAll("goa-checkbox") || [],
+    ) as HTMLElement[];
+    return showSelectAll && _selectAllEl
+      ? [_selectAllEl, ...listItems]
+      : listItems;
+  }
+
+  function focusCheckboxAt(index: number) {
+    const checkboxes = getCheckboxList();
+    if (checkboxes.length === 0) return;
+    const checkbox = checkboxes[index];
+    if (!checkbox) return;
+    const input = findFirstFocusableNode([checkbox]) as HTMLElement | null;
+    if (!input) return;
+
+    input.focus();
+    _focusedIndex = index;
+  }
+
+  function focusFirstCheckbox() {
+    focusCheckboxAt(0);
+  }
+
+  function focusLastCheckbox() {
+    const checkboxes = getCheckboxList();
+    if (checkboxes.length === 0) return;
+
+    focusCheckboxAt(checkboxes.length - 1);
+  }
+
+  function focusNextCheckbox() {
+    const checkboxes = getCheckboxList();
+    if (checkboxes.length === 0) return;
+
+    const index = Math.min(_focusedIndex + 1, checkboxes.length - 1);
+    focusCheckboxAt(index);
+  }
+
+  function focusPreviousCheckbox() {
+    // If filterable and focus is on the first checkbox, move focus to the filter input
+    if (filterable && _focusedIndex === 0) {
+      focusFilterTextbox();
+      return;
+    }
+
+    // Otherwise focus the previous checkbox or keep focus at the first checkbox
+    const index = Math.max(_focusedIndex - 1, 0);
+    focusCheckboxAt(index);
+  }
+
+  function focusFilterTextbox() {
+    _filterInputEl?.focus();
+  }
+
+  function handleFilterKeydown(e: KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      e.stopPropagation();
+      focusFirstCheckbox();
+    }
+  }
+
+  function handleSelectAllChange(e: Event) {
+    e.stopPropagation();
+    const detail = (e as CustomEvent<{ checked: boolean }>).detail;
+    if (!detail) return;
+
+    // Checks if select all is checked or not?
+    value = detail.checked ? _visibleOptions.map((o) => o.value) : [];
+
+    dispatch(
+      _rootEl,
+      "_change",
+      { name, value, labels: value.map((v) => _labelMap[v] || v) },
+      { bubbles: true },
+    );
+  }
+
+  function handleCheckboxListChange(e: Event) {
+    e.stopPropagation();
+    const detail = (e as CustomEvent).detail;
+    if (!detail) return;
+    const newValues: string[] = detail.value || [];
+    value = newValues;
+
+    dispatch(
+      _rootEl,
+      "_change",
+      { name, value, labels: value.map((v) => _labelMap[v] || v) },
+      { bubbles: true },
+    );
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (disabled) return;
+    switch (e.key) {
+      case "Enter":
+      case " ":
+        if (!_isOpen) {
+          e.preventDefault();
+          _isOpen = true;
+        }
+        break;
+
+      case "Escape":
+        if (_isOpen) {
+          e.preventDefault();
+          e.stopPropagation();
+          _isOpen = false;
+          focusTriggerWithoutOpening();
+        }
+        break;
+
+      case "Tab":
+        if (_isOpen) {
+          _isOpen = false;
+        }
+        break;
+
+      case "ArrowDown":
+        if (!_isOpen) {
+          e.preventDefault();
+          _isOpen = true;
+        } else {
+          e.preventDefault();
+          focusNextCheckbox();
+        }
+        break;
+
+      case "ArrowUp":
+        if (_isOpen) {
+          e.preventDefault();
+          focusPreviousCheckbox();
+        }
+        break;
+
+      case "End":
+        if (_isOpen) {
+          e.preventDefault();
+          focusLastCheckbox();
+        }
+        break;
+
+      case "Home":
+        if (_isOpen) {
+          e.preventDefault();
+          focusFirstCheckbox();
+        }
+        break;
+    }
+  }
+
+  function handleClearIconClick() {
+    clearAndFocusFilter();
+  }
+
+  function handleClearIconKeyDown(e: KeyboardEvent) {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    e.preventDefault();
+    e.stopPropagation();
+    clearAndFocusFilter();
+  }
+
+  function clearAndFocusFilter() {
+    if (disabled) return;
+    _filterText = "";
+    if (filterable) {
+      requestAnimationFrame(focusFilterTextbox);
+    }
+  }
+</script>
+
+<div
+  bind:this={_rootEl}
+  class="root"
+  style={styles(calculateMargin(mt, mr, mb, ml), style("width", width))}
+  data-testid={testid}
+>
+  <slot />
+  <goa-popover
+    bind:this={_popoverEl}
+    padded="false"
+    tabindex="-1"
+    filterablecontext="true"
+    open={_isOpen}
+    width={_popoverWidth}
+    {disabled}
+  >
+    <div slot="target">
+      <div
+        bind:this={_triggerEl}
+        data-testid={testid ? `${testid}-trigger` : undefined}
+        class="trigger"
+        class:compact={size === "compact"}
+        class:disabled
+        class:error
+        role="combobox"
+        tabindex={disabled ? -1 : 0}
+        aria-haspopup="dialog"
+        aria-expanded={_isOpen}
+        aria-controls={_contentId}
+        aria-label={ariaLabel || undefined}
+        aria-labelledby={ariaLabelledBy || undefined}
+        aria-disabled={disabled || undefined}
+        on:keydown={handleKeydown}
+        on:mousedown={handleTriggerMouseDown}
+        on:focus={handleTriggerFocus}
+      >
+        {#if leadingIcon || filterable}
+          <goa-icon
+            class="dropdown-input--leading-icon"
+            data-testid={testid ? `${testid}-leading-icon` : undefined}
+            size={size === "compact" ? "small" : "medium"}
+            type={filterable ? "search" : leadingIcon}
+          />
+        {/if}
+        {#if _isOpen && filterable}
+          <input
+            bind:this={_filterInputEl}
+            bind:value={_filterText}
+            class="filter-input"
+            type="text"
+            placeholder="Filter..."
+            aria-label="Filter options"
+            autocomplete="off"
+            data-testid={testid ? `${testid}-filter-input` : undefined}
+            on:click|stopPropagation
+            on:keydown={handleFilterKeydown}
+          />
+        {:else}
+          <span class="value-display" class:placeholder={!_hasValue}>
+            {_hasValue ? _displayText : placeholder || "—Select—"}
+          </span>
+        {/if}
+        {#if _isOpen && filterable && _filterText.length > 0}
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+          <goa-icon-button
+            id={name}
+            data-testid="clear-icon"
+            tabindex={disabled ? undefined : 0}
+            arialabel={`clear ${ariaLabel || name}`}
+            on:click={handleClearIconClick}
+            on:keydown={handleClearIconKeyDown}
+            class="dropdown-icon--clear"
+            class:disabled
+            disabled={disabled ? "true" : "false"}
+            size={size === "compact" ? "xsmall" : "medium"}
+            theme="filled"
+            variant="dark"
+            icon="close"
+          />
+        {:else}
+          <goa-icon
+            type={_isOpen ? "chevron-up" : "chevron-down"}
+            size="medium"
+            aria-hidden="true"
+          />
+        {/if}
+      </div>
+    </div>
+
+    <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+    <div
+      id={_contentId}
+      role="dialog"
+      aria-label={placeholder || "Options"}
+      class="content"
+      style="max-height: {maxHeight}; "
+      on:keydown={handleKeydown}
+    >
+      {#if showSelectAll && _options.length > 0}
+        <goa-checkbox
+          bind:this={_selectAllEl}
+          name="select-all"
+          value="select-all"
+          text="Select all"
+          data-testid={testid ? `${testid}-select-all` : undefined}
+          version="2"
+          checked={fromBoolean(_allVisibleSelected)}
+          indeterminate={fromBoolean(_someVisibleSelected)}
+          disabled={fromBoolean(disabled)}
+          {size}
+          on:_change={handleSelectAllChange}
+        />
+        <hr class="select-all-divider" />
+      {/if}
+      {#if _options.length > 0}
+        <goa-checkbox-list
+          bind:this={_checkboxListEl}
+          {name}
+          {value}
+          disabled={fromBoolean(disabled)}
+          version="2"
+          {size}
+          testid={testid ? `${testid}-checkbox-list` : undefined}
+          on:_change={handleCheckboxListChange}
+        >
+          {#each _visibleOptions as option (option.value)}
+            <goa-checkbox
+              name={option.value}
+              value={option.value}
+              text={option.label || option.value}
+              version="2"
+              checked={fromBoolean(value.includes(option.value))}
+              {size}
+            />
+          {/each}
+        </goa-checkbox-list>
+      {/if}
+    </div>
+  </goa-popover>
+</div>
+
+<style>
+  :host {
+    box-sizing: border-box;
+    font-family: var(--goa-font-family-sans);
+    display: block;
+  }
+
+  .root {
+    width: 100%;
+  }
+
+  .trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--goa-space-xs);
+    width: 100%;
+    min-height: var(--goa-dropdown-multiselect-height, 56px);
+    padding: 0 var(--goa-dropdown-multiselect-padding-lr, var(--goa-space-s));
+    box-shadow: var(
+      --goa-dropdown-multiselect-border,
+      inset 0 0 0 var(--goa-input-border-width-default)
+        var(--goa-input-color-border-default)
+    );
+    border-radius: var(
+      --goa-dropdown-multiselect-border-radius,
+      var(--goa-input-border-radius-input)
+    );
+    color: var(
+      --goa-dropdown-multiselect-color-text,
+      var(--goa-input-color-text-default)
+    );
+    background: var(
+      --goa-dropdown-multiselect-color-bg,
+      var(--goa-input-color-background-default)
+    );
+    transition: var(
+      --goa-dropdown-multiselect-transition,
+      box-shadow 0.05s ease-in
+    );
+    cursor: pointer;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .trigger:hover {
+    box-shadow: var(
+      --goa-dropdown-multiselect-border-hover,
+      inset 0 0 0 var(--goa-input-border-width-focus)
+        var(--goa-input-color-border-hover)
+    );
+  }
+
+  .trigger.compact {
+    min-height: var(--goa-dropdown-multiselect-compact-height, 40px);
+    padding: var(
+      --goa-dropdown-multiselect-compact-padding,
+      0 var(--goa-space-s)
+    );
+  }
+
+  .trigger:focus-visible {
+    box-shadow: var(
+      --goa-dropdown-multiselect-border-focus,
+      inset 0 0 0 var(--goa-input-border-width-focus)
+        var(--goa-input-color-border-focus)
+    );
+  }
+
+  .trigger.error {
+    box-shadow: var(
+      --goa-dropdown-multiselect-border-error,
+      inset 0 0 0 var(--goa-input-border-width-focus)
+        var(--goa-input-color-border-error)
+    );
+  }
+
+  .trigger.error:hover {
+    box-shadow: var(
+      --goa-dropdown-multiselect-border-error-hover,
+      inset 0 0 0 var(--goa-input-border-width-focus)
+        var(--goa-input-color-border-error-hover)
+    );
+  }
+
+  .trigger.disabled {
+    box-shadow: var(
+      --goa-dropdown-multiselect-border-disabled,
+      inset 0 0 0 var(--goa-input-border-width-default)
+        var(--goa-input-color-border-disabled)
+    );
+    background: var(
+      --goa-dropdown-multiselect-color-bg-disabled,
+      var(--goa-input-color-background-disabled)
+    );
+    color: var(
+      --goa-dropdown-multiselect-color-text-disabled,
+      var(--goa-input-color-text-disabled)
+    );
+    cursor: default;
+  }
+
+  .value-display {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    font: var(
+      --goa-dropdown-multiselect-typography,
+      var(--goa-typography-body-m)
+    );
+    color: var(
+      --goa-dropdown-multiselect-color-text,
+      var(--goa-input-color-text-default)
+    );
+  }
+
+  .disabled .value-display {
+    color: var(
+      --goa-dropdown-multiselect-color-text-disabled,
+      var(--goa-input-color-text-disabled)
+    );
+  }
+
+  .value-display.placeholder {
+    color: var(
+      --goa-dropdown-multiselect-color-text-placeholder,
+      var(--goa-input-color-text-default)
+    );
+  }
+
+  .filter-input {
+    flex: 1;
+    border: none;
+    outline: none;
+    background: transparent;
+    font: var(
+      --goa-dropdown-multiselect-typography,
+      var(--goa-typography-body-m)
+    );
+    color: var(
+      --goa-dropdown-multiselect-color-text,
+      var(--goa-input-color-text-default)
+    );
+    min-width: 0;
+    padding: 0;
+  }
+
+  .filter-input::placeholder {
+    color: var(
+      --goa-dropdown-multiselect-color-text-placeholder,
+      var(--goa-input-color-text-default)
+    );
+  }
+
+  .content {
+    overflow-y: auto;
+    padding: var(
+      --goa-dropdown-multiselect-padding,
+      var(--goa-space-m) var(--goa-space-s)
+    );
+  }
+
+  .select-all-divider {
+    border: none;
+    border-top: var(
+      --goa-dropdown-multiselect-divider,
+      var(--goa-border-width-s) solid var(--goa-color-greyscale-200)
+    );
+    margin: var(--goa-space-m) 0;
+  }
+</style>

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -40,6 +40,7 @@
     FieldsetSetValueRelayDetail,
     FieldsetResetFieldsMsg,
   } from "../../types/relay-types";
+  import { isFilterMatch } from "../../common/filtering";
 
   interface EventHandler {
     handleKeyUp: (e: KeyboardEvent) => void;
@@ -334,7 +335,10 @@
   function assignOptionSlot(detail: DropdownItemMountedRelayDetail) {
     const dropdownRoot = _rootEl.getRootNode();
     const itemRoot = detail.el.getRootNode();
-    if (!(dropdownRoot instanceof ShadowRoot) || !(itemRoot instanceof ShadowRoot)) {
+    if (
+      !(dropdownRoot instanceof ShadowRoot) ||
+      !(itemRoot instanceof ShadowRoot)
+    ) {
       return;
     }
 
@@ -499,29 +503,6 @@
     if (_filterable) {
       setDisplayedValue();
     }
-  }
-
-  // Match against the filter text and the text the user sees, which is the
-  // label, or the value when no label is set. Both are searched so that adding
-  // a filter supplies extra search terms rather than replacing the visible text.
-  function isFilterMatch(option: Option, filter: string, partialMatch = true) {
-    // empty string matches all
-    if (filter.length === 0) return true;
-
-    const targets = [option.filter, option.label || option.value].filter(
-      (target) => target !== "",
-    );
-    filter = filter.toLowerCase().trim();
-
-    return targets.some((target) => {
-      const value = target.toLowerCase();
-
-      if (!partialMatch) {
-        return value === filter;
-      }
-
-      return value.startsWith(filter) || value.includes(" " + filter);
-    });
   }
 
   // update the value show to the user in the <input> element

--- a/libs/web-components/src/components/dropdown/DropdownItem.svelte
+++ b/libs/web-components/src/components/dropdown/DropdownItem.svelte
@@ -5,6 +5,7 @@
 />
 
 <script lang="ts" context="module">
+  import { FilterOption } from "../../common/filtering";
   export type DropdownItemMountType = "append" | "prepend" | "reset";
   export type DropdownItemMountedRelayDetail = {
     el: HTMLElement;
@@ -13,18 +14,14 @@
     label: string;
     hasSlotContent: boolean;
     mountType: DropdownItemMountType;
-  }
+  };
   export type DropdownItemDestroyRelayDetail = {
     value: string;
-  }
+  };
   export const DropdownItemMountedMsg = "dropdown-item:mounted";
   export const DropdownItemDestroyMsg = "dropdown-item:destroyed";
 
-  export type Option = {
-    label: string;
-    value: string;
-    filter: string;
-    hasSlotContent: boolean;
+  export type Option = FilterOption & {
     mountType: DropdownItemMountType;
   };
 </script>
@@ -65,7 +62,7 @@
         mountType: mount,
       },
       { bubbles: true, timeout: 10 },
-      );
+    );
   });
 
   // Use the slotted content's text as the default filter value. Separate text
@@ -104,12 +101,12 @@
 
   function addMessageListener() {
     receive(_rootEl, (action, data) => {
-      switch(action) {
+      switch (action) {
         case "dropdown:bind":
-          _parentEl = (data as { el: HTMLElement}).el;
+          _parentEl = (data as { el: HTMLElement }).el;
           break;
       }
-    })
+    });
   }
 
   onDestroy(() => {

--- a/libs/web-components/src/index.ts
+++ b/libs/web-components/src/index.ts
@@ -26,6 +26,7 @@ export * from "./components/divider/Divider.svelte";
 export * from "./components/drawer/Drawer.svelte";
 export * from "./components/dropdown/Dropdown.svelte";
 export * from "./components/dropdown/DropdownItem.svelte";
+export * from "./components/dropdown-multiselect/DropdownMultiselect.svelte";
 export * from "./components/file-upload-card/FileUploadCard.svelte";
 export * from "./components/file-upload-input/FileUploadInput.svelte";
 export * from "./components/filter-chip/FilterChip.svelte";


### PR DESCRIPTION
This PR creates a dropdown multiselect list component  by combining the CheckboxList and Popover Components.

The only AC left in Story 1233 is a link to a Figma that doesn't exist anymore. 🤷

The Multiselect has documentation as part of the PR https://govalta.github.io/ui-components/pr-preview/pr-3936/components/dropdown-multiselect/#angular#properties

We've added these features:

- Filtering (try filtering by "lake" or "grand" in the PR page filter for Alberta Cities)
- Select All
  - when filtering it should only select all of the visible filtered items 
- Truncating overflow in the placeholder using the `labelFormat` attribute:
	- with ellipsis (`list`)
	- with text (10 items) (`count`)
- Compact size

This closes #1233.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

This is a brand new component. Testing pages are available in the React and Angular playground, as well as documentation pages. It would be great testing for you to add it to your pages as well.