### PR TITLE
feat(#3924): add dark mode experimental section to homepage

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -76,6 +76,41 @@ import CardLite from '../components/CardLite.astro';
       />
     </div>
 
+    <!-- Dark Mode Experimental -->
+    <div class="cta-section dark-mode-section">
+      <div class="cta-text">
+        <h2>Dark mode — experimental</h2>
+        <p>
+          Dark mode is available as an experimental capability in the design system. Try it in your service and share what you learn — your feedback helps shape how we develop it further.
+        </p>
+        <ul class="dark-mode-links">
+          <li>
+            <goa-link version="2" trailingicon="arrow-forward">
+              <a href="https://design.alberta.ca/get-started/designers/designing-for-dark-mode/">Designing for dark mode</a>
+            </goa-link>
+          </li>
+          <li>
+            <goa-link version="2" trailingicon="arrow-forward">
+              <a href="https://design.alberta.ca/get-started/developers/dark-mode-theme/">Dark mode theme</a>
+            </goa-link>
+          </li>
+          <li>
+            <goa-link version="2" trailingicon="open">
+              <a href="https://goa-dio.slack.com/archives/C02PLLT9HQ9" target="_blank" rel="noopener noreferrer">#design-system-support on Slack</a>
+            </goa-link>
+          </li>
+          <li>
+            <goa-link version="2" trailingicon="open">
+              <a href="https://forms.cloud.microsoft/Pages/ResponsePage.aspx?id=Bhy1K5uvxUKL9Tw7exCFC3Ec1TzonW9AiPeNaYegn-5UN09LVjlJNDY4UDlSTUlNNlZYTVZLTTYwRC4u" target="_blank" rel="noopener noreferrer">Share your feedback</a>
+            </goa-link>
+          </li>
+        </ul>
+      </div>
+      <div class="cta-image">
+        <img src={withBase(`/images/home/splash-reel.png`)} alt="Dark mode preview placeholder" />
+      </div>
+    </div>
+
     <!-- Research Tools -->
     <h2 class="section-heading">Research tools</h2>
     <p class="section-description">
@@ -264,6 +299,15 @@ import CardLite from '../components/CardLite.astro';
     font: var(--goa-typography-body-m);
     color: var(--goa-color-text-secondary);
     margin: 0 0 var(--goa-space-m);
+  }
+
+  .dark-mode-links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--goa-space-s);
   }
 
   .cta-image {


### PR DESCRIPTION
## Description

Adds a new dark mode experimental feature section to the homepage, placed below "Select your service pattern" and before "Research tools".

The section uses the same full-width CTA layout as "Build your service using the design system" and includes:
- Brief description framing dark mode as experimental
- Link to designer docs (Designing for dark mode)
- Link to developer docs (Dark mode theme)
- Link to #design-system-support on Slack
- Link to the MS Forms feedback form

Note: the section image is currently a placeholder (`splash-reel.png`). The final dark mode image will be swapped in before this PR is marked ready.

Fixes #3924

## Steps to test

1. Run `npm run serve:docs` (or equivalent)
2. Visit the homepage
3. Scroll past "Select your service pattern"
4. Verify the dark mode section appears before "Research tools"
5. Verify all four links are present and resolve correctly

## Checklist
- [x] Section added in correct position
- [x] Designer docs linked
- [x] Developer docs linked
- [x] Slack channel linked
- [x] MS Forms feedback link included
- [ ] Final dark mode image (placeholder in place for now)