### PR TITLE
fix(#3679): Add border-box css directives for Table

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3679/bug3679.component.html
+++ b/apps/prs/angular/src/routes/bugs/3679/bug3679.component.html
@@ -63,4 +63,33 @@
       </tbody>
     </goab-table>
   </div>
+  <div style="margin-top: 1rem; width: 600px; background-color: #fff8e1; outline: 2px dashed #ffa000;">
+    <h2 style="margin: 0; padding: 0.5rem;">Test inside fixed 600px container (table should fill container exactly)</h2>
+    <goab-table version="2" width="100%">
+      <thead>
+        <tr>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Job</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Carol</td>
+          <td>Willick</td>
+          <td>Teacher</td>
+        </tr>
+        <tr>
+          <td>Gunther</td>
+          <td>Centralperk</td>
+          <td>Barista</td>
+        </tr>
+        <tr>
+          <td>Janice</td>
+          <td>Litman</td>
+          <td>Sales</td>
+        </tr>
+      </tbody>
+    </goab-table>
+  </div>
 </div>

--- a/apps/prs/angular/src/routes/bugs/3679/bug3679.component.html
+++ b/apps/prs/angular/src/routes/bugs/3679/bug3679.component.html
@@ -1,0 +1,66 @@
+<div>
+  <h1>Bug 3679: Table: 1px horizontal overflow from v2 border</h1>
+  <p>
+    The V2 table container has <code>width: 100%</code> (inline style) and
+    <code>border: 1px solid</code> but no <code>box-sizing: border-box</code>. The border adds 2px to the total rendered
+    width, causing 1px horizontal scroll on both sides.
+  </p>
+  <goab-container>
+    <h2>Test inside GoabContainer</h2>
+    <goab-table version="2" width="100%">
+      <thead>
+        <tr>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Job</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Joey</td>
+          <td>Tribbiani</td>
+          <td>Actor</td>
+        </tr>
+        <tr>
+          <td>Chandler</td>
+          <td>Bing</td>
+          <td>Statistical Analysis and Data Reconfiguration</td>
+        </tr>
+        <tr>
+          <td>Ross</td>
+          <td>Geller</td>
+          <td>Paleontologist</td>
+        </tr>
+      </tbody>
+    </goab-table>
+  </goab-container>
+  <div style="margin-top: 1rem; width: 40%;">
+    <h2>Test inside div with width 40%</h2>
+    <goab-table version="2" width="100%">
+      <thead>
+        <tr>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Job</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Rachel</td>
+          <td>Green</td>
+          <td>Barrista</td>
+        </tr>
+        <tr>
+          <td>Monica</td>
+          <td>Geller</td>
+          <td>Chef</td>
+        </tr>
+        <tr>
+          <td>Phoebe</td>
+          <td>Buffay</td>
+          <td>Musician</td>
+        </tr>
+      </tbody>
+    </goab-table>
+  </div>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3679/bug3679.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3679/bug3679.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabContainer, GoabTable } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3679",
+  templateUrl: "./bug3679.component.html",
+  imports: [GoabContainer, GoabTable],
+})
+export class Bug3679Component {}

--- a/apps/prs/angular/src/routes/bugs/3679/bug3679.route.json
+++ b/apps/prs/angular/src/routes/bugs/3679/bug3679.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Table: 1px horizontal overflow from v2 border",
+  "path": "bugs/3679",
+  "id": "3679",
+  "type": "bug"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3679.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3679.route.ts
@@ -1,0 +1,10 @@
+import { Bug3679Route } from "../../../routes/bugs/bug3679";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3679",
+  path: "bugs/3679",
+  title: "Table: 1px horizontal overflow from v2 border",
+  component: Bug3679Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3679.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3679.tsx
@@ -1,0 +1,73 @@
+import { GoabContainer, GoabTable } from "@abgov/react-components";
+
+export function Bug3679Route() {
+  return (
+    <div>
+      <h1>Bug 3679: Table: 1px horizontal overflow from v2 border</h1>
+      <p>
+        The V2 table container has <code>width: 100%</code> (inline style) and
+        <code>border: 1px solid</code> but no
+        <code>box-sizing: border-box</code>. The border adds 2px to the total rendered
+        width, causing 1px horizontal scroll on both sides.
+      </p>
+      <GoabContainer>
+        <h2>Test inside GoabContainer</h2>
+        <GoabTable>
+          <thead>
+            <tr>
+              <th>First Name</th>
+              <th>Last Name</th>
+              <th>Job</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Joey</td>
+              <td>Tribbiani</td>
+              <td>Actor</td>
+            </tr>
+            <tr>
+              <td>Chandler</td>
+              <td>Bing</td>
+              <td>Statistical Analysis and Data Reconfiguration</td>
+            </tr>
+            <tr>
+              <td>Ross</td>
+              <td>Geller</td>
+              <td>Paleontologist</td>
+            </tr>
+          </tbody>
+        </GoabTable>
+      </GoabContainer>
+      <div style={{ marginTop: "1rem", width: "40%" }}>
+        <h2>Test inside div with width 40%</h2>
+        <GoabTable>
+          <thead>
+            <tr>
+              <th>First Name</th>
+              <th>Last Name</th>
+              <th>Job</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Rachel</td>
+              <td>Green</td>
+              <td>Barrista</td>
+            </tr>
+            <tr>
+              <td>Monica</td>
+              <td>Geller</td>
+              <td>Chef</td>
+            </tr>
+            <tr>
+              <td>Phoebe</td>
+              <td>Buffay</td>
+              <td>Musician</td>
+            </tr>
+          </tbody>
+        </GoabTable>
+      </div>
+    </div>
+  );
+}

--- a/apps/prs/react/src/routes/bugs/bug3679.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3679.tsx
@@ -68,6 +68,44 @@ export function Bug3679Route() {
           </tbody>
         </GoabTable>
       </div>
+      <div
+        style={{
+          marginTop: "1rem",
+          width: "600px",
+          backgroundColor: "#fff8e1",
+          outline: "2px dashed #ffa000",
+        }}
+      >
+        <h2 style={{ margin: 0, padding: "0.5rem" }}>
+          Test inside fixed 600px container (table should fill container exactly)
+        </h2>
+        <GoabTable>
+          <thead>
+            <tr>
+              <th>First Name</th>
+              <th>Last Name</th>
+              <th>Job</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Carol</td>
+              <td>Willick</td>
+              <td>Teacher</td>
+            </tr>
+            <tr>
+              <td>Gunther</td>
+              <td>Centralperk</td>
+              <td>Barista</td>
+            </tr>
+            <tr>
+              <td>Janice</td>
+              <td>Litman</td>
+              <td>Sales</td>
+            </tr>
+          </tbody>
+        </GoabTable>
+      </div>
     </div>
   );
 }

--- a/libs/web-components/src/components/table/Table.svelte
+++ b/libs/web-components/src/components/table/Table.svelte
@@ -139,7 +139,10 @@
 
     _headings?.forEach((heading) => {
       const name = heading.getAttribute("name");
-      const direction = heading.getAttribute("direction") as SortDirection | "none" | null;
+      const direction = heading.getAttribute("direction") as
+        | SortDirection
+        | "none"
+        | null;
       const sortOrder = Number(heading.getAttribute("sort-order")) || 0;
       if (name && direction && direction !== "none") {
         entries.push({ column: name, direction, order: sortOrder });
@@ -154,8 +157,8 @@
       if (withoutSortOrder.length > 0) {
         console.warn(
           `[goa-table] Multiple headers have initial sort direction but no sort-order set ` +
-          `[${withoutSortOrder.map((e) => e.column).join(", ")}]. ` +
-          `Falling back to DOM order. Add sort-order="1", sort-order="2" to set explicit priority.`,
+            `[${withoutSortOrder.map((e) => e.column).join(", ")}]. ` +
+            `Falling back to DOM order. Add sort-order="1", sort-order="2" to set explicit priority.`,
         );
       }
     }
@@ -241,12 +244,7 @@
 
   function dispatchSortEvent() {
     if (sortMode === "multi") {
-      dispatch(
-        _rootEl,
-        "_multisort",
-        { sorts: _sorts },
-        { bubbles: true },
-      );
+      dispatch(_rootEl, "_multisort", { sorts: _sorts }, { bubbles: true });
     } else {
       const firstSort = _sorts[0];
       dispatch(
@@ -284,6 +282,10 @@
 </div>
 
 <style>
+  :host {
+    box-sizing: border-box;
+  }
+
   /* other styles can be found in the assets/css/components.css file */
   .goatable {
     width: 0;
@@ -298,5 +300,6 @@
     border: var(--goa-table-container-border, 1px solid #e7e7e7);
     border-radius: var(--goa-table-border-radius-container, 16px);
     overflow: hidden;
+    box-sizing: border-box;
   }
 </style>


### PR DESCRIPTION
This PR resolves https://github.com/GovAlta/ui-components/issues/3679

# Before (the change)

Table would have a 1px horizontal scrollbar in some cases.

# After (the change)

Table does not have horizontal scrollbar unless in case of content overflow.

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
