### PR TITLE
fix(#3323): use anchor/fixed positioning for Tooltip

### DIFF
--- a/apps/prs/angular/src/routes/bugs/bug3323/bug3323.component.html
+++ b/apps/prs/angular/src/routes/bugs/bug3323/bug3323.component.html
@@ -1,0 +1,46 @@
+<goab-text tag="h1" mt="m" mb="s">Fix 3323 - Tooltip popover positioning</goab-text>
+<goab-text>
+  CSS anchor positioning support in this browser:
+  <strong>{{ supportsCssAnchorPositioning ? "Supported" : "Not supported" }}</strong
+  >.
+</goab-text>
+
+<goab-text tag="h2" mt="m" mb="s">Tooltip in callout</goab-text>
+<goab-callout emphasis="low">
+  <goab-tooltip content="This tooltip shoudn't be cut off">
+    <goab-button type="tertiary" size="compact">Hover me</goab-button>
+  </goab-tooltip>
+</goab-callout>
+
+<goab-text tag="h2" mt="m" mb="s">Tooltip in container</goab-text>
+<goab-container>
+  <goab-tooltip content="This tooltip shoudn't be cut off">
+    <goab-icon type="information-circle"></goab-icon>
+  </goab-tooltip>
+</goab-container>
+
+<goab-text tag="h2" mt="m" mb="s">Basic tooltip</goab-text>
+<goab-tooltip content="Additional information about this item">
+  <goab-button type="secondary">Hover me</goab-button>
+</goab-tooltip>
+
+<goab-text tag="h2" mt="m" mb="s">Horizontal alignment</goab-text>
+<goab-grid minChildWidth="60px">
+  <goab-tooltip content="Left aligned tooltip" hAlign="left">
+    <goab-icon type="information-circle" />
+  </goab-tooltip>
+  <goab-tooltip content="Center aligned tooltip" hAlign="center">
+    <goab-icon type="information-circle" />
+  </goab-tooltip>
+  <goab-tooltip content="Right aligned tooltip" hAlign="right">
+    <goab-icon type="information-circle" />
+  </goab-tooltip>
+</goab-grid>
+
+<goab-text tag="h2" mt="m" mb="s"> Long Tooltip </goab-text>
+<goab-tooltip
+  content="This is a deliberately long tooltip message that should render at a readable width, wrap naturally, and not collapse into a one-pixel column on first hover."
+  maxWidth="320px"
+>
+  <goab-button type="tertiary" size="compact"> Long tooltip </goab-button>
+</goab-tooltip>

--- a/apps/prs/angular/src/routes/bugs/bug3323/bug3323.component.html
+++ b/apps/prs/angular/src/routes/bugs/bug3323/bug3323.component.html
@@ -1,4 +1,4 @@
-<goab-text tag="h1" mt="m" mb="s">Fix 3323 - Tooltip popover positioning</goab-text>
+<goab-text tag="h1" mt="m" mb="s">Fix 3323 - Tooltip with fixed positioning</goab-text>
 <goab-text>
   CSS anchor positioning support in this browser:
   <strong>{{ supportsCssAnchorPositioning ? "Supported" : "Not supported" }}</strong

--- a/apps/prs/angular/src/routes/bugs/bug3323/bug3323.component.ts
+++ b/apps/prs/angular/src/routes/bugs/bug3323/bug3323.component.ts
@@ -1,0 +1,31 @@
+import { Component } from "@angular/core";
+import {
+  GoabButton,
+  GoabCallout,
+  GoabContainer,
+  GoabIcon,
+  GoabTooltip,
+  GoabText,
+  GoabGrid,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3323",
+  templateUrl: "./bug3323.component.html",
+  imports: [
+    GoabButton,
+    GoabCallout,
+    GoabContainer,
+    GoabIcon,
+    GoabTooltip,
+    GoabText,
+    GoabGrid,
+  ],
+})
+export class Bug3323Component {
+  readonly supportsCssAnchorPositioning =
+    typeof CSS !== "undefined" &&
+    typeof CSS.supports === "function" &&
+    CSS.supports("anchor-name: --goa-tooltip-target");
+}

--- a/apps/prs/angular/src/routes/bugs/bug3323/bug3323.route.json
+++ b/apps/prs/angular/src/routes/bugs/bug3323/bug3323.route.json
@@ -2,5 +2,5 @@
   "type": "bug",
   "id": "3323",
   "path": "bugs/bug3323",
-  "title": "Tooltip popover positioning"
+  "title": "Tooltip with fixed positioning"
 }

--- a/apps/prs/angular/src/routes/bugs/bug3323/bug3323.route.json
+++ b/apps/prs/angular/src/routes/bugs/bug3323/bug3323.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3323",
+  "path": "bugs/bug3323",
+  "title": "Tooltip popover positioning"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3323.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3323.route.ts
@@ -1,0 +1,10 @@
+import { Bug3323Route } from "../../../routes/bugs/bug3323";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3323",
+  path: "bugs/bug3323",
+  title: "Tooltip popover positioning",
+  component: Bug3323Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/app/routes/bugs/bug3323.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3323.route.ts
@@ -5,6 +5,6 @@ export default {
   type: "bug",
   id: "3323",
   path: "bugs/bug3323",
-  title: "Tooltip popover positioning",
+  title: "Tooltip with fixed positioning",
   component: Bug3323Route,
 } satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3323.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3323.tsx
@@ -18,7 +18,7 @@ export function Bug3323Route() {
   return (
     <>
       <GoabText tag="h1" mt="m" mb="s">
-        Fix 3323 - Tooltip popover positioning
+        Fix 3323 - Tooltip with fixed positioning
       </GoabText>
       <GoabText>
         CSS anchor positioning support in this browser:{" "}

--- a/apps/prs/react/src/routes/bugs/bug3323.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3323.tsx
@@ -1,0 +1,83 @@
+import type { CSSProperties } from "react";
+import {
+  GoabButton,
+  GoabCallout,
+  GoabTooltip,
+  GoabIcon,
+  GoabContainer,
+  GoabText,
+  GoabGrid,
+} from "@abgov/react-components";
+
+const supportsCssAnchorPositioning =
+  typeof CSS !== "undefined" &&
+  typeof CSS.supports === "function" &&
+  CSS.supports("anchor-name: --goa-tooltip-target");
+
+export function Bug3323Route() {
+  return (
+    <>
+      <GoabText tag="h1" mt="m" mb="s">
+        Fix 3323 - Tooltip popover positioning
+      </GoabText>
+      <GoabText>
+        CSS anchor positioning support in this browser:{" "}
+        <strong>{supportsCssAnchorPositioning ? "Supported" : "Not supported"}</strong>.
+      </GoabText>
+
+      <GoabText tag="h2" mt="l" mb="s">
+        Tooltip in callout
+      </GoabText>
+      <GoabCallout emphasis="low">
+        <GoabTooltip content="This tooltip shoudn't be cut off">
+          <GoabButton type="tertiary" size="compact">
+            Hover me
+          </GoabButton>
+        </GoabTooltip>
+      </GoabCallout>
+
+      <GoabText tag="h2" mt="l" mb="s">
+        Tooltip in container
+      </GoabText>
+      <GoabContainer>
+        <GoabTooltip content="This tooltip shoudn't be cut off">
+          <GoabIcon type="information-circle" />
+        </GoabTooltip>
+      </GoabContainer>
+
+      <GoabText tag="h2" mt="l" mb="s">
+        Basic tooltip
+      </GoabText>
+      <GoabTooltip content="Additional information about this item">
+        <GoabButton type="secondary">Hover me</GoabButton>
+      </GoabTooltip>
+
+      <GoabText tag="h2" mt="l" mb="s">
+        Horizontal alignment
+      </GoabText>
+      <GoabGrid minChildWidth="60px">
+        <GoabTooltip content="Left aligned tooltip" hAlign="left">
+          <GoabIcon type="information-circle" />
+        </GoabTooltip>
+        <GoabTooltip content="Center aligned tooltip" hAlign="center">
+          <GoabIcon type="information-circle" />
+        </GoabTooltip>
+        <GoabTooltip content="Right aligned tooltip" hAlign="right">
+          <GoabIcon type="information-circle" />
+        </GoabTooltip>
+      </GoabGrid>
+
+      <GoabText tag="h2" mt="l" mb="s">
+        Long Tooltip
+      </GoabText>
+      <GoabTooltip
+        content="This is a deliberately long tooltip message that should render at a readable width, wrap naturally, and not collapse into a one-pixel column on first hover."
+        maxWidth="320px"
+      >
+        <GoabButton type="tertiary" size="compact">
+          Long tooltip
+        </GoabButton>
+      </GoabTooltip>
+    </>
+  );
+}

--- a/libs/react-components/specs/tooltip.browser.spec.tsx
+++ b/libs/react-components/specs/tooltip.browser.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from "vitest-browser-react";
+import { page } from "@vitest/browser/context";
 
 import { GoabTooltip, GoabButton } from "../src";
 import { expect, describe, it, vi } from "vitest";
@@ -324,7 +325,9 @@ describe("Tooltip Browser Tests", () => {
     );
   });
 
-  it("should apply maxWidth using CSS custom property", async () => {
+  it("should apply maxWidth for long tooltip content", async () => {
+    await page.viewport(1280, 800);
+
     const Component = () => {
       return (
         <div data-testid="container">
@@ -338,8 +341,10 @@ describe("Tooltip Browser Tests", () => {
               </div>
             }
             maxWidth="300px"
+            hAlign="right"
+            testId="test-tooltip"
           >
-            <GoabButton>Constrained tooltip</GoabButton>
+            <GoabButton>Tooltip</GoabButton>
           </GoabTooltip>
         </div>
       );
@@ -347,34 +352,41 @@ describe("Tooltip Browser Tests", () => {
 
     const result = render(<Component />);
     const container = result.getByTestId("container");
+    const host = container.element().querySelector("goa-tooltip") as HTMLElement | null;
 
-    await vi.waitFor(
-      () => {
-        const tooltipEl = container
-          .element()
-          .querySelector("goa-tooltip") as HTMLElement | null;
-        expect(tooltipEl).toBeTruthy();
+    vi.useFakeTimers();
+    try {
+      expect(host).toBeTruthy();
 
-        tooltipEl?.dispatchEvent(new Event("mouseenter", { bubbles: true }));
+      await vi.waitFor(() => {
+        const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+        expect(hoverTarget).toBeTruthy();
+      });
 
-        const tooltipTextEl =
-          tooltipEl?.shadowRoot?.querySelector<HTMLElement>(".tooltip-text");
-        expect(tooltipTextEl).toBeTruthy();
+      const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+      hoverTarget?.dispatchEvent(new MouseEvent("mouseenter"));
 
-        const inlineWidth = tooltipTextEl?.style.width;
-        expect(inlineWidth).toBeTruthy();
+      await vi.advanceTimersByTimeAsync(350);
 
-        const numericWidth = parseInt(inlineWidth || "0", 10);
-        expect(numericWidth).toBeGreaterThan(0);
+      await vi.waitFor(() => {
+        const tooltipTextEl = host?.shadowRoot?.querySelector(
+          ".tooltip-text",
+        ) as HTMLElement | null;
 
-        // Should not exceed declared maxWidth of 300px (padding/internal adjustments already applied)
-        expect(numericWidth).toBeLessThanOrEqual(300);
-      },
-      { timeout: 3000 },
-    );
+        expect(tooltipTextEl?.classList.contains("show")).toBe(true);
+
+        const renderedWidth = tooltipTextEl?.getBoundingClientRect().width ?? 0;
+
+        expect(renderedWidth).toBeGreaterThan(200);
+        expect(renderedWidth).toBeLessThanOrEqual(301);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("should accept valid px units for maxWidth", async () => {
+    await page.viewport(1280, 800);
     const Component = () => {
       return (
         <div data-testid="container">
@@ -390,34 +402,41 @@ describe("Tooltip Browser Tests", () => {
 
     const result = render(<Component />);
     const container = result.getByTestId("container");
+    const host = container.element().querySelector("goa-tooltip") as HTMLElement | null;
 
-    await vi.waitFor(
-      () => {
-        const tooltipEl = container
-          .element()
-          .querySelector("goa-tooltip") as HTMLElement | null;
-        expect(tooltipEl).toBeTruthy();
+    vi.useFakeTimers();
+    try {
+      expect(host).toBeTruthy();
 
-        // Trigger tooltip visibility
-        tooltipEl?.dispatchEvent(new Event("mouseenter", { bubbles: true }));
+      await vi.waitFor(() => {
+        const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+        expect(hoverTarget).toBeTruthy();
+      });
 
-        const tooltipTextEl =
-          tooltipEl?.shadowRoot?.querySelector<HTMLElement>(".tooltip-text");
-        expect(tooltipTextEl).toBeTruthy();
+      const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+      hoverTarget?.dispatchEvent(new MouseEvent("mouseenter"));
 
-        // Check that width is constrained by maxWidth
-        const inlineWidth = tooltipTextEl?.style.width;
-        expect(inlineWidth).toBeTruthy();
+      await vi.advanceTimersByTimeAsync(350);
 
-        const numericWidth = parseInt(inlineWidth || "0", 10);
-        expect(numericWidth).toBeGreaterThan(0);
-        expect(numericWidth).toBeLessThanOrEqual(250);
-      },
-      { timeout: 3000 },
-    );
+      await vi.waitFor(() => {
+        const tooltipTextEl = host?.shadowRoot?.querySelector(
+          ".tooltip-text",
+        ) as HTMLElement | null;
+
+        expect(tooltipTextEl?.classList.contains("show")).toBe(true);
+
+        const renderedWidth = tooltipTextEl?.getBoundingClientRect().width ?? 0;
+
+        expect(renderedWidth).toBeGreaterThan(200);
+        expect(renderedWidth).toBeLessThanOrEqual(251);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("should use default width when maxWidth has invalid percentage unit", async () => {
+    await page.viewport(1280, 800);
     const Component = () => {
       return (
         <div data-testid="container">
@@ -433,37 +452,41 @@ describe("Tooltip Browser Tests", () => {
 
     const result = render(<Component />);
     const container = result.getByTestId("container");
+    const host = container.element().querySelector("goa-tooltip") as HTMLElement | null;
 
-    await vi.waitFor(
-      () => {
-        const tooltipEl = container
-          .element()
-          .querySelector("goa-tooltip") as HTMLElement | null;
-        expect(tooltipEl).toBeTruthy();
+    vi.useFakeTimers();
+    try {
+      expect(host).toBeTruthy();
 
-        // Trigger tooltip visibility
-        tooltipEl?.dispatchEvent(new Event("mouseenter", { bubbles: true }));
+      await vi.waitFor(() => {
+        const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+        expect(hoverTarget).toBeTruthy();
+      });
 
-        const tooltipTextEl =
-          tooltipEl?.shadowRoot?.querySelector<HTMLElement>(".tooltip-text");
-        expect(tooltipTextEl).toBeTruthy();
+      const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+      hoverTarget?.dispatchEvent(new MouseEvent("mouseenter"));
 
-        // Should use default width (400px) since percentage is invalid
-        const inlineWidth = tooltipTextEl?.style.width;
-        expect(inlineWidth).toBeTruthy();
+      await vi.advanceTimersByTimeAsync(350);
 
-        const numericWidth = parseInt(inlineWidth || "0", 10);
-        expect(numericWidth).toBeGreaterThan(0);
+      await vi.waitFor(() => {
+        const tooltipTextEl = host?.shadowRoot?.querySelector(
+          ".tooltip-text",
+        ) as HTMLElement | null;
 
-        // Should use default maxWidth of 400px (minus padding adjustments)
-        // The actual width will be constrained by the default 400px maxWidth
-        expect(numericWidth).toBeLessThanOrEqual(400);
-      },
-      { timeout: 3000 },
-    );
+        expect(tooltipTextEl?.classList.contains("show")).toBe(true);
+
+        const renderedWidth = tooltipTextEl?.getBoundingClientRect().width ?? 0;
+
+        expect(renderedWidth).toBeGreaterThan(300);
+        expect(renderedWidth).toBeLessThanOrEqual(401);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("should use default width when maxWidth has invalid em unit", async () => {
+    await page.viewport(1280, 800);
     const Component = () => {
       return (
         <div data-testid="container">
@@ -479,36 +502,41 @@ describe("Tooltip Browser Tests", () => {
 
     const result = render(<Component />);
     const container = result.getByTestId("container");
+    const host = container.element().querySelector("goa-tooltip") as HTMLElement | null;
 
-    await vi.waitFor(
-      () => {
-        const tooltipEl = container
-          .element()
-          .querySelector("goa-tooltip") as HTMLElement | null;
-        expect(tooltipEl).toBeTruthy();
+    vi.useFakeTimers();
+    try {
+      expect(host).toBeTruthy();
 
-        // Trigger tooltip visibility
-        tooltipEl?.dispatchEvent(new Event("mouseenter", { bubbles: true }));
+      await vi.waitFor(() => {
+        const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+        expect(hoverTarget).toBeTruthy();
+      });
 
-        const tooltipTextEl =
-          tooltipEl?.shadowRoot?.querySelector<HTMLElement>(".tooltip-text");
-        expect(tooltipTextEl).toBeTruthy();
+      const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+      hoverTarget?.dispatchEvent(new MouseEvent("mouseenter"));
 
-        // Should use default width (400px) since em unit is invalid
-        const inlineWidth = tooltipTextEl?.style.width;
-        expect(inlineWidth).toBeTruthy();
+      await vi.advanceTimersByTimeAsync(350);
 
-        const numericWidth = parseInt(inlineWidth || "0", 10);
-        expect(numericWidth).toBeGreaterThan(0);
+      await vi.waitFor(() => {
+        const tooltipTextEl = host?.shadowRoot?.querySelector(
+          ".tooltip-text",
+        ) as HTMLElement | null;
 
-        // Should use default maxWidth of 400px (minus padding adjustments)
-        expect(numericWidth).toBeLessThanOrEqual(400);
-      },
-      { timeout: 3000 },
-    );
+        expect(tooltipTextEl?.classList.contains("show")).toBe(true);
+
+        const renderedWidth = tooltipTextEl?.getBoundingClientRect().width ?? 0;
+
+        expect(renderedWidth).toBeGreaterThan(300);
+        expect(renderedWidth).toBeLessThanOrEqual(401);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("should use default width when maxWidth has invalid ch unit", async () => {
+    await page.viewport(1280, 800);
     const Component = () => {
       return (
         <div data-testid="container">
@@ -524,36 +552,41 @@ describe("Tooltip Browser Tests", () => {
 
     const result = render(<Component />);
     const container = result.getByTestId("container");
+    const host = container.element().querySelector("goa-tooltip") as HTMLElement | null;
 
-    await vi.waitFor(
-      () => {
-        const tooltipEl = container
-          .element()
-          .querySelector("goa-tooltip") as HTMLElement | null;
-        expect(tooltipEl).toBeTruthy();
+    vi.useFakeTimers();
+    try {
+      expect(host).toBeTruthy();
 
-        // Trigger tooltip visibility
-        tooltipEl?.dispatchEvent(new Event("mouseenter", { bubbles: true }));
+      await vi.waitFor(() => {
+        const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+        expect(hoverTarget).toBeTruthy();
+      });
 
-        const tooltipTextEl =
-          tooltipEl?.shadowRoot?.querySelector<HTMLElement>(".tooltip-text");
-        expect(tooltipTextEl).toBeTruthy();
+      const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+      hoverTarget?.dispatchEvent(new MouseEvent("mouseenter"));
 
-        // Should use default width (400px) since ch unit is invalid
-        const inlineWidth = tooltipTextEl?.style.width;
-        expect(inlineWidth).toBeTruthy();
+      await vi.advanceTimersByTimeAsync(350);
 
-        const numericWidth = parseInt(inlineWidth || "0", 10);
-        expect(numericWidth).toBeGreaterThan(0);
+      await vi.waitFor(() => {
+        const tooltipTextEl = host?.shadowRoot?.querySelector(
+          ".tooltip-text",
+        ) as HTMLElement | null;
 
-        // Should use default maxWidth of 400px (minus padding adjustments)
-        expect(numericWidth).toBeLessThanOrEqual(400);
-      },
-      { timeout: 3000 },
-    );
+        expect(tooltipTextEl?.classList.contains("show")).toBe(true);
+
+        const renderedWidth = tooltipTextEl?.getBoundingClientRect().width ?? 0;
+
+        expect(renderedWidth).toBeGreaterThan(200);
+        expect(renderedWidth).toBeLessThanOrEqual(401);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("should use default width when maxWidth has completely invalid value", async () => {
+    await page.viewport(1280, 800);
     const Component = () => {
       return (
         <div data-testid="container">
@@ -569,32 +602,36 @@ describe("Tooltip Browser Tests", () => {
 
     const result = render(<Component />);
     const container = result.getByTestId("container");
+    const host = container.element().querySelector("goa-tooltip") as HTMLElement | null;
 
-    await vi.waitFor(
-      () => {
-        const tooltipEl = container
-          .element()
-          .querySelector("goa-tooltip") as HTMLElement | null;
-        expect(tooltipEl).toBeTruthy();
+    vi.useFakeTimers();
+    try {
+      expect(host).toBeTruthy();
 
-        // Trigger tooltip visibility
-        tooltipEl?.dispatchEvent(new Event("mouseenter", { bubbles: true }));
+      await vi.waitFor(() => {
+        const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+        expect(hoverTarget).toBeTruthy();
+      });
 
-        const tooltipTextEl =
-          tooltipEl?.shadowRoot?.querySelector<HTMLElement>(".tooltip-text");
-        expect(tooltipTextEl).toBeTruthy();
+      const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+      hoverTarget?.dispatchEvent(new MouseEvent("mouseenter"));
 
-        // Should use default width (400px) since value is completely invalid
-        const inlineWidth = tooltipTextEl?.style.width;
-        expect(inlineWidth).toBeTruthy();
+      await vi.advanceTimersByTimeAsync(350);
 
-        const numericWidth = parseInt(inlineWidth || "0", 10);
-        expect(numericWidth).toBeGreaterThan(0);
+      await vi.waitFor(() => {
+        const tooltipTextEl = host?.shadowRoot?.querySelector(
+          ".tooltip-text",
+        ) as HTMLElement | null;
 
-        // Should use default maxWidth of 400px (minus padding adjustments)
-        expect(numericWidth).toBeLessThanOrEqual(400);
-      },
-      { timeout: 3000 },
-    );
+        expect(tooltipTextEl?.classList.contains("show")).toBe(true);
+
+        const renderedWidth = tooltipTextEl?.getBoundingClientRect().width ?? 0;
+
+        expect(renderedWidth).toBeGreaterThan(200);
+        expect(renderedWidth).toBeLessThanOrEqual(401);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/libs/web-components/src/components/tooltip/Tooltip.svelte
+++ b/libs/web-components/src/components/tooltip/Tooltip.svelte
@@ -50,7 +50,7 @@
     if (!maxwidth) return "";
 
     // Check for 'px' unit
-    if (!maxwidth.endsWith('px')) {
+    if (!maxwidth.endsWith("px")) {
       return "";
     }
 
@@ -78,10 +78,18 @@
   let _screenSize = 0;
   let _rootEl: HTMLElement;
   let _tooltipEl: HTMLElement;
+  let _targetEl: HTMLElement;
   let _initialPosition: Position;
+  let _computedAlign: Alignment = "center";
   let _tooltipVisible = false;
   let _showTooltipTimeout: ReturnType<typeof setTimeout> | undefined;
   let _hideTooltipTimeout: ReturnType<typeof setTimeout> | undefined;
+  let _positionRafId: number | null = null;
+  const _needsManualPositioning =
+    typeof document !== "undefined" &&
+    !("anchorName" in document.documentElement.style);
+  const _manualGap = 12;
+  const _manualOffset = 16;
 
   // Use a unique id for each tooltip instance.
   // So screen readers can identify the tooltip instance when
@@ -91,17 +99,7 @@
   // Reactive
 
   $: {
-    if (_rootEl && _tooltipEl) {
-      _rootEl.style.setProperty(
-        "--target-width",
-        `${_rootEl.getBoundingClientRect().width / 2}px`,
-      );
-    }
-  }
-
-  // call checkAndAdjustPosition function when content changes
-  $: {
-    content && checkAndAdjustPosition();
+    content && reconcileTooltipLayout(); // Check position when content changes.
   }
 
   // Hooks
@@ -113,24 +111,39 @@
     maxwidth = validateMaxWidth(maxwidth);
 
     _initialPosition = position;
+    _computedAlign = halign;
     _tooltipInstanceId = Math.random().toString(36);
 
-    window.addEventListener("resize", checkAndAdjustPosition);
-    checkAndAdjustPosition();
+    window.addEventListener("resize", onWindowResize);
   });
 
   onDestroy(() => {
-    window.removeEventListener("resize", checkAndAdjustPosition);
+    window.removeEventListener("resize", onWindowResize);
+
     clearTimeout(_showTooltipTimeout);
     clearTimeout(_hideTooltipTimeout);
+
+    if (_needsManualPositioning || _positionRafId !== null) {
+      stopManualPositioning();
+    }
   });
 
   // Functions
 
   const showTooltip = () => {
     _showTooltipTimeout = setTimeout(() => {
+      // Measure target width here — layout is guaranteed to be available on hover
+      updateTargetWidth();
       _tooltipVisible = true;
-      checkAndAdjustPosition();
+
+      // Popover promotion to the top layer can require one paint before
+      // dimensions are stable, so size/position on the next frame.
+      requestAnimationFrame(() => {
+        reconcileTooltipLayout();
+        if (_needsManualPositioning) {
+          startManualPositioning();
+        }
+      });
     }, 300);
   };
 
@@ -140,8 +153,36 @@
     _hideTooltipTimeout = setTimeout(() => {
       _tooltipVisible = false;
       position = _initialPosition;
+      _computedAlign = halign;
+      if (_needsManualPositioning || _positionRafId !== null) {
+        stopManualPositioning();
+      }
     }, 500);
   };
+
+  function startManualPositioning() {
+    if (!_needsManualPositioning || _positionRafId !== null) {
+      return;
+    }
+
+    const loop = () => {
+      updateManualPopoverCoordinates();
+      _positionRafId = requestAnimationFrame(loop);
+    };
+
+    _positionRafId = requestAnimationFrame(loop);
+  }
+
+  function stopManualPositioning() {
+    if (_positionRafId !== null) {
+      cancelAnimationFrame(_positionRafId);
+      _positionRafId = null;
+    }
+  }
+
+  function onWindowResize() {
+    reconcileTooltipLayout();
+  }
 
   // Mouse click also fires on:focus on a tabindex=0 element, but we only want
   // to reveal the tooltip on keyboard-driven focus so JS state stays aligned
@@ -153,84 +194,203 @@
     showTooltip();
   }
 
-  async function checkAndAdjustPosition() {
-    // angular needs time to render the _tooltipEl
-    await tick();
-
-    if (!_tooltipEl || !_rootEl) {
-      return;
-    }
-
-    // determine the bounding rectangle of the tooltip and root element
-    const tooltipRect = _tooltipEl.getBoundingClientRect();
-    const rootRect = _rootEl.getBoundingClientRect();
-
-    const spaceTop = rootRect.top;
-    const spaceBottom = window.innerHeight - rootRect.bottom;
-    const spaceLeft = rootRect.left;
-    const spaceRight = window.innerWidth - rootRect.right;
-
-    const calculatedMaxWidth = maxwidth && maxwidth.endsWith('px') ? parseFloat(maxwidth) : 400;
+  function applyTooltipWidth(
+    tooltipRect: DOMRect,
+    targetRect: DOMRect,
+    spaceLeft: number,
+    spaceRight: number,
+  ) {
+    const viewportWidth = _screenSize || window.innerWidth;
+    const calculatedMaxWidth =
+      maxwidth && maxwidth.endsWith("px") ? parseFloat(maxwidth) : 400;
     const newWidth = Math.min(
-      _screenSize * 0.8,
+      viewportWidth * 0.8,
       calculatedMaxWidth,
       tooltipRect.width,
       Math.max(spaceLeft, spaceRight) - 10,
     );
     const shouldWrapContent =
-      (maxwidth && maxwidth.endsWith('px')) ||
-      newWidth > rootRect.width ||
+      (maxwidth && maxwidth.endsWith("px")) ||
+      newWidth > targetRect.width ||
       newWidth > spaceLeft ||
       newWidth > spaceRight;
-    _tooltipEl.style.width = `${newWidth - 32}px`;
 
-    if (shouldWrapContent) {
-      _tooltipEl.style.whiteSpace = "normal";
-    } else {
-      _tooltipEl.style.whiteSpace = "nowrap";
+    _tooltipEl.style.width = `${Math.ceil(Math.max(newWidth - 32, 1))}px`;
+    _tooltipEl.style.whiteSpace = shouldWrapContent ? "normal" : "nowrap";
+  }
+
+  function getAdjustedPosition(
+    currentPosition: Position,
+    tooltipRect: DOMRect,
+    spaceTop: number,
+    spaceBottom: number,
+    spaceLeft: number,
+    spaceRight: number,
+  ): Position {
+    let adjustedPosition = currentPosition;
+
+    if (currentPosition === "bottom" && tooltipRect.height > spaceBottom) {
+      adjustedPosition = "top";
+    } else if (currentPosition === "top" && tooltipRect.height > spaceTop) {
+      adjustedPosition = "bottom";
     }
 
-    let newPosition = position; // use a local variable to determine the new position
-    let newAlign = halign; // use a local variable to determine the new position
-
-    // check if there is enough space for the tooltip in the initial position
-    if (position === "bottom" && tooltipRect.height > spaceBottom) {
-      newPosition = "top";
-    } else if (position === "top" && tooltipRect.height > spaceTop) {
-      newPosition = "bottom";
+    if (currentPosition === "right" && tooltipRect.width > spaceRight) {
+      adjustedPosition = "left";
+    } else if (currentPosition === "left" && tooltipRect.width > spaceLeft) {
+      adjustedPosition = "right";
     }
 
-    // similar check for left and right position
-    if (position === "right" && tooltipRect.width > spaceRight) {
-      newPosition = "left";
-    } else if (position === "left" && tooltipRect.width > spaceLeft) {
-      newPosition = "right";
+    return adjustedPosition;
+  }
+
+  function resolveTopBottomAlign(
+    requestedAlign: Alignment,
+    targetRect: DOMRect,
+    tooltipRect: DOMRect,
+    offset: number,
+  ): Alignment {
+    const viewportWidth = window.innerWidth;
+    const centerLeft =
+      targetRect.left + (targetRect.width - tooltipRect.width) / 2;
+    const rightLeft = targetRect.left - offset;
+    const leftLeft = targetRect.right - tooltipRect.width + offset;
+
+    const projectedLeftByAlign = (align: Alignment): number => {
+      if (align === "left") return leftLeft;
+      if (align === "right") return rightLeft;
+      return centerLeft;
+    };
+
+    const overflowsViewport = (left: number): boolean => {
+      const right = left + tooltipRect.width;
+      return left < 0 || right > viewportWidth;
+    };
+
+    const overflowAmount = (left: number): number => {
+      const right = left + tooltipRect.width;
+      return Math.max(0, -left) + Math.max(0, right - viewportWidth);
+    };
+
+    const requestedLeft = projectedLeftByAlign(requestedAlign);
+    const requestedOverflows = overflowsViewport(requestedLeft);
+
+    if (!requestedOverflows) {
+      return requestedAlign;
     }
 
-    // similar check for left and right alignmewnt
-    if (halign === "right" && tooltipRect.width > spaceRight) {
-      newAlign = "left";
-    } else if (halign === "left" && tooltipRect.width > spaceLeft) {
-      newAlign = "right";
-    } else if (
-      halign === "center" &&
-      (position === "top" || position === "bottom") &&
-      (tooltipRect.width / 2 > spaceLeft || tooltipRect.width / 2 > spaceRight)
-    ) {
-      newAlign = spaceLeft > spaceRight ? "left" : "right";
+    if (requestedAlign === "right" || requestedAlign === "left") {
+      const oppositeAlign: Alignment =
+        requestedAlign === "right" ? "left" : "right";
+      const oppositeLeft = projectedLeftByAlign(oppositeAlign);
+
+      if (!overflowsViewport(oppositeLeft)) {
+        return oppositeAlign;
+      }
+
+      if (overflowAmount(oppositeLeft) < overflowAmount(requestedLeft)) {
+        return oppositeAlign;
+      }
+
+      return requestedAlign;
     }
+
+    const leftOverflow = overflowAmount(leftLeft);
+    const rightOverflow = overflowAmount(rightLeft);
+    return leftOverflow <= rightOverflow ? "left" : "right";
+  }
+
+  async function reconcileTooltipLayout() {
+    // angular needs time to render the _tooltipEl
+    await tick();
+
+    if (!_tooltipEl || !_rootEl || !_targetEl || !_tooltipVisible) {
+      return;
+    }
+
+    // determine the bounding rectangle of the tooltip and target element
+    let tooltipRect = _tooltipEl.getBoundingClientRect();
+    const targetRect = _targetEl.getBoundingClientRect();
+
+    const spaceTop = targetRect.top;
+    const spaceBottom = window.innerHeight - targetRect.bottom;
+    const spaceLeft = targetRect.left;
+    const spaceRight = window.innerWidth - targetRect.right;
+    applyTooltipWidth(tooltipRect, targetRect, spaceLeft, spaceRight);
+
+    // Re-measure the tooltip rect after applying width/white-space
+    // since text wrapping can change the tooltip's dimensions
+    tooltipRect = _tooltipEl.getBoundingClientRect();
+
+    const newPosition = getAdjustedPosition(
+      position,
+      tooltipRect,
+      spaceTop,
+      spaceBottom,
+      spaceLeft,
+      spaceRight,
+    );
+
+    const newAlign =
+      newPosition === "top" || newPosition === "bottom"
+        ? resolveTopBottomAlign(halign, targetRect, tooltipRect, _manualOffset)
+        : "center";
 
     // update tooltip position
     position = newPosition;
-    halign = newAlign;
+    _computedAlign = newAlign;
+  }
+
+  function updateManualPopoverCoordinates() {
+    if (!_tooltipVisible || !_tooltipEl || !_targetEl) return;
+
+    const targetRect = _targetEl.getBoundingClientRect();
+    const tooltipRect = _tooltipEl.getBoundingClientRect();
+    const gap = _manualGap;
+    const offset = _manualOffset;
+
+    if (position === "top") {
+      _tooltipEl.style.top = `${targetRect.top - tooltipRect.height - gap}px`;
+      _tooltipEl.style.left = `${targetRect.left + (targetRect.width - tooltipRect.width) / 2}px`;
+    } else if (position === "bottom") {
+      _tooltipEl.style.top = `${targetRect.bottom + gap}px`;
+      _tooltipEl.style.left = `${targetRect.left + (targetRect.width - tooltipRect.width) / 2}px`;
+    } else if (position === "left") {
+      _tooltipEl.style.top = `${targetRect.top + (targetRect.height - tooltipRect.height) / 2}px`;
+      _tooltipEl.style.left = `${targetRect.left - tooltipRect.width - gap}px`;
+    } else if (position === "right") {
+      _tooltipEl.style.top = `${targetRect.top + (targetRect.height - tooltipRect.height) / 2}px`;
+      _tooltipEl.style.left = `${targetRect.right + gap}px`;
+    }
+
+    // Adjust horizontal alignment for top/bottom positions
+    if (position === "top" || position === "bottom") {
+      if (_computedAlign === "left") {
+        // tooltip's right edge aligns with target's right edge
+        _tooltipEl.style.left = `${targetRect.right - tooltipRect.width + offset}px`;
+      } else if (_computedAlign === "right") {
+        // tooltip's left edge aligns with target's left edge
+        _tooltipEl.style.left = `${targetRect.left - offset}px`;
+      }
+    }
+  }
+
+  function updateTargetWidth() {
+    if (!_rootEl || !_tooltipEl || !_targetEl) return;
+
+    const targetHalfWidth = `${_targetEl.getBoundingClientRect().width / 2}px`;
+    _rootEl.style.setProperty("--target-width", targetHalfWidth);
   }
 </script>
 
 <svelte:window bind:innerWidth={_screenSize} />
 
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
-  class="tooltip align-{halign}"
+  class="tooltip"
+  class:use-anchor-based-positioning={!_needsManualPositioning}
+  class:use-manual-positioning={_needsManualPositioning}
   bind:this={_rootEl}
   on:mouseenter={() => {
     clearTimeout(_hideTooltipTimeout);
@@ -240,19 +400,24 @@
   on:focus={handleFocus}
   on:blur={hideTooltip}
   data-testid={testid}
-  role="tooltip"
   aria-describedby="{_tooltipInstanceId}-tooltip"
   tabindex="0"
   style={calculateMargin(mt, mr, mb, ml)}
 >
-  <div class="tooltip-target">
+  <div
+    class="tooltip-target"
+    bind:this={_targetEl}
+    aria-describedby="{_tooltipInstanceId}-tooltip"
+  >
     <slot />
   </div>
   <span
     id="{_tooltipInstanceId}-tooltip"
-    class="tooltip-text {position} align-{halign}"
+    class="tooltip-text {position} align-{_computedAlign}"
     bind:this={_tooltipEl}
-    style="visibility: {_tooltipVisible ? 'visible' : 'hidden'}"
+    role="tooltip"
+    aria-hidden={!_tooltipVisible}
+    class:show={_tooltipVisible}
   >
     {#if $$slots.content}
       <slot name="content" />
@@ -282,49 +447,123 @@
   }
 
   .tooltip-text {
-    visibility: hidden;
+    pointer-events: none;
     font: var(--goa-tooltip-text-size);
     background-color: var(--goa-tooltip-color-bg);
     color: var(--goa-tooltip-color-text);
     text-align: center;
     border-radius: var(--goa-tooltip-border-radius);
-    position: absolute;
-    z-index: 2;
+    position: fixed;
+    z-index: 9999;
     opacity: 0;
-    transition: opacity 0.3s;
+    transition: opacity var(--goa-motion-duration-medium-2)
+      var(--goa-motion-curve-productive);
     padding: var(--goa-tooltip-padding);
     text-align: left;
     white-space: nowrap;
     display: flex;
     flex-direction: column;
+    overflow: visible;
+    border-width: 0;
+  }
+
+  .show.tooltip-text {
+    opacity: 1;
+  }
+
+  .use-manual-positioning .tooltip-text {
+    position: fixed;
+    z-index: 9999;
+    top: auto;
+    bottom: auto;
+    left: auto;
+    right: auto;
+  }
+
+  .use-anchor-based-positioning .tooltip-text {
+    position-anchor: --goa-tooltip-target;
+    margin: 0;
+    inset-block-start: anchor(bottom);
+    inset-inline-start: anchor(left);
   }
 
   .tooltip-target {
     margin: var(--goa-tooltip-gap);
     height: auto;
     display: flex;
+    cursor: pointer;
   }
 
-  .tooltip-text.bottom {
-    top: calc(100% + 10px);
+  .use-anchor-based-positioning .tooltip-target {
+    anchor-name: --goa-tooltip-target;
   }
 
-  .tooltip-text.top {
-    bottom: calc(100% + 10px);
+  /* Positions */
+
+  .use-anchor-based-positioning .tooltip-text.bottom {
+    inset-block-start: anchor(bottom);
+    inset-inline-start: anchor(center);
+    translate: -50% var(--goa-space-s);
   }
 
-  .tooltip-text.right {
-    left: calc(100% + 10px);
+  .use-anchor-based-positioning .tooltip-text.top {
+    inset-block-start: anchor(top);
+    inset-inline-start: anchor(center);
+    translate: -50% calc(-100% - var(--goa-space-s));
   }
 
-  .tooltip-text.left {
-    right: calc(100% + 10px);
+  .use-anchor-based-positioning .tooltip-text.right {
+    inset-block-start: anchor(center);
+    inset-inline-start: anchor(right);
+    translate: var(--goa-space-s) -50%;
   }
 
-  .tooltip:hover .tooltip-text,
-  .tooltip:focus-visible .tooltip-text {
-    opacity: 1;
+  .use-anchor-based-positioning .tooltip-text.left {
+    inset-block-start: anchor(center);
+    inset-inline-start: anchor(left);
+    translate: calc(-100% - var(--goa-space-s)) -50%;
   }
+
+  /* Alignments */
+  .use-anchor-based-positioning .tooltip-text.bottom.align-right {
+    inset-inline-start: anchor(left);
+    translate: calc(var(--goa-space-m) * -1) var(--goa-space-s);
+  }
+
+  .use-anchor-based-positioning .tooltip-text.top.align-right {
+    inset-inline-start: anchor(left);
+    translate: calc(var(--goa-space-m) * -1) calc(-100% - var(--goa-space-s));
+  }
+
+  .use-anchor-based-positioning .tooltip-text.bottom.align-left {
+    inset-inline-start: anchor(right);
+    translate: calc(-100% + var(--goa-space-m)) var(--goa-space-s);
+  }
+
+  .use-anchor-based-positioning .tooltip-text.top.align-left {
+    inset-inline-start: anchor(right);
+    translate: calc(-100% + var(--goa-space-m)) calc(-100% - var(--goa-space-s));
+  }
+
+  /* Overflow fallbacks: flip to opposite alignment when tooltip goes off-screen */
+  @position-try --align-right-flipped-bottom {
+    inset-inline-start: anchor(right);
+    translate: calc(-100% + var(--goa-space-m)) var(--goa-space-s);
+  }
+  @position-try --align-right-flipped-top {
+    inset-inline-start: anchor(right);
+    translate: calc(-100% + var(--goa-space-m)) calc(-100% - var(--goa-space-s));
+  }
+  @position-try --align-left-flipped-bottom {
+    inset-inline-start: anchor(left);
+    translate: calc(var(--goa-space-m) * -1) var(--goa-space-s);
+  }
+  @position-try --align-left-flipped-top {
+    inset-inline-start: anchor(left);
+    translate: calc(var(--goa-space-m) * -1) calc(-100% - var(--goa-space-s));
+  }
+
+  /* Callout */
 
   .tooltip-text.bottom::before,
   .tooltip-text.top::before,
@@ -371,27 +610,21 @@
 
   .tooltip-text.bottom.align-left::before,
   .tooltip-text.top.align-left::before {
-    left: calc(100% - (var(--target-width) + 1rem));
+    left: calc(100% - (var(--target-width) + var(--goa-space-m)));
   }
 
   .tooltip-text.bottom.align-right::before,
   .tooltip-text.top.align-right::before {
-    left: calc(var(--target-width) + 1rem);
+    left: calc(var(--target-width) + var(--goa-space-m));
   }
 
-  .tooltip.align-right {
-    justify-content: flex-start;
-  }
-  .tooltip.align-left {
-    justify-content: flex-end;
+  .use-anchor-based-positioning .tooltip-text.bottom.align-right::before,
+  .use-anchor-based-positioning .tooltip-text.top.align-right::before {
+    left: calc(var(--target-width) + var(--goa-space-m));
   }
 
-  .tooltip-text.align-right {
-    left: 0;
-    margin-left: -1rem;
-  }
-  .tooltip-text.align-left {
-    right: 0;
-    margin-right: -1rem;
+  .use-anchor-based-positioning .tooltip-text.bottom.align-left::before,
+  .use-anchor-based-positioning .tooltip-text.top.align-left::before {
+    left: calc(100% - var(--target-width) - var(--goa-space-m));
   }
 </style>

--- a/libs/web-components/src/components/tooltip/tooltip.spec.ts
+++ b/libs/web-components/src/components/tooltip/tooltip.spec.ts
@@ -20,25 +20,35 @@ it("shows and hides tooltip on mouseenter/mouseleave", async () => {
   const tooltipContainer = container.querySelector(".tooltip");
   const tooltipEl = container.querySelector(".tooltip-text") as HTMLElement;
 
-  // Initially, tooltip should be hidden
-  expect(tooltipEl.style.visibility).toBe("hidden");
+  // Initially, tooltip should be hidden (no show class)
+  expect(tooltipEl.classList.contains("show")).toBe(false);
+  expect(tooltipEl.getAttribute("aria-hidden")).toBe("true");
 
   // Simulate mouse enter
   expect(tooltipContainer).toBeTruthy();
   if (!tooltipContainer) return;
 
-  await fireEvent.mouseEnter(tooltipContainer);
+  vi.useFakeTimers();
+  try {
+    await fireEvent.mouseEnter(tooltipContainer);
+    vi.advanceTimersByTime(350);
 
-  await waitFor(() => expect(tooltipEl.style.visibility).toBe("visible"), {
-    timeout: 350,
-  });
+    await waitFor(() =>
+      expect(tooltipEl.classList.contains("show")).toBe(true),
+    );
+    expect(tooltipEl.getAttribute("aria-hidden")).toBe("false");
 
-  // Simulate mouse leave
-  await fireEvent.mouseLeave(tooltipContainer);
+    // Simulate mouse leave
+    await fireEvent.mouseLeave(tooltipContainer);
+    vi.advanceTimersByTime(550);
 
-  await waitFor(() => expect(tooltipEl.style.visibility).toBe("hidden"), {
-    timeout: 600,
-  });
+    await waitFor(() =>
+      expect(tooltipEl.classList.contains("show")).toBe(false),
+    );
+    expect(tooltipEl.getAttribute("aria-hidden")).toBe("true");
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 it("validates the props", async () => {
@@ -93,26 +103,29 @@ it.skip("should try and change tooltip position on window resize", async () => {
 });
 
 it("does not exceed 80% of the screen size or 400px", async () => {
-  const { container } = render(Tooltip, { content: "Hello, Tooltip!" });
+  const { container } = render(Tooltip, {
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+  });
+  const tooltipContainer = container.querySelector(".tooltip");
   const tooltipEl = container.querySelector(".tooltip-text") as HTMLElement;
 
-  // Mock getBoundingClientRect to return a large width
-  tooltipEl.getBoundingClientRect = () => ({
-    width: 500,
-    height: 100,
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
-  });
+  expect(tooltipContainer).toBeTruthy();
+  if (!tooltipContainer) return;
 
-  // Simulate window resize to trigger the tooltip"s responsive behavior
-  global.dispatchEvent(new Event("resize"));
+  vi.useFakeTimers();
+  try {
+    // Simulate mouse enter
+    await fireEvent.mouseEnter(tooltipContainer);
+    vi.advanceTimersByTime(350);
 
-  await tick(); // to wait for Svelte"s reactive updates
-
-  // Verify that the tooltip"s width has been adjusted
-  expect(parseInt(tooltipEl.style.width, 10)).toBeLessThanOrEqual(400);
+    await waitFor(() =>
+      // Verify that the tooltip"s width has been adjusted
+      expect(parseInt(tooltipEl.style.width, 10)).toBeLessThanOrEqual(400),
+    );
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 it("cursor style remains same on hover", async () => {
@@ -122,56 +135,54 @@ it("cursor style remains same on hover", async () => {
   expect(tooltipContainer).toBeTruthy();
   if (!tooltipContainer) return;
 
-  const initialCursorStyle = window.getComputedStyle(tooltipContainer).cursor;
-  await fireEvent.mouseEnter(tooltipContainer);
+  vi.useFakeTimers();
+  try {
+    const initialCursorStyle = window.getComputedStyle(tooltipContainer).cursor;
+    await fireEvent.mouseEnter(tooltipContainer);
+    vi.advanceTimersByTime(350);
 
-  await waitFor(
-    () => {
+    await waitFor(() => {
       const cursorStyleOnHover =
         window.getComputedStyle(tooltipContainer).cursor;
       expect(cursorStyleOnHover).toBe(initialCursorStyle);
-    },
-    { timeout: 500 },
-  );
+    });
 
-  await fireEvent.mouseLeave(tooltipContainer);
+    await fireEvent.mouseLeave(tooltipContainer);
+    vi.advanceTimersByTime(350);
 
-  await waitFor(
-    () => {
+    await waitFor(() => {
       const cursorStyleOnLeave =
         window.getComputedStyle(tooltipContainer).cursor;
       expect(cursorStyleOnLeave).toBe(initialCursorStyle);
-    },
-    { timeout: 500 },
-  );
+    });
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 it("should render tooltip with maxwidth property", async () => {
   const { container } = render(Tooltip, {
-    content: "Hello, Tooltip!",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
     maxwidth: "300px",
   });
+    const tooltipContainer = container.querySelector(".tooltip");
   const tooltipEl = container.querySelector(".tooltip-text") as HTMLElement;
 
-  expect(tooltipEl).toBeTruthy();
+  expect(tooltipContainer).toBeTruthy();
+  if (!tooltipContainer) return;
 
-  // Mock getBoundingClientRect to simulate a tooltip that would exceed maxwidth
-  tooltipEl.getBoundingClientRect = () => ({
-    width: 500,
-    height: 100,
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
-    x: 0,
-    y: 0,
-    toJSON: () => ({}),
-  });
+  vi.useFakeTimers();
+  try {
+    // Simulate mouse enter
+    await fireEvent.mouseEnter(tooltipContainer);
+    vi.advanceTimersByTime(350);
 
-  // Trigger resize to apply maxwidth calculation
-  global.dispatchEvent(new Event("resize"));
-  await tick();
-
-  // The width should be constrained by maxwidth (300px - 32px padding = 268px)
-  expect(parseInt(tooltipEl.style.width, 10)).toBeLessThanOrEqual(268);
+    await waitFor(() =>
+      // The width should be constrained by maxwidth (300px - 32px padding = 268px)
+      expect(parseInt(tooltipEl.style.width, 10)).toBeLessThanOrEqual(268),
+    );
+  } finally {
+    vi.useRealTimers();
+  }
 });


### PR DESCRIPTION
This PR fixes the tooltip getting cropped by parent components with the following changes:
- Switch to CSS anchor positioning so the tooltip is always on top
- Use fixed positioning as a fallback for older browsers that don't support CSS anchor positioning
- Improves the alignment calculations so the tooltip doesn't overflow the viewport


## Using CSS Anchor Positioning

<img width="304" height="182" alt="tooltip-in-callout" src="https://github.com/user-attachments/assets/87ce1482-3484-400a-83a4-8930a236ff7b" />

<img width="514" height="168" alt="tooltips-anchor" src="https://github.com/user-attachments/assets/a4d6cfc8-1dd4-47c4-9207-ee5cc0f4a770" />


## Using fixed position fallback

<img width="666" height="160" alt="tooltips-fixed-fallback" src="https://github.com/user-attachments/assets/27daeb54-2928-4f85-9d7f-c0e3d1c3a90e" />


## Note

- The original version of the PR used the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API). We removed it because it caused issues for desktop and mobile Safari 
