### PR TITLE
(spike) Editable HTML in the config sandbox

### DIFF
--- a/docs/src/components/CodeSnippet.css
+++ b/docs/src/components/CodeSnippet.css
@@ -155,6 +155,32 @@ code {
   font-style: italic;
 }
 
+/* Brief 121: editable HTML block. Visually matches a code block but accepts
+   direct edits; the only affordance is the text-caret cursor on hover. */
+.editable-html {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: var(--goa-space-m, 1rem);
+  border: none;
+  background: var(--goa-color-greyscale-100, #f1f1f1);
+  color: var(--goa-color-text-default, #333);
+  font-family: "SF Mono", Monaco, "Courier New", monospace;
+  font-size: var(--goa-font-size-2);
+  line-height: 1.6;
+  resize: vertical;
+  outline: none;
+  white-space: pre;
+  overflow: auto;
+}
+
+/* Lift the focus outline up to the wrapper so its corners round with the
+   wrapper's border-radius instead of getting clipped by overflow:hidden. */
+.code-snippet:has(.editable-html:focus) {
+  outline: var(--goa-border-width-l, 0.1875rem) solid var(--goa-color-interactive-focus);
+}
+
 /* Highlight.js theme */
 .hljs {
   color: var(--goa-color-text-default, #333);

--- a/docs/src/components/CodeSnippet.css
+++ b/docs/src/components/CodeSnippet.css
@@ -155,7 +155,7 @@ code {
   font-style: italic;
 }
 
-/* Brief 121: editable HTML block. Visually matches a code block but accepts
+/* Editable HTML block. Visually matches a code block but accepts
    direct edits; the only affordance is the text-caret cursor on hover. */
 .editable-html {
   display: block;

--- a/docs/src/components/CodeSnippet.tsx
+++ b/docs/src/components/CodeSnippet.tsx
@@ -53,6 +53,12 @@ interface CodeSnippetProps {
   title?: string;
   /** Extract and display CSS, setup, and JSX/template as separate blocks (default: true for frameworkCode) */
   extractParts?: boolean;
+  /**
+   * When provided, the Web Components HTML block becomes editable in place. The
+   * callback fires (debounced) with the new HTML on each edit. The parent uses
+   * this to drive a live re-render of its preview.
+   */
+  onHtmlEdit?: (html: string) => void;
 }
 
 const FRAMEWORK_LABELS: Record<Framework, string> = {
@@ -190,6 +196,59 @@ function SingleCodeBlock({
 }
 
 // ============================================================================
+// Editable HTML Block (Brief 121)
+// ============================================================================
+
+interface EditableHtmlBlockProps {
+  html: string;
+  onEdit: (html: string) => void;
+}
+
+/**
+ * Plain-text textarea version of the WC HTML block. Local state owns the value
+ * so cursor position stays stable while typing; the parent only hears the
+ * debounced "new HTML" event and decides what to do with it.
+ *
+ * The canonical `html` prop changes when the variant switches, which resets
+ * the textarea content back to the new variant's canonical HTML.
+ */
+function EditableHtmlBlock({ html, onEdit }: EditableHtmlBlockProps) {
+  const [value, setValue] = useState(html);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setValue(html);
+  }, [html]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    setValue(newValue);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => onEdit(newValue), 300);
+  };
+
+  const lineCount = value.split("\n").length;
+  const minHeight = Math.max(80, Math.min(lineCount * 20 + 32, 400));
+
+  return (
+    <div className="code-snippet">
+      <div className="code-blocks">
+        <div className="code-block editable-html-block">
+          <textarea
+            className="editable-html"
+            value={value}
+            onChange={handleChange}
+            spellCheck={false}
+            style={{ minHeight: `${minHeight}px` }}
+            aria-label="Editable HTML preview source"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
 // Main CodeSnippet Component
 // ============================================================================
 
@@ -204,6 +263,7 @@ export function CodeSnippet({
   maxHeight,
   title,
   extractParts = true,
+  onHtmlEdit,
 }: CodeSnippetProps) {
   // Initialize from global preference (falls back to initialFramework prop if not set)
   const [selectedFramework, setSelectedFramework] = useState<Framework>(() => {
@@ -427,24 +487,32 @@ export function CodeSnippet({
   const renderWebComponentsBlocks = (wc?: string | WebComponentsExample) => {
     if (!wc) return <div className="no-code">No Web Components code available</div>;
 
-    // Object form: use fields directly
+    let css: string | undefined;
+    let javascript: string | undefined;
+    let html: string;
+
     if (typeof wc !== "string") {
-      return (
-        <>
-          {wc.css && wrapCodeBlock(wc.css, "css", "css")}
-          {wc.js && wrapCodeBlock(wc.js, "javascript", "js")}
-          {wrapCodeBlock(wc.html, "html", "html")}
-        </>
-      );
+      css = wc.css;
+      javascript = wc.js;
+      html = wc.html;
+    } else {
+      const extracted = extractWebComponentsCode(wc);
+      css = extracted.css;
+      javascript = extracted.javascript;
+      html = extracted.html;
     }
 
-    // String form: parse via extractor (handles inline <style> and <script>)
-    const extracted = extractWebComponentsCode(wc);
+    const htmlBlock = onHtmlEdit ? (
+      <EditableHtmlBlock html={html} onEdit={onHtmlEdit} key="html" />
+    ) : (
+      wrapCodeBlock(html, "html", "html")
+    );
+
     return (
       <>
-        {extracted.css && wrapCodeBlock(extracted.css, "css", "css")}
-        {extracted.javascript && wrapCodeBlock(extracted.javascript, "javascript", "js")}
-        {wrapCodeBlock(extracted.html, "html", "html")}
+        {css && wrapCodeBlock(css, "css", "css")}
+        {javascript && wrapCodeBlock(javascript, "javascript", "js")}
+        {htmlBlock}
       </>
     );
   };

--- a/docs/src/components/CodeSnippet.tsx
+++ b/docs/src/components/CodeSnippet.tsx
@@ -196,7 +196,7 @@ function SingleCodeBlock({
 }
 
 // ============================================================================
-// Editable HTML Block (Brief 121)
+// Editable HTML Block
 // ============================================================================
 
 interface EditableHtmlBlockProps {

--- a/docs/src/components/ConfigurationPreview.tsx
+++ b/docs/src/components/ConfigurationPreview.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 // Note: Using web component directly for v2 styling (React wrapper doesn't pass version prop)
 import { GoabTooltip } from "@abgov/react-components";
 import { CodeSnippet } from "./CodeSnippet";
+import { extractWebComponentsCode } from "../lib/extract-code-parts";
 import { useGitHubIssueCount } from "../hooks/useGitHubIssueCount";
 import type { ComponentConfigurations } from "@/data/configurations";
 import DOMPurify from "dompurify";
@@ -44,6 +45,9 @@ export function ConfigurationPreview({
   const [selectedConfigId, setSelectedConfigId] = useState(
     configurations.defaultConfigurationId,
   );
+  // User-edited HTML for the current variant. undefined means "use the canonical
+  // HTML from the config." Resets to undefined whenever the variant changes.
+  const [editedHtml, setEditedHtml] = useState<string | undefined>(undefined);
   const previewRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLElement | null>(null);
   const issueCount = useGitHubIssueCount(componentName);
@@ -53,18 +57,32 @@ export function ConfigurationPreview({
     (c) => c.id === selectedConfigId,
   );
 
-  // Update preview when configuration changes
+  // Update preview when configuration changes (or when the user edits the HTML).
+  // The user only edits the HTML portion via the editable code block; CSS and JS
+  // for the variant are spliced back in from the canonical config.
   useEffect(() => {
     if (previewRef.current && selectedConfig) {
       const webComponentCode = selectedConfig.code.webComponents;
-      const rawCode =
-        typeof webComponentCode === "string"
-          ? webComponentCode
-          : [
-              webComponentCode.css ? `<style>${webComponentCode.css}</style>` : "",
-              webComponentCode.html,
-              webComponentCode.js ? `<script>${webComponentCode.js}</script>` : "",
-            ].join("");
+
+      let canonicalHtml: string;
+      let cssPart: string | undefined;
+      let jsPart: string | undefined;
+      if (typeof webComponentCode === "string") {
+        const extracted = extractWebComponentsCode(webComponentCode);
+        canonicalHtml = extracted.html;
+        cssPart = extracted.css;
+        jsPart = extracted.javascript;
+      } else {
+        canonicalHtml = webComponentCode.html;
+        cssPart = webComponentCode.css;
+        jsPart = webComponentCode.js;
+      }
+
+      const rawCode = [
+        cssPart ? `<style>${cssPart}</style>` : "",
+        editedHtml ?? canonicalHtml,
+        jsPart ? `<script>${jsPart}</script>` : "",
+      ].join("");
 
       const previewHtml = configurations.previewWrapper
         ? configurations.previewWrapper.replace("{{slot}}", rawCode)
@@ -104,7 +122,13 @@ export function ConfigurationPreview({
         }
       }
     }
-  }, [selectedConfig]);
+  }, [selectedConfig, editedHtml]);
+
+  // Reset edits when the user switches to a different variant. Each variant has
+  // its own code, so a prior edit's text wouldn't translate meaningfully.
+  useEffect(() => {
+    setEditedHtml(undefined);
+  }, [selectedConfigId]);
 
   // Handle configuration dropdown change
   const handleConfigChange = useCallback(
@@ -205,6 +229,7 @@ export function ConfigurationPreview({
           }}
           maxHeight={200}
           showCopy={true}
+          onHtmlEdit={setEditedHtml}
         />
       </div>
 


### PR DESCRIPTION
## Summary

You can now type into the code snippet for the web component of any config sandbox and the preview updates as you go. The idea is to let people try their own content or markup without leaving the page.

This is a quick spike for the team to give feedback on. 

## Why
A user cannot currently change the content of the config examples at the top of each component page. In our old design system website, we had a more fully featured sandbox where a team could edit properties and change content. We changed our approach to use a range of configured templates to show the component properties and variants so that it would be easier for us to maintain. Previously, there were also a lot of issues where certain properties and variants would not show up properly in the playground sandbox. 

This now gives the user the ability to edit the code and see the preview update. You can edit and add content, but you can also add more components, other content, change variants, and more within that sandbox preview now.  

## How to try it

1. Open any component page, e.g. `/components/badge` or `/components/accordion`
2. Scroll to the code area below the preview, click the Web Components tab
3. Click into the HTML. You should see the text cursor.
4. Type. After a brief pause the preview above updates.
5. Switch variants in the dropdown. Your edits clear, original HTML comes back.
6. Hard refresh resets everything.

## Only the Web Components tab is editable

The preview is the web component HTML you see in that tab, put straight onto the page. So editing the HTML changes what's shown. The React and Angular tabs are there to show how to use the same thing in those frameworks. Making those editable wouldn't reach the preview. 

## What's not in here

- The CSS and JS blocks of the Web Components tab (still read-only)
- React and Angular tabs (still read-only)
- Mirroring edits between framework tabs
- Edits sticking around after a page refresh
- Syntax highlighting while typing

## Open questions

- Is the cursor changing enough of a signal that you can edit, or does it need a visible hint?
- Should this also work on single-example pages, not just the configurable previews?
- Is being limited to the Web Components tab fine, or worth exploring how to mirror edits into the React/Angular code shown alongside?

## Test plan

- [ ] Component pages still load and previews still show
- [ ] Editing the HTML updates the preview after a brief pause
- [ ] Switching variants clears edits
- [ ] React and Angular tabs stay read-only
- [ ] Full page reload resets edits
- [ ] Focus outline matches the rest of the design system

<img width="1261" height="1135" alt="image" src="https://github.com/user-attachments/assets/e4d8f3ea-b29b-4dda-ab09-c81598a2005a" />