### PR TITLE
chore(#3770): generate MCP data from docs site content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ NOTES.md
 /test-results
 __screenshots__
 docs/.astro
+docs/generated/mcp/
+docs/generated/md-bundle/
 
 # environment
 .env

--- a/docs/generated/component-apis/temporary-notification.json
+++ b/docs/generated/component-apis/temporary-notification.json
@@ -1,6 +1,6 @@
 {
   "componentSlug": "temporary-notification",
-  "extractedFrom": "libs/web-components/src/components/temporary-notification/TemporaryNotification.svelte",
+  "extractedFrom": "libs/web-components/src/components/temporary-notification/TemporaryNotificationCtrl.svelte",
   "frameworks": {
     "react": {
       "props": [
@@ -77,6 +77,18 @@
           "description": "Direction the notification animates from when appearing or disappearing."
         },
         {
+          "name": "horizontal-position",
+          "type": "\"left\" | \"center\" | \"right\"",
+          "values": [
+            "left",
+            "center",
+            "right"
+          ],
+          "required": false,
+          "default": "center",
+          "description": "Horizontal position of the notification container."
+        },
+        {
           "name": "message",
           "type": "string",
           "required": false,
@@ -93,8 +105,8 @@
         {
           "name": "testid",
           "type": "string",
-          "required": false,
-          "default": "",
+          "required": true,
+          "default": null,
           "description": "Sets a data-testid attribute for automated testing."
         },
         {
@@ -110,6 +122,17 @@
           "required": false,
           "default": "basic",
           "description": "The notification type which determines the visual style and icon."
+        },
+        {
+          "name": "vertical-position",
+          "type": "\"top\" | \"bottom\"",
+          "values": [
+            "top",
+            "bottom"
+          ],
+          "required": false,
+          "default": "bottom",
+          "description": "Vertical position of the notification container."
         },
         {
           "name": "visible",

--- a/docs/generated/component-apis/temporary-notification.json
+++ b/docs/generated/component-apis/temporary-notification.json
@@ -59,24 +59,6 @@
     "webComponents": {
       "props": [
         {
-          "name": "action-text",
-          "type": "string",
-          "required": false,
-          "default": "",
-          "description": "Text for the optional action button. When provided, displays a clickable link button."
-        },
-        {
-          "name": "animation-direction",
-          "type": "\"up\" | \"down\"",
-          "values": [
-            "up",
-            "down"
-          ],
-          "required": false,
-          "default": "down",
-          "description": "Direction the notification animates from when appearing or disappearing."
-        },
-        {
           "name": "horizontal-position",
           "type": "\"left\" | \"center\" | \"right\"",
           "values": [
@@ -89,39 +71,11 @@
           "description": "Horizontal position of the notification container."
         },
         {
-          "name": "message",
-          "type": "string",
-          "required": false,
-          "default": "",
-          "description": "The notification message text to display."
-        },
-        {
-          "name": "progress",
-          "type": "number",
-          "required": false,
-          "default": "-1",
-          "description": "Progress value from 0-100. Use -1 to hide the progress bar. Only applies when type is \"progress\"."
-        },
-        {
           "name": "testid",
           "type": "string",
           "required": true,
           "default": null,
           "description": "Sets a data-testid attribute for automated testing."
-        },
-        {
-          "name": "type",
-          "type": "\"basic\" | \"success\" | \"failure\" | \"indeterminate\" | \"progress\"",
-          "values": [
-            "basic",
-            "success",
-            "failure",
-            "indeterminate",
-            "progress"
-          ],
-          "required": false,
-          "default": "basic",
-          "description": "The notification type which determines the visual style and icon."
         },
         {
           "name": "vertical-position",
@@ -133,13 +87,6 @@
           "required": false,
           "default": "bottom",
           "description": "Vertical position of the notification container."
-        },
-        {
-          "name": "visible",
-          "type": "boolean",
-          "required": false,
-          "default": "true",
-          "description": "Controls whether the notification is visible."
         }
       ],
       "events": [],

--- a/docs/src/content/components/table-sort-header.mdx
+++ b/docs/src/content/components/table-sort-header.mdx
@@ -1,0 +1,10 @@
+---
+name: Table Sort Header
+description: Sortable column header used inside a table to let users sort rows by that column.
+status: stable
+category: content-layout
+hidden: true
+subcomponent: true
+relatedComponents:
+  - table
+---

--- a/docs/src/content/components/table.mdx
+++ b/docs/src/content/components/table.mdx
@@ -11,5 +11,6 @@ tags:
 relatedComponents:
   - data-grid
   - pagination
+  - table-sort-header
 figmaUrl: https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/Component-library?node-id=27343-613386
 ---

--- a/docs/src/content/guidance/badge-arialabel-icon-only.mdx
+++ b/docs/src/content/guidance/badge-arialabel-icon-only.mdx
@@ -12,6 +12,6 @@ appliesTo:
     - badge
 relatedProps:
   - ariaLabel
-  - icon
+  - iconType
 status: published
 ---

--- a/docs/src/content/guidance/datepicker-calendar-variant.mdx
+++ b/docs/src/content/guidance/datepicker-calendar-variant.mdx
@@ -10,7 +10,7 @@ appliesTo:
   components:
     - date-picker
 relatedProps:
-  - variant
+  - type
 status: published
 ---
 

--- a/docs/src/content/guidance/datepicker-input-variant.mdx
+++ b/docs/src/content/guidance/datepicker-input-variant.mdx
@@ -10,12 +10,12 @@ appliesTo:
   components:
     - date-picker
 relatedProps:
-  - variant
+  - type
 status: published
 ---
 
 <Preview>
   <goa-form-item label="Date of birth">
-    <goa-date-picker name="dob" variant="input"></goa-date-picker>
+    <goa-date-picker name="dob" type="input"></goa-date-picker>
   </goa-form-item>
 </Preview>

--- a/docs/src/content/guidance/page-requires-one-column-layout.mdx
+++ b/docs/src/content/guidance/page-requires-one-column-layout.mdx
@@ -6,9 +6,6 @@ topic: other
 tags:
   - layout
   - page-structure
-appliesTo:
-  components:
-    - one-column-layout
 status: published
 ---
 

--- a/docs/src/scripts/content-generators/checks/component-refs.ts
+++ b/docs/src/scripts/content-generators/checks/component-refs.ts
@@ -1,0 +1,37 @@
+import type { AnyRecord, Finding } from "../types";
+import { collectIdsAndAliases, pushBrokenRefs } from "./lib";
+
+/**
+ * Validates the four cross-references that target component ids:
+ *   - components.relatedComponents
+ *   - examples.components
+ *   - guidance.appliesTo.components
+ *   - productTypes.components
+ *
+ * All produce error-severity findings when a referenced id is not in the
+ * components collection (either as a canonical id or as an alias).
+ */
+export function checkComponentRefs(records: AnyRecord[]): Finding[] {
+  const findings: Finding[] = [];
+  const componentIds = collectIdsAndAliases(records, "components");
+
+  for (const r of records) {
+    if (r.collection === "components") {
+      pushBrokenRefs(findings, r, "relatedComponents", r.relatedComponents, componentIds);
+    } else if (r.collection === "examples") {
+      pushBrokenRefs(findings, r, "components", r.components, componentIds);
+    } else if (r.collection === "guidance") {
+      pushBrokenRefs(
+        findings,
+        r,
+        "appliesTo.components",
+        r.appliesTo?.components,
+        componentIds,
+      );
+    } else if (r.collection === "productTypes") {
+      pushBrokenRefs(findings, r, "components", r.components, componentIds);
+    }
+  }
+
+  return findings;
+}

--- a/docs/src/scripts/content-generators/checks/id-refs.ts
+++ b/docs/src/scripts/content-generators/checks/id-refs.ts
@@ -1,0 +1,26 @@
+import type { AnyRecord, Finding } from "../types";
+import { collectIds, collectIdsAndAliases, pushBrokenRefs } from "./lib";
+
+/**
+ * Validates cross-references against guidance and example ids:
+ *   - components.relatedGuidance → guidance ids
+ *   - examples.relatedExamples → example ids (and aliases, since examples
+ *     carry old-slug aliases via EXAMPLE_SLUG_ALIASES)
+ *
+ * Both produce error-severity findings.
+ */
+export function checkIdRefs(records: AnyRecord[]): Finding[] {
+  const findings: Finding[] = [];
+  const guidanceIds = collectIds(records, "guidance");
+  const exampleIds = collectIdsAndAliases(records, "examples");
+
+  for (const r of records) {
+    if (r.collection === "components") {
+      pushBrokenRefs(findings, r, "relatedGuidance", r.relatedGuidance, guidanceIds);
+    } else if (r.collection === "examples") {
+      pushBrokenRefs(findings, r, "relatedExamples", r.relatedExamples, exampleIds);
+    }
+  }
+
+  return findings;
+}

--- a/docs/src/scripts/content-generators/checks/index.ts
+++ b/docs/src/scripts/content-generators/checks/index.ts
@@ -1,0 +1,15 @@
+import type { AnyRecord, Finding } from "../types";
+import { checkComponentRefs } from "./component-refs";
+import { checkIdRefs } from "./id-refs";
+import { checkPropRefs } from "./prop-refs";
+
+/**
+ * Run all cross-validation checks against the loaded records.
+ */
+export function runChecks(records: AnyRecord[]): Finding[] {
+  return [
+    ...checkComponentRefs(records),
+    ...checkIdRefs(records),
+    ...checkPropRefs(records),
+  ];
+}

--- a/docs/src/scripts/content-generators/checks/lib.ts
+++ b/docs/src/scripts/content-generators/checks/lib.ts
@@ -1,0 +1,81 @@
+import { distance } from "fastest-levenshtein";
+import type { AnyRecord, Finding } from "../types";
+
+const MAX_EDIT_DISTANCE = 2;
+
+/** Returns the set of ids for records in the given collection. */
+export function collectIds(
+  records: AnyRecord[],
+  collection: AnyRecord["collection"],
+): Set<string> {
+  const ids = new Set<string>();
+  for (const r of records) {
+    if (r.collection === collection) ids.add(r.id);
+  }
+  return ids;
+}
+
+/**
+ * Returns the set of ids plus aliases for records in the given collection.
+ * Lets cross-references match either the canonical id or any legacy/sub-component
+ * name surfaced on the record's aliases array.
+ */
+export function collectIdsAndAliases(
+  records: AnyRecord[],
+  collection: AnyRecord["collection"],
+): Set<string> {
+  const set = new Set<string>();
+  for (const r of records) {
+    if (r.collection !== collection) continue;
+    set.add(r.id);
+    const aliases = (r as { aliases?: string[] }).aliases;
+    if (Array.isArray(aliases)) for (const a of aliases) set.add(a);
+  }
+  return set;
+}
+
+/**
+ * For each ref in `refs` that does not appear in `validIds`, push an
+ * error-severity Finding describing the broken reference. Populates
+ * `hint` when a close-by valid id exists.
+ */
+export function pushBrokenRefs(
+  findings: Finding[],
+  source: AnyRecord,
+  field: string,
+  refs: string[] | undefined,
+  validIds: Set<string>,
+): void {
+  if (!Array.isArray(refs)) return;
+  for (const ref of refs) {
+    if (validIds.has(ref)) continue;
+    findings.push({
+      severity: "error",
+      source: { collection: source.collection, id: source.id },
+      field,
+      brokenRef: ref,
+      hint: computeHint(ref, validIds),
+    });
+  }
+}
+
+/**
+ * If any id in `validIds` is within MAX_EDIT_DISTANCE of `ref`, return
+ * `did you mean "<closest>"?`. If multiple ids tie, take the first by
+ * sort order. Returns undefined if no id is close enough.
+ */
+export function computeHint(ref: string, validIds: Set<string>): string | undefined {
+  let best: string | undefined;
+  let bestDistance = MAX_EDIT_DISTANCE + 1;
+
+  const sorted = [...validIds].sort();
+  for (const candidate of sorted) {
+    const d = distance(ref, candidate);
+    if (d < bestDistance) {
+      bestDistance = d;
+      best = candidate;
+    }
+  }
+
+  return best ? `did you mean "${best}"?` : undefined;
+}

--- a/docs/src/scripts/content-generators/checks/prop-refs.ts
+++ b/docs/src/scripts/content-generators/checks/prop-refs.ts
@@ -1,0 +1,95 @@
+import type { AnyRecord, ComponentRecord, Finding } from "../types";
+import { computeHint } from "./lib";
+
+/**
+ * Validates guidance.relatedProps against the extracted prop names on the
+ * components named in guidance.appliesTo.components.
+ *
+ * Warn-level. A relatedProps entry is valid if it exists on AT LEAST ONE
+ * of the linked components, matching the semantic "this guidance is about
+ * this prop, which lives on one of these components."
+ *
+ * Skips guidance atoms whose appliesTo.components references components
+ * that do not exist; component-refs.ts reports those separately.
+ */
+export function checkPropRefs(records: AnyRecord[]): Finding[] {
+  const findings: Finding[] = [];
+  const componentMap = new Map<string, ComponentRecord>();
+  for (const r of records) {
+    if (r.collection === "components") componentMap.set(r.id, r);
+  }
+
+  for (const r of records) {
+    if (r.collection !== "guidance") continue;
+    if (!Array.isArray(r.relatedProps) || r.relatedProps.length === 0) continue;
+    const linkedComponents = r.appliesTo?.components;
+    if (!Array.isArray(linkedComponents) || linkedComponents.length === 0) {
+      continue;
+    }
+
+    // Build the union of props across linked components that exist.
+    // Missing components are reported by component-refs.ts; skip them here
+    // to avoid double-reports.
+    const allValidProps = new Set<string>();
+    const knownComponents: string[] = [];
+    for (const componentId of linkedComponents) {
+      const component = componentMap.get(componentId);
+      if (!component) continue;
+      knownComponents.push(componentId);
+      for (const propName of extractPropNames(component)) {
+        allValidProps.add(propName);
+      }
+    }
+    if (knownComponents.length === 0) continue;
+
+    for (const propRef of r.relatedProps) {
+      if (allValidProps.has(propRef)) continue;
+      findings.push({
+        severity: "warning",
+        source: { collection: "guidance", id: r.id },
+        field: "relatedProps",
+        brokenRef: propRef,
+        context:
+          knownComponents.length === 1
+            ? `on component "${knownComponents[0]}"`
+            : `on components ${knownComponents.map((c) => `"${c}"`).join(", ")}`,
+        notFoundMessage: "not in extracted props",
+        hint: computeHint(propRef, allValidProps),
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Walks the component's api blob (frameworks.{react,angular,webComponents}.props[])
+ * and returns the union of all prop names declared across frameworks.
+ */
+function extractPropNames(component: ComponentRecord): Set<string> {
+  const names = new Set<string>();
+  const api = component.api;
+  if (!api || typeof api !== "object") return names;
+
+  const frameworks = (api as Record<string, unknown>).frameworks;
+  if (!frameworks || typeof frameworks !== "object") return names;
+
+  for (const key of ["react", "angular", "webComponents"]) {
+    const framework = (frameworks as Record<string, unknown>)[key];
+    if (!framework || typeof framework !== "object") continue;
+    const props = (framework as Record<string, unknown>).props;
+    if (!Array.isArray(props)) continue;
+    for (const prop of props) {
+      if (
+        typeof prop === "object" &&
+        prop !== null &&
+        "name" in prop &&
+        typeof (prop as { name: unknown }).name === "string"
+      ) {
+        names.add((prop as { name: string }).name);
+      }
+    }
+  }
+
+  return names;
+}

--- a/docs/src/scripts/content-generators/checks/prop-refs.ts
+++ b/docs/src/scripts/content-generators/checks/prop-refs.ts
@@ -1,5 +1,6 @@
 import type { AnyRecord, ComponentRecord, Finding } from "../types";
 import { computeHint } from "./lib";
+import { buildComponentLookup } from "../transforms/component-lookup";
 
 /**
  * Validates guidance.relatedProps against the extracted prop names on the
@@ -9,15 +10,19 @@ import { computeHint } from "./lib";
  * of the linked components, matching the semantic "this guidance is about
  * this prop, which lives on one of these components."
  *
+ * Component slugs resolve through aliases, so a guidance atom that points
+ * at `text-area` validates against the props of the canonical `textarea`
+ * record.
+ *
  * Skips guidance atoms whose appliesTo.components references components
  * that do not exist; component-refs.ts reports those separately.
  */
 export function checkPropRefs(records: AnyRecord[]): Finding[] {
   const findings: Finding[] = [];
-  const componentMap = new Map<string, ComponentRecord>();
-  for (const r of records) {
-    if (r.collection === "components") componentMap.set(r.id, r);
-  }
+  const components = records.filter(
+    (r): r is ComponentRecord => r.collection === "components",
+  );
+  const lookup = buildComponentLookup(components);
 
   for (const r of records) {
     if (r.collection !== "guidance") continue;
@@ -33,7 +38,7 @@ export function checkPropRefs(records: AnyRecord[]): Finding[] {
     const allValidProps = new Set<string>();
     const knownComponents: string[] = [];
     for (const componentId of linkedComponents) {
-      const component = componentMap.get(componentId);
+      const component = lookup.get(componentId);
       if (!component) continue;
       knownComponents.push(componentId);
       for (const propName of extractPropNames(component)) {

--- a/docs/src/scripts/content-generators/checks/render.ts
+++ b/docs/src/scripts/content-generators/checks/render.ts
@@ -1,0 +1,54 @@
+import type { Finding } from "../types";
+
+/**
+ * Render the findings to stderr. Errors first, then warnings, then a summary.
+ * No-op when there are zero findings.
+ */
+export function renderFindings(findings: Finding[]): void {
+  const errors = findings.filter((f) => f.severity === "error");
+  const warnings = findings.filter((f) => f.severity === "warning");
+
+  if (errors.length === 0 && warnings.length === 0) return;
+
+  if (errors.length > 0) {
+    process.stderr.write(`\n✗ ERRORS (${errors.length})\n`);
+    renderGroup(errors);
+  }
+
+  if (warnings.length > 0) {
+    process.stderr.write(`\n⚠ WARNINGS (${warnings.length})\n`);
+    renderGroup(warnings);
+  }
+
+  process.stderr.write(
+    `\nSummary: ${errors.length} ${plural("error", errors.length)}, ` +
+      `${warnings.length} ${plural("warning", warnings.length)}.\n\n`,
+  );
+}
+
+function renderGroup(findings: Finding[]): void {
+  const bySource = new Map<string, Finding[]>();
+  for (const f of findings) {
+    const key = `${f.source.collection}/${f.source.id}`;
+    if (!bySource.has(key)) bySource.set(key, []);
+    bySource.get(key)!.push(f);
+  }
+
+  for (const [key, group] of bySource) {
+    process.stderr.write(`\n  ${key}\n`);
+    for (const f of group) {
+      process.stderr.write(`    ${renderLine(f)}\n`);
+    }
+  }
+}
+
+function renderLine(f: Finding): string {
+  const ref = f.context ? `"${f.brokenRef}" ${f.context}` : `"${f.brokenRef}"`;
+  const notFound = f.notFoundMessage ?? "not found";
+  const tail = f.hint ? `${notFound}, ${f.hint}` : notFound;
+  return `${f.field} references ${ref} (${tail})`;
+}
+
+function plural(word: string, n: number): string {
+  return n === 1 ? word : `${word}s`;
+}

--- a/docs/src/scripts/content-generators/config.ts
+++ b/docs/src/scripts/content-generators/config.ts
@@ -1,0 +1,44 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const WORKSPACE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../..",
+);
+
+export const paths = {
+  workspaceRoot: WORKSPACE_ROOT,
+  content: {
+    components: path.join(WORKSPACE_ROOT, "docs/src/content/components"),
+    examples: path.join(WORKSPACE_ROOT, "docs/src/content/examples"),
+    guidance: path.join(WORKSPACE_ROOT, "docs/src/content/guidance"),
+    foundations: path.join(WORKSPACE_ROOT, "docs/src/content/foundations"),
+    getStarted: path.join(WORKSPACE_ROOT, "docs/src/content/get-started"),
+    productTypes: path.join(WORKSPACE_ROOT, "docs/src/content/productTypes"),
+  },
+  code: {
+    componentApis: path.join(WORKSPACE_ROOT, "docs/generated/component-apis"),
+    libs: path.join(WORKSPACE_ROOT, "libs"),
+  },
+  output: {
+    mcp: path.join(WORKSPACE_ROOT, "docs/generated/mcp"),
+    mdBundle: path.join(WORKSPACE_ROOT, "docs/generated/md-bundle"),
+  },
+} as const;
+
+export type CollectionName =
+  | "components"
+  | "examples"
+  | "guidance"
+  | "foundations"
+  | "get-started"
+  | "productTypes";
+
+export const collectionNames: CollectionName[] = [
+  "components",
+  "examples",
+  "guidance",
+  "foundations",
+  "get-started",
+  "productTypes",
+];

--- a/docs/src/scripts/content-generators/index.ts
+++ b/docs/src/scripts/content-generators/index.ts
@@ -1,0 +1,100 @@
+import { loadComponents } from "./loaders/components";
+import { loadExamples } from "./loaders/examples";
+import { loadGuidance } from "./loaders/guidance";
+import { loadFoundations } from "./loaders/foundations";
+import { loadGetStarted } from "./loaders/get-started";
+import { loadProductTypes } from "./loaders/productTypes";
+import { loadComponentApis } from "./loaders/component-apis";
+import { loadFrameworkIdentifiers } from "./loaders/framework-identifiers";
+import { addComponentAliases, addExampleAliases } from "./transforms/aliases";
+import { linkGuidanceToComponents } from "./transforms/link-guidance";
+import { writeMcpJson } from "./outputs/mcp-json";
+import { runChecks } from "./checks";
+import { renderFindings } from "./checks/render";
+import type { AnyRecord, ComponentRecord } from "./types";
+
+function main(): void {
+  const start = performance.now();
+
+  // 1. Load raw data from all sources.
+  const componentsRaw = loadComponents();
+  const examplesRaw = loadExamples();
+  const guidance = loadGuidance();
+  const foundations = loadFoundations();
+  const getStarted = loadGetStarted();
+  const productTypes = loadProductTypes();
+  const apis = loadComponentApis();
+  const fwIds = loadFrameworkIdentifiers();
+
+  // 2. Merge code-derived facts (framework ids, API blob) into components.
+  let components: ComponentRecord[] = componentsRaw.map((c) => {
+    const fw = fwIds.get(c.id);
+    const api = apis.get(c.id);
+    let apiBlob: Record<string, unknown> | undefined;
+    if (api) {
+      const { componentSlug: _slug, ...rest } = api;
+      void _slug;
+      apiBlob = rest;
+    }
+    return {
+      ...c,
+      webComponentTag: fw?.webComponentTag,
+      reactClassName: fw?.reactClassName,
+      angularSelector: fw?.angularSelector,
+      // Carry extra react class names as a starting point for aliases.
+      aliases: fw && fw.reactClassNames.length > 1 ? fw.reactClassNames.slice(1) : [],
+      api: apiBlob,
+    };
+  });
+
+  // 3. Transforms.
+  components = addComponentAliases(components);
+  components = linkGuidanceToComponents(components, guidance);
+  const examples = addExampleAliases(examplesRaw);
+
+  // 4. Cross-validation checks.
+  const records: AnyRecord[] = [
+    ...components,
+    ...examples,
+    ...guidance,
+    ...foundations,
+    ...getStarted,
+    ...productTypes,
+  ];
+  const findings = runChecks(records);
+  renderFindings(findings);
+  const errorCount = findings.filter((f) => f.severity === "error").length;
+  if (errorCount > 0) {
+    process.stderr.write(
+      `[content-generators] skipped output because of ${errorCount} ${errorCount === 1 ? "error" : "errors"}. ` +
+        `Existing files in docs/generated/mcp/ are unchanged.\n`,
+    );
+    process.exit(1);
+  }
+
+  // 5. Output.
+  const result = writeMcpJson(records);
+  const elapsed = Math.round(performance.now() - start);
+
+  // 6. Report.
+  const withFw = components.filter((c) => c.webComponentTag).length;
+  const withApi = components.filter((c) => c.api).length;
+  const withAliases = components.filter((c) => c.aliases && c.aliases.length > 0).length;
+  const withGuidance = components.filter(
+    (c) => c.relatedGuidance && c.relatedGuidance.length > 0,
+  ).length;
+  const examplesWithAliases = examples.filter((e) => e.aliases.length > 0).length;
+  const examplesWithProductType = examples.filter((e) => e.productType).length;
+
+  process.stdout.write(
+    `[content-generators] wrote ${result.written} records in ${elapsed}ms\n` +
+      `  components:    ${components.length} (${withFw} with fw ids, ${withApi} with api, ${withAliases} with aliases, ${withGuidance} with linked guidance)\n` +
+      `  examples:      ${examples.length} (${examplesWithAliases} with aliases, ${examplesWithProductType} with productType)\n` +
+      `  guidance:      ${guidance.length}\n` +
+      `  foundations:   ${foundations.length}\n` +
+      `  get-started:   ${getStarted.length}\n` +
+      `  productTypes:  ${productTypes.length}\n`,
+  );
+}
+
+main();

--- a/docs/src/scripts/content-generators/loaders/component-apis.ts
+++ b/docs/src/scripts/content-generators/loaders/component-apis.ts
@@ -1,0 +1,32 @@
+import * as fs from "fs";
+import * as path from "path";
+import { paths } from "../config";
+
+export interface ComponentApi {
+  componentSlug: string;
+  extractedFrom?: string;
+  frameworks?: Record<string, unknown>;
+  events?: unknown[];
+  slots?: unknown[];
+  [key: string]: unknown;
+}
+
+export function loadComponentApis(): Map<string, ComponentApi> {
+  const map = new Map<string, ComponentApi>();
+  const dir = paths.code.componentApis;
+  if (!fs.existsSync(dir)) return map;
+
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const raw = fs.readFileSync(path.join(dir, file), "utf8");
+      const data = JSON.parse(raw) as ComponentApi;
+      const slug = data.componentSlug ?? file.replace(/\.json$/, "");
+      map.set(slug, { ...data, componentSlug: slug });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[loadComponentApis] failed to parse ${file}: ${message}\n`);
+    }
+  }
+  return map;
+}

--- a/docs/src/scripts/content-generators/loaders/components.ts
+++ b/docs/src/scripts/content-generators/loaders/components.ts
@@ -1,0 +1,35 @@
+import * as fs from "fs";
+import * as path from "path";
+import { paths } from "../config";
+import { parseFrontmatter } from "./frontmatter";
+import { asString, asStringArray, listMdxFiles } from "./lib";
+import type { ComponentRecord } from "../types";
+
+export function loadComponents(): ComponentRecord[] {
+  const records: ComponentRecord[] = [];
+
+  for (const filePath of listMdxFiles(paths.content.components)) {
+    const slug = path.basename(filePath, ".mdx");
+    const raw = fs.readFileSync(filePath, "utf8");
+    const { data, body } = parseFrontmatter(raw);
+
+    records.push({
+      id: asString(data.id) ?? slug,
+      collection: "components",
+      name: asString(data.name) ?? slug,
+      description: asString(data.description),
+      status: asString(data.status) ?? "stable",
+      category: asString(data.category) ?? "utilities",
+      tags: asStringArray(data.tags),
+      aliases: [],
+      relatedComponents: asStringArray(data.relatedComponents),
+      figmaUrl: asString(data.figmaUrl),
+      hidden: data.hidden === true ? true : undefined,
+      subcomponent: data.subcomponent === true ? true : undefined,
+      body: body.trim(),
+    });
+  }
+
+  records.sort((a, b) => a.id.localeCompare(b.id));
+  return records;
+}

--- a/docs/src/scripts/content-generators/loaders/examples.ts
+++ b/docs/src/scripts/content-generators/loaders/examples.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { paths } from "../config";
 import { parseFrontmatter } from "./frontmatter";
-import { asString, asStringArray, listDirectories } from "./lib";
+import { asString, asStringArray, findIndexMdxFolders } from "./lib";
 import type { ExampleRecord } from "../types";
 
 const PAGE_LIKE_SIZES = new Set(["page", "task", "product"]);
@@ -18,10 +18,9 @@ const VALID_SIZES = new Set<ExampleRecord["size"]>([
 export function loadExamples(): ExampleRecord[] {
   const records: ExampleRecord[] = [];
 
-  for (const folder of listDirectories(paths.content.examples)) {
+  for (const folder of findIndexMdxFolders(paths.content.examples)) {
     const slug = path.basename(folder);
     const indexPath = path.join(folder, "index.mdx");
-    if (!fs.existsSync(indexPath)) continue;
 
     const raw = fs.readFileSync(indexPath, "utf8");
     const { data, body } = parseFrontmatter(raw);

--- a/docs/src/scripts/content-generators/loaders/examples.ts
+++ b/docs/src/scripts/content-generators/loaders/examples.ts
@@ -1,0 +1,96 @@
+import * as fs from "fs";
+import * as path from "path";
+import { paths } from "../config";
+import { parseFrontmatter } from "./frontmatter";
+import { asString, asStringArray, listDirectories } from "./lib";
+import type { ExampleRecord } from "../types";
+
+const PAGE_LIKE_SIZES = new Set(["page", "task", "product"]);
+
+const VALID_SIZES = new Set<ExampleRecord["size"]>([
+  "interaction",
+  "section",
+  "page",
+  "task",
+  "product",
+]);
+
+export function loadExamples(): ExampleRecord[] {
+  const records: ExampleRecord[] = [];
+
+  for (const folder of listDirectories(paths.content.examples)) {
+    const slug = path.basename(folder);
+    const indexPath = path.join(folder, "index.mdx");
+    if (!fs.existsSync(indexPath)) continue;
+
+    const raw = fs.readFileSync(indexPath, "utf8");
+    const { data, body } = parseFrontmatter(raw);
+
+    const sizeRaw = asString(data.size);
+    if (!sizeRaw || !VALID_SIZES.has(sizeRaw as ExampleRecord["size"])) {
+      // Schema enforces this on the docs site; skip malformed entries here
+      // rather than emitting garbage downstream.
+      continue;
+    }
+    const size = sizeRaw as ExampleRecord["size"];
+
+    const productType = asString(data.productType);
+    const productTypeNarrowed =
+      productType === "workspace" || productType === "public-form"
+        ? productType
+        : undefined;
+
+    const frameworks = pickFrameworks(folder, data.frameworks, size);
+
+    records.push({
+      id: asString(data.id) ?? slug,
+      collection: "examples",
+      title: asString(data.title) ?? slug,
+      description: asString(data.description),
+      size,
+      tags: asStringArray(data.tags),
+      components: asStringArray(data.components),
+      relatedExamples: asStringArray(data.relatedExamples),
+      aliases: asStringArray(data.aliases),
+      status: asString(data.status) ?? "published",
+      productType: productTypeNarrowed,
+      frameworks,
+      previewImage: asString(data.previewImage),
+      figmaUrl: asString(data.figmaUrl),
+      accessibilityNotes: asString(data.accessibilityNotes),
+      hidden: data.hidden === true ? true : undefined,
+      previewUrl: asString(data.previewUrl),
+      reactSourceUrl: asString(data.reactSourceUrl),
+      angularSourceUrl: asString(data.angularSourceUrl),
+      sourceUrl: asString(data.sourceUrl),
+      stackblitzUrl: asString(data.stackblitzUrl),
+      body: body.trim(),
+    });
+  }
+
+  records.sort((a, b) => a.id.localeCompare(b.id));
+  return records;
+}
+
+function pickFrameworks(
+  folder: string,
+  declared: unknown,
+  size: ExampleRecord["size"],
+): string[] | undefined {
+  // Trust the frontmatter when it's set (page-like sizes can declare this).
+  const declaredArr = asStringArray(declared);
+  if (declaredArr.length > 0) return declaredArr;
+
+  // Page-like sizes are meant to declare frameworks in frontmatter; if absent,
+  // don't infer from sibling files (page-scale entries often live outside the
+  // example folder).
+  if (PAGE_LIKE_SIZES.has(size)) return undefined;
+
+  // Interaction/section entries: detect from sibling files as before.
+  const detected: string[] = [];
+  if (fs.existsSync(path.join(folder, "react.tsx"))) detected.push("react");
+  if (fs.existsSync(path.join(folder, "angular.html"))) detected.push("angular");
+  if (fs.existsSync(path.join(folder, "web-components.html")))
+    detected.push("web-components");
+  return detected.length > 0 ? detected : undefined;
+}

--- a/docs/src/scripts/content-generators/loaders/foundations.ts
+++ b/docs/src/scripts/content-generators/loaders/foundations.ts
@@ -1,0 +1,30 @@
+import * as fs from "fs";
+import * as path from "path";
+import { paths } from "../config";
+import { parseFrontmatter } from "./frontmatter";
+import { asString, asStringArray, listMdxFiles } from "./lib";
+import type { FoundationRecord } from "../types";
+
+export function loadFoundations(): FoundationRecord[] {
+  const records: FoundationRecord[] = [];
+
+  for (const filePath of listMdxFiles(paths.content.foundations)) {
+    const slug = path.basename(filePath, ".mdx");
+    const raw = fs.readFileSync(filePath, "utf8");
+    const { data, body } = parseFrontmatter(raw);
+
+    records.push({
+      id: asString(data.id) ?? slug,
+      collection: "foundations",
+      title: asString(data.title) ?? slug,
+      description: asString(data.description) ?? "",
+      category: asString(data.category) ?? "design",
+      tags: asStringArray(data.tags),
+      status: asString(data.status) ?? "published",
+      body: body.trim(),
+    });
+  }
+
+  records.sort((a, b) => a.id.localeCompare(b.id));
+  return records;
+}

--- a/docs/src/scripts/content-generators/loaders/framework-identifiers.ts
+++ b/docs/src/scripts/content-generators/loaders/framework-identifiers.ts
@@ -1,0 +1,188 @@
+import * as fs from "fs";
+import * as path from "path";
+import { paths } from "../config";
+
+export interface FrameworkIdentifiers {
+  webComponentTag?: string;
+  reactClassName?: string;
+  angularSelector?: string;
+  // All React export names found in the wrapper for this slug.
+  // First entry is the canonical/primary name; the rest are aliases.
+  reactClassNames: string[];
+}
+
+const WC_COMPONENTS_DIR = "web-components/src/components";
+const REACT_LIB_DIR = "react-components/src/lib";
+const ANGULAR_LIB_DIR = "angular-components/src/lib/components";
+
+// Map is keyed by FOLDER NAME, which matches the doc slug for the
+// vast majority of components. Code-identifiers (tag, React class, selector)
+// found inside go into the record's fields. Divergence between folder name
+// and the embedded tag (e.g. footer/ folder with goa-app-footer tag) is
+// expected. The aliases transform turns those divergences into alias entries.
+
+export function loadFrameworkIdentifiers(): Map<string, FrameworkIdentifiers> {
+  const bySlug = new Map<string, FrameworkIdentifiers>();
+  const getOrInit = (slug: string): FrameworkIdentifiers => {
+    let r = bySlug.get(slug);
+    if (!r) {
+      r = { reactClassNames: [] };
+      bySlug.set(slug, r);
+    }
+    return r;
+  };
+
+  // 1) Web components: walk libs/web-components/src/components/<folder>/<X>.svelte.
+  // A folder can host more than one custom element (e.g. temporary-notification/
+  // contains both goa-temp-notification and goa-temp-notification-ctrl). Gather
+  // every tag so the React-side bridge can resolve aux tags to the parent slug;
+  // the canonical webComponentTag stays the first one found.
+  const wcRoot = path.join(paths.code.libs, WC_COMPONENTS_DIR);
+  const tagToWcFolder = new Map<string, string>();
+  if (fs.existsSync(wcRoot)) {
+    for (const folder of fs.readdirSync(wcRoot, { withFileTypes: true })) {
+      if (!folder.isDirectory()) continue;
+      const tags = readWebComponentTags(path.join(wcRoot, folder.name));
+      if (tags.length === 0) continue;
+      const rec = getOrInit(folder.name);
+      rec.webComponentTag = tags[0];
+      for (const tag of tags) {
+        if (!tagToWcFolder.has(tag)) tagToWcFolder.set(tag, folder.name);
+      }
+    }
+  }
+
+  // 2) React wrappers. Bucket by the IntrinsicElement tag declaration when
+  // present (most reliable bridge to the web-component slug); fall back to
+  // folder name for files that don't declare one.
+
+  const reactRoot = path.join(paths.code.libs, REACT_LIB_DIR);
+  if (fs.existsSync(reactRoot)) {
+    for (const folder of fs.readdirSync(reactRoot, { withFileTypes: true })) {
+      if (!folder.isDirectory()) continue;
+      const folderPath = path.join(reactRoot, folder.name);
+
+      for (const tsxFile of walkFiles(folderPath, ".tsx")) {
+        if (tsxFile.endsWith(".spec.tsx") || tsxFile.endsWith(".test.tsx")) continue;
+        const raw = fs.readFileSync(tsxFile, "utf8");
+        const exports = extractReactExports(raw);
+        if (exports.length === 0) continue;
+
+        // Find any IntrinsicElement declarations in this file.
+        const intrinsicTags = [...raw.matchAll(/IntrinsicElements\s*\{[\s\S]*?\}/g)]
+          .flatMap((m) => [...m[0].matchAll(/"(goa-[a-z0-9-]+)"\s*:/g)])
+          .map((m) => m[1]);
+
+        // Determine the target slug: prefer the WC folder linked to the
+        // tag (handles textarea/text-area mismatch); otherwise use the
+        // React folder name as the slug.
+        const targetSlugs = new Set<string>();
+        for (const tag of intrinsicTags) {
+          const wcFolder = tagToWcFolder.get(tag);
+          if (wcFolder) targetSlugs.add(wcFolder);
+        }
+        if (targetSlugs.size === 0) targetSlugs.add(folder.name);
+
+        for (const slug of targetSlugs) {
+          const rec = getOrInit(slug);
+          for (const name of exports) {
+            if (!rec.reactClassNames.includes(name)) {
+              rec.reactClassNames.push(name);
+            }
+          }
+          if (!rec.reactClassName) rec.reactClassName = rec.reactClassNames[0];
+        }
+      }
+    }
+  }
+
+  // 3) Angular selectors.
+  const angularRoot = path.join(paths.code.libs, ANGULAR_LIB_DIR);
+  if (fs.existsSync(angularRoot)) {
+    for (const folder of fs.readdirSync(angularRoot, { withFileTypes: true })) {
+      if (!folder.isDirectory()) continue;
+      const selector = readAngularSelector(path.join(angularRoot, folder.name));
+      if (selector) {
+        const rec = getOrInit(folder.name);
+        rec.angularSelector = selector;
+      }
+    }
+  }
+
+  return bySlug;
+}
+
+function readWebComponentTags(folderPath: string): string[] {
+  const tags: string[] = [];
+  for (const file of fs.readdirSync(folderPath)) {
+    if (!file.endsWith(".svelte")) continue;
+    if (file.includes(".test.")) continue;
+    const raw = fs.readFileSync(path.join(folderPath, file), "utf8");
+    // Two customElement forms in this codebase:
+    //   <svelte:options customElement="goa-foo" />
+    //   <svelte:options customElement={{ tag: "goa-foo", ... }} />
+    const block = raw.match(/<svelte:options[\s\S]*?\/>/);
+    if (!block) continue;
+    const tagMatch = block[0].match(/["'](goa-[a-z0-9-]+)["']/);
+    if (tagMatch && !tags.includes(tagMatch[1])) tags.push(tagMatch[1]);
+  }
+  return tags;
+}
+
+function readReactExports(folderPath: string): string[] {
+  const names: string[] = [];
+  for (const file of walkFiles(folderPath, ".tsx")) {
+    if (file.endsWith(".spec.tsx") || file.endsWith(".test.tsx")) continue;
+    const raw = fs.readFileSync(file, "utf8");
+    for (const n of extractReactExports(raw)) {
+      if (!names.includes(n)) names.push(n);
+    }
+  }
+  return names;
+}
+
+function readAngularSelector(folderPath: string): string | undefined {
+  for (const file of fs.readdirSync(folderPath)) {
+    if (!file.endsWith(".ts")) continue;
+    if (file.endsWith(".spec.ts") || file.endsWith(".test.ts")) continue;
+    const raw = fs.readFileSync(path.join(folderPath, file), "utf8");
+    const m = raw.match(/selector\s*:\s*["']goab-([a-z0-9-]+)["']/);
+    if (m) return `goab-${m[1]}`;
+  }
+  return undefined;
+}
+
+function walkFiles(dir: string, ext: string): string[] {
+  const out: string[] = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkFiles(full, ext));
+    else if (entry.isFile() && entry.name.endsWith(ext)) out.push(full);
+  }
+  return out;
+}
+
+function extractReactExports(src: string): string[] {
+  const names = new Set<string>();
+  for (const m of src.matchAll(/export\s+function\s+(Goab[A-Z][A-Za-z0-9]*)/g)) {
+    names.add(m[1]);
+  }
+  for (const m of src.matchAll(/export\s+const\s+(Goab[A-Z][A-Za-z0-9]*)\s*[:=]/g)) {
+    names.add(m[1]);
+  }
+  for (const block of src.matchAll(/export\s*\{([^}]+)\}/g)) {
+    for (const part of block[1].split(",")) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+      const asMatch = trimmed.match(/(?:[A-Za-z0-9_]+)\s+as\s+(Goab[A-Z][A-Za-z0-9]*)/);
+      if (asMatch) {
+        names.add(asMatch[1]);
+        continue;
+      }
+      const direct = trimmed.match(/^(Goab[A-Z][A-Za-z0-9]*)$/);
+      if (direct) names.add(direct[1]);
+    }
+  }
+  return [...names];
+}

--- a/docs/src/scripts/content-generators/loaders/framework-identifiers.ts
+++ b/docs/src/scripts/content-generators/loaders/framework-identifiers.ts
@@ -54,7 +54,7 @@ export function loadFrameworkIdentifiers(): Map<string, FrameworkIdentifiers> {
 
     bySlug.set(slug, {
       webComponentTag: tag,
-      reactClassName: react?.classNames[0],
+      reactClassName: pickReactClassName(tag, react?.classNames ?? []),
       reactClassNames: react?.classNames ?? [],
       angularSelector,
     });
@@ -96,9 +96,21 @@ function buildAngularWrapperIndex(): Map<string, string> {
     const selectorMatch = content.match(/selector\s*:\s*["']goab-([a-z0-9-]+)["']/);
     if (!selectorMatch) continue;
     const stem = selectorMatch[1];
-    const tag = `goa-${stem}`;
     const selector = `goab-${stem}`;
-    if (!byTag.has(tag)) byTag.set(tag, selector);
+    // Read the web component tag the template actually renders rather than
+    // deriving it from the selector stem. They diverge for wrappers like
+    // goab-temporary-notification-ctrl, whose tag is goa-temp-notification-ctrl.
+    const tagMatch = content.match(/<(goa-[a-z0-9-]+)/);
+    if (!tagMatch) continue;
+    const tag = tagMatch[1];
+    // One tag can have several wrappers (goa-input <- goab-input and
+    // goab-input-number). Prefer the wrapper whose selector stem matches the
+    // tag stem; otherwise keep the first seen, which covers the divergent
+    // goab-temporary-notification-ctrl -> goa-temp-notification-ctrl case.
+    const tagStem = tag.replace(/^goa-/, "");
+    if (!byTag.has(tag) || stem === tagStem) {
+      byTag.set(tag, selector);
+    }
   }
 
   return byTag;
@@ -149,6 +161,30 @@ function extractGoabComponentExports(src: string): string[] {
   return [...names].filter(
     (n) => !n.endsWith("Props") && !n.endsWith("Detail") && !n.endsWith("Event"),
   );
+}
+
+/** Canonical React class for a tag: `goa-dropdown-item` -> `GoabDropdownItem`. */
+function tagToReactClassName(tag: string): string {
+  const pascal = tag
+    .replace(/^goa-/, "")
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+  return `Goab${pascal}`;
+}
+
+/**
+ * Pick the React class for a tag. A wrapper file can export more than one Goab
+ * component (e.g. a deprecated alias declared before the real one), so prefer
+ * the class whose name matches the tag and fall back to the first export.
+ */
+function pickReactClassName(
+  tag: string,
+  classNames: string[],
+): string | undefined {
+  if (classNames.length === 0) return undefined;
+  const canonical = tagToReactClassName(tag);
+  return classNames.includes(canonical) ? canonical : classNames[0];
 }
 
 function walkSourceFiles(root: string, ext: string): string[] {

--- a/docs/src/scripts/content-generators/loaders/framework-identifiers.ts
+++ b/docs/src/scripts/content-generators/loaders/framework-identifiers.ts
@@ -1,169 +1,131 @@
 import * as fs from "fs";
 import * as path from "path";
 import { paths } from "../config";
+import { loadComponentApis } from "./component-apis";
 
 export interface FrameworkIdentifiers {
   webComponentTag?: string;
   reactClassName?: string;
   angularSelector?: string;
-  // All React export names found in the wrapper for this slug.
-  // First entry is the canonical/primary name; the rest are aliases.
+  // All Goab class exports from the React wrapper file. First entry is the
+  // canonical/primary name; the rest (rare in practice) ride along.
   reactClassNames: string[];
 }
 
-const WC_COMPONENTS_DIR = "web-components/src/components";
 const REACT_LIB_DIR = "react-components/src/lib";
 const ANGULAR_LIB_DIR = "angular-components/src/lib/components";
 
-// Map is keyed by FOLDER NAME, which matches the doc slug for the
-// vast majority of components. Code-identifiers (tag, React class, selector)
-// found inside go into the record's fields. Divergence between folder name
-// and the embedded tag (e.g. footer/ folder with goa-app-footer tag) is
-// expected. The aliases transform turns those divergences into alias entries.
+interface ReactWrapperInfo {
+  file: string;
+  classNames: string[];
+}
 
+/**
+ * Derives framework identifiers per docs slug:
+ *   - canonical Svelte file comes from extract-api's `extractedFrom`
+ *     (already resolved via React-wrapper auto-derivation; see extract-api.ts)
+ *   - that Svelte file's `<svelte:options customElement>` tag is the truth
+ *     for `webComponentTag`
+ *   - the React wrapper that declares that tag in its IntrinsicElements
+ *     supplies the React class names
+ *   - the Angular wrapper with the matching selector (`goab-<tag-stem>`)
+ *     supplies the Angular selector
+ *
+ * Replaces the previous folder-conflation approach where every React/Angular
+ * file inside `<folder>/` landed on a single slug derived from the folder
+ * name. That caused sibling sub-components (e.g. `GoabMenuAction` next to
+ * `GoabMenuButton`, or `GoabTableSortHeader` next to `GoabTable`) to leak
+ * their tags/selectors/classes onto the parent slug.
+ */
 export function loadFrameworkIdentifiers(): Map<string, FrameworkIdentifiers> {
   const bySlug = new Map<string, FrameworkIdentifiers>();
-  const getOrInit = (slug: string): FrameworkIdentifiers => {
-    let r = bySlug.get(slug);
-    if (!r) {
-      r = { reactClassNames: [] };
-      bySlug.set(slug, r);
-    }
-    return r;
-  };
+  const apis = loadComponentApis();
+  const tagToReact = buildReactWrapperIndex();
+  const tagToAngular = buildAngularWrapperIndex();
 
-  // 1) Web components: walk libs/web-components/src/components/<folder>/<X>.svelte.
-  // A folder can host more than one custom element (e.g. temporary-notification/
-  // contains both goa-temp-notification and goa-temp-notification-ctrl). Gather
-  // every tag so the React-side bridge can resolve aux tags to the parent slug;
-  // the canonical webComponentTag stays the first one found.
-  const wcRoot = path.join(paths.code.libs, WC_COMPONENTS_DIR);
-  const tagToWcFolder = new Map<string, string>();
-  if (fs.existsSync(wcRoot)) {
-    for (const folder of fs.readdirSync(wcRoot, { withFileTypes: true })) {
-      if (!folder.isDirectory()) continue;
-      const tags = readWebComponentTags(path.join(wcRoot, folder.name));
-      if (tags.length === 0) continue;
-      const rec = getOrInit(folder.name);
-      rec.webComponentTag = tags[0];
-      for (const tag of tags) {
-        if (!tagToWcFolder.has(tag)) tagToWcFolder.set(tag, folder.name);
-      }
-    }
-  }
+  for (const [slug, api] of apis) {
+    if (!api.extractedFrom) continue;
+    const svelteFile = path.join(paths.workspaceRoot, api.extractedFrom);
+    const tag = readSvelteCustomElementTag(svelteFile);
+    if (!tag) continue;
 
-  // 2) React wrappers. Bucket by the IntrinsicElement tag declaration when
-  // present (most reliable bridge to the web-component slug); fall back to
-  // folder name for files that don't declare one.
+    const react = tagToReact.get(tag);
+    const angularSelector = tagToAngular.get(tag);
 
-  const reactRoot = path.join(paths.code.libs, REACT_LIB_DIR);
-  if (fs.existsSync(reactRoot)) {
-    for (const folder of fs.readdirSync(reactRoot, { withFileTypes: true })) {
-      if (!folder.isDirectory()) continue;
-      const folderPath = path.join(reactRoot, folder.name);
-
-      for (const tsxFile of walkFiles(folderPath, ".tsx")) {
-        if (tsxFile.endsWith(".spec.tsx") || tsxFile.endsWith(".test.tsx")) continue;
-        const raw = fs.readFileSync(tsxFile, "utf8");
-        const exports = extractReactExports(raw);
-        if (exports.length === 0) continue;
-
-        // Find any IntrinsicElement declarations in this file.
-        const intrinsicTags = [...raw.matchAll(/IntrinsicElements\s*\{[\s\S]*?\}/g)]
-          .flatMap((m) => [...m[0].matchAll(/"(goa-[a-z0-9-]+)"\s*:/g)])
-          .map((m) => m[1]);
-
-        // Determine the target slug: prefer the WC folder linked to the
-        // tag (handles textarea/text-area mismatch); otherwise use the
-        // React folder name as the slug.
-        const targetSlugs = new Set<string>();
-        for (const tag of intrinsicTags) {
-          const wcFolder = tagToWcFolder.get(tag);
-          if (wcFolder) targetSlugs.add(wcFolder);
-        }
-        if (targetSlugs.size === 0) targetSlugs.add(folder.name);
-
-        for (const slug of targetSlugs) {
-          const rec = getOrInit(slug);
-          for (const name of exports) {
-            if (!rec.reactClassNames.includes(name)) {
-              rec.reactClassNames.push(name);
-            }
-          }
-          if (!rec.reactClassName) rec.reactClassName = rec.reactClassNames[0];
-        }
-      }
-    }
-  }
-
-  // 3) Angular selectors.
-  const angularRoot = path.join(paths.code.libs, ANGULAR_LIB_DIR);
-  if (fs.existsSync(angularRoot)) {
-    for (const folder of fs.readdirSync(angularRoot, { withFileTypes: true })) {
-      if (!folder.isDirectory()) continue;
-      const selector = readAngularSelector(path.join(angularRoot, folder.name));
-      if (selector) {
-        const rec = getOrInit(folder.name);
-        rec.angularSelector = selector;
-      }
-    }
+    bySlug.set(slug, {
+      webComponentTag: tag,
+      reactClassName: react?.classNames[0],
+      reactClassNames: react?.classNames ?? [],
+      angularSelector,
+    });
   }
 
   return bySlug;
 }
 
-function readWebComponentTags(folderPath: string): string[] {
-  const tags: string[] = [];
-  for (const file of fs.readdirSync(folderPath)) {
-    if (!file.endsWith(".svelte")) continue;
-    if (file.includes(".test.")) continue;
-    const raw = fs.readFileSync(path.join(folderPath, file), "utf8");
-    // Two customElement forms in this codebase:
-    //   <svelte:options customElement="goa-foo" />
-    //   <svelte:options customElement={{ tag: "goa-foo", ... }} />
-    const block = raw.match(/<svelte:options[\s\S]*?\/>/);
-    if (!block) continue;
-    const tagMatch = block[0].match(/["'](goa-[a-z0-9-]+)["']/);
-    if (tagMatch && !tags.includes(tagMatch[1])) tags.push(tagMatch[1]);
-  }
-  return tags;
-}
+function buildReactWrapperIndex(): Map<string, ReactWrapperInfo> {
+  const byTag = new Map<string, ReactWrapperInfo>();
+  const root = path.join(paths.code.libs, REACT_LIB_DIR);
+  if (!fs.existsSync(root)) return byTag;
 
-function readReactExports(folderPath: string): string[] {
-  const names: string[] = [];
-  for (const file of walkFiles(folderPath, ".tsx")) {
-    if (file.endsWith(".spec.tsx") || file.endsWith(".test.tsx")) continue;
-    const raw = fs.readFileSync(file, "utf8");
-    for (const n of extractReactExports(raw)) {
-      if (!names.includes(n)) names.push(n);
+  for (const tsxFile of walkSourceFiles(root, ".tsx")) {
+    const content = fs.readFileSync(tsxFile, "utf8");
+    const tags = extractIntrinsicTags(content);
+    if (tags.length === 0) continue;
+    const classNames = extractGoabComponentExports(content);
+    if (classNames.length === 0) continue;
+    for (const tag of tags) {
+      // First wrapper found wins; siblings on the same tag would be a
+      // structural anomaly to flag separately.
+      if (!byTag.has(tag)) {
+        byTag.set(tag, { file: tsxFile, classNames });
+      }
     }
   }
-  return names;
+
+  return byTag;
 }
 
-function readAngularSelector(folderPath: string): string | undefined {
-  for (const file of fs.readdirSync(folderPath)) {
-    if (!file.endsWith(".ts")) continue;
-    if (file.endsWith(".spec.ts") || file.endsWith(".test.ts")) continue;
-    const raw = fs.readFileSync(path.join(folderPath, file), "utf8");
-    const m = raw.match(/selector\s*:\s*["']goab-([a-z0-9-]+)["']/);
-    if (m) return `goab-${m[1]}`;
+function buildAngularWrapperIndex(): Map<string, string> {
+  const byTag = new Map<string, string>();
+  const root = path.join(paths.code.libs, ANGULAR_LIB_DIR);
+  if (!fs.existsSync(root)) return byTag;
+
+  for (const tsFile of walkSourceFiles(root, ".ts")) {
+    const content = fs.readFileSync(tsFile, "utf8");
+    const selectorMatch = content.match(/selector\s*:\s*["']goab-([a-z0-9-]+)["']/);
+    if (!selectorMatch) continue;
+    const stem = selectorMatch[1];
+    const tag = `goa-${stem}`;
+    const selector = `goab-${stem}`;
+    if (!byTag.has(tag)) byTag.set(tag, selector);
   }
+
+  return byTag;
+}
+
+function readSvelteCustomElementTag(svelteFile: string): string | undefined {
+  if (!fs.existsSync(svelteFile)) return undefined;
+  const content = fs.readFileSync(svelteFile, "utf8");
+  // Two `customElement` forms in this codebase:
+  //   <svelte:options customElement="goa-foo" />
+  //   <svelte:options customElement={{ tag: "goa-foo", ... }} />
+  const simple = content.match(/customElement\s*=\s*["'](goa-[a-z0-9-]+)["']/);
+  if (simple) return simple[1];
+  const object = content.match(/customElement\s*=\s*\{\{\s*tag\s*:\s*["'](goa-[a-z0-9-]+)["']/);
+  if (object) return object[1];
   return undefined;
 }
 
-function walkFiles(dir: string, ext: string): string[] {
-  const out: string[] = [];
-  if (!fs.existsSync(dir)) return out;
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...walkFiles(full, ext));
-    else if (entry.isFile() && entry.name.endsWith(ext)) out.push(full);
-  }
-  return out;
+function extractIntrinsicTags(src: string): string[] {
+  return [...src.matchAll(/IntrinsicElements\s*\{[\s\S]*?\}/g)]
+    .flatMap((m) => [...m[0].matchAll(/["'](goa-[a-z0-9-]+)["']\s*:/g)])
+    .map((m) => m[1]);
 }
 
-function extractReactExports(src: string): string[] {
+function extractGoabComponentExports(src: string): string[] {
+  // Goab classes that are components (functions or constants), not types.
+  // Filters out *Props/*Detail/*Event type exports.
   const names = new Set<string>();
   for (const m of src.matchAll(/export\s+function\s+(Goab[A-Z][A-Za-z0-9]*)/g)) {
     names.add(m[1]);
@@ -175,7 +137,7 @@ function extractReactExports(src: string): string[] {
     for (const part of block[1].split(",")) {
       const trimmed = part.trim();
       if (!trimmed) continue;
-      const asMatch = trimmed.match(/(?:[A-Za-z0-9_]+)\s+as\s+(Goab[A-Z][A-Za-z0-9]*)/);
+      const asMatch = trimmed.match(/[A-Za-z0-9_]+\s+as\s+(Goab[A-Z][A-Za-z0-9]*)/);
       if (asMatch) {
         names.add(asMatch[1]);
         continue;
@@ -184,5 +146,28 @@ function extractReactExports(src: string): string[] {
       if (direct) names.add(direct[1]);
     }
   }
-  return [...names];
+  return [...names].filter(
+    (n) => !n.endsWith("Props") && !n.endsWith("Detail") && !n.endsWith("Event"),
+  );
+}
+
+function walkSourceFiles(root: string, ext: string): string[] {
+  const out: string[] = [];
+  if (!fs.existsSync(root)) return out;
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && entry.name.endsWith(ext)) {
+        if (entry.name.endsWith(`.spec${ext}`)) continue;
+        if (entry.name.endsWith(`.test${ext}`)) continue;
+        out.push(full);
+      }
+    }
+  }
+  return out;
 }

--- a/docs/src/scripts/content-generators/loaders/frontmatter.ts
+++ b/docs/src/scripts/content-generators/loaders/frontmatter.ts
@@ -1,0 +1,164 @@
+// Minimal YAML-frontmatter parser tuned for the shapes used in this repo's
+// content collections: scalars, arrays of strings, single-level nested
+// objects, inline `[a, b]` arrays. Recursive descent: easier to reason about
+// than the stack-based approach for nested objects.
+
+export interface ParsedFrontmatter {
+  data: Record<string, unknown>;
+  body: string;
+}
+
+export function parseFrontmatter(raw: string): ParsedFrontmatter {
+  const lines = raw.split("\n");
+  if (lines[0] !== "---") return { data: {}, body: raw };
+
+  let endIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === "---") {
+      endIdx = i;
+      break;
+    }
+  }
+  if (endIdx === -1) return { data: {}, body: raw };
+
+  const yamlLines = lines.slice(1, endIdx);
+  const body = lines.slice(endIdx + 1).join("\n");
+  const [data] = parseObject(yamlLines, 0, 0);
+  return { data, body };
+}
+
+function leadingSpaces(line: string): number {
+  return line.length - line.trimStart().length;
+}
+
+function isBlankOrComment(line: string | undefined): boolean {
+  if (line === undefined) return true;
+  const trimmed = line.trim();
+  return trimmed === "" || trimmed.startsWith("#");
+}
+
+function nextContentLine(lines: string[], startIdx: number): number {
+  let i = startIdx;
+  while (i < lines.length && isBlankOrComment(lines[i])) i++;
+  return i;
+}
+
+function parseObject(
+  lines: string[],
+  startIdx: number,
+  expectedIndent: number,
+): [Record<string, unknown>, number] {
+  const obj: Record<string, unknown> = {};
+  let i = startIdx;
+
+  while (i < lines.length) {
+    if (isBlankOrComment(lines[i])) {
+      i++;
+      continue;
+    }
+    const indent = leadingSpaces(lines[i]);
+    if (indent < expectedIndent) break;
+    if (indent > expectedIndent) {
+      // Unexpected deeper indent at this scope. Skip defensively.
+      i++;
+      continue;
+    }
+
+    const trimmed = lines[i].trimStart();
+    // Top-level array item shouldn't appear here (parseArray handles those).
+    if (trimmed.startsWith("- ") || trimmed === "-") break;
+
+    const colon = trimmed.indexOf(":");
+    if (colon === -1) {
+      i++;
+      continue;
+    }
+    const key = trimmed.slice(0, colon).trim();
+    const valueText = trimmed.slice(colon + 1).trim();
+
+    if (valueText === "") {
+      // Open scope: peek at next content line to decide array vs object.
+      const nextIdx = nextContentLine(lines, i + 1);
+      if (nextIdx >= lines.length) {
+        i++;
+        continue;
+      }
+      const nextIndent = leadingSpaces(lines[nextIdx]);
+      if (nextIndent <= expectedIndent) {
+        // Empty scope.
+        i++;
+        continue;
+      }
+      const nextTrimmed = lines[nextIdx].trimStart();
+      if (nextTrimmed.startsWith("- ") || nextTrimmed === "-") {
+        const [arr, consumed] = parseArray(lines, nextIdx, nextIndent);
+        obj[key] = arr;
+        i = consumed;
+      } else {
+        const [sub, consumed] = parseObject(lines, nextIdx, nextIndent);
+        obj[key] = sub;
+        i = consumed;
+      }
+    } else if (valueText.startsWith("[") && valueText.endsWith("]")) {
+      obj[key] = parseInlineArray(valueText);
+      i++;
+    } else {
+      obj[key] = parseScalar(valueText);
+      i++;
+    }
+  }
+
+  return [obj, i];
+}
+
+function parseArray(
+  lines: string[],
+  startIdx: number,
+  expectedIndent: number,
+): [unknown[], number] {
+  const arr: unknown[] = [];
+  let i = startIdx;
+
+  while (i < lines.length) {
+    if (isBlankOrComment(lines[i])) {
+      i++;
+      continue;
+    }
+    const indent = leadingSpaces(lines[i]);
+    if (indent < expectedIndent) break;
+    if (indent > expectedIndent) {
+      // Deeper than array item indent. Shouldn't happen for our shapes; skip.
+      i++;
+      continue;
+    }
+    const trimmed = lines[i].trimStart();
+    if (!trimmed.startsWith("- ") && trimmed !== "-") break;
+
+    const valueText = trimmed === "-" ? "" : trimmed.slice(2).trim();
+    arr.push(parseScalar(valueText));
+    i++;
+  }
+
+  return [arr, i];
+}
+
+function parseInlineArray(text: string): unknown[] {
+  const inner = text.slice(1, -1).trim();
+  if (!inner) return [];
+  return inner.split(",").map((s) => parseScalar(s.trim()));
+}
+
+function parseScalar(text: string): unknown {
+  if (text === "") return "";
+  if (text === "true") return true;
+  if (text === "false") return false;
+  if (text === "null" || text === "~") return null;
+  if (/^-?\d+(\.\d+)?$/.test(text)) return Number(text);
+  if (
+    (text.startsWith('"') && text.endsWith('"')) ||
+    (text.startsWith("'") && text.endsWith("'"))
+  ) {
+    return text.slice(1, -1);
+  }
+  return text;
+}

--- a/docs/src/scripts/content-generators/loaders/frontmatter.ts
+++ b/docs/src/scripts/content-generators/loaders/frontmatter.ts
@@ -99,6 +99,16 @@ function parseObject(
         obj[key] = sub;
         i = consumed;
       }
+    } else if (/^[|>][+-]?$/.test(valueText)) {
+      // YAML block scalar: `|` keeps newlines, `>` folds them into spaces.
+      const [text, consumed] = parseBlockScalar(
+        lines,
+        i + 1,
+        expectedIndent,
+        valueText[0] as "|" | ">",
+      );
+      obj[key] = text;
+      i = consumed;
     } else if (valueText.startsWith("[") && valueText.endsWith("]")) {
       obj[key] = parseInlineArray(valueText);
       i++;
@@ -146,6 +156,42 @@ function parseInlineArray(text: string): unknown[] {
   const inner = text.slice(1, -1).trim();
   if (!inner) return [];
   return inner.split(",").map((s) => parseScalar(s.trim()));
+}
+
+function parseBlockScalar(
+  lines: string[],
+  startIdx: number,
+  parentIndent: number,
+  style: "|" | ">",
+): [string, number] {
+  const collected: string[] = [];
+  let blockIndent: number | null = null;
+  let i = startIdx;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === "") {
+      collected.push("");
+      i++;
+      continue;
+    }
+    const indent = leadingSpaces(line);
+    if (indent <= parentIndent) break;
+    if (blockIndent === null) blockIndent = indent;
+    collected.push(line.slice(blockIndent));
+    i++;
+  }
+
+  // Clip chomping (YAML default): drop trailing blank lines.
+  while (collected.length > 0 && collected[collected.length - 1] === "") {
+    collected.pop();
+  }
+
+  const text =
+    style === ">"
+      ? collected.join(" ").replace(/\s+/g, " ").trim()
+      : collected.join("\n");
+  return [text, i];
 }
 
 function parseScalar(text: string): unknown {

--- a/docs/src/scripts/content-generators/loaders/get-started.ts
+++ b/docs/src/scripts/content-generators/loaders/get-started.ts
@@ -1,0 +1,32 @@
+import * as fs from "fs";
+import * as path from "path";
+import { paths } from "../config";
+import { parseFrontmatter } from "./frontmatter";
+import { asNumber, asString, walkMdxFiles } from "./lib";
+import type { GetStartedRecord } from "../types";
+
+export function loadGetStarted(): GetStartedRecord[] {
+  const records: GetStartedRecord[] = [];
+
+  for (const filePath of walkMdxFiles(paths.content.getStarted)) {
+    const rel = path.relative(paths.content.getStarted, filePath);
+    const slug = rel.replace(/\.mdx$/, "");
+    const raw = fs.readFileSync(filePath, "utf8");
+    const { data, body } = parseFrontmatter(raw);
+
+    records.push({
+      id: asString(data.id) ?? slug,
+      collection: "get-started",
+      title: asString(data.title) ?? slug,
+      navLabel: asString(data.navLabel),
+      description: asString(data.description),
+      section: asString(data.section) ?? "intro",
+      order: asNumber(data.order, 0),
+      status: asString(data.status) ?? "published",
+      body: body.trim(),
+    });
+  }
+
+  records.sort((a, b) => a.id.localeCompare(b.id));
+  return records;
+}

--- a/docs/src/scripts/content-generators/loaders/guidance.ts
+++ b/docs/src/scripts/content-generators/loaders/guidance.ts
@@ -1,0 +1,42 @@
+import * as fs from "fs";
+import * as path from "path";
+import { paths } from "../config";
+import { parseFrontmatter } from "./frontmatter";
+import { asString, asStringArray, listMdxFiles } from "./lib";
+import type { GuidanceRecord } from "../types";
+
+export function loadGuidance(): GuidanceRecord[] {
+  const records: GuidanceRecord[] = [];
+
+  for (const filePath of listMdxFiles(paths.content.guidance)) {
+    const slug = path.basename(filePath, ".mdx");
+    const raw = fs.readFileSync(filePath, "utf8");
+    const { data, body } = parseFrontmatter(raw);
+
+    const appliesToRaw = data.appliesTo as
+      | { components?: unknown; contexts?: unknown }
+      | undefined;
+    const appliesTo = appliesToRaw
+      ? {
+          components: asStringArray(appliesToRaw.components),
+          contexts: asStringArray(appliesToRaw.contexts),
+        }
+      : undefined;
+
+    records.push({
+      id: asString(data.id) ?? slug,
+      collection: "guidance",
+      type: asString(data.type) ?? "info",
+      description: asString(data.description) ?? "",
+      topic: asString(data.topic) ?? "other",
+      tags: asStringArray(data.tags),
+      appliesTo,
+      relatedProps: asStringArray(data.relatedProps),
+      status: asString(data.status) ?? "published",
+      body: body.trim(),
+    });
+  }
+
+  records.sort((a, b) => a.id.localeCompare(b.id));
+  return records;
+}

--- a/docs/src/scripts/content-generators/loaders/lib.ts
+++ b/docs/src/scripts/content-generators/loaders/lib.ts
@@ -1,0 +1,45 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+export function asStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === "string");
+}
+
+export function asNumber(v: unknown, fallback = 0): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : fallback;
+}
+
+export function listMdxFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith(".mdx"))
+    .map((e) => path.join(dir, e.name));
+}
+
+export function walkMdxFiles(dir: string, baseDir = dir): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkMdxFiles(full, baseDir));
+    } else if (entry.isFile() && entry.name.endsWith(".mdx")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+export function listDirectories(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => path.join(dir, e.name));
+}

--- a/docs/src/scripts/content-generators/loaders/lib.ts
+++ b/docs/src/scripts/content-generators/loaders/lib.ts
@@ -43,3 +43,21 @@ export function listDirectories(dir: string): string[] {
     .filter((e) => e.isDirectory())
     .map((e) => path.join(dir, e.name));
 }
+
+// Walks the tree for index.mdx files and returns the folder containing each.
+// Used by example collections that nest by productType (workspace/case-detail).
+export function findIndexMdxFolders(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const folders: string[] = [];
+  function walk(current: string): void {
+    if (fs.existsSync(path.join(current, "index.mdx"))) {
+      folders.push(current);
+      return;
+    }
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.isDirectory()) walk(path.join(current, entry.name));
+    }
+  }
+  walk(dir);
+  return folders;
+}

--- a/docs/src/scripts/content-generators/loaders/productTypes.ts
+++ b/docs/src/scripts/content-generators/loaders/productTypes.ts
@@ -1,0 +1,36 @@
+import * as fs from "fs";
+import * as path from "path";
+import { paths } from "../config";
+import { parseFrontmatter } from "./frontmatter";
+import { asString, asStringArray, listDirectories } from "./lib";
+import type { ProductTypeRecord } from "../types";
+
+export function loadProductTypes(): ProductTypeRecord[] {
+  const records: ProductTypeRecord[] = [];
+
+  for (const folder of listDirectories(paths.content.productTypes)) {
+    const slug = path.basename(folder);
+    const indexPath = path.join(folder, "index.mdx");
+    if (!fs.existsSync(indexPath)) continue;
+
+    const raw = fs.readFileSync(indexPath, "utf8");
+    const { data, body } = parseFrontmatter(raw);
+
+    records.push({
+      id: asString(data.id) ?? slug,
+      collection: "productTypes",
+      title: asString(data.title) ?? slug,
+      summary: asString(data.summary) ?? "",
+      heroImage: asString(data.heroImage),
+      demoUrl: asString(data.demoUrl),
+      sourceUrl: asString(data.sourceUrl),
+      tags: asStringArray(data.tags),
+      components: asStringArray(data.components),
+      status: asString(data.status) ?? "published",
+      body: body.trim(),
+    });
+  }
+
+  records.sort((a, b) => a.id.localeCompare(b.id));
+  return records;
+}

--- a/docs/src/scripts/content-generators/outputs/mcp-json.ts
+++ b/docs/src/scripts/content-generators/outputs/mcp-json.ts
@@ -13,10 +13,20 @@ export function writeMcpJson(records: AnyRecord[]): { written: number } {
 
   fs.mkdirSync(paths.output.mcp, { recursive: true });
 
+  // Clear stale files in each collection folder before writing. Renamed or
+  // removed records would otherwise leave orphan JSON behind. Errors block
+  // the orchestrator before this point (see index.ts), so the previous
+  // output stays as last-known-good on a failed run.
   let written = 0;
   for (const [collection, list] of byCollection) {
     const dir = path.join(paths.output.mcp, collection);
-    fs.mkdirSync(dir, { recursive: true });
+    if (fs.existsSync(dir)) {
+      for (const entry of fs.readdirSync(dir)) {
+        if (entry.endsWith(".json")) fs.unlinkSync(path.join(dir, entry));
+      }
+    } else {
+      fs.mkdirSync(dir, { recursive: true });
+    }
     for (const rec of list) {
       // Flatten nested ids (e.g. "designers/designing-with-ds") into a
       // filesystem-safe filename. The canonical id lives in the JSON body.

--- a/docs/src/scripts/content-generators/outputs/mcp-json.ts
+++ b/docs/src/scripts/content-generators/outputs/mcp-json.ts
@@ -1,0 +1,47 @@
+import * as fs from "fs";
+import * as path from "path";
+import { paths } from "../config";
+import type { AnyRecord } from "../types";
+
+export function writeMcpJson(records: AnyRecord[]): { written: number } {
+  const byCollection = new Map<string, AnyRecord[]>();
+  for (const rec of records) {
+    const list = byCollection.get(rec.collection) ?? [];
+    list.push(rec);
+    byCollection.set(rec.collection, list);
+  }
+
+  fs.mkdirSync(paths.output.mcp, { recursive: true });
+
+  let written = 0;
+  for (const [collection, list] of byCollection) {
+    const dir = path.join(paths.output.mcp, collection);
+    fs.mkdirSync(dir, { recursive: true });
+    for (const rec of list) {
+      // Flatten nested ids (e.g. "designers/designing-with-ds") into a
+      // filesystem-safe filename. The canonical id lives in the JSON body.
+      const filename = rec.id.replace(/\//g, "__") + ".json";
+      const file = path.join(dir, filename);
+      const payload = sortKeys(rec);
+      fs.writeFileSync(file, JSON.stringify(payload, null, 2) + "\n", "utf8");
+      written++;
+    }
+  }
+  return { written };
+}
+
+// Deterministic key order so byte-identical reruns are possible. Lets a
+// downstream freshness check detect content changes via file hash.
+function sortKeys<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys) as unknown as T;
+  }
+  if (value && typeof value === "object") {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = sortKeys((value as Record<string, unknown>)[key]);
+    }
+    return sorted as unknown as T;
+  }
+  return value;
+}

--- a/docs/src/scripts/content-generators/sync-to-dcp.sh
+++ b/docs/src/scripts/content-generators/sync-to-dcp.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Sync the content-generators output into the dcp-monorepo MCP's data/.
+# Manual invocation, no idempotency checks, no PR generation.
+# Phase 4 replaces this with an automated CI step.
+#
+# Set DCP_MONOREPO_DATA to the local path of dcp-monorepo's design-system-mcp
+# data folder. Example:
+#   export DCP_MONOREPO_DATA=/path/to/dcp-monorepo/apps/design-system-mcp/data
+#   bash docs/src/scripts/content-generators/sync-to-dcp.sh
+
+set -euo pipefail
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../generated/mcp" && pwd)"
+DEST="${DCP_MONOREPO_DATA:-}"
+
+if [[ -z "$DEST" ]]; then
+  echo "[sync] DCP_MONOREPO_DATA env var not set." >&2
+  echo "[sync] Set it to the path of dcp-monorepo's design-system-mcp data folder." >&2
+  echo "[sync] Example: export DCP_MONOREPO_DATA=/path/to/dcp-monorepo/apps/design-system-mcp/data" >&2
+  exit 1
+fi
+
+if [[ ! -d "$SRC" ]]; then
+  echo "[sync] Source not found: $SRC" >&2
+  echo "[sync] Run: npx tsx docs/src/scripts/content-generators/index.ts" >&2
+  exit 1
+fi
+
+if [[ ! -d "$DEST" ]]; then
+  echo "[sync] Destination not found: $DEST" >&2
+  exit 1
+fi
+
+echo "[sync] Clearing old subfolders in $DEST..."
+rm -rf \
+  "$DEST/components" \
+  "$DEST/examples" \
+  "$DEST/guidance" \
+  "$DEST/foundations" \
+  "$DEST/get-started" \
+  "$DEST/productTypes" \
+  "$DEST/design" \
+  "$DEST/development"
+
+echo "[sync] Copying $SRC -> $DEST"
+cp -R "$SRC/." "$DEST/"
+
+for c in components examples guidance foundations get-started productTypes; do
+  if [[ -d "$DEST/$c" ]]; then
+    count=$(find "$DEST/$c" -type f -name '*.json' | wc -l | tr -d ' ')
+    echo "  $c: $count files"
+  fi
+done
+
+echo "[sync] Done."

--- a/docs/src/scripts/content-generators/transforms/aliases.ts
+++ b/docs/src/scripts/content-generators/transforms/aliases.ts
@@ -16,14 +16,12 @@ const EXAMPLE_SLUG_ALIASES: Record<string, string[]> = {
 
 // Legacy or sub-component names that don't show up from code derivation
 // (no matching React class, web component tag, or Angular selector). Used
-// when a renamed component still appears in older content references, or
-// when a sub-component reasonably routes to its parent for navigation.
+// when a renamed component still appears in older content references.
 const COMPONENT_SLUG_ALIASES: Record<string, string[]> = {
   // newSlug: [oldSlug1, oldSlug2, ...]
   "text-area": ["textarea"],
   notification: ["notification-banner"],
   "menu-button": ["multi-action-button"],
-  table: ["table-sort-header"],
 };
 
 export function addComponentAliases(components: ComponentRecord[]): ComponentRecord[] {

--- a/docs/src/scripts/content-generators/transforms/aliases.ts
+++ b/docs/src/scripts/content-generators/transforms/aliases.ts
@@ -1,0 +1,71 @@
+import type { ComponentRecord, ExampleRecord } from "../types";
+
+// Manually curated old → new slug renames. Until the docs site catches up,
+// the OLD slug is the current id and there's nothing to alias. Once the docs
+// rename a record (e.g. PR #3888 batches), the NEW slug becomes the id and
+// the OLD slug becomes the alias here. This list is the bridge during the
+// transition.
+const EXAMPLE_SLUG_ALIASES: Record<string, string[]> = {
+  // newSlug: [oldSlug1, oldSlug2, ...]
+  "result-page": ["confirm-that-an-application-was-submitted"],
+  "question-page": [
+    "ask-a-user-one-question-at-a-time",
+    "give-more-information-before-asking-a-question-a",
+  ],
+};
+
+// Legacy or sub-component names that don't show up from code derivation
+// (no matching React class, web component tag, or Angular selector). Used
+// when a renamed component still appears in older content references, or
+// when a sub-component reasonably routes to its parent for navigation.
+const COMPONENT_SLUG_ALIASES: Record<string, string[]> = {
+  // newSlug: [oldSlug1, oldSlug2, ...]
+  "text-area": ["textarea"],
+  notification: ["notification-banner"],
+  "menu-button": ["multi-action-button"],
+  table: ["table-sort-header"],
+};
+
+export function addComponentAliases(components: ComponentRecord[]): ComponentRecord[] {
+  return components.map((c) => {
+    const aliases = new Set<string>(c.aliases);
+
+    if (c.reactClassName && c.reactClassName !== expectedReactName(c.id)) {
+      // Stale wrapper name that doesn't match the doc slug.
+      // e.g. GoabAppFooter on footer's aliases.
+      aliases.add(c.reactClassName);
+    }
+    if (c.webComponentTag) {
+      const tagSlug = c.webComponentTag.replace(/^goa-/, "");
+      if (tagSlug !== c.id) aliases.add(tagSlug);
+    }
+    if (c.angularSelector) {
+      const selSlug = c.angularSelector.replace(/^goab-/, "");
+      if (selSlug !== c.id) aliases.add(selSlug);
+    }
+    const manual = COMPONENT_SLUG_ALIASES[c.id];
+    if (manual) for (const s of manual) aliases.add(s);
+
+    return { ...c, aliases: [...aliases].sort() };
+  });
+}
+
+export function addExampleAliases(examples: ExampleRecord[]): ExampleRecord[] {
+  return examples.map((ex) => {
+    const aliases = new Set<string>(ex.aliases);
+    const oldSlugs = EXAMPLE_SLUG_ALIASES[ex.id];
+    if (oldSlugs) for (const s of oldSlugs) aliases.add(s);
+    return { ...ex, aliases: [...aliases].sort() };
+  });
+}
+
+function expectedReactName(slug: string): string {
+  // Convention: GoabPascalCase(slug). e.g. "form-item" → "GoabFormItem".
+  return (
+    "Goab" +
+    slug
+      .split("-")
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join("")
+  );
+}

--- a/docs/src/scripts/content-generators/transforms/component-lookup.ts
+++ b/docs/src/scripts/content-generators/transforms/component-lookup.ts
@@ -1,0 +1,21 @@
+import type { ComponentRecord } from "../types";
+
+// Builds a slug → component lookup keyed by both canonical id and every alias.
+// Lets cross-references that point at legacy slugs (app-footer, text-area,
+// notification-banner, multi-action-button) resolve to the current canonical
+// record without forcing source MDX edits.
+//
+// Run after addComponentAliases so aliases are populated.
+export function buildComponentLookup(
+  components: ComponentRecord[],
+): Map<string, ComponentRecord> {
+  const lookup = new Map<string, ComponentRecord>();
+  for (const c of components) {
+    lookup.set(c.id, c);
+    for (const alias of c.aliases ?? []) {
+      // Don't overwrite a canonical id with an alias collision.
+      if (!lookup.has(alias)) lookup.set(alias, c);
+    }
+  }
+  return lookup;
+}

--- a/docs/src/scripts/content-generators/transforms/link-guidance.ts
+++ b/docs/src/scripts/content-generators/transforms/link-guidance.ts
@@ -1,26 +1,33 @@
 import type { ComponentRecord, GuidanceRecord } from "../types";
+import { buildComponentLookup } from "./component-lookup";
 
 // For each component, attach the list of guidance entry ids that target it
 // via guidance.appliesTo.components. The MCP `get` on a component can then
 // surface guidance inline, so consumers retrieve a component and its related
 // guidance in a single call instead of separate searches.
+//
+// guidance.appliesTo.components is alias-aware: legacy slugs like "app-footer"
+// resolve through the alias map to the canonical "footer" record.
 export function linkGuidanceToComponents(
   components: ComponentRecord[],
   guidance: GuidanceRecord[],
 ): ComponentRecord[] {
-  const byComponent = new Map<string, string[]>();
+  const lookup = buildComponentLookup(components);
+  const byCanonicalId = new Map<string, Set<string>>();
   for (const g of guidance) {
     const targets = g.appliesTo?.components ?? [];
     for (const slug of targets) {
-      const list = byComponent.get(slug) ?? [];
-      list.push(g.id);
-      byComponent.set(slug, list);
+      const canonical = lookup.get(slug);
+      if (!canonical) continue;
+      const set = byCanonicalId.get(canonical.id) ?? new Set<string>();
+      set.add(g.id);
+      byCanonicalId.set(canonical.id, set);
     }
   }
 
   return components.map((c) => {
-    const linked = byComponent.get(c.id);
-    if (!linked || linked.length === 0) return c;
+    const linked = byCanonicalId.get(c.id);
+    if (!linked || linked.size === 0) return c;
     return { ...c, relatedGuidance: [...linked].sort() };
   });
 }

--- a/docs/src/scripts/content-generators/transforms/link-guidance.ts
+++ b/docs/src/scripts/content-generators/transforms/link-guidance.ts
@@ -1,0 +1,26 @@
+import type { ComponentRecord, GuidanceRecord } from "../types";
+
+// For each component, attach the list of guidance entry ids that target it
+// via guidance.appliesTo.components. The MCP `get` on a component can then
+// surface guidance inline, so consumers retrieve a component and its related
+// guidance in a single call instead of separate searches.
+export function linkGuidanceToComponents(
+  components: ComponentRecord[],
+  guidance: GuidanceRecord[],
+): ComponentRecord[] {
+  const byComponent = new Map<string, string[]>();
+  for (const g of guidance) {
+    const targets = g.appliesTo?.components ?? [];
+    for (const slug of targets) {
+      const list = byComponent.get(slug) ?? [];
+      list.push(g.id);
+      byComponent.set(slug, list);
+    }
+  }
+
+  return components.map((c) => {
+    const linked = byComponent.get(c.id);
+    if (!linked || linked.length === 0) return c;
+    return { ...c, relatedGuidance: [...linked].sort() };
+  });
+}

--- a/docs/src/scripts/content-generators/types.ts
+++ b/docs/src/scripts/content-generators/types.ts
@@ -1,0 +1,119 @@
+import type { CollectionName } from "./config";
+
+export interface BaseRecord {
+  id: string;
+  collection: CollectionName;
+  body: string;
+}
+
+export interface ComponentRecord extends BaseRecord {
+  collection: "components";
+  name: string;
+  description?: string;
+  status: string;
+  category: string;
+  tags: string[];
+  aliases: string[];
+  relatedComponents: string[];
+  figmaUrl?: string;
+  hidden?: boolean;
+  subcomponent?: boolean;
+  webComponentTag?: string;
+  reactClassName?: string;
+  angularSelector?: string;
+  // Full API blob from generated/component-apis/*.json (minus componentSlug).
+  // Contains per-framework props/events/slots. Consumers navigate it.
+  api?: Record<string, unknown>;
+  // Guidance ids that target this component via guidance.appliesTo.components.
+  relatedGuidance?: string[];
+}
+
+export interface ExampleRecord extends BaseRecord {
+  collection: "examples";
+  title: string;
+  description?: string;
+  size: "interaction" | "section" | "page" | "task" | "product";
+  tags: string[];
+  components: string[];
+  relatedExamples: string[];
+  aliases: string[];
+  status: string;
+  productType?: "workspace" | "public-form";
+  frameworks?: string[];
+  previewImage?: string;
+  figmaUrl?: string;
+  accessibilityNotes?: string;
+  hidden?: boolean;
+  // Page-like fields (page, task, product sizes only)
+  previewUrl?: string;
+  reactSourceUrl?: string;
+  angularSourceUrl?: string;
+  sourceUrl?: string;
+  stackblitzUrl?: string;
+}
+
+export interface GuidanceRecord extends BaseRecord {
+  collection: "guidance";
+  type: string;
+  description: string;
+  topic: string;
+  tags: string[];
+  appliesTo?: {
+    components?: string[];
+    contexts?: string[];
+  };
+  relatedProps: string[];
+  status: string;
+}
+
+export interface FoundationRecord extends BaseRecord {
+  collection: "foundations";
+  title: string;
+  description: string;
+  category: string;
+  tags: string[];
+  status: string;
+}
+
+export interface GetStartedRecord extends BaseRecord {
+  collection: "get-started";
+  title: string;
+  navLabel?: string;
+  description?: string;
+  section: string;
+  order: number;
+  status: string;
+}
+
+export interface ProductTypeRecord extends BaseRecord {
+  collection: "productTypes";
+  title: string;
+  summary: string;
+  heroImage?: string;
+  demoUrl?: string;
+  sourceUrl?: string;
+  tags: string[];
+  components: string[];
+  status: string;
+}
+
+export type AnyRecord =
+  | ComponentRecord
+  | ExampleRecord
+  | GuidanceRecord
+  | FoundationRecord
+  | GetStartedRecord
+  | ProductTypeRecord;
+
+export interface Finding {
+  severity: "error" | "warning";
+  source: { collection: CollectionName; id: string };
+  field: string;
+  brokenRef: string;
+  /** Extra context appended after the broken ref, e.g. `on component "checkbox"`. */
+  context?: string;
+  /** Override the default "not found" suffix, e.g. `not in extracted props`. */
+  notFoundMessage?: string;
+  /** Optional "did you mean..." string populated by the check. */
+  hint?: string;
+}

--- a/docs/src/scripts/extract-api.ts
+++ b/docs/src/scripts/extract-api.ts
@@ -1967,17 +1967,137 @@ function removeStaleApiFiles(validComponentNames: string[]): void {
 }
 
 // =============================================================================
+// Slug → Svelte resolution
+// =============================================================================
+
+/**
+ * Resolves a docs slug to its canonical Svelte file via the React wrapper's
+ * IntrinsicElements declaration. The wrapper is the source of truth for
+ * which custom element it presents to the consuming app, so its tag points
+ * to the matching Svelte file even when the docs slug, the wrapper filename,
+ * and the Svelte filename don't agree (e.g. docs slug `temporary-notification`
+ * but the public element lives in `TemporaryNotificationCtrl.svelte`).
+ *
+ * Returns undefined when the slug has no resolvable React wrapper, so the
+ * caller can fall back to the naming-convention heuristic.
+ */
+function resolveSvelteViaReactWrapper(slug: string): string | undefined {
+  const reactRoot = path.join(WORKSPACE_ROOT, "libs/react-components/src/lib");
+  if (!fs.existsSync(reactRoot)) return undefined;
+
+  const reactFile = findReactWrapperForSlug(slug, reactRoot);
+  if (!reactFile) return undefined;
+
+  const tag = extractIntrinsicElementTag(fs.readFileSync(reactFile, "utf-8"));
+  if (!tag) return undefined;
+
+  return findSvelteDeclaringTag(tag);
+}
+
+/**
+ * Two attempts in order:
+ * 1. Direct: `<slug>.tsx` somewhere under reactRoot.
+ * 2. Discovery: a Svelte file inside `libs/.../<slug>/` declares a tag,
+ *    and exactly one React wrapper anywhere wraps that tag. This handles
+ *    `temporary-notification` (no `temporary-notification.tsx` exists, but
+ *    `temporary-notification-ctrl.tsx` wraps `goa-temp-notification-ctrl`,
+ *    which is declared in the slug's Svelte folder).
+ */
+function findReactWrapperForSlug(slug: string, reactRoot: string): string | undefined {
+  const direct = findFirstFileByName(reactRoot, `${slug}.tsx`);
+  if (direct) return direct;
+
+  const componentPath = path.join(UI_COMPONENTS_PATH, slug);
+  if (!fs.existsSync(componentPath) || !fs.statSync(componentPath).isDirectory()) {
+    return undefined;
+  }
+
+  const wrappedFiles = new Set<string>();
+  for (const file of fs.readdirSync(componentPath)) {
+    if (!file.endsWith(".svelte") || file.includes(".test.")) continue;
+    const tag = extractTagName(fs.readFileSync(path.join(componentPath, file), "utf-8"));
+    if (!tag) continue;
+    const wrapper = findReactWrapperForTag(tag, reactRoot);
+    if (wrapper) wrappedFiles.add(wrapper);
+  }
+
+  if (wrappedFiles.size === 1) return [...wrappedFiles][0];
+  return undefined;
+}
+
+function findReactWrapperForTag(tag: string, reactRoot: string): string | undefined {
+  const declRegex = new RegExp(`["']${escapeRegExp(tag)}["']\\s*:`);
+  const stack = [reactRoot];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (
+        entry.isFile() &&
+        entry.name.endsWith(".tsx") &&
+        !entry.name.endsWith(".spec.tsx") &&
+        !entry.name.endsWith(".test.tsx")
+      ) {
+        if (declRegex.test(fs.readFileSync(full, "utf-8"))) return full;
+      }
+    }
+  }
+  return undefined;
+}
+
+function extractIntrinsicElementTag(content: string): string | undefined {
+  // declare module "react" { ... interface IntrinsicElements { "goa-foo": ... } }
+  const match = content.match(/IntrinsicElements\s*\{[\s\S]*?["'](goa-[a-z0-9-]+)["']\s*:/);
+  return match ? match[1] : undefined;
+}
+
+function findSvelteDeclaringTag(tag: string): string | undefined {
+  const stack = [UI_COMPONENTS_PATH];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (
+        entry.isFile() &&
+        entry.name.endsWith(".svelte") &&
+        !entry.name.includes(".test.")
+      ) {
+        const content = fs.readFileSync(full, "utf-8");
+        if (extractTagName(content) === tag) return full;
+      }
+    }
+  }
+  return undefined;
+}
+
+// =============================================================================
 // Main Extraction
 // =============================================================================
 
 function extractComponentAPI(componentName: string): ExtractedComponentAPI | null {
   const componentPath = path.join(UI_COMPONENTS_PATH, componentName);
 
-  // Find the Svelte file by the component's public name first, then fall back
-  // to any .svelte file inside a matching directory.
-  const svelteFileName = `${capitalize(toCamelCase(componentName))}.svelte`;
-  let svelteFilePath = findFirstFileByName(UI_COMPONENTS_PATH, svelteFileName);
+  // 1. Auto-derive via the React wrapper. The React wrapper's
+  //    IntrinsicElements declaration is the source of truth for which
+  //    custom element it wraps, so its tag points at the canonical
+  //    svelte file. Handles the menu-button / temporary-notification
+  //    case where the docs slug and the public element's filename
+  //    diverge.
+  let svelteFilePath = resolveSvelteViaReactWrapper(componentName);
 
+  // 2. Fall back to the naming convention (works for the majority).
+  if (!svelteFilePath) {
+    const svelteFileName = `${capitalize(toCamelCase(componentName))}.svelte`;
+    svelteFilePath = findFirstFileByName(UI_COMPONENTS_PATH, svelteFileName) ?? undefined;
+  }
+
+  // 3. Final fallback: any svelte inside a directory matching the slug.
   if (!svelteFilePath && fs.existsSync(componentPath) && fs.statSync(componentPath).isDirectory()) {
     const files = fs.readdirSync(componentPath);
     const svelteFile = files.find((f) => f.endsWith(".svelte"));

--- a/docs/src/scripts/extract-api.ts
+++ b/docs/src/scripts/extract-api.ts
@@ -2294,7 +2294,6 @@ function mergeItemArray<T extends { name: string; description: string }>(
   context: string,
 ): T[] {
   const existingByName = new Map(existing.map((item) => [item.name, item]));
-  const nextNames = new Set(next.map((item) => item.name));
 
   // Backfill non-empty descriptions from existing into new items that have empty ones
   const merged: T[] = next.map((item) => {
@@ -2304,18 +2303,6 @@ function mergeItemArray<T extends { name: string; description: string }>(
     }
     return item;
   });
-
-  // Preserve items from existing that are absent in the new extraction
-  // (but skip deprecated entries — they are intentionally excluded)
-  for (const existingItem of existing) {
-    if (!nextNames.has(existingItem.name)) {
-      if ((existingItem as Record<string, unknown>).deprecated) continue;
-      console.warn(
-        `  Preserved manually-added entry "${existingItem.name}" in ${context} (not found in extraction — check source)`,
-      );
-      merged.push(existingItem);
-    }
-  }
 
   return merged.sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -2356,8 +2343,8 @@ function saveComponentAPI(api: ExtractedComponentAPI): void {
 
   const filePath = path.join(OUTPUT_PATH, `${api.componentSlug}.json`);
 
-  // Merge with existing file to preserve manually-added entries that the extractor
-  // cannot see (e.g. props defined in function-level intersections, or wrapper gaps).
+  // Merge with existing file to backfill descriptions when the new extraction
+  // has none for an entry.
   let merged = api;
   if (fs.existsSync(filePath)) {
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "astro": "5.18.1",
         "date-fns": "3.6.0",
         "dompurify": "3.4.0",
+        "fastest-levenshtein": "^1.0.16",
         "flexsearch": "0.8.212",
         "highlight.js": "11.11.1",
         "react": "19.2.4",
@@ -25801,6 +25802,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "astro": "5.18.1",
     "date-fns": "3.6.0",
     "dompurify": "3.4.0",
+    "fastest-levenshtein": "^1.0.16",
     "flexsearch": "0.8.212",
     "highlight.js": "11.11.1",
     "react": "19.2.4",


### PR DESCRIPTION
## Summary

Generator pipeline at `docs/src/scripts/content-generators/` reads from the docs content collections (components, examples, guidance, foundations, get-started, productTypes) and emits JSON the design-system-mcp consumes. Output lands in `docs/generated/mcp/`, gitignored.

The docs site becomes the single source of truth for design system knowledge. The MCP no longer carries a separate set of hand-maintained data files.

### Pipeline shape

Four stages: `loaders/` read content, `transforms/` normalize and cross-link records, `checks/` cross-validate references, `outputs/` serialize to disk. Deterministic key order so reruns produce byte-identical output.

### Where each field comes from

- **Technical facts** (web component tag, React class name, Angular selector, props/events/slots): from the code in `libs/*` and `generated/component-apis/`. Never from frontmatter, so they can't drift.
- **Curation** (description, status, category, tags, related items): from frontmatter in docs collections.
- **Aliases**: derived automatically. Stale wrapper names like `GoabAppFooter` and `GoabTemporaryNotificationCtrl` land on the parent component's aliases array so old lookups still resolve. A small `COMPONENT_SLUG_ALIASES` map in `transforms/aliases.ts` captures legacy or sub-component names (text-area, notification, menu-button, table sub-components) that don't come from code.

### Cross-validation

The `checks/` stage walks all loaded records and verifies cross-references before output is written:

- 6 error-level checks for id-shaped references: `components.relatedComponents`, `components.relatedGuidance`, `examples.components`, `examples.relatedExamples`, `guidance.appliesTo.components`, `productTypes.components`. References resolve through aliases when available.
- 1 warn-level check for `guidance.relatedProps` against extracted prop names on the linked components (valid if the prop exists on any of them, since a single `relatedProps` entry usually describes a prop that lives on one of several related components).
- Broken references include a "did you mean..." hint when within 2 edits of a known id.
- Errors block output and preserve the previous `docs/generated/mcp/` on disk; warnings ship through.

Current state on dev: 0 errors, 0 warnings.

### Sync to dcp-monorepo

A sync script copies the output into the design-system-mcp's `data/` folder. Manual for now, automated later. The paired PR over in dcp-monorepo brings the corresponding data-loader changes.

The generator is also invoked manually for now (`npx tsx docs/src/scripts/content-generators/index.ts`); it's not part of `docs:build` yet. Both the generator run and the sync get wired up in a follow-up.

Paired with: GovAlta/dcp-monorepo#342

Fixes #3770

## Test plan

- [ ] `npx tsx docs/src/scripts/content-generators/index.ts` from the repo root produces output under `docs/generated/mcp/` with 6 folders.
- [ ] `footer` component's JSON includes `GoabAppFooter` and `app-footer` in its aliases.
- [ ] `question-page` example JSON includes the 9 old-slug aliases.
- [ ] `temporary-notification` component JSON shows `GoabTemporaryNotificationCtrl` as an alias.
- [ ] `docs/generated/mcp/` is gitignored.
- [ ] Introducing a broken `relatedComponents` ref in any component frontmatter blocks output (exit 1) and prints the error with a suggestion. Existing files in `docs/generated/mcp/` remain unchanged.
- [ ] Introducing a broken `relatedProps` ref in any guidance atom prints a warning but allows output to ship.
