### PR TITLE
chore: regenerate stale generated docs file to clean baseline

### DIFF
--- a/docs/generated/component-apis/temporary-notification.json
+++ b/docs/generated/component-apis/temporary-notification.json
@@ -63,7 +63,7 @@
           "type": "string",
           "required": false,
           "default": "",
-          "description": "Text for the optional action button. When provided, displays a clickable link button."
+          "description": "Text for the optional action button. When provided, displays a tertiary action button."
         },
         {
           "name": "animation-direction",
@@ -88,7 +88,7 @@
           "type": "number",
           "required": false,
           "default": "-1",
-          "description": "Progress value from 0-100. Use -1 to hide the progress bar. Only applies when type is \"progress\"."
+          "description": "Progress value from 0-100. Only applies when type is \"progress\"."
         },
         {
           "name": "testid",
@@ -119,7 +119,16 @@
           "description": "Controls whether the notification is visible."
         }
       ],
-      "events": [],
+      "events": [
+        {
+          "name": "action",
+          "type": "CustomEvent",
+          "description": "",
+          "frameworks": [
+            "webComponents"
+          ]
+        }
+      ],
       "slots": []
     }
   }


### PR DESCRIPTION
Running the docs generators surfaced one committed output (`temporary-notification.json`) that had drifted from its Svelte source. This catches it up so dev is a clean baseline.
