### PR TITLE
chore(#3868): add pre-commit hook to keep generated docs files in sync

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook: keep committed docs generated files in sync with their sources.
+#
+# When a commit stages source that feeds a docs generator, this regenerates the
+# docs outputs and blocks the commit if the staged outputs are stale. The
+# generators are deterministic, so when the staged outputs are already fresh this
+# is a no-op and the commit proceeds with no change.
+#
+# Install once per clone:
+#   git config core.hooksPath .githooks
+#
+# Covers:
+#   docs/generated/component-apis/*.json   from libs/*/src/components/** (Svelte JSDoc)
+#   docs/public/search-index.json          from docs/src/content/** (MDX frontmatter)
+#
+# To add a new generator, extend SOURCE_REGEX and OUTPUTS below and run it in the
+# regenerate step. See docs/ARCHITECTURE.md.
+#
+# Limitation: this validates the working tree, not the staged snapshot. With
+# partial staging (git add -p, or staging some edits while leaving others
+# unstaged) the generators read working-tree source, which can differ from what
+# is being committed. Accepted for simplicity; see docs/ARCHITECTURE.md.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Sources that feed a generator, and the output paths those generators own.
+# extract-api scans three libs roots: Svelte components (web-components/src/components),
+# React wrappers (react-components/src/lib), and Angular wrappers
+# (angular-components/src/lib/components). build:search-index scans MDX in docs/src/content.
+SOURCE_REGEX='^(libs/(web-components/src/components|react-components/src/lib|angular-components/src/lib/components)/|docs/src/content/)'
+OUTPUTS=(docs/generated/component-apis docs/public/search-index.json)
+
+# 1. Only act when staged changes touch a generator source.
+# Capture to a variable rather than piping to grep: under `set -o pipefail`, grep -q
+# can close the pipe early, making git diff exit with SIGPIPE and silently skipping
+# the check on very large commits.
+staged="$(git diff --cached --name-only)"
+if ! grep -Eq "$SOURCE_REGEX" <<<"$staged"; then
+  exit 0
+fi
+
+# 2. The generators need docs dependencies (tsx). Without them we cannot verify
+#    that committed outputs match the source, so block the commit with a clear,
+#    actionable message instead of letting a potentially-stale commit through.
+if [ ! -x docs/node_modules/.bin/tsx ]; then
+  echo "pre-commit: cannot verify generated docs files: docs dependencies missing." >&2
+  echo "            run 'npm install' in docs/ and commit again." >&2
+  exit 1
+fi
+
+echo "pre-commit: checking generated docs files are up to date..." >&2
+
+# 3. Regenerate. If a generator cannot run (for example a missing dependency),
+#    skip with a clear warning instead of blocking the commit or printing a stack.
+genlog="$(mktemp)"
+if ! ( cd docs && npm --silent run extract-api && npm --silent run build:search-index ) >"$genlog" 2>&1; then
+  echo "pre-commit: skipping freshness check: a generator did not run." >&2
+  echo "            ensure dependencies are installed (npm install at the repo root and in docs/)." >&2
+  sed 's/^/            | /' "$genlog" >&2 || true
+  rm -f "$genlog"
+  exit 0
+fi
+rm -f "$genlog"
+
+# 4. Stale if regenerated outputs differ from what is staged (modified tracked
+#    files) or if a brand-new output was produced (untracked, e.g. a new
+#    component's JSON that was never generated).
+stale=0
+if ! git diff --quiet -- "${OUTPUTS[@]}"; then stale=1; fi
+if [ -n "$(git ls-files --others --exclude-standard -- "${OUTPUTS[@]}")" ]; then stale=1; fi
+
+if [ "$stale" -ne 0 ]; then
+  echo "pre-commit: generated docs files are out of date." >&2
+  echo "            in docs/, run 'npm run extract-api' and 'npm run build:search-index'," >&2
+  echo "            stage the result, and commit again." >&2
+  echo "" >&2
+  git status --short -- "${OUTPUTS[@]}" >&2
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,6 +13,7 @@
 #
 # Covers:
 #   docs/generated/component-apis/*.json   from Svelte components + React/Angular wrappers
+#                                          + shared types and controllers (libs/common)
 #   docs/public/search-index.json          from docs/src/content/** (MDX frontmatter)
 #
 # To add a new generator, extend SOURCE_REGEX and OUTPUTS below and run it in the
@@ -28,10 +29,11 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 # Sources that feed a generator, and the output paths those generators own.
-# extract-api scans three libs roots: Svelte components (web-components/src/components),
-# React wrappers (react-components/src/lib), and Angular wrappers
-# (angular-components/src/lib/components). build:search-index scans MDX in docs/src/content.
-SOURCE_REGEX='^(libs/(web-components/src/components|react-components/src/lib|angular-components/src/lib/components)/|docs/src/content/)'
+# extract-api scans four libs roots: Svelte components (web-components/src/components),
+# React wrappers (react-components/src/lib), Angular wrappers
+# (angular-components/src/lib/components), and shared types plus imperative-API
+# controllers (common/src/lib). build:search-index scans MDX in docs/src/content.
+SOURCE_REGEX='^(libs/(web-components/src/components|react-components/src/lib|angular-components/src/lib/components|common/src/lib)/|docs/src/content/)'
 OUTPUTS=(docs/generated/component-apis docs/public/search-index.json)
 
 # 1. Only act when staged changes touch a generator source.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,14 +4,15 @@
 #
 # When a commit stages source that feeds a docs generator, this regenerates the
 # docs outputs and blocks the commit if the staged outputs are stale. The
-# generators are deterministic, so when the staged outputs are already fresh this
-# is a no-op and the commit proceeds with no change.
+# generators run on every such commit; they are deterministic, so when the staged
+# outputs are already fresh the regenerated files are byte-identical and the
+# commit proceeds with nothing new to stage.
 #
-# Install once per clone:
-#   git config core.hooksPath .githooks
+# Installed automatically when you `npm install` in docs/ (a `prepare` script
+# sets core.hooksPath). To set it by hand: git config core.hooksPath .githooks
 #
 # Covers:
-#   docs/generated/component-apis/*.json   from libs/*/src/components/** (Svelte JSDoc)
+#   docs/generated/component-apis/*.json   from Svelte components + React/Angular wrappers
 #   docs/public/search-index.json          from docs/src/content/** (MDX frontmatter)
 #
 # To add a new generator, extend SOURCE_REGEX and OUTPUTS below and run it in the
@@ -53,15 +54,15 @@ fi
 
 echo "pre-commit: checking generated docs files are up to date..." >&2
 
-# 3. Regenerate. If a generator cannot run (for example a missing dependency),
-#    skip with a clear warning instead of blocking the commit or printing a stack.
+# 3. Regenerate. If a generator fails to run we cannot verify the outputs are
+#    fresh, so block the commit rather than letting a possibly-stale file through.
 genlog="$(mktemp)"
 if ! ( cd docs && npm --silent run extract-api && npm --silent run build:search-index ) >"$genlog" 2>&1; then
-  echo "pre-commit: skipping freshness check: a generator did not run." >&2
+  echo "pre-commit: cannot verify generated docs files: a generator failed to run." >&2
   echo "            ensure dependencies are installed (npm install at the repo root and in docs/)." >&2
   sed 's/^/            | /' "$genlog" >&2 || true
   rm -f "$genlog"
-  exit 0
+  exit 1
 fi
 rm -f "$genlog"
 
@@ -74,8 +75,8 @@ if [ -n "$(git ls-files --others --exclude-standard -- "${OUTPUTS[@]}")" ]; then
 
 if [ "$stale" -ne 0 ]; then
   echo "pre-commit: generated docs files are out of date." >&2
-  echo "            in docs/, run 'npm run extract-api' and 'npm run build:search-index'," >&2
-  echo "            stage the result, and commit again." >&2
+  echo "            the regenerated files are already in your working tree." >&2
+  echo "            stage them with 'git add ${OUTPUTS[*]}' and commit again." >&2
   echo "" >&2
   git status --short -- "${OUTPUTS[@]}" >&2
   exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,8 +8,8 @@
 # outputs are already fresh the regenerated files are byte-identical and the
 # commit proceeds with nothing new to stage.
 #
-# Installed automatically when you `npm install` in docs/ (a `prepare` script
-# sets core.hooksPath). To set it by hand: git config core.hooksPath .githooks
+# Installed automatically by the root `npm install` (a `prepare` script sets
+# core.hooksPath). To set it by hand: git config core.hooksPath .githooks
 #
 # Covers:
 #   docs/generated/component-apis/*.json   from Svelte components + React/Angular wrappers
@@ -43,13 +43,21 @@ if ! grep -Eq "$SOURCE_REGEX" <<<"$staged"; then
   exit 0
 fi
 
-# 2. The generators need docs dependencies (tsx). Without them we cannot verify
-#    that committed outputs match the source, so block the commit with a clear,
-#    actionable message instead of letting a potentially-stale commit through.
+# 2. The generators need docs dependencies (tsx). A root `npm install` does not
+#    install them (docs is a separate package), so a contributor working only in
+#    libs/ may not have them. When a docs/src/content change is staged the author
+#    is working in docs, so block and tell them to install. For a libs-only commit,
+#    skip with a warning rather than block the whole component team; the CI
+#    freshness check is the backstop for that case.
 if [ ! -x docs/node_modules/.bin/tsx ]; then
-  echo "pre-commit: cannot verify generated docs files: docs dependencies missing." >&2
-  echo "            run 'npm install' in docs/ and commit again." >&2
-  exit 1
+  if grep -Eq '^docs/src/content/' <<<"$staged"; then
+    echo "pre-commit: cannot verify generated docs files: docs dependencies missing." >&2
+    echo "            run 'npm install' in docs/ and commit again." >&2
+    exit 1
+  fi
+  echo "pre-commit: skipping generated-docs check: docs dependencies not installed." >&2
+  echo "            run 'npm install' in docs/ to check component changes too." >&2
+  exit 0
 fi
 
 echo "pre-commit: checking generated docs files are up to date..." >&2

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -43,21 +43,15 @@ if ! grep -Eq "$SOURCE_REGEX" <<<"$staged"; then
   exit 0
 fi
 
-# 2. The generators need docs dependencies (tsx). A root `npm install` does not
-#    install them (docs is a separate package), so a contributor working only in
-#    libs/ may not have them. When a docs/src/content change is staged the author
-#    is working in docs, so block and tell them to install. For a libs-only commit,
-#    skip with a warning rather than block the whole component team; the CI
-#    freshness check is the backstop for that case.
+# 2. The generators need docs dependencies (tsx). The root `postinstall` runs
+#    `npm install --prefix docs`, so a normal `npm install` at the repo root sets
+#    these up for everyone and the hook always has what it needs. If they are
+#    still missing the environment is not set up, so block rather than let a
+#    possibly-stale file through.
 if [ ! -x docs/node_modules/.bin/tsx ]; then
-  if grep -Eq '^docs/src/content/' <<<"$staged"; then
-    echo "pre-commit: cannot verify generated docs files: docs dependencies missing." >&2
-    echo "            run 'npm install' in docs/ and commit again." >&2
-    exit 1
-  fi
-  echo "pre-commit: skipping generated-docs check: docs dependencies not installed." >&2
-  echo "            run 'npm install' in docs/ to check component changes too." >&2
-  exit 0
+  echo "pre-commit: cannot verify generated docs files: docs dependencies missing." >&2
+  echo "            run 'npm install' at the repo root and commit again." >&2
+  exit 1
 fi
 
 echo "pre-commit: checking generated docs files are up to date..." >&2

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,16 +87,24 @@ When a commit stages a file that feeds a generator, the hook regenerates the out
   - `libs/angular-components/src/lib/components/**` (Angular wrappers, feed `extract-api`)
   - `docs/src/content/**` (MDX frontmatter, feeds `build:search-index`)
 - If none of those are staged, the hook does nothing.
-- If the regenerated output matches what you staged, the commit goes through. The generators are deterministic, so a file that is already fresh comes back byte-identical and nothing is slowed down.
+- If the regenerated output matches what you staged, the commit goes through with no new files to stage. The generators still run on every commit that touches a watched source; they are deterministic, so an already-fresh file comes back byte-identical.
 - If they differ, the commit is blocked, naming the file that drifted and what to run.
 
-### Install it (one time per clone)
+### Install it
+
+Running `npm install` in `docs/` wires up the hook automatically. A `prepare` script in `docs/package.json` points git at the tracked `.githooks/` directory:
+
+```json
+"prepare": "git config core.hooksPath .githooks || true"
+```
+
+The hook needs the docs dependencies to run, so installing it from `docs/` keeps the two together: the people set up to build the docs are the ones who get the hook. The `|| true` keeps `npm install` from failing where git is not available (CI images, tarball installs).
+
+To set it by hand, or to confirm it is set:
 
 ```bash
 git config core.hooksPath .githooks
 ```
-
-That points git at the tracked `.githooks/` directory. There is no automatic installer. It is one command, run once, worth doing right after cloning.
 
 ### Docs dependencies are required
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,13 +92,13 @@ When a commit stages a file that feeds a generator, the hook regenerates the out
 
 ### Install it
 
-Running `npm install` in `docs/` wires up the hook automatically. A `prepare` script in `docs/package.json` points git at the tracked `.githooks/` directory:
+Running `npm install` at the repo root wires up the hook automatically. A `prepare` script in the root `package.json` points git at the tracked `.githooks/` directory:
 
 ```json
 "prepare": "git config core.hooksPath .githooks || true"
 ```
 
-The hook needs the docs dependencies to run, so installing it from `docs/` keeps the two together: the people set up to build the docs are the ones who get the hook. The `|| true` keeps `npm install` from failing where git is not available (CI images, tarball installs).
+`prepare` runs at the end of every root `npm install`, so a fresh clone gets the hook after its first install with no extra step. The `|| true` keeps `npm install` from failing where git is not available (CI images, tarball installs).
 
 To set it by hand, or to confirm it is set:
 
@@ -106,9 +106,12 @@ To set it by hand, or to confirm it is set:
 git config core.hooksPath .githooks
 ```
 
-### Docs dependencies are required
+### Docs dependencies and the missing-deps behavior
 
-The generators need the docs dependencies (`tsx`). If `docs/node_modules` is missing, the hook blocks the commit and tells you to run `npm install` in `docs/`. This is a one-time setup per clone; once it is in place the hook just works for any source you stage.
+The generators need the docs dependencies (`tsx`), which a root `npm install` does not install (docs is a separate package). The hook handles a missing `docs/node_modules` based on what you are committing:
+
+- Staging a `docs/src/content` change: the hook blocks and tells you to run `npm install` in `docs/`. If you are editing docs, you should have the docs tooling.
+- Staging only component sources (`libs/`): the hook skips with a warning instead of blocking, so it never gets in the way of component work. Run `npm install` in `docs/` once if you want it to check your component changes too. Until then the CI freshness check is the backstop.
 
 ### Bypassing
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,6 +85,7 @@ When a commit stages a file that feeds a generator, the hook regenerates the out
   - `libs/web-components/src/components/**` (Svelte JSDoc, feeds `extract-api`)
   - `libs/react-components/src/lib/**` (React wrappers, feed `extract-api`)
   - `libs/angular-components/src/lib/components/**` (Angular wrappers, feed `extract-api`)
+  - `libs/common/src/lib/**` (shared types and imperative-API controllers, feed `extract-api`)
   - `docs/src/content/**` (MDX frontmatter, feeds `build:search-index`)
 - If none of those are staged, the hook does nothing.
 - If the regenerated output matches what you staged, the commit goes through with no new files to stage. The generators still run on every commit that touches a watched source; they are deterministic, so an already-fresh file comes back byte-identical.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,6 +71,55 @@ The site resolves monorepo packages directly via aliases in `astro.config.mjs`:
 
 ---
 
+## Keeping generated files in sync
+
+The generated files (`generated/component-apis/*.json` and `public/search-index.json`) are committed to git so they show up in PR diffs. The catch: they only refresh when someone runs the build, and most component PRs never touch docs. So the committed files drift out of sync with the Svelte and MDX they come from (see [#3868](https://github.com/GovAlta/ui-components/issues/3868)).
+
+A pre-commit hook keeps them honest.
+
+### What the hook does
+
+When a commit stages a file that feeds a generator, the hook regenerates the outputs and blocks the commit if the committed versions are stale.
+
+- Sources it watches:
+  - `libs/web-components/src/components/**` (Svelte JSDoc, feeds `extract-api`)
+  - `libs/react-components/src/lib/**` (React wrappers, feed `extract-api`)
+  - `libs/angular-components/src/lib/components/**` (Angular wrappers, feed `extract-api`)
+  - `docs/src/content/**` (MDX frontmatter, feeds `build:search-index`)
+- If none of those are staged, the hook does nothing.
+- If the regenerated output matches what you staged, the commit goes through. The generators are deterministic, so a file that is already fresh comes back byte-identical and nothing is slowed down.
+- If they differ, the commit is blocked, naming the file that drifted and what to run.
+
+### Install it (one time per clone)
+
+```bash
+git config core.hooksPath .githooks
+```
+
+That points git at the tracked `.githooks/` directory. There is no automatic installer. It is one command, run once, worth doing right after cloning.
+
+### Docs dependencies are required
+
+The generators need the docs dependencies (`tsx`). If `docs/node_modules` is missing, the hook blocks the commit and tells you to run `npm install` in `docs/`. This is a one-time setup per clone; once it is in place the hook just works for any source you stage.
+
+### Bypassing
+
+`git commit --no-verify` skips the hook. Avoid it. A bypassed commit can put a stale file on `dev`, which is the exact problem this prevents. If the hook keeps stopping you, a generated file really is out of date.
+
+### Adding a new generator
+
+To bring a new generator under the same net:
+
+1. Make sure it runs from a single npm script in `docs/` and is deterministic (same input gives byte-identical output, so no timestamps or unsorted file reads).
+2. Add its source path to `SOURCE_REGEX` and its output path to `OUTPUTS` in `.githooks/pre-commit`, and run it in the regenerate step.
+3. Add it to the content sources table above.
+
+### Known limitation
+
+The hook checks the working tree, not the staged snapshot. With partial staging (`git add -p`, or staging a source change while leaving other edits to the same file unstaged), the generators read the working-tree version, which can differ from what you are committing. In that case the hook may stop a commit that is actually consistent. Stage the regenerated output, or commit the rest of your edits, and it clears. This is a deliberate trade-off to keep the hook simple.
+
+---
+
 ## Content collections
 
 Defined in `src/content/config.ts`. Four collections:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,7 +92,7 @@ When a commit stages a file that feeds a generator, the hook regenerates the out
 
 ### Install it
 
-Running `npm install` at the repo root wires up the hook automatically. A `prepare` script in the root `package.json` points git at the tracked `.githooks/` directory:
+Running `npm install` at the repo root wires up the hook automatically. A `prepare` script in the root `package.json` points git at the tracked `.githooks/` directory, and a `postinstall` script installs the docs dependencies the generators need (see below):
 
 ```json
 "prepare": "git config core.hooksPath .githooks || true"
@@ -106,12 +106,11 @@ To set it by hand, or to confirm it is set:
 git config core.hooksPath .githooks
 ```
 
-### Docs dependencies and the missing-deps behavior
+### Docs dependencies
 
-The generators need the docs dependencies (`tsx`), which a root `npm install` does not install (docs is a separate package). The hook handles a missing `docs/node_modules` based on what you are committing:
+The generators need the docs dependencies (`tsx`). The docs are a separate npm package, so the root `package.json` has a `postinstall` that runs `npm install --prefix docs`. A single `npm install` at the repo root therefore installs them for everyone, and the hook always has what it needs to run.
 
-- Staging a `docs/src/content` change: the hook blocks and tells you to run `npm install` in `docs/`. If you are editing docs, you should have the docs tooling.
-- Staging only component sources (`libs/`): the hook skips with a warning instead of blocking, so it never gets in the way of component work. Run `npm install` in `docs/` once if you want it to check your component changes too. Until then the CI freshness check is the backstop.
+If `docs/node_modules` is missing anyway (for example an interrupted install), the hook blocks with a message to run `npm install` at the repo root, rather than letting a possibly-stale file through.
 
 ### Bypassing
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,8 +10,7 @@
     "extract-api": "npx tsx src/scripts/extract-api.ts --all",
     "preview": "astro preview",
     "generate-previews": "npx tsx src/scripts/generate-preview-images.ts",
-    "astro": "astro",
-    "prepare": "git config core.hooksPath .githooks || true"
+    "astro": "astro"
   },
   "dependencies": {
     "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@^2.8.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,8 @@
     "extract-api": "npx tsx src/scripts/extract-api.ts --all",
     "preview": "astro preview",
     "generate-previews": "npx tsx src/scripts/generate-preview-images.ts",
-    "astro": "astro"
+    "astro": "astro",
+    "prepare": "git config core.hooksPath .githooks || true"
   },
   "dependencies": {
     "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@^2.8.0",

--- a/docs/src/scripts/build-search-index.ts
+++ b/docs/src/scripts/build-search-index.ts
@@ -389,7 +389,10 @@ function findMdxFiles(dir: string): string[] {
     return files;
   }
 
-  for (const entry of readdirSync(dir)) {
+  // Sort so file order is stable across machines and filesystems. The freshness
+  // hook compares regenerated output byte-for-byte, so traversal order (and thus
+  // the order of entries in the index) must be deterministic.
+  for (const entry of readdirSync(dir).sort()) {
     const fullPath = join(dir, entry);
     const stat = statSync(fullPath);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@abgov/ui-components",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@angular/animations": "21.2.6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "docs:preview": "npm run --prefix astro preview",
     "docs:start": "npm run --prefix astro start",
     "lint": "nx run-many --target=lint --exclude=angular --exclude=react --exclude=web",
+    "postinstall": "npm install --prefix docs",
     "prepare": "git config core.hooksPath .githooks || true",
     "pretest:pr": "npx nx run common:build && npx nx run web-components:build && npx nx run react-components:build",
     "serve:dev:angular": "nx run angular-dev:serve:development",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "docs:preview": "npm run --prefix astro preview",
     "docs:start": "npm run --prefix astro start",
     "lint": "nx run-many --target=lint --exclude=angular --exclude=react --exclude=web",
+    "prepare": "git config core.hooksPath .githooks || true",
     "pretest:pr": "npx nx run common:build && npx nx run web-components:build && npx nx run react-components:build",
     "serve:dev:angular": "nx run angular-dev:serve:development",
     "serve:dev:react": "nx run react-dev:serve:development",


### PR DESCRIPTION
## What this does

The docs site commits two generated files: the component API JSON (`docs/generated/component-apis/`) and the search index (`docs/public/search-index.json`). They only refresh when someone runs the docs build, and most component PRs never touch docs, so the committed files quietly fall behind the Svelte and MDX they come from. This is #3868.

This adds a pre-commit hook that regenerates those outputs when you stage a file that feeds them, and blocks the commit if the committed versions are stale. If nothing generator-related is staged, the hook does nothing.

## What's in here

1. **The hook** at `.githooks/pre-commit`. Watches the three libs source roots that feed `extract-api` (`web-components/src/components`, `react-components/src/lib`, `angular-components/src/lib/components`) and `docs/src/content/**` (MDX frontmatter, feeds `build:search-index`). Because the generators are deterministic, a file that is already fresh comes back byte-identical, so there is no friction when you have done the right thing.
2. **Determinism fix** in `build-search-index.ts`. The search index listed files in whatever order the filesystem returned, which differs between macOS and Linux. It now sorts them so the output is identical on every machine. Without this the hook would flip-flop between contributors.
3. **Docs** in `docs/ARCHITECTURE.md`: what the hook does, the one-time install, and how to bring a new generator under it.

## Install

Run `npm install` at the repo root. A `prepare` script points `core.hooksPath` at `.githooks` (the hook), and a `postinstall` runs `npm install --prefix docs` so you also get the docs dependencies the generators need. To set the hook by hand: `git config core.hooksPath .githooks`.

## How to test

1. `git config core.hooksPath .githooks`
2. Edit a JSDoc comment in any Svelte component, stage it, try to commit. The hook blocks and tells you to regenerate.
3. Run `npm run extract-api` in `docs/`, stage the JSON, commit again. It passes.
4. Same idea with an MDX frontmatter change and `npm run build:search-index`.
5. Edit a non-source file and commit. No hook, no friction.

## Deferred to follow-ups

A CI check that does the same thing on GitHub (a backstop for bypassed or uninstalled hooks), collapsing the generated files in PR diffs, and a merge driver for conflicts. All build on this and are out of scope here.

Closes #3868


