### PR TITLE
feat(#3789): add AI tools and resources section to get-started

### DIFF
--- a/docs/src/components/Breadcrumbs.astro
+++ b/docs/src/components/Breadcrumbs.astro
@@ -55,6 +55,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   "examples": "Examples",
   "designers": "Designers",
   "developers": "Developers",
+  "ai-tools-and-resources": "AI Tools and Resources",
 };
 
 function segmentToLabel(segment: string): string {

--- a/docs/src/components/CodeSnippet.css
+++ b/docs/src/components/CodeSnippet.css
@@ -124,10 +124,12 @@
   mask-image: linear-gradient(to bottom, black 0%, black 60%, transparent 100%);
 }
 
-pre {
+.code-snippet .code-block .code-container pre,
+.framework-switcher .code-block .code-container pre {
   margin: 0;
-  padding: var(--goa-space-m, 1rem);
-  overflow-x: auto;
+  padding: var(--goa-space-s, 0.75rem) var(--goa-space-m, 1rem);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 code {

--- a/docs/src/components/SiteNav.tsx
+++ b/docs/src/components/SiteNav.tsx
@@ -94,9 +94,7 @@ function getInitialMenuState(): boolean {
 }
 
 const EMPTY_GET_STARTED_NAV: GetStartedNav = {
-  topPages: [],
-  groups: [],
-  bottomPages: [],
+  sections: [],
 };
 
 export function SiteNav({

--- a/docs/src/components/nav/GetStartedSubMenu.tsx
+++ b/docs/src/components/nav/GetStartedSubMenu.tsx
@@ -1,14 +1,13 @@
 /**
  * GetStartedSubMenu.tsx
  *
- * Sub-menu for Get Started section showing grouped pages.
- * Uses GoabWorkSideMenuGroup for expandable Designers/Developers sections.
- *
- * Nav structure is sourced from the get-started content collection via
+ * Sub-menu for Get Started section showing pages organized into sections.
+ * Each section is either flat (a list of items) or grouped (items inside an
+ * expandable group with a heading). Sections render in the order returned by
  * `getGetStartedNav()` in lib/get-started-nav.ts.
  */
 
-import { type MouseEvent } from "react";
+import { Fragment, type MouseEvent } from "react";
 import {
   GoabWorkSideMenu,
   GoabWorkSideMenuItem,
@@ -16,7 +15,7 @@ import {
 } from "@abgov/react-components";
 import { MenuSecondaryContent } from "./MenuSecondaryContent";
 import { withBase } from "@/lib/base-url";
-import type { GetStartedNav } from "@/lib/get-started-nav";
+import type { GetStartedNav, GetStartedNavSection } from "@/lib/get-started-nav";
 
 interface GetStartedSubMenuProps {
   isOpen: boolean;
@@ -41,6 +40,36 @@ export function GetStartedSubMenu({
     onBack();
   };
 
+  const renderSection = (section: GetStartedNavSection) => {
+    if (section.type === "flat") {
+      return (
+        <Fragment key={section.slug}>
+          {section.pages.map((page) => (
+            <GoabWorkSideMenuItem key={page.url} label={page.label} url={withBase(page.url)} />
+          ))}
+        </Fragment>
+      );
+    }
+
+    const containsCurrentPage = section.pages.some((p) => p.url === currentUrl);
+
+    const handleGroupClickCapture = () => {
+      if (!isOpen && onExpandMenu) {
+        onExpandMenu();
+      }
+    };
+
+    return (
+      <div key={section.slug} onClickCapture={handleGroupClickCapture}>
+        <GoabWorkSideMenuGroup heading={section.name} open={containsCurrentPage}>
+          {section.pages.map((page) => (
+            <GoabWorkSideMenuItem key={page.url} label={page.label} url={withBase(page.url)} />
+          ))}
+        </GoabWorkSideMenuGroup>
+      </div>
+    );
+  };
+
   const primaryContent = (
     <>
       {/* Back to parent menu */}
@@ -48,50 +77,7 @@ export function GetStartedSubMenu({
         <GoabWorkSideMenuItem label="All" icon="arrow-back" url="/__back__" />
       </div>
 
-      {/* Top-level pages */}
-      {items.topPages.map((page) => (
-        <GoabWorkSideMenuItem
-          key={page.url}
-          label={page.label}
-          url={withBase(page.url)}
-        />
-      ))}
-
-      {/* Grouped sections */}
-      <div>
-        {items.groups.map((group) => {
-          const containsCurrentPage = group.pages.some((p) => p.url === currentUrl);
-
-          const handleGroupClickCapture = () => {
-            if (!isOpen && onExpandMenu) {
-              onExpandMenu();
-            }
-          };
-
-          return (
-            <div key={group.slug} onClickCapture={handleGroupClickCapture}>
-              <GoabWorkSideMenuGroup heading={group.name} open={containsCurrentPage}>
-                {group.pages.map((page) => (
-                  <GoabWorkSideMenuItem
-                    key={page.url}
-                    label={page.label}
-                    url={withBase(page.url)}
-                  />
-                ))}
-              </GoabWorkSideMenuGroup>
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Bottom pages */}
-      {items.bottomPages.map((page) => (
-        <GoabWorkSideMenuItem
-          key={page.url}
-          label={page.label}
-          url={withBase(page.url)}
-        />
-      ))}
+      {items.sections.map(renderSection)}
     </>
   );
 

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -267,7 +267,15 @@ const getStarted = defineCollection({
     description: z.string().optional(),
     // Submenu placement. "intro" and "appendix" are top-level (above and below
     // the grouped sections); "designers" and "developers" are grouped.
-    section: z.enum(["intro", "designers", "developers", "appendix"]),
+    section: z.enum([
+      "intro",
+      "designers",
+      "developers",
+      "qa-testing",
+      "ai-tools-and-resources",
+      "contribute",
+      "out-of-support",
+    ]),
     // Sort order within section.
     order: z.number(),
     status: z.enum(["published", "draft", "deprecated"]).default("published"),

--- a/docs/src/content/get-started/ai-tools-and-resources.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources.mdx
@@ -8,6 +8,7 @@ order: 1
 status: published
 ---
 import DropInCallout from "../../components/DropInCallout.astro";
+import { CodeSnippet } from "../../components/CodeSnippet";
 import { withBase } from "@/lib/base-url";
 
 <goa-text size="heading-xl" mt="none" mb="m">AI tools and resources</goa-text>
@@ -31,8 +32,8 @@ import { withBase } from "@/lib/base-url";
         <td>Component APIs, examples, and guidance, like asking a reference librarian</td>
       </tr>
       <tr>
-        <td><a href="#workflows">Workflows / Skills</a></td>
-        <td>Workflows that load when the work matches.</td>
+        <td><a href="#skills">Skills</a></td>
+        <td>Skills that load when the work matches.</td>
         <td>Layered instructions for using the design system in your work, like a playbook for the work at hand</td>
       </tr>
       <tr>
@@ -57,18 +58,21 @@ import { withBase } from "@/lib/base-url";
 <p>Reach for it for instant lookup, or to surface details that would take longer to find by browsing.</p>
 <p><goa-link><a href={withBase("/get-started/ai-tools-and-resources/goa-design-system-mcp")}>View more</a></goa-link></p>
 
-<goa-text as="h2" id="workflows" size="heading-m">Workflows</goa-text>
-<p>Workflows are stored as plain Markdown. Some AI tools auto-load them when the request matches; others let you paste them in or reference them as project rules. Anthropic calls them skills; other tools have their own names for the same idea.</p>
+<goa-text as="h2" id="skills" size="heading-m">Skills</goa-text>
+<p>Skills are the SKILL.md open standard: plain Markdown instructions your AI loads when the work matches. Most major AI tools read them, including Claude Code, Cursor, and Copilot.</p>
+<p>You add a skill with a single command pointed at our repo, the same way you'd add our package. Run <code>npx skills update</code> to pull the latest, or add that to a SessionStart hook so it refreshes automatically.</p>
 
 <goa-text size="heading-s">using-goa-design-system</goa-text>
-<p>Tell your AI what you're working on, like a public form or a case management tool. It walks your AI through the product type, examples, and components that fit.</p>
+<p>Tell your AI what you're working on, like a public form or a case management tool. It walks your AI down the system's structure, from product type to templates to the components that fit, and surfaces the known gotchas before any code is written.</p>
 <p>Reach for it any time you want your AI to follow the design system's patterns, whether you're starting fresh or building on existing work.</p>
-<p><strong>How to access it:</strong> <em>[installation instructions to be confirmed]</em></p>
+<p><strong>How to add it:</strong></p>
+<CodeSnippet language="bash" showCopy client:visible code={`npx skills add GovAlta/ui-components --skill using-goa-design-system`} />
 
 <goa-text size="heading-s">content-design</goa-text>
 <p>Tell your AI to write or refine a piece of user-facing copy, like an error message or a status update. It names the reader first, a citizen or a worker, then shapes the wording to fit, because the same message reads differently for each.</p>
 <p>Reach for it when you're working on the words in a service: labels, guidance, errors, empty states, notifications.</p>
-<p><strong>How to access it:</strong> <em>[installation instructions to be confirmed]</em></p>
+<p><strong>How to add it:</strong></p>
+<CodeSnippet language="bash" showCopy client:visible code={`npx skills add GovAlta/ui-components --skill content-design`} />
 
 <goa-text as="h2" id="md-files" size="heading-m">MD files</goa-text>
 <p>Useful when you want to give your AI broad design system context, include the reference in a project, or reach for the content offline.</p>

--- a/docs/src/content/get-started/ai-tools-and-resources.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources.mdx
@@ -2,17 +2,16 @@
 id: ai-tools-and-resources
 title: AI tools and resources
 navLabel: Overview
-description: AI tools and resources to help you and your AI editor work better with the GoA Design System
+description: AI tools and resources to help you and your AI work better with the GoA Design System
 section: ai-tools-and-resources
 order: 1
 status: published
 ---
 import DropInCallout from "../../components/DropInCallout.astro";
-import { CodeSnippet } from "../../components/CodeSnippet";
 import { withBase } from "@/lib/base-url";
 
 <goa-text size="heading-xl" mt="none" mb="m">AI tools and resources</goa-text>
-<goa-text size="body-l" mt="none" mb="2xl">An overview of the AI tools available to help you and your AI editor work with the GoA Design System.</goa-text>
+<goa-text size="body-l" mt="none" mb="2xl">These tools help you and your AI work with the GoA Design System. Each tool serves a different purpose, so use them together depending on the task.</goa-text>
 
 <goa-text as="h2" id="ai-toolset" size="heading-m">AI toolset</goa-text>
 
@@ -27,19 +26,19 @@ import { withBase } from "@/lib/base-url";
     </thead>
     <tbody>
       <tr>
-        <td><a href={withBase("/get-started/ai-tools-and-resources/goa-design-system-mcp")}>GoA design system MCP</a></td>
+        <td><a href={withBase("/get-started/ai-tools-and-resources/goa-design-system-mcp")}>GoA Design System MCP</a></td>
         <td>Lookup tool. Your AI calls it on demand.</td>
         <td>Component APIs, examples, and guidance, like asking a reference librarian</td>
       </tr>
       <tr>
         <td><a href={withBase("/get-started/ai-tools-and-resources/skills")}>Skills</a></td>
-        <td>Skills that load when the work matches.</td>
-        <td>Layered instructions for using the design system in your work, like a playbook for the work at hand</td>
+        <td>Instructions that load when the work matches.</td>
+        <td>Layered instructions for using the Design System in your work, like a playbook for the work at hand</td>
       </tr>
       <tr>
-        <td><a href="#md-files">MD files</a></td>
+        <td><span style={{ display: "inline-flex", flexDirection: "column", alignItems: "flex-start", gap: "0.375rem" }}><a href="#md-files">MD files</a><goa-badge version="2" type="default" icon="false" emphasis="subtle" content="Coming soon"></goa-badge></span></td>
         <td>Static reference. Pasted upfront, stays in your AI's session.</td>
-        <td>The full design system reference, like a textbook on the desk</td>
+        <td>The full Design System reference, like a textbook on the desk</td>
       </tr>
       <tr>
         <td><a href="#figma-mcp">Figma MCP</a> (external)</td>
@@ -51,25 +50,23 @@ import { withBase } from "@/lib/base-url";
 </goa-table>
 
 <goa-callout version="2" type="information" emphasis="low" heading="Use these tools together" mt="none" mb="2xl">
-  <goa-text size="body-m" mt="2xs" mb="none">Each tool serves a different purpose. They all read from the same content this site renders, so answers stay consistent. Use them in combination, depending on the task at hand.</goa-text>
+  <goa-text size="body-m" mt="2xs" mb="none">All tools read from the same content this site renders, so answers stay consistent no matter which one you use.</goa-text>
 </goa-callout>
 
-<goa-text as="h2" id="goa-design-system-mcp" size="heading-m">GoA design system MCP</goa-text>
-<p>Reach for it for instant lookup, or to surface details that would take longer to find by browsing.</p>
+<goa-text as="h2" id="goa-design-system-mcp" size="heading-m">GoA Design System MCP</goa-text>
+<p>Your AI pulls live Design System knowledge as it builds, so it uses the right components, the right props, and real examples instead of guessing.</p>
 <p><goa-link><a href={withBase("/get-started/ai-tools-and-resources/goa-design-system-mcp")}>View more</a></goa-link></p>
-<p><strong>How to connect</strong></p>
-<CodeSnippet language="javascript" showCopy client:visible code={`https://mcp.design.alberta.ca/mcp`} />
 
 <goa-text as="h2" id="skills" size="heading-m">Skills</goa-text>
-<p>Skills are the SKILL.md open standard: plain Markdown instructions your AI loads when the work matches. Most major AI tools read them, including Claude Code, Cursor, and Copilot.</p>
+<p>Plain Markdown instruction files give your AI a workflow to follow when the work matches, so it builds a GoA service with the right structure, templates, and patterns from the start.</p>
 <p><goa-link><a href={withBase("/get-started/ai-tools-and-resources/skills")}>View more</a></goa-link></p>
 
-<goa-text as="h2" id="md-files" size="heading-m">MD files</goa-text>
-<p>Useful when you want to give your AI broad design system context, include the reference in a project, or reach for the content offline.</p>
+<goa-text as="h2" id="md-files" size="heading-m">MD files <goa-badge version="2" type="default" icon="false" emphasis="subtle" ml="xs" content="Coming soon" style={{ verticalAlign: "middle" }}></goa-badge></goa-text>
+<p>Useful when you want to give your AI broad Design System context, include the reference in a project, or reach for the content offline.</p>
 <p><strong>How to access it:</strong> Per-framework downloadable bundles (React, Angular, Web Components), coming soon.</p>
 
 <goa-text as="h2" id="figma-mcp" size="heading-m">Figma MCP</goa-text>
-<p>Built and maintained by Figma. Pair it with the GoA design system MCP when work spans design and code, so your AI can bridge Figma designs to real coded components from the design system.</p>
+<p>Built and maintained by Figma. Pair it with the GoA Design System MCP when work spans design and code, so your AI can bridge Figma designs to real coded components from the Design System.</p>
 <p><strong>How to access it:</strong> <goa-link trailingicon="open"><a href="https://help.figma.com/hc/en-us/articles/32132100833559-Guide-to-the-Figma-MCP-server" target="_blank">Figma's guide to the MCP server</a></goa-link></p>
 
 <DropInCallout />

--- a/docs/src/content/get-started/ai-tools-and-resources.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources.mdx
@@ -32,7 +32,7 @@ import { withBase } from "@/lib/base-url";
         <td>Component APIs, examples, and guidance, like asking a reference librarian</td>
       </tr>
       <tr>
-        <td><a href="#skills">Skills</a></td>
+        <td><a href={withBase("/get-started/ai-tools-and-resources/skills")}>Skills</a></td>
         <td>Skills that load when the work matches.</td>
         <td>Layered instructions for using the design system in your work, like a playbook for the work at hand</td>
       </tr>
@@ -57,26 +57,16 @@ import { withBase } from "@/lib/base-url";
 <goa-text as="h2" id="goa-design-system-mcp" size="heading-m">GoA design system MCP</goa-text>
 <p>Reach for it for instant lookup, or to surface details that would take longer to find by browsing.</p>
 <p><goa-link><a href={withBase("/get-started/ai-tools-and-resources/goa-design-system-mcp")}>View more</a></goa-link></p>
+<p><strong>How to connect</strong></p>
+<CodeSnippet language="javascript" showCopy client:visible code={`https://mcp.design.alberta.ca/mcp`} />
 
 <goa-text as="h2" id="skills" size="heading-m">Skills</goa-text>
 <p>Skills are the SKILL.md open standard: plain Markdown instructions your AI loads when the work matches. Most major AI tools read them, including Claude Code, Cursor, and Copilot.</p>
-<p>You add a skill with a single command pointed at our repo, the same way you'd add our package. Run <code>npx skills update</code> to pull the latest, or add that to a SessionStart hook so it refreshes automatically.</p>
-
-<goa-text size="heading-s">using-goa-design-system</goa-text>
-<p>Tell your AI what you're working on, like a public form or a case management tool. It walks your AI down the system's structure, from product type to templates to the components that fit, and surfaces the known gotchas before any code is written.</p>
-<p>Reach for it any time you want your AI to follow the design system's patterns, whether you're starting fresh or building on existing work.</p>
-<p><strong>How to add it:</strong></p>
-<CodeSnippet language="bash" showCopy client:visible code={`npx skills add GovAlta/ui-components --skill using-goa-design-system`} />
-
-<goa-text size="heading-s">content-design</goa-text>
-<p>Tell your AI to write or refine a piece of user-facing copy, like an error message or a status update. It names the reader first, a citizen or a worker, then shapes the wording to fit, because the same message reads differently for each.</p>
-<p>Reach for it when you're working on the words in a service: labels, guidance, errors, empty states, notifications.</p>
-<p><strong>How to add it:</strong></p>
-<CodeSnippet language="bash" showCopy client:visible code={`npx skills add GovAlta/ui-components --skill content-design`} />
+<p><goa-link><a href={withBase("/get-started/ai-tools-and-resources/skills")}>View more</a></goa-link></p>
 
 <goa-text as="h2" id="md-files" size="heading-m">MD files</goa-text>
 <p>Useful when you want to give your AI broad design system context, include the reference in a project, or reach for the content offline.</p>
-<p><strong>How to access it:</strong> <em>[download path to be confirmed]</em></p>
+<p><strong>How to access it:</strong> Per-framework downloadable bundles (React, Angular, Web Components), coming soon.</p>
 
 <goa-text as="h2" id="figma-mcp" size="heading-m">Figma MCP</goa-text>
 <p>Built and maintained by Figma. Pair it with the GoA design system MCP when work spans design and code, so your AI can bridge Figma designs to real coded components from the design system.</p>

--- a/docs/src/content/get-started/ai-tools-and-resources.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources.mdx
@@ -1,0 +1,81 @@
+---
+id: ai-tools-and-resources
+title: AI tools and resources
+navLabel: Overview
+description: AI tools and resources to help you and your AI editor work better with the GoA Design System
+section: ai-tools-and-resources
+order: 1
+status: published
+---
+import DropInCallout from "../../components/DropInCallout.astro";
+import { withBase } from "@/lib/base-url";
+
+<goa-text size="heading-xl" mt="none" mb="m">AI tools and resources</goa-text>
+<goa-text size="body-l" mt="none" mb="2xl">An overview of the AI tools available to help you and your AI editor work with the GoA Design System.</goa-text>
+
+<goa-text as="h2" id="ai-toolset" size="heading-m">AI toolset</goa-text>
+
+<goa-table version="2" width="100%" mb="m">
+  <table width="100%">
+    <thead>
+      <tr>
+        <th>Tool</th>
+        <th>How it works</th>
+        <th>What it gives your AI</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href={withBase("/get-started/ai-tools-and-resources/goa-design-system-mcp")}>GoA design system MCP</a></td>
+        <td>Lookup tool. Your AI calls it on demand.</td>
+        <td>Component APIs, examples, and guidance, like asking a reference librarian</td>
+      </tr>
+      <tr>
+        <td><a href="#workflows">Workflows / Skills</a></td>
+        <td>Workflows that load when the work matches.</td>
+        <td>Layered instructions for using the design system in your work, like a playbook for the work at hand</td>
+      </tr>
+      <tr>
+        <td><a href="#md-files">MD files</a></td>
+        <td>Static reference. Pasted upfront, stays in your AI's session.</td>
+        <td>The full design system reference, like a textbook on the desk</td>
+      </tr>
+      <tr>
+        <td><a href="#figma-mcp">Figma MCP</a> (external)</td>
+        <td>Lookup tool. Your AI calls it on demand.</td>
+        <td>Read a design in Figma to get the components, variables, and specs, like lifting measurements off a blueprint</td>
+      </tr>
+    </tbody>
+  </table>
+</goa-table>
+
+<goa-callout version="2" type="information" emphasis="low" heading="Use these tools together" mt="none" mb="2xl">
+  <goa-text size="body-m" mt="2xs" mb="none">Each tool serves a different purpose. They all read from the same content this site renders, so answers stay consistent. Use them in combination, depending on the task at hand.</goa-text>
+</goa-callout>
+
+<goa-text as="h2" id="goa-design-system-mcp" size="heading-m">GoA design system MCP</goa-text>
+<p>Reach for it for instant lookup, or to surface details that would take longer to find by browsing.</p>
+<p><goa-link><a href={withBase("/get-started/ai-tools-and-resources/goa-design-system-mcp")}>View more</a></goa-link></p>
+
+<goa-text as="h2" id="workflows" size="heading-m">Workflows</goa-text>
+<p>Workflows are stored as plain Markdown. Some AI tools auto-load them when the request matches; others let you paste them in or reference them as project rules. Anthropic calls them skills; other tools have their own names for the same idea.</p>
+
+<goa-text size="heading-s">using-goa-design-system</goa-text>
+<p>Tell your AI what you're working on, like a public form or a case management tool. It walks your AI through the product type, examples, and components that fit.</p>
+<p>Reach for it any time you want your AI to follow the design system's patterns, whether you're starting fresh or building on existing work.</p>
+<p><strong>How to access it:</strong> <em>[installation instructions to be confirmed]</em></p>
+
+<goa-text size="heading-s">content-design</goa-text>
+<p>Tell your AI to write or refine a piece of user-facing copy, like an error message or a status update. It names the reader first, a citizen or a worker, then shapes the wording to fit, because the same message reads differently for each.</p>
+<p>Reach for it when you're working on the words in a service: labels, guidance, errors, empty states, notifications.</p>
+<p><strong>How to access it:</strong> <em>[installation instructions to be confirmed]</em></p>
+
+<goa-text as="h2" id="md-files" size="heading-m">MD files</goa-text>
+<p>Useful when you want to give your AI broad design system context, include the reference in a project, or reach for the content offline.</p>
+<p><strong>How to access it:</strong> <em>[download path to be confirmed]</em></p>
+
+<goa-text as="h2" id="figma-mcp" size="heading-m">Figma MCP</goa-text>
+<p>Built and maintained by Figma. Pair it with the GoA design system MCP when work spans design and code, so your AI can bridge Figma designs to real coded components from the design system.</p>
+<p><strong>How to access it:</strong> <goa-link trailingicon="open"><a href="https://help.figma.com/hc/en-us/articles/32132100833559-Guide-to-the-Figma-MCP-server" target="_blank">Figma's guide to the MCP server</a></goa-link></p>
+
+<DropInCallout />

--- a/docs/src/content/get-started/ai-tools-and-resources.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources.mdx
@@ -41,7 +41,7 @@ import { withBase } from "@/lib/base-url";
         <td>The full Design System reference, like a textbook on the desk</td>
       </tr>
       <tr>
-        <td><a href="#figma-mcp">Figma MCP</a> (external)</td>
+        <td><span style={{ display: "inline-flex", flexDirection: "column", alignItems: "flex-start", gap: "0.375rem" }}><a href="#figma-mcp">Figma MCP</a><goa-badge version="2" type="default" icon="false" emphasis="subtle" content="External"></goa-badge></span></td>
         <td>Lookup tool. Your AI calls it on demand.</td>
         <td>Read a design in Figma to get the components, variables, and specs, like lifting measurements off a blueprint</td>
       </tr>
@@ -61,9 +61,12 @@ import { withBase } from "@/lib/base-url";
 <p>Plain Markdown instruction files give your AI a workflow to follow when the work matches, so it builds a GoA service with the right structure, templates, and patterns from the start.</p>
 <p><goa-link><a href={withBase("/get-started/ai-tools-and-resources/skills")}>View more</a></goa-link></p>
 
-<goa-text as="h2" id="md-files" size="heading-m">MD files <goa-badge version="2" type="default" icon="false" emphasis="subtle" ml="xs" content="Coming soon" style={{ verticalAlign: "middle" }}></goa-badge></goa-text>
+<div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: "var(--goa-space-xs)", marginTop: "var(--goa-space-2xl)", marginBottom: "var(--goa-space-m)" }}>
+  <goa-text as="h2" id="md-files" size="heading-m" mt="none" mb="none">MD files</goa-text>
+  <goa-badge version="2" type="default" icon="false" emphasis="subtle" content="Coming soon"></goa-badge>
+</div>
 <p>Useful when you want to give your AI broad Design System context, include the reference in a project, or reach for the content offline.</p>
-<p><strong>How to access it:</strong> Per-framework downloadable bundles (React, Angular, Web Components), coming soon.</p>
+<p><strong>How to access it:</strong> Per-framework downloadable bundles (React, Angular, Web Components).</p>
 
 <goa-text as="h2" id="figma-mcp" size="heading-m">Figma MCP</goa-text>
 <p>Built and maintained by Figma. Pair it with the GoA Design System MCP when work spans design and code, so your AI can bridge Figma designs to real coded components from the Design System.</p>

--- a/docs/src/content/get-started/ai-tools-and-resources/goa-design-system-mcp.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources/goa-design-system-mcp.mdx
@@ -1,0 +1,245 @@
+---
+id: ai-tools-and-resources/goa-design-system-mcp
+title: GoA design system MCP
+navLabel: Design system MCP
+description: A live lookup tool your AI editor uses for component APIs, examples, and guidance
+section: ai-tools-and-resources
+order: 2
+status: published
+---
+import DropInCallout from "../../../components/DropInCallout.astro";
+import { CodeSnippet } from "../../../components/CodeSnippet";
+import { CodeCopy } from "../../../components/CodeCopy";
+import { withBase } from "@/lib/base-url";
+
+<goa-text size="heading-xl" mt="none" mb="m">GoA design system MCP</goa-text>
+<goa-text size="body-l" mt="none" mb="2xl">The live lookup tool your AI editor calls when it needs design system component APIs, examples, or guidance.</goa-text>
+
+<goa-callout version="2" type="information" emphasis="low" heading="Quick start: Point your AI tool at this endpoint" mt="none" mb="m">
+  <CodeSnippet language="javascript" showCopy client:visible code={`https://design-system-mcp-dcp-prod.apps.aro-01.int.gov.ab.ca/mcp`} />
+  <goa-text version="2" size="body-m" mt="s" mb="none"><goa-link version="2"><a href="#setup">View tool-specific setup</a></goa-link></goa-text>
+</goa-callout>
+
+<goa-callout version="2" type="information" emphasis="low" mt="m" mb="l">
+  <goa-text version="2" size="body-s" mt="none" mb="none">The MCP is one tool in a larger AI toolset. For the overview of all available AI tools and how they fit together, see <a href={withBase("/get-started/ai-tools-and-resources")}>AI tools and resources</a>.</goa-text>
+</goa-callout>
+
+<goa-text as="h2" id="whats-included" size="heading-m" mt="2xl">What's included</goa-text>
+
+<p>Everything the MCP returns comes from the same content this site renders.</p>
+
+<goa-table version="2" width="100%" mb="2xl">
+  <table width="100%">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>What's in it</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Components</strong></td>
+        <td>The full GoA component library with props, variants, and accessibility notes. React, Angular, and Web Components.</td>
+      </tr>
+      <tr>
+        <td><strong>Examples</strong></td>
+        <td>Workspace and Public form product types, page patterns, section patterns, and smaller task examples.</td>
+      </tr>
+      <tr>
+        <td><strong>Guidance</strong></td>
+        <td>Do's, don'ts, and tips that apply across components. Accessibility grounded in WCAG 2.2 AA.</td>
+      </tr>
+    </tbody>
+  </table>
+</goa-table>
+
+<goa-text as="h2" id="what-can-you-ask" size="heading-m" mt="2xl">What can you ask?</goa-text>
+
+<p>You ask your AI editor in plain language. It reaches for the MCP when one of these is the right answer.</p>
+
+<goa-table version="2" width="100%" mb="l">
+  <table width="100%">
+    <thead>
+      <tr>
+        <th>About a component</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.5rem" }}>
+            <span>"What props does the Table component have?"</span>
+            <CodeCopy client:only="react" code="What props does the Table component have?" />
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.5rem" }}>
+            <span>"How does FormItem handle error states?"</span>
+            <CodeCopy client:only="react" code="How does FormItem handle error states?" />
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.5rem" }}>
+            <span>"Which GoA component should I use for a card layout?"</span>
+            <CodeCopy client:only="react" code="Which GoA component should I use for a card layout?" />
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</goa-table>
+
+<goa-table version="2" width="100%" mb="l">
+  <table width="100%">
+    <thead>
+      <tr>
+        <th>For an example or pattern</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.5rem" }}>
+            <span>"Find dashboard examples in the workspace product type"</span>
+            <CodeCopy client:only="react" code="Find dashboard examples in the workspace product type" />
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.5rem" }}>
+            <span>"Show me React examples for a question page"</span>
+            <CodeCopy client:only="react" code="Show me React examples for a question page" />
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.5rem" }}>
+            <span>"What's a good example of a filter bar?"</span>
+            <CodeCopy client:only="react" code="What's a good example of a filter bar?" />
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</goa-table>
+
+<goa-table version="2" width="100%" mb="2xl">
+  <table width="100%">
+    <thead>
+      <tr>
+        <th>For guidance, do's, and don'ts</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.5rem" }}>
+            <span>"What's the guidance for labelling buttons?"</span>
+            <CodeCopy client:only="react" code="What's the guidance for labelling buttons?" />
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.5rem" }}>
+            <span>"Show me the do's and don'ts for dropdowns"</span>
+            <CodeCopy client:only="react" code="Show me the do's and don'ts for dropdowns" />
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.5rem" }}>
+            <span>"What accessibility guidance applies to forms?"</span>
+            <CodeCopy client:only="react" code="What accessibility guidance applies to forms?" />
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</goa-table>
+
+<goa-text as="h2" id="setup" size="heading-m" mt="2xl">Setup</goa-text>
+
+<p>Find your AI tool below to connect it. There's nothing to install.</p>
+
+<goa-callout version="2" type="important" emphasis="low" mt="m" mb="m">
+  <goa-text version="2" size="body-m" mt="none" mb="none">To verify your setup, restart your AI tool and ask "Look up the GoA Button component." You should get a response covering Button's props, variants, and usage.</goa-text>
+</goa-callout>
+
+<goa-text as="h4" size="heading-xs" mt="xl">Claude Code</goa-text>
+
+<p><goa-link mt="s" trailingicon="open"><a href="https://code.claude.com/docs/en/mcp" target="_blank" rel="noopener noreferrer">View Claude Code's MCP documentation</a></goa-link></p>
+
+<p>The fastest path is the <code>claude mcp add</code> command:</p>
+
+<CodeSnippet
+  language="javascript"
+  showCopy
+  client:visible
+  code={`claude mcp add --transport http goa-design-system https://design-system-mcp-dcp-prod.apps.aro-01.int.gov.ab.ca/mcp --scope user`}
+/>
+
+<goa-text as="h4" size="heading-xs" mt="xl">Claude Desktop</goa-text>
+
+<p><goa-link mt="s" trailingicon="open"><a href="https://modelcontextprotocol.io/docs/develop/connect-local-servers" target="_blank" rel="noopener noreferrer">View Claude Desktop's MCP setup guide</a></goa-link></p>
+
+<p>Claude Desktop only supports local (stdio) MCP servers, so connect through the <code>mcp-remote</code> bridge. Edit the config file at:</p>
+
+<ul>
+  <li>Mac: <code>~/Library/Application Support/Claude/claude_desktop_config.json</code></li>
+  <li>Windows: <code>%APPDATA%\Claude\claude_desktop_config.json</code></li>
+</ul>
+
+<CodeSnippet
+  language="json"
+  showCopy
+  client:visible
+  code={`{
+  "mcpServers": {
+    "goa-design-system": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://design-system-mcp-dcp-prod.apps.aro-01.int.gov.ab.ca/mcp"]
+    }
+  }
+}`}
+/>
+
+<goa-text as="h4" size="heading-xs" mt="xl">Cursor</goa-text>
+
+<p><goa-link mt="s" trailingicon="open"><a href="https://cursor.com/docs/mcp" target="_blank" rel="noopener noreferrer">View Cursor's MCP documentation</a></goa-link></p>
+
+<p>Cursor supports remote HTTP MCP servers directly. Open <strong>Settings &gt; Tools &amp; MCP</strong> to add a server, or edit <code>~/.cursor/mcp.json</code> (global) or <code>.cursor/mcp.json</code> in your project:</p>
+
+<CodeSnippet
+  language="json"
+  showCopy
+  client:visible
+  code={`{
+  "mcpServers": {
+    "goa-design-system": {
+      "url": "https://design-system-mcp-dcp-prod.apps.aro-01.int.gov.ab.ca/mcp"
+    }
+  }
+}`}
+/>
+
+<goa-text as="h4" size="heading-xs" mt="xl">ChatGPT</goa-text>
+
+<p><goa-link mt="s" trailingicon="open"><a href="https://help.openai.com/en/articles/12584461-developer-mode-apps-and-full-mcp-connectors-in-chatgpt-beta" target="_blank" rel="noopener noreferrer">View ChatGPT's MCP connectors guide</a></goa-link></p>
+
+<p>Custom MCP connectors are in beta and require a ChatGPT Plus or Pro subscription. In ChatGPT, open <strong>Settings &gt; Connectors &gt; Advanced</strong> and turn on <strong>Developer mode</strong>. A new <strong>Add custom connector</strong> button appears. Click it, paste this MCP endpoint URL, set authentication to <strong>None</strong>, and save:</p>
+
+<CodeSnippet code="https://design-system-mcp-dcp-prod.apps.aro-01.int.gov.ab.ca/mcp" language="javascript" showCopy client:visible />
+
+<goa-callout version="2" type="information" emphasis="low" mt="xl" mb="2xl">
+  <goa-text version="2" size="body-m" mt="none" mb="none">Using a different AI tool? If it supports remote MCP servers, paste the MCP endpoint URL into its config. For stdio-only tools, bridge through <code>npx mcp-remote &lt;URL&gt;</code>. <goa-link version="2" trailingicon="open"><a href="https://modelcontextprotocol.io/clients" target="_blank" rel="noopener noreferrer">View the list of MCP-compatible clients</a></goa-link></goa-text>
+</goa-callout>
+
+<DropInCallout />

--- a/docs/src/content/get-started/ai-tools-and-resources/goa-design-system-mcp.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources/goa-design-system-mcp.mdx
@@ -16,9 +16,9 @@ import { withBase } from "@/lib/base-url";
 <goa-text size="body-l" mt="none" mb="2xl">The live lookup tool your AI editor calls when it needs design system component APIs, examples, or guidance.</goa-text>
 
 <goa-callout version="2" type="information" emphasis="low" heading="Quick start: Point your AI tool at this endpoint" mt="none" mb="m">
-  <CodeSnippet language="javascript" showCopy client:visible code={`https://design-system-mcp-dcp-prod.apps.aro-01.int.gov.ab.ca/mcp`} />
-  <goa-text version="2" size="body-m" mt="s" mb="none"><goa-link version="2"><a href="#setup">View tool-specific setup</a></goa-link></goa-text>
+  <CodeSnippet language="javascript" showCopy client:visible code={`https://mcp.design.alberta.ca/mcp`} />
 </goa-callout>
+<goa-text version="2" size="body-m" mt="s" mb="none"><goa-link version="2"><a href="#setup">View tool-specific setup</a></goa-link></goa-text>
 
 <goa-callout version="2" type="information" emphasis="low" mt="m" mb="l">
   <goa-text version="2" size="body-s" mt="none" mb="none">The MCP is one tool in a larger AI toolset. For the overview of all available AI tools and how they fit together, see <a href={withBase("/get-started/ai-tools-and-resources")}>AI tools and resources</a>.</goa-text>
@@ -183,7 +183,7 @@ import { withBase } from "@/lib/base-url";
   language="javascript"
   showCopy
   client:visible
-  code={`claude mcp add --transport http goa-design-system https://design-system-mcp-dcp-prod.apps.aro-01.int.gov.ab.ca/mcp --scope user`}
+  code={`claude mcp add --transport http goa-design-system https://mcp.design.alberta.ca/mcp --scope user`}
 />
 
 <goa-text as="h4" size="heading-xs" mt="xl">Claude Desktop</goa-text>
@@ -205,7 +205,7 @@ import { withBase } from "@/lib/base-url";
   "mcpServers": {
     "goa-design-system": {
       "command": "npx",
-      "args": ["mcp-remote", "https://design-system-mcp-dcp-prod.apps.aro-01.int.gov.ab.ca/mcp"]
+      "args": ["mcp-remote", "https://mcp.design.alberta.ca/mcp"]
     }
   }
 }`}
@@ -224,7 +224,7 @@ import { withBase } from "@/lib/base-url";
   code={`{
   "mcpServers": {
     "goa-design-system": {
-      "url": "https://design-system-mcp-dcp-prod.apps.aro-01.int.gov.ab.ca/mcp"
+      "url": "https://mcp.design.alberta.ca/mcp"
     }
   }
 }`}
@@ -236,7 +236,7 @@ import { withBase } from "@/lib/base-url";
 
 <p>Custom MCP connectors are in beta and require a ChatGPT Plus or Pro subscription. In ChatGPT, open <strong>Settings &gt; Connectors &gt; Advanced</strong> and turn on <strong>Developer mode</strong>. A new <strong>Add custom connector</strong> button appears. Click it, paste this MCP endpoint URL, set authentication to <strong>None</strong>, and save:</p>
 
-<CodeSnippet code="https://design-system-mcp-dcp-prod.apps.aro-01.int.gov.ab.ca/mcp" language="javascript" showCopy client:visible />
+<CodeSnippet code="https://mcp.design.alberta.ca/mcp" language="javascript" showCopy client:visible />
 
 <goa-callout version="2" type="information" emphasis="low" mt="xl" mb="2xl">
   <goa-text version="2" size="body-m" mt="none" mb="none">Using a different AI tool? If it supports remote MCP servers, paste the MCP endpoint URL into its config. For stdio-only tools, bridge through <code>npx mcp-remote &lt;URL&gt;</code>. <goa-link version="2" trailingicon="open"><a href="https://modelcontextprotocol.io/clients" target="_blank" rel="noopener noreferrer">View the list of MCP-compatible clients</a></goa-link></goa-text>

--- a/docs/src/content/get-started/ai-tools-and-resources/goa-design-system-mcp.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources/goa-design-system-mcp.mdx
@@ -1,8 +1,8 @@
 ---
 id: ai-tools-and-resources/goa-design-system-mcp
-title: GoA design system MCP
-navLabel: Design system MCP
-description: A live lookup tool your AI editor uses for component APIs, examples, and guidance
+title: GoA Design System MCP
+navLabel: Design System MCP
+description: A live lookup tool your AI uses for component APIs, examples, and guidance
 section: ai-tools-and-resources
 order: 2
 status: published
@@ -12,8 +12,8 @@ import { CodeSnippet } from "../../../components/CodeSnippet";
 import { CodeCopy } from "../../../components/CodeCopy";
 import { withBase } from "@/lib/base-url";
 
-<goa-text size="heading-xl" mt="none" mb="m">GoA design system MCP</goa-text>
-<goa-text size="body-l" mt="none" mb="2xl">The live lookup tool your AI editor calls when it needs design system component APIs, examples, or guidance.</goa-text>
+<goa-text size="heading-xl" mt="none" mb="m">GoA Design System MCP</goa-text>
+<goa-text size="body-l" mt="none" mb="2xl">The live lookup tool your AI calls when it needs Design System component APIs, examples, or guidance.</goa-text>
 
 <goa-callout version="2" type="information" emphasis="low" heading="Quick start: Point your AI tool at this endpoint" mt="none" mb="m">
   <CodeSnippet language="javascript" showCopy client:visible code={`https://mcp.design.alberta.ca/mcp`} />
@@ -55,7 +55,7 @@ import { withBase } from "@/lib/base-url";
 
 <goa-text as="h2" id="what-can-you-ask" size="heading-m" mt="2xl">What can you ask?</goa-text>
 
-<p>You ask your AI editor in plain language. It reaches for the MCP when one of these is the right answer.</p>
+<p>Ask your AI in plain language. It calls the MCP when a component, example, or guidance answer fits the request.</p>
 
 <goa-table version="2" width="100%" mb="l">
   <table width="100%">
@@ -173,7 +173,7 @@ import { withBase } from "@/lib/base-url";
   <goa-text version="2" size="body-m" mt="none" mb="none">To verify your setup, restart your AI tool and ask "Look up the GoA Button component." You should get a response covering Button's props, variants, and usage.</goa-text>
 </goa-callout>
 
-<goa-text as="h4" size="heading-xs" mt="xl">Claude Code</goa-text>
+<goa-text as="h4" size="heading-xs" mt="xl">Claude Code (CLI)</goa-text>
 
 <p><goa-link mt="s" trailingicon="open"><a href="https://code.claude.com/docs/en/mcp" target="_blank" rel="noopener noreferrer">View Claude Code's MCP documentation</a></goa-link></p>
 
@@ -234,9 +234,17 @@ import { withBase } from "@/lib/base-url";
 
 <p><goa-link mt="s" trailingicon="open"><a href="https://help.openai.com/en/articles/12584461-developer-mode-apps-and-full-mcp-connectors-in-chatgpt-beta" target="_blank" rel="noopener noreferrer">View ChatGPT's MCP connectors guide</a></goa-link></p>
 
-<p>Custom MCP connectors are in beta and require a ChatGPT Plus or Pro subscription. In ChatGPT, open <strong>Settings &gt; Connectors &gt; Advanced</strong> and turn on <strong>Developer mode</strong>. A new <strong>Add custom connector</strong> button appears. Click it, paste this MCP endpoint URL, set authentication to <strong>None</strong>, and save:</p>
+<p>Custom apps are in beta and require a ChatGPT Plus or Pro subscription.</p>
 
-<CodeSnippet code="https://mcp.design.alberta.ca/mcp" language="javascript" showCopy client:visible />
+<ol>
+  <li>In ChatGPT, open <strong>Settings &gt; Apps &gt; Advanced settings</strong> and turn on <strong>Developer mode</strong>.</li>
+  <li>Select <strong>Add app</strong>. A New App form opens.</li>
+  <li>Enter a <strong>Name</strong> (for example, "GoA Design System").</li>
+  <li>Under <strong>Connection</strong>, select <strong>Server URL</strong> and paste the MCP endpoint URL: <CodeSnippet code="https://mcp.design.alberta.ca/mcp" language="javascript" showCopy client:visible /></li>
+  <li>Set <strong>Authentication</strong> to <strong>None</strong>.</li>
+  <li>Check <strong>I understand and want to continue</strong> to acknowledge the risk warning.</li>
+  <li>Save.</li>
+</ol>
 
 <goa-callout version="2" type="information" emphasis="low" mt="xl" mb="2xl">
   <goa-text version="2" size="body-m" mt="none" mb="none">Using a different AI tool? If it supports remote MCP servers, paste the MCP endpoint URL into its config. For stdio-only tools, bridge through <code>npx mcp-remote &lt;URL&gt;</code>. <goa-link version="2" trailingicon="open"><a href="https://modelcontextprotocol.io/clients" target="_blank" rel="noopener noreferrer">View the list of MCP-compatible clients</a></goa-link></goa-text>

--- a/docs/src/content/get-started/ai-tools-and-resources/skills.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources/skills.mdx
@@ -2,7 +2,7 @@
 id: ai-tools-and-resources/skills
 title: Skills
 navLabel: Skills
-description: Plain-Markdown workflows your AI loads when the work matches, for building GoA services
+description: Plain Markdown instruction files that give your AI a workflow to follow, for building GoA services
 section: ai-tools-and-resources
 order: 3
 status: published
@@ -12,7 +12,7 @@ import { CodeSnippet } from "../../../components/CodeSnippet";
 import { withBase } from "@/lib/base-url";
 
 <goa-text size="heading-xl" mt="none" mb="m">Skills</goa-text>
-<goa-text size="body-l" mt="none" mb="2xl">Plain-Markdown workflows your AI loads on its own when your work matches. They follow the open SKILL.md standard, so the same files work across Claude Code, Cursor, Copilot, and more.</goa-text>
+<goa-text size="body-l" mt="none" mb="2xl">Plain Markdown instruction files give your AI a workflow to follow when the work matches. They follow the open SKILL.md standard, so the same files work across Claude Code, Cursor, Copilot, and more.</goa-text>
 
 <goa-callout version="2" type="information" emphasis="low" mt="m" mb="l">
   <goa-text version="2" size="body-s" mt="none" mb="none">Skills are one tool in a larger AI toolset. For the overview of all available AI tools and how they fit together, see <a href={withBase("/get-started/ai-tools-and-resources")}>AI tools and resources</a>.</goa-text>
@@ -21,25 +21,25 @@ import { withBase } from "@/lib/base-url";
 <goa-text as="h2" id="available-skills" size="heading-m" mt="2xl">Available skills</goa-text>
 
 <goa-text size="heading-s" mt="l">using-goa-design-system</goa-text>
-<goa-text size="body-m">The navigator. From a plain description of what you're building, like a public form or a case-management tool, it walks your AI to the right product type, page and section templates, and components, pulling live specs from the MCP.</goa-text>
-<goa-text size="body-m">It loads when you're scoping or building a screen, page, or feature, so your AI follows the design system's structure from the start rather than guessing.</goa-text>
+<goa-text size="body-m">This skill identifies the right product type, page and section templates, and components for what you're building. Describe what you're working on in plain language (a public form or a case-management tool, for example), and it pulls the relevant structure and live component specs from the MCP.</goa-text>
+<goa-text size="body-m">It loads when you're scoping or building a screen, page, or feature, so your AI follows the Design System's structure from the start rather than guessing.</goa-text>
 <goa-text size="body-m"><strong>How to add it:</strong></goa-text>
 <CodeSnippet language="bash" showCopy client:visible code={`npx skills add GovAlta/ui-components --skill using-goa-design-system`} />
-<p><goa-link mt="s" trailingicon="open"><a href="https://github.com/GovAlta/ui-components/tree/dev/skills/using-goa-design-system" target="_blank" rel="noopener noreferrer">Read more on GitHub</a></goa-link></p>
+<p><goa-link mt="s" trailingicon="open"><a href="https://github.com/GovAlta/ui-components/tree/dev/skills/using-goa-design-system" target="_blank" rel="noopener noreferrer">View on GitHub</a></goa-link></p>
 
 <goa-text size="heading-s" mt="xl">content-design</goa-text>
-<goa-text size="body-m">The writer. Designs user-facing copy for its reader, a citizen or a worker, because the same message is two different jobs for the two of them.</goa-text>
+<goa-text size="body-m">This skill writes user-facing copy tailored to its reader (a citizen or a worker) because the same message requires a different approach for each audience.</goa-text>
 <goa-text size="body-m">It loads when you're working on the words in a service: labels, guidance, errors, empty states, and notifications.</goa-text>
 <goa-text size="body-m"><strong>How to add it:</strong></goa-text>
 <CodeSnippet language="bash" showCopy client:visible code={`npx skills add GovAlta/ui-components --skill content-design`} />
-<p><goa-link mt="s" trailingicon="open"><a href="https://github.com/GovAlta/ui-components/tree/dev/skills/content-design" target="_blank" rel="noopener noreferrer">Read more on GitHub</a></goa-link></p>
+<p><goa-link mt="s" trailingicon="open"><a href="https://github.com/GovAlta/ui-components/tree/dev/skills/content-design" target="_blank" rel="noopener noreferrer">View on GitHub</a></goa-link></p>
 
 <goa-text as="h2" id="how-they-work" size="heading-m" mt="2xl">How they work</goa-text>
 <goa-text size="body-m">Each skill is a folder with a SKILL.md file plus any supporting notes. Your AI reads the short description at startup and loads the full instructions only when your request matches, so they add capability without crowding the context.</goa-text>
 <goa-text size="body-m">Because they follow the open Agent Skills standard, the same files work in Claude Code, Cursor, GitHub Copilot, and other tools that read the format.</goa-text>
 
 <goa-text as="h2" id="updates" size="heading-m" mt="2xl">Updates</goa-text>
-<goa-text size="body-m">The skills track this repo's dev branch, so you can keep them up to date:</goa-text>
+<goa-text size="body-m">Skills track the dev branch of the GoA Design System repository. To keep them current, run:</goa-text>
 <CodeSnippet language="bash" showCopy client:visible code={`npx skills update`} />
 <goa-text size="body-m" mt="m" mb="none">To update automatically, add <code>npx skills update -g -y</code> to a SessionStart hook in your AI tool and they refresh every session. You'll only get an update when a skill itself changes, not every time something else in the repo changes.</goa-text>
 

--- a/docs/src/content/get-started/ai-tools-and-resources/skills.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources/skills.mdx
@@ -1,0 +1,50 @@
+---
+id: ai-tools-and-resources/skills
+title: Skills
+navLabel: Skills
+description: Plain-Markdown workflows your AI loads when the work matches, for building GoA services
+section: ai-tools-and-resources
+order: 3
+status: published
+---
+import DropInCallout from "../../../components/DropInCallout.astro";
+import { CodeSnippet } from "../../../components/CodeSnippet";
+import { withBase } from "@/lib/base-url";
+
+<goa-text size="heading-xl" mt="none" mb="m">Skills</goa-text>
+<goa-text size="body-l" mt="none" mb="2xl">Plain-Markdown workflows your AI loads on its own when your work matches. They follow the open SKILL.md standard, so the same files work across Claude Code, Cursor, Copilot, and more.</goa-text>
+
+<goa-callout version="2" type="information" emphasis="low" mt="m" mb="l">
+  <goa-text version="2" size="body-s" mt="none" mb="none">Skills are one tool in a larger AI toolset. For the overview of all available AI tools and how they fit together, see <a href={withBase("/get-started/ai-tools-and-resources")}>AI tools and resources</a>.</goa-text>
+</goa-callout>
+
+<goa-text as="h2" id="available-skills" size="heading-m" mt="2xl">Available skills</goa-text>
+
+<goa-text size="heading-s" mt="l">using-goa-design-system</goa-text>
+<goa-text size="body-m">The navigator. From a plain description of what you're building, like a public form or a case-management tool, it walks your AI to the right product type, page and section templates, and components, pulling live specs from the MCP.</goa-text>
+<goa-text size="body-m">It loads when you're scoping or building a screen, page, or feature, so your AI follows the design system's structure from the start rather than guessing.</goa-text>
+<goa-text size="body-m"><strong>How to add it:</strong></goa-text>
+<CodeSnippet language="bash" showCopy client:visible code={`npx skills add GovAlta/ui-components --skill using-goa-design-system`} />
+<p><goa-link mt="s" trailingicon="open"><a href="https://github.com/GovAlta/ui-components/tree/dev/skills/using-goa-design-system" target="_blank" rel="noopener noreferrer">Read more on GitHub</a></goa-link></p>
+
+<goa-text size="heading-s" mt="xl">content-design</goa-text>
+<goa-text size="body-m">The writer. Designs user-facing copy for its reader, a citizen or a worker, because the same message is two different jobs for the two of them.</goa-text>
+<goa-text size="body-m">It loads when you're working on the words in a service: labels, guidance, errors, empty states, and notifications.</goa-text>
+<goa-text size="body-m"><strong>How to add it:</strong></goa-text>
+<CodeSnippet language="bash" showCopy client:visible code={`npx skills add GovAlta/ui-components --skill content-design`} />
+<p><goa-link mt="s" trailingicon="open"><a href="https://github.com/GovAlta/ui-components/tree/dev/skills/content-design" target="_blank" rel="noopener noreferrer">Read more on GitHub</a></goa-link></p>
+
+<goa-text as="h2" id="how-they-work" size="heading-m" mt="2xl">How they work</goa-text>
+<goa-text size="body-m">Each skill is a folder with a SKILL.md file plus any supporting notes. Your AI reads the short description at startup and loads the full instructions only when your request matches, so they add capability without crowding the context.</goa-text>
+<goa-text size="body-m">Because they follow the open Agent Skills standard, the same files work in Claude Code, Cursor, GitHub Copilot, and other tools that read the format.</goa-text>
+
+<goa-text as="h2" id="updates" size="heading-m" mt="2xl">Updates</goa-text>
+<goa-text size="body-m">The skills track this repo's dev branch, so you can keep them up to date:</goa-text>
+<CodeSnippet language="bash" showCopy client:visible code={`npx skills update`} />
+<goa-text size="body-m" mt="m" mb="none">To update automatically, add <code>npx skills update -g -y</code> to a SessionStart hook in your AI tool and they refresh every session. You'll only get an update when a skill itself changes, not every time something else in the repo changes.</goa-text>
+
+<goa-callout version="2" type="information" emphasis="low" mt="xl" mb="2xl">
+  <goa-text version="2" size="body-m" mt="none" mb="none">Using a tool without the <code>skills</code> CLI? Clone a skill folder from the <goa-link version="2" trailingicon="open"><a href="https://github.com/GovAlta/ui-components/tree/dev/skills" target="_blank" rel="noopener noreferrer">skills directory</a></goa-link> into your tool's skills folder, for example <code>~/.claude/skills</code>, <code>.cursor/skills</code>, or <code>.github/skills</code>.</goa-text>
+</goa-callout>
+
+<DropInCallout />

--- a/docs/src/content/get-started/contribute.mdx
+++ b/docs/src/content/get-started/contribute.mdx
@@ -2,8 +2,8 @@
 id: contribute
 title: Contribute
 description: How to contribute to the GoA Design System
-section: appendix
-order: 2
+section: contribute
+order: 1
 status: published
 ---
 import { withBase } from "@/lib/base-url";

--- a/docs/src/content/get-started/out-of-support.mdx
+++ b/docs/src/content/get-started/out-of-support.mdx
@@ -2,8 +2,8 @@
 id: out-of-support
 title: Out of support versions
 description: Design System versions that are no longer supported
-section: appendix
-order: 3
+section: out-of-support
+order: 1
 status: published
 ---
 import { withBase } from "@/lib/base-url";

--- a/docs/src/content/get-started/qa-testing.mdx
+++ b/docs/src/content/get-started/qa-testing.mdx
@@ -2,7 +2,7 @@
 id: qa-testing
 title: QA testing
 description: Testing process for Design System components
-section: appendix
+section: qa-testing
 order: 1
 status: published
 ---

--- a/docs/src/lib/get-started-nav.ts
+++ b/docs/src/lib/get-started-nav.ts
@@ -4,11 +4,12 @@
  * Builds the Get Started submenu structure from the content collection.
  * Used by layouts to pass nav data to SiteNav -> GetStartedSubMenu.
  *
- * Section convention:
- * - "intro"      => top-level pages above grouped sections
- * - "designers"  => Designers group
- * - "developers" => Developers group
- * - "appendix"   => top-level pages below grouped sections
+ * Each section in the submenu is either:
+ * - "flat" — a list of items rendered without a group header
+ * - "grouped" — items rendered inside an expandable group with a heading
+ *
+ * Sections appear in `SECTION_ORDER` regardless of type, so flat and grouped
+ * sections can interleave freely.
  */
 
 import { getCollection } from "astro:content";
@@ -18,26 +19,37 @@ export interface GetStartedNavItem {
   url: string;
 }
 
-export interface GetStartedNavGroup {
-  name: string;
+export interface GetStartedNavSection {
   slug: string;
+  type: "flat" | "grouped";
+  name?: string;
   pages: GetStartedNavItem[];
 }
 
 export interface GetStartedNav {
-  topPages: GetStartedNavItem[];
-  groups: GetStartedNavGroup[];
-  bottomPages: GetStartedNavItem[];
+  sections: GetStartedNavSection[];
 }
 
-/** Display metadata for the grouped sections (not stored in content collection) */
-const GROUP_META: Record<string, { name: string }> = {
-  designers: { name: "Designers" },
-  developers: { name: "Developers" },
-};
+/** Display order of sections in the submenu (top to bottom). */
+const SECTION_ORDER = [
+  "intro",
+  "designers",
+  "developers",
+  "qa-testing",
+  "ai-tools-and-resources",
+  "contribute",
+  "out-of-support",
+];
 
-/** Canonical display order for grouped sections in the submenu */
-const GROUP_ORDER = ["designers", "developers"];
+/**
+ * Sections that render with a group heading. Any section listed here is
+ * "grouped"; everything else in `SECTION_ORDER` is "flat".
+ */
+const SECTION_NAMES: Record<string, string> = {
+  designers: "Designers",
+  developers: "Developers",
+  "ai-tools-and-resources": "AI tools and resources",
+};
 
 function entryToItem(entry: {
   slug: string;
@@ -62,16 +74,17 @@ export async function getGetStartedNav(): Promise<GetStartedNav> {
   const entries = await getCollection("get-started");
   const published = entries.filter((e) => e.data.status !== "deprecated");
 
-  const topPages = bySection(published, "intro").map(entryToItem);
-  const bottomPages = bySection(published, "appendix").map(entryToItem);
+  const sections: GetStartedNavSection[] = SECTION_ORDER
+    .filter((slug) => published.some((e) => e.data.section === slug))
+    .map((slug) => {
+      const isGrouped = slug in SECTION_NAMES;
+      return {
+        slug,
+        type: isGrouped ? "grouped" : "flat",
+        name: isGrouped ? SECTION_NAMES[slug] : undefined,
+        pages: bySection(published, slug).map(entryToItem),
+      };
+    });
 
-  const groups = GROUP_ORDER.filter((slug) =>
-    published.some((e) => e.data.section === slug),
-  ).map((slug) => ({
-    name: GROUP_META[slug].name,
-    slug,
-    pages: bySection(published, slug).map(entryToItem),
-  }));
-
-  return { topPages, groups, bottomPages };
+  return { sections };
 }


### PR DESCRIPTION
## What this is

A first version of the AI tools and resources area in Get Started: an overview of the AI tools for working with the design system, plus a full MCP setup guide for Claude Code, Claude Desktop, Cursor, and ChatGPT.

## Outstanding questions
The overview page leaves two "how to access it" spots open on purpose:
1. **Where the MD files live** and how teams download them.
2. **How teams install the skill** (the using-goa-design-system workflow): clone, download, drop in a folder?

Closes #3789.
