### PR TITLE
fix(#3972): add Acumin Variable

### DIFF
--- a/libs/web-components/src/assets/css/fonts.css
+++ b/libs/web-components/src/assets/css/fonts.css
@@ -51,3 +51,14 @@
   font-style: normal;
   font-weight: 400;
 }
+
+@font-face {
+  font-family: "acumin-variable";
+  src: url("https://use.typekit.net/af/80814c/0000000000000000774be2a6/31/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff2"),
+    url("https://use.typekit.net/af/80814c/0000000000000000774be2a6/31/d?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("woff"),
+    url("https://use.typekit.net/af/80814c/0000000000000000774be2a6/31/a?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n4&v=3") format("opentype");
+  font-display: auto;
+  font-style: normal;
+  font-weight: 100 900;
+  font-stretch: normal;
+}


### PR DESCRIPTION
This PR adds the Acumin Variable typeface for the v2 Design Tokens to use.

## How to test (In Firefox)
1. Open the [Docs PR Preview](https://govalta.github.io/ui-components/pr-preview/pr-3984/) in Firefox
2. Open "Web Developer Tools"
3. Select a text element in "Inspector"
4. Select the "Font" tab in the right-hand panel
5. You should see "acumin-variable" in "Fonts Used"

<img width="1505" height="882" alt="image" src="https://github.com/user-attachments/assets/89a6778a-3318-4d86-8f25-d36cafab8705" />

In contrast, you can see "Arial" in "Fonts Used" on our production Docs site.

<img width="1502" height="881" alt="image" src="https://github.com/user-attachments/assets/f070b2e3-0b81-4085-b563-fc23ff6c90c6" />

