### PR TITLE
fix(#3987): vertically align component titles and labels

### DIFF
--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -481,11 +481,10 @@
 
   .heading {
     font: var(--goa-accordion-heading);
-    padding: 0.125rem 1rem 0 0;
+    padding-right: var(--goa-space-m);
   }
 
   .heading-small {
-    padding-top: 0.25rem;
     line-height: 1.75rem;
     font: var(--goa-accordion-heading);
   }

--- a/libs/web-components/src/components/app-header/AppHeader.svelte
+++ b/libs/web-components/src/components/app-header/AppHeader.svelte
@@ -1204,7 +1204,7 @@
   .v2.mobile .v2-service-name {
     font: var(--goa-app-header-typography-service-name-mobile);
     color: var(--goa-app-header-color-service-name);
-    margin-top: 5px; /* Visually center single-line service name with logo */
+    margin-top: 6px; /* Visually center single-line service name with logo */
   }
 
   .v2 .v2-secondary-text {

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -451,7 +451,6 @@ max-width: ${maxwidth};
     background-color: var(--goa-checkbox-color-bg);
     height: var(--goa-checkbox-size);
     width: var(--goa-checkbox-size);
-    margin-top: 3px; /* aligns the checkbox with the text */
     display: flex;
     justify-content: center;
     flex: 0 0 auto; /* prevent squishing of checkbox */
@@ -590,10 +589,6 @@ max-width: ${maxwidth};
   }
 
   /* Version 2 */
-
-  .v2 .text {
-    margin-top: var(--goa-space-2xs);
-  }
 
   .v2 .container svg {
     margin: 6px 3px;

--- a/libs/web-components/src/components/drawer/Drawer.svelte
+++ b/libs/web-components/src/components/drawer/Drawer.svelte
@@ -282,7 +282,7 @@
           {#if heading || $$slots.heading}
             {#if heading}
               {#if version === "2"}
-                <goa-text size="heading-s" as="h3" mt="2xs" mb="none"
+                <goa-text size="heading-s" as="h3" mt="3xs" mb="none"
                   >{heading}</goa-text
                 >
               {:else}

--- a/libs/web-components/src/components/notification/Notification.svelte
+++ b/libs/web-components/src/components/notification/Notification.svelte
@@ -184,7 +184,7 @@
 
   /* V2: Improved vertical alignment with icon */
   .v2 .content {
-    margin-top: 3px;
+    margin-top: 2px;
   }
 
   :global(::slotted(a)) {

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -348,7 +348,7 @@
   }
   /* V2: Adjust for different line-height */
   .radio.v2 .label {
-    margin-top: 1px; /* V2: Optical centering - slight downward adjustment */
+    margin-top: -1px;
   }
 
   /* V2 compact: Use smaller gap */

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -346,10 +346,6 @@
     margin-top: -3px; /* V1: Optical centering - move text up */
     padding-left: var(--goa-radio-gap-label, var(--goa-space-s));
   }
-  /* V2: Adjust for different line-height */
-  .radio.v2 .label {
-    margin-top: -1px;
-  }
 
   /* V2 compact: Use smaller gap */
   .radio.v2.compact .label {

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuGroup.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuGroup.svelte
@@ -114,7 +114,7 @@
     outline-offset: 2px;
   }
   summary goa-icon {
-    margin-top: 3px;
+    margin-top: var(--goa-space-3xs);
   }
   .group {
     border-left: var(


### PR DESCRIPTION
This PR makes minor margin tweaks to component labels and headers so they look more vertically aligned with the Acumin Variable typeface.

You can use the [Docs preview](https://govalta.github.io/ui-components/pr-preview/pr-3992/) to see the changes in the following components:
- [Accordion](https://govalta.github.io/ui-components/pr-preview/pr-3992/components/accordion/#react#properties)
- [App Header (Mobile variant)](https://govalta.github.io/ui-components/pr-preview/pr-3992/components/app-header/#properties#web-components)
- [Checkbox](https://govalta.github.io/ui-components/pr-preview/pr-3992/components/checkbox/#properties#web-components)
- [Drawer](https://govalta.github.io/ui-components/pr-preview/pr-3992/components/drawer/#react#properties)
- [Notification banner](https://govalta.github.io/ui-components/pr-preview/pr-3992/components/notification/#react#properties)
- [Radio item](https://govalta.github.io/ui-components/pr-preview/pr-3992/components/radio-group/#react#properties)
- [Work Side Menu Group](https://govalta.github.io/ui-components/pr-preview/pr-3992/components/work-side-menu/#web-components#properties)

I've used Figma as a reference for any discrepancies.

All components should be using the Acumin Variable typeface but you can confirm by using Firefox's [Fonts Tab](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_fonts/index.html) in DevTools.

<img width="581" height="394" alt="image" src="https://github.com/user-attachments/assets/82ed8442-b10a-42a9-89ef-823a3501b746" />
