### PR TITLE
Website: Reorganize roadmap page by fiscal quarter

### DIFF
--- a/docs/src/content/get-started/roadmap.mdx
+++ b/docs/src/content/get-started/roadmap.mdx
@@ -16,12 +16,12 @@ status: published
 
 <goa-divider mt="xl" mb="xl"></goa-divider>
 
-<h2 id="now">Now</h2>
-<goa-text size="body-s" mt="none" mb="l"><strong>Focus:</strong> Drive DS 2.0 adoption momentum, protect post-launch stability, and prove DS 2.0 helps teams move faster through prescriptive guidance and examples.</goa-text>
+<h2 id="q1">Q1 (April - June)</h2>
+<goa-text size="body-s" mt="none" mb="l"><strong>Focus:</strong> Drive design system adoption momentum, enable AI-assisted workflows through the design system MCP, and make an informed decision on Vue support.</goa-text>
 
-<h3 id="adoption-measurement">DS 2.0 adoption and satisfaction measurement</h3>
-<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Establish reliable DS 2.0 adoption tracking and reporting, and pair it with satisfaction signals from designers, developers, and end users to understand whether DS 2.0 is improving service outcomes as teams upgrade.</goa-text>
-<goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Enables accurate progress reporting and provides evidence that DS 2.0 is improving usability, accessibility, and experience quality, not only adoption.</goa-text>
+<h3 id="adoption-measurement">Design system adoption and satisfaction measurement</h3>
+<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Establish reliable design system adoption tracking and reporting, and pair it with satisfaction signals from designers, developers, and end users to understand whether the updated design system is improving service outcomes as teams upgrade.</goa-text>
+<goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Enables accurate progress reporting and provides evidence that the updated design system is improving usability, accessibility, and experience quality, not only adoption.</goa-text>
 <goa-text size="body-s" mt="none" mb="m"><strong>Examples:</strong></goa-text>
 <ul>
   <li><goa-text as="span" size="body-s" mt="none" mb="none">Create a mechanism to reliably collect and report adoption rate</goa-text></li>
@@ -31,14 +31,24 @@ status: published
 </ul>
 
 <h3 id="product-acceleration">Product acceleration enablement</h3>
-<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Provide prescriptive guidance and resources that help teams get to screens, prototypes, and working experiences faster using DS 2.0.</goa-text>
+<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Provide prescriptive guidance and resources that help teams get to screens, prototypes, and working experiences faster using the updated design system.</goa-text>
 <goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Reduces time to first screens and improves consistency by helping teams start from proven patterns instead of building from scratch.</goa-text>
 <goa-text size="body-s" mt="none" mb="m"><strong>Examples:</strong></goa-text>
 <ul>
-  <li><goa-text as="span" size="body-s" mt="none" mb="none">Create resources that show how to quickly prototype with DS 2.0 components and examples</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Create resources that show how to quickly prototype with design system components and examples</goa-text></li>
   <li><goa-text as="span" size="body-s" mt="none" mb="none">Provide contextual starting points for teams using Public form and Workspace templates</goa-text></li>
-  <li><goa-text as="span" size="body-s" mt="none" mb="none">Pilot DS 2.0 with teams to generate strong examples to share</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Pilot the updated design system with teams to generate strong examples to share</goa-text></li>
   <li><goa-text as="span" size="body-s" mt="none" mb="none">Create and publish migration success stories</goa-text></li>
+</ul>
+
+<h3 id="vue-support-decision">Vue support decision</h3>
+<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Explore and define the minimum work required to confidently state the design system officially supports Vue, including scope, constraints, and support model.</goa-text>
+<goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Prevents unclear commitments and reduces strategic risk by enabling an informed investment decision aligned to organizational needs.</goa-text>
+<goa-text size="body-s" mt="none" mb="m"><strong>Examples:</strong></goa-text>
+<ul>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Define what "official Vue support" means</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Outline the minimum supportable scope</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Identify implications for documentation, maintenance, testing, and support</goa-text></li>
 </ul>
 
 <h3 id="design-system-mcp">Design system MCP</h3>
@@ -52,31 +62,49 @@ status: published
   <li><goa-text as="span" size="body-s" mt="none" mb="none">Document recommended workflows for teams</goa-text></li>
 </ul>
 
-<h3 id="vue-support-decision">Vue support decision</h3>
-<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Explore and define the minimum work required to confidently state DS 2.0 officially supports Vue, including scope, constraints, and support model.</goa-text>
-<goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Prevents unclear commitments and reduces strategic risk by enabling an informed investment decision aligned to organizational needs.</goa-text>
+<goa-divider mt="xl" mb="xl"></goa-divider>
+
+<h2 id="q2">Q2 (July - September)</h2>
+<goa-text size="body-s" mt="none" mb="l"><strong>Focus:</strong> Improve the core Public form and Workspace experience and execute on the chosen Vue direction.</goa-text>
+
+<h3 id="public-form-next-phase">Public form next phase</h3>
+<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Build on the existing public form offering to make it faster to implement and easier to use, while preserving the flexibility product teams need.</goa-text>
+<goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Unlocks downstream public form capability work and reduces the effort required for teams to build consistent, high-quality public-facing services.</goa-text>
 <goa-text size="body-s" mt="none" mb="m"><strong>Examples:</strong></goa-text>
 <ul>
-  <li><goa-text as="span" size="body-s" mt="none" mb="none">Define what "official Vue support" means</goa-text></li>
-  <li><goa-text as="span" size="body-s" mt="none" mb="none">Outline the minimum supportable scope</goa-text></li>
-  <li><goa-text as="span" size="body-s" mt="none" mb="none">Identify implications for documentation, maintenance, testing, and support</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Identify gaps and opportunities in the current public form offering</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Determine what needs to be built, adapted, or improved to better support the public form use case</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Deliver improvements so teams can build on a more complete and supportable foundation</goa-text></li>
+</ul>
+
+<h3 id="capability-improvements">Public form and Workspace capability improvements</h3>
+<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Enhance key Public form and Workspace capabilities based on adoption needs and workflow requirements.</goa-text>
+<goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Improves feature sets and reduces the need for custom one-off solutions by making common workflows easier to implement with the updated design system.</goa-text>
+<goa-text size="body-s" mt="none" mb="m"><strong>Examples:</strong></goa-text>
+<ul>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Build the review, revise, resubmit feature</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Navigation pattern for multi-step Workspace workflows</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Comments component for Workspace</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Combined Public form and Workspace playground</goa-text></li>
+</ul>
+
+<h3 id="vue-follow-through">Vue follow-through</h3>
+<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Based on Vue discovery, either implement formal Vue support or clearly position Angular and React as the recommended approach for teams using AI-assisted workflows.</goa-text>
+<goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Provides clear direction to product teams and reduces uncertainty, enabling progress on a supported path while keeping support sustainable for the design system team.</goa-text>
+<goa-text size="body-s" mt="none" mb="m"><strong>Examples:</strong></goa-text>
+<ul>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Publish Vue support guidance and expectations</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Implement agreed scope if approved</goa-text></li>
+  <li><goa-text as="span" size="body-s" mt="none" mb="none">Publish recommended alternatives if Vue support is not pursued</goa-text></li>
 </ul>
 
 <goa-divider mt="xl" mb="xl"></goa-divider>
 
-<h2 id="next">Next</h2>
-<goa-text size="body-s" mt="none" mb="l"><strong>Focus:</strong> Improve the core Public form and Workspace experience, mature reusable patterns and examples, reduce adoption friction through better packaging, and execute on the chosen Vue direction.</goa-text>
-
-<h3 id="capability-improvements">Public form and Workspace capability improvements</h3>
-<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Enhance key Public form and Workspace capabilities based on adoption needs and workflow requirements.</goa-text>
-<goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Improves feature sets and reduces the need for custom one-off solutions by making common workflows easier to implement with DS 2.0.</goa-text>
-<goa-text size="body-s" mt="none" mb="m"><strong>Example:</strong></goa-text>
-<ul>
-  <li><goa-text as="span" size="body-s" mt="none" mb="none">Build the review, revise, resubmit feature</goa-text></li>
-</ul>
+<h2 id="q3">Q3 (October - December)</h2>
+<goa-text size="body-s" mt="none" mb="l"><strong>Focus:</strong> Mature reusable patterns and examples, and reduce adoption friction through better library packaging and tech stack upgrades.</goa-text>
 
 <h3 id="pattern-maturity">Examples and pattern maturity</h3>
-<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Expand and refine examples and position them as adaptable reusable patterns that teams can apply with confidence.</goa-text>
+<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Expand and refine examples and position them as adaptable reusable assets that teams can apply with confidence.</goa-text>
 <goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Improves self-serve success and product consistency, reducing implementation variance and support demand over time.</goa-text>
 <goa-text size="body-s" mt="none" mb="m"><strong>Examples:</strong></goa-text>
 <ul>
@@ -93,20 +121,10 @@ status: published
   <li><goa-text as="span" size="body-s" mt="none" mb="none">Update to Svelte 5</goa-text></li>
 </ul>
 
-<h3 id="vue-follow-through">Vue follow-through</h3>
-<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Based on Vue discovery, either implement formal Vue support or clearly position Angular and React as the recommended approach for teams using AI-assisted workflows.</goa-text>
-<goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Provides clear direction to product teams and reduces uncertainty, enabling progress on a supported path while keeping support sustainable for the design system team.</goa-text>
-<goa-text size="body-s" mt="none" mb="m"><strong>Examples:</strong></goa-text>
-<ul>
-  <li><goa-text as="span" size="body-s" mt="none" mb="none">Publish Vue support guidance and expectations</goa-text></li>
-  <li><goa-text as="span" size="body-s" mt="none" mb="none">Implement agreed scope if approved</goa-text></li>
-  <li><goa-text as="span" size="body-s" mt="none" mb="none">Publish recommended alternatives if Vue support is not pursued</goa-text></li>
-</ul>
-
 <goa-divider mt="xl" mb="xl"></goa-divider>
 
-<h2 id="later">Later</h2>
-<goa-text size="body-s" mt="none" mb="l"><strong>Focus:</strong> Support DS 2.0 version updates and improve documentation and communications quality to support scaling and sustainability.</goa-text>
+<h2 id="q4">Q4 (January - March)</h2>
+<goa-text size="body-s" mt="none" mb="l"><strong>Focus:</strong> Support design system version updates and improve documentation and communications quality to support scaling and sustainability.</goa-text>
 
 <h3 id="docs-improvements">Documentation and communications improvements</h3>
 <goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Improve how teams access and understand design system guidance, and communicate design system value areas like accessibility more clearly.</goa-text>
@@ -117,8 +135,8 @@ status: published
   <li><goa-text as="span" size="body-s" mt="none" mb="none">Articulate accessibility work more clearly (what is covered and how it supports teams)</goa-text></li>
 </ul>
 
-<h3 id="capacity-support">Targeted capacity support for DS 2.0 version updates</h3>
-<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Provide targeted design system team capacity to help remaining DS 1.x product teams complete the DS 2.0 version update.</goa-text>
+<h3 id="capacity-support">Targeted capacity support for design system version updates</h3>
+<goa-text size="body-s" mt="none" mb="m"><strong>Objective:</strong> Provide targeted design system team capacity to help remaining product teams complete the design system version update.</goa-text>
 <goa-text size="body-s" mt="none" mb="m"><strong>Benefit:</strong> Accelerates adoption progress and unblocks teams facing more difficult migrations, supporting adoption targets while keeping support sustainable through a focus on teams most in need.</goa-text>
 <goa-text size="body-s" mt="none" mb="m"><strong>Example:</strong></goa-text>
 


### PR DESCRIPTION
## Summary

- Replaces Now/Next/Later sections with Q1 (April - June), Q2 (July - September), Q3 (October - December), Q4 (January - March) headings
- Remaps all existing roadmap items into their appropriate fiscal quarter per the AC
- Updates each quarter's focus statement to reflect its specific items

## Before / After

Before: roadmap organized into Now, Next, Later sections.
After: roadmap organized into four fiscal quarters for the 2026-27 fiscal year.

## Steps to test

1. Navigate to the roadmap page on the website
2. Confirm Now/Next/Later headings are replaced with Q1 through Q4 headings
3. Confirm each quarter contains the items specified in the AC
4. Confirm focus statements reflect the items in each quarter

- [x] Setup steps read
- [x] Tested in React

Fixes #3995