### PR TITLE
fix(#4001): scope PreviewLayout's full-viewport reset to its own pages

### DIFF
--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -107,10 +107,22 @@ const ogUrl = new URL(withBase(Astro.url.pathname), Astro.site).href;
 
       html {
         color-scheme: light;
+        /* Match the page's grey wrapper so the scroll overflow / overscroll
+           area (visible on elastic scroll) blends instead of showing white.
+           Same token as .layout-wrapper, so it matches in light/dark/forced-dark. */
+        background: var(--goa-color-greyscale-50);
       }
 
       html[data-theme="dark"] {
         color-scheme: dark;
+      }
+
+      /* Below 624px the layouts flip the page wrapper to white, so match the
+         overscroll area there too instead of leaving it grey. */
+      @media (max-width: 623px) {
+        html {
+          background: var(--goa-color-greyscale-white);
+        }
       }
 
       body {

--- a/docs/src/layouts/PreviewLayout.astro
+++ b/docs/src/layouts/PreviewLayout.astro
@@ -48,7 +48,7 @@ const resolvedBackUrl = withBase(backUrl);
     <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
     <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
   </head>
-  <body>
+  <body class="preview-doc">
     <header class="preview-bar">
       <goa-link size="small" leadingicon="arrow-back">
         <a href={resolvedBackUrl} data-back-link>
@@ -103,14 +103,11 @@ const resolvedBackUrl = withBase(backUrl);
 </html>
 
 <style is:global>
-  html,
-  body {
+  /* Scoped to .preview-doc (set on this layout's own body) so this
+     full-viewport reset cannot leak onto pages that use BaseLayout. */
+  body.preview-doc {
     margin: 0;
     padding: 0;
-    height: 100%;
-  }
-
-  body {
     font-family: var(--goa-font-family-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif);
     color: var(--goa-color-text-default, #333);
     background: var(--goa-color-surface-default, #fff);
@@ -145,7 +142,9 @@ const resolvedBackUrl = withBase(backUrl);
 
   /* GoA layout web components default to display:inline because their
      :host rules don't set display:block. Force them to block layout so
-     they fill their parent container in preview routes. */
+     they fill their parent container. Intentionally global: inline
+     <Preview> examples on guidance/docs pages render these components
+     outside this layout and rely on it too. */
   goa-one-column-layout,
   goa-page-block,
   goa-app-header,


### PR DESCRIPTION
## What was happening
On the docs site, the page background only covered the first screen. On any page taller than the window, scrolling down revealed a white strip where the background should continue. It showed on Get Started, Components, Examples, and Foundations pages, in both light and dark mode, and was most obvious in dark mode. The home page was unaffected because it fits in one screen.

## Why
PreviewLayout (the shell for full page example previews) carried a global reset that set `html, body { height: 100% }` and made the body a flex column. Because it was global, it applied to every page, not just the preview routes. `height: 100%` locks the body to exactly one screen, so on longer pages the body could not grow to fit its content. The page background sits on the body, so it stopped at the fold and the white underneath showed through.

## The fix
Scope that reset to the preview pages. PreviewLayout now adds a `preview-doc` class to its own `body`, and the reset targets `body.preview-doc` instead of every `html`/`body`. Preview pages render exactly as before. Every other page keeps a body that can grow with its content, so the background fills the full height.

The `goa-*` layout rule in the same block stays global on purpose: inline examples on guidance and docs pages render those layout components outside this layout and depend on it.

## Also in this PR
Set the docs `html` background to the same grey token the page wrapper uses, so the scroll overflow area (the elastic overscroll space past the top and bottom of the page on macOS and iOS) matches the page instead of showing white. It uses the same `--goa-color-greyscale-50` token as `.layout-wrapper`, so it tracks light, dark, and forced dark automatically. Below 624px, where the layouts switch the wrapper to white, the overscroll matches that too.

## Verified
- Doc pages: the body and grey background now grow to the full document height instead of stopping at one screen.
- Preview pages: unchanged. Full-height shell and layout components still render correctly (checked the 404 preview).

Closes #4001.
