### PR TITLE
fix(#3824): use goa-space-l gap between pagination Previous and Next buttons

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3824/bug3824.component.html
+++ b/apps/prs/angular/src/routes/bugs/3824/bug3824.component.html
@@ -1,0 +1,10 @@
+<goab-text tag="h1" mt="m" mb="s">Bug 3824 - Pagination: gap between Previous and Next buttons should be goa-space-l</goab-text>
+<goab-text mb="m">
+  The gap between Previous and Next buttons should be <code>goa-space-l</code> (1.5rem).
+</goab-text>
+
+<goab-pagination
+  [itemCount]="100"
+  [pageNumber]="pageNumber"
+  (onChange)="onPageChange($event)"
+/>

--- a/apps/prs/angular/src/routes/bugs/3824/bug3824.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3824/bug3824.component.ts
@@ -1,0 +1,16 @@
+import { Component } from "@angular/core";
+import { GoabPagination, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3824",
+  templateUrl: "./bug3824.component.html",
+  imports: [GoabPagination, GoabText],
+})
+export class Bug3824Component {
+  pageNumber = 1;
+
+  onPageChange(event: { page: number }) {
+    this.pageNumber = event.page;
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3824/bug3824.route.json
+++ b/apps/prs/angular/src/routes/bugs/3824/bug3824.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3824",
+  "path": "bugs/3824",
+  "title": "Pagination button gap"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3824.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3824.route.ts
@@ -1,0 +1,10 @@
+import { Bug3824Route } from "../../../routes/bugs/bug3824";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3824",
+  path: "bugs/3824",
+  title: "Pagination button gap",
+  component: Bug3824Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3824.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3824.tsx
@@ -1,0 +1,22 @@
+import { GoabPagination, GoabText } from "@abgov/react-components";
+import { useState } from "react";
+
+export function Bug3824Route() {
+  const [page, setPage] = useState(1);
+
+  return (
+    <div style={{ display: "grid", gap: "2rem" }}>
+      <GoabText tag="h1" mb="m">
+        Bug 3824 - Pagination: gap between Previous and Next buttons should be goa-space-l
+      </GoabText>
+      <GoabText mb="m">
+        The gap between Previous and Next buttons should be <code>goa-space-l</code> (1.5rem).
+      </GoabText>
+      <GoabPagination
+        itemCount={100}
+        pageNumber={page}
+        onChange={({ page }) => setPage(page)}
+      />
+    </div>
+  );
+}

--- a/libs/web-components/src/components/pagination/Pagination.svelte
+++ b/libs/web-components/src/components/pagination/Pagination.svelte
@@ -137,7 +137,7 @@
         <span>of {itemcount <= 0 ? "1" : _pageCount}</span>
       </goa-block>
     {/if}
-    <goa-block alignment="center" gap="m" data-testid="page-links">
+    <goa-block alignment="center" gap="l" data-testid="page-links">
       <!-- svelte-ignore a11y-no-static-element-interactions -->
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <goa-button


### PR DESCRIPTION
## Description

Fixes #3824

The gap between the Previous and Next buttons in the Pagination component was set to `gap="m"` on the inner `goa-block`. This changes it to `gap="l"` to match the `goa-space-l` token as specified.

## Changes

- `libs/web-components/src/components/pagination/Pagination.svelte`: changed `gap="m"` to `gap="l"` on the `goa-block` wrapping the Previous/Next buttons. CSS-only change, no wrapper updates needed.

## Before / After

- Before: `~1rem` gap between Previous and Next buttons
- After: `~1.5rem` gap between Previous and Next buttons (goa-space-l)

## Steps to test

1. Run `npm run serve:prs:react`
2. Navigate to "3824 Pagination button gap" in the side menu
3. Confirm the gap between Previous and Next buttons is visually larger than before

## Checklist

- [x] Setup steps read
- [x] Unit tests pass
- [x] Tested in React playground