### PR TITLE
fix(#4020): show the right properties on the Temporary Notification page

### DIFF
--- a/docs/generated/component-apis/temporary-notification.json
+++ b/docs/generated/component-apis/temporary-notification.json
@@ -92,5 +92,92 @@
       "events": [],
       "slots": []
     }
-  }
+  },
+  "staticMethods": [
+    {
+      "name": "show",
+      "signature": "TemporaryNotification.show(message, options)",
+      "returnType": "string",
+      "description": "Displays a temporary notification from your component. Returns the notification's UUID, which you can use to dismiss it or update its progress.",
+      "params": [
+        {
+          "name": "message",
+          "type": "string",
+          "required": true,
+          "description": "The message to display in the notification."
+        },
+        {
+          "name": "options.type",
+          "type": "GoabTemporaryNotificationType",
+          "values": [
+            "basic",
+            "success",
+            "failure",
+            "indeterminate",
+            "progress"
+          ],
+          "required": false,
+          "description": "The type of notification, which determines its styling and icon. Use \"indeterminate\" to show an animated progress bar while work of unknown length runs, or \"progress\" to show a progress bar you update with setProgress(). Defaults to \"basic\"."
+        },
+        {
+          "name": "options.duration",
+          "type": "\"long\" | \"medium\" | \"short\" | number",
+          "required": false,
+          "description": "How long the notification stays before it auto-dismisses: \"short\" (about 3 seconds), \"medium\" (about 4 seconds), \"long\" (about 6 seconds), or a number of milliseconds. Only \"basic\", \"success\", and \"failure\" notifications auto-dismiss (default \"short\"). \"indeterminate\" and \"progress\" notifications have no default duration and stay until you dismiss them."
+        },
+        {
+          "name": "options.actionText",
+          "type": "string",
+          "required": false,
+          "description": "Text for an action button. When set, the notification shows a button the user can select."
+        },
+        {
+          "name": "options.action",
+          "type": "() => void",
+          "required": false,
+          "description": "Function to run when the action button is selected."
+        },
+        {
+          "name": "options.cancelUUID",
+          "type": "string",
+          "required": false,
+          "description": "UUID of an existing notification to cancel when this one is shown."
+        }
+      ]
+    },
+    {
+      "name": "dismiss",
+      "signature": "TemporaryNotification.dismiss(uuid)",
+      "returnType": "void",
+      "description": "Hides a notification, using the UUID that show() returns.",
+      "params": [
+        {
+          "name": "uuid",
+          "type": "string",
+          "required": true,
+          "description": "The UUID of the notification to dismiss. This is the value that show() returns."
+        }
+      ]
+    },
+    {
+      "name": "setProgress",
+      "signature": "TemporaryNotification.setProgress(uuid, progress)",
+      "returnType": "void",
+      "description": "Updates the progress shown on a progress notification, using the UUID that show() returns.",
+      "params": [
+        {
+          "name": "uuid",
+          "type": "string",
+          "required": true,
+          "description": "The UUID of the progress notification to update. This is the value that show() returns."
+        },
+        {
+          "name": "progress",
+          "type": "number",
+          "required": true,
+          "description": "The progress to display, from 0 to 100."
+        }
+      ]
+    }
+  ]
 }

--- a/docs/src/components/StaticMethods.astro
+++ b/docs/src/components/StaticMethods.astro
@@ -1,0 +1,154 @@
+---
+/**
+ * StaticMethods - Documents imperative helper methods (e.g. TemporaryNotification.show)
+ * that are exposed as a static API rather than element props.
+ *
+ * Framework-agnostic: a single signature snippet plus a params table, rendered the
+ * same way regardless of the selected framework. Visual language matches PropsTable.
+ */
+import type { StaticMethod } from "../lib/content-queries";
+
+interface Props {
+  methods: StaticMethod[];
+}
+
+const { methods } = Astro.props;
+---
+
+{
+  methods.map((method) => (
+    <div class="api-section">
+      <div class="api-heading">
+        <h3 id={`method-${method.name}`}>{method.name}()</h3>
+      </div>
+
+      {method.description && <p class="static-method-description">{method.description}</p>}
+
+      <pre class="static-method-signature"><code>{method.signature}{method.returnType ? `: ${method.returnType}` : ""}</code></pre>
+
+      <goa-container version="2" type="interactive">
+        <goa-data-grid keyboard-nav="layout" keyboard-icon-position="right">
+          {method.params.map((param) => (
+            <div class="prop-row" data-grid="row">
+              <div class="prop-cell prop-cell-name" data-grid="cell">
+                <span class="prop-name">{param.name}</span>
+                {param.required && (
+                  <goa-badge version="2" type="important" icon="false" content="Required" />
+                )}
+              </div>
+              <div class="prop-cell prop-cell-type" data-grid="cell">
+                <span class="prop-type">{param.type}</span>
+                {param.values && param.values.length > 0 && (
+                  <span class="prop-type-details">{param.values.join(" | ")}</span>
+                )}
+              </div>
+              {param.description && (
+                <div class="prop-cell prop-cell-description" data-grid="cell">
+                  {param.description}
+                </div>
+              )}
+            </div>
+          ))}
+        </goa-data-grid>
+      </goa-container>
+    </div>
+  ))
+}
+
+<style>
+  .api-section {
+    margin-bottom: var(--goa-space-xl);
+  }
+
+  .api-heading {
+    display: flex;
+    align-items: center;
+    gap: var(--goa-space-m);
+    margin-bottom: var(--goa-space-m);
+  }
+
+  .api-section h3 {
+    font: var(--goa-typography-heading-s);
+    margin-bottom: 0;
+    color: var(--goa-color-text-default);
+  }
+
+  .static-method-description {
+    font: var(--goa-typography-body-m);
+    color: var(--goa-color-text-secondary);
+    margin: 0 0 var(--goa-space-m);
+    max-width: 65ch;
+  }
+
+  .static-method-signature {
+    background: var(--goa-color-greyscale-100);
+    border-radius: var(--goa-border-radius-m);
+    padding: var(--goa-space-s) var(--goa-space-m);
+    margin: 0 0 var(--goa-space-m);
+    overflow-x: auto;
+  }
+
+  .static-method-signature code {
+    font: var(--goa-typography-number-s);
+    color: var(--goa-color-text-default);
+  }
+
+  .prop-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0;
+    border-bottom: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
+    padding: var(--goa-space-m) 0;
+  }
+
+  .prop-row:first-child {
+    padding-top: 0;
+  }
+
+  .prop-row:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  .prop-cell {
+    padding: var(--goa-space-2xs);
+    border-radius: var(--goa-border-radius-s);
+  }
+
+  .prop-cell-name {
+    display: flex;
+    align-items: baseline;
+    gap: var(--goa-space-xs);
+    margin-right: var(--goa-space-xs);
+  }
+
+  .prop-cell-name goa-badge {
+    margin-left: var(--goa-space-xs);
+    margin-right: var(--goa-space-xs);
+  }
+
+  .prop-cell-description {
+    flex-basis: 100%;
+    font: var(--goa-typography-body-s);
+    color: var(--goa-color-text-default);
+  }
+
+  .prop-name {
+    font: var(--goa-typography-number-s);
+    font-weight: var(--goa-font-weight-bold);
+    color: var(--goa-color-text-default);
+  }
+
+  .prop-type {
+    font: var(--goa-typography-number-s);
+    color: var(--goa-color-info-text-dark);
+  }
+
+  .prop-type-details {
+    display: block;
+    margin-top: var(--goa-space-3xs);
+    font: var(--goa-typography-body-xs);
+    color: var(--goa-color-greyscale-700);
+  }
+</style>

--- a/docs/src/lib/content-queries.ts
+++ b/docs/src/lib/content-queries.ts
@@ -45,11 +45,22 @@ export interface SubComponentApi {
   frameworks: FrameworkApiMap;
 }
 
+export type StaticMethodParam = Omit<PropDefinition, "default" | "deprecated" | "typeLabel">;
+
+export interface StaticMethod {
+  name: string;
+  signature: string;
+  returnType: string;
+  description: string;
+  params: StaticMethodParam[];
+}
+
 export interface ComponentApi {
   componentSlug: string;
   extractedFrom: string;
   frameworks: FrameworkApiMap;
   subComponents?: SubComponentApi[];
+  staticMethods?: StaticMethod[];
 }
 
 // Load all component API JSON files at build time using Vite glob import

--- a/docs/src/pages/components/[slug].astro
+++ b/docs/src/pages/components/[slug].astro
@@ -4,6 +4,7 @@ import { getCollection, render } from 'astro:content';
 import ComponentPageLayout from '../../layouts/ComponentPageLayout.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import PropsTable from '../../components/PropsTable.astro';
+import StaticMethods from '../../components/StaticMethods.astro';
 import GuidanceGrid from '../../components/GuidanceGrid.astro';
 import ExampleDisplay from '../../components/ExampleDisplay.astro';
 import ConfigurationPreview from '../../components/ConfigurationPreview';
@@ -113,6 +114,9 @@ const v1DocsUrl = `https://v1.design.alberta.ca/components/${slug}`;
         {api ? (
           <>
             <PropsTable frameworks={api.frameworks} />
+            {api.staticMethods && api.staticMethods.length > 0 && (
+              <StaticMethods methods={api.staticMethods} />
+            )}
             {api.subComponents && api.subComponents.length > 0 && (
               api.subComponents.map((sub) => (
                 <div class="sub-component-section">

--- a/docs/src/scripts/extract-api.ts
+++ b/docs/src/scripts/extract-api.ts
@@ -37,6 +37,23 @@ const DOCS_COMPONENT_CONTENT_PATH = path.join(
   "docs/src/content/components",
 );
 
+// Components that expose an imperative helper API (e.g. TemporaryNotification.show)
+// are documented from their controller source rather than from element props. Each
+// entry points at that controller file; the parsing lives in the "Static helper
+// methods" section below.
+interface StaticMethodSource {
+  source: string; // path to the controller source file, relative to the workspace root
+  namespace: string; // exported const whose object members are the public methods
+}
+
+const STATIC_METHOD_SOURCES: Record<string, StaticMethodSource> = {
+  "temporary-notification": {
+    source:
+      "libs/common/src/lib/temporary-notification-controller/temporary-notification-controller.ts",
+    namespace: "TemporaryNotification",
+  },
+};
+
 // =============================================================================
 // Output Types (matching content model spec)
 // =============================================================================
@@ -86,6 +103,23 @@ interface ExtractedComponentAPI {
       slots: ExtractedSlot[];
     };
   };
+  staticMethods?: ExtractedStaticMethod[];
+}
+
+interface ExtractedStaticMethodParam {
+  name: string;
+  type: string;
+  values?: string[]; // Allowed values for union types
+  required: boolean;
+  description: string;
+}
+
+interface ExtractedStaticMethod {
+  name: string; // e.g. "show"
+  signature: string; // e.g. "TemporaryNotification.show(message, options)"
+  returnType: string;
+  description: string;
+  params: ExtractedStaticMethodParam[];
 }
 
 // =============================================================================
@@ -2077,6 +2111,237 @@ function findSvelteDeclaringTag(tag: string): string | undefined {
 }
 
 // =============================================================================
+// Static helper methods (imperative APIs that are not element props)
+// =============================================================================
+
+// A few components expose an imperative helper (e.g. TemporaryNotification.show)
+// rather than, or alongside, element props. Everything rendered in the docs is
+// parsed from the controller source so it cannot drift: the method list comes
+// from the exported namespace object, signatures, params, and return types from
+// the function declarations, descriptions from their JSDoc (@param tags for
+// positional params), and option fields from the options type, where members
+// tagged @internal are omitted.
+
+// Resolve a same-file union type alias (e.g. GoabTemporaryNotificationType) to its
+// string-literal members, so a field typed as that alias can show its allowed values.
+function parseTypeAliasUnionValues(
+  typeName: string,
+  sourceFile: ts.SourceFile,
+): string[] | undefined {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isTypeAliasDeclaration(statement) || statement.name.text !== typeName) continue;
+    if (!ts.isUnionTypeNode(statement.type)) return undefined;
+    const values = statement.type.types
+      .map((member) =>
+        ts.isLiteralTypeNode(member) && ts.isStringLiteral(member.literal)
+          ? member.literal.text
+          : null,
+      )
+      .filter((value): value is string => value !== null);
+    return values.length > 0 ? values : undefined;
+  }
+  return undefined;
+}
+
+// Read the property signatures of a `type X = { ... }` object-literal alias.
+function findTypeLiteralMembers(
+  typeName: string,
+  sourceFile: ts.SourceFile,
+): Map<string, ts.PropertySignature> {
+  const members = new Map<string, ts.PropertySignature>();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isTypeAliasDeclaration(statement) || statement.name.text !== typeName) continue;
+    if (!ts.isTypeLiteralNode(statement.type)) break;
+    for (const member of statement.type.members) {
+      if (ts.isPropertySignature(member) && member.name && ts.isIdentifier(member.name)) {
+        members.set(member.name.text, member);
+      }
+    }
+    break;
+  }
+  return members;
+}
+
+interface NodeJSDocInfo {
+  description: string;
+  internal: boolean;
+  paramDocs: Map<string, string>;
+}
+
+// Read a node's JSDoc via the AST: the description text, whether the node is
+// tagged @internal, and the text of each @param tag keyed by param name.
+function readNodeJSDoc(node: ts.Node): NodeJSDocInfo {
+  const collapse = (text: string | undefined): string => (text ?? "").replace(/\s+/g, " ").trim();
+
+  let description = "";
+  let internal = false;
+  const paramDocs = new Map<string, string>();
+
+  for (const doc of ts.getJSDocCommentsAndTags(node)) {
+    if (ts.isJSDoc(doc)) {
+      const text = collapse(ts.getTextOfJSDocComment(doc.comment));
+      if (text) description = description ? `${description} ${text}` : text;
+    }
+  }
+  for (const tag of ts.getJSDocTags(node)) {
+    if (tag.tagName.text === "internal") internal = true;
+    if (ts.isJSDocParameterTag(tag) && ts.isIdentifier(tag.name)) {
+      paramDocs.set(tag.name.text, collapse(ts.getTextOfJSDocComment(tag.comment)));
+    }
+  }
+  return { description, internal, paramDocs };
+}
+
+// The public method list (and its docs order) is the exported namespace object,
+// e.g. `export const TemporaryNotification = { show, dismiss, setProgress }`.
+function findNamespaceMethodNames(namespace: string, sourceFile: ts.SourceFile): string[] {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || declaration.name.text !== namespace) continue;
+      if (!declaration.initializer || !ts.isObjectLiteralExpression(declaration.initializer)) {
+        return [];
+      }
+      return declaration.initializer.properties
+        .map((property) =>
+          (ts.isShorthandPropertyAssignment(property) || ts.isPropertyAssignment(property)) &&
+          ts.isIdentifier(property.name)
+            ? property.name.text
+            : null,
+        )
+        .filter((name): name is string => name !== null);
+    }
+  }
+  return [];
+}
+
+// Expand an options-bag parameter (typed `Partial<X>` or `X`, where X is an
+// object-literal type alias in the same file) into one row per public field,
+// in the field declaration order. Fields tagged @internal are omitted.
+function expandOptionsBagParam(
+  paramName: string,
+  param: ts.ParameterDeclaration,
+  sourceFile: ts.SourceFile,
+): ExtractedStaticMethodParam[] | undefined {
+  const typeNode = param.type;
+  if (!typeNode || !ts.isTypeReferenceNode(typeNode)) return undefined;
+
+  let aliasName = typeNode.typeName.getText(sourceFile);
+  let isPartial = false;
+  if (aliasName === "Partial" && typeNode.typeArguments?.length === 1) {
+    const inner = typeNode.typeArguments[0];
+    if (!ts.isTypeReferenceNode(inner)) return undefined;
+    aliasName = inner.typeName.getText(sourceFile);
+    isPartial = true;
+  }
+
+  const members = findTypeLiteralMembers(aliasName, sourceFile);
+  if (members.size === 0) return undefined;
+
+  // Every field is optional when the bag is a Partial, and also when the bag
+  // parameter itself can be omitted.
+  const bagOptional = Boolean(param.questionToken || param.initializer);
+
+  const optionParams: ExtractedStaticMethodParam[] = [];
+  for (const [field, member] of members) {
+    const doc = readNodeJSDoc(member);
+    if (doc.internal) continue;
+    const rawType = cleanType(member.type?.getText(sourceFile)?.trim() || "unknown");
+    const values = parseTypeAliasUnionValues(rawType, sourceFile);
+    optionParams.push({
+      name: `${paramName}.${field}`,
+      type: rawType,
+      ...(values ? { values } : {}),
+      required: isPartial || bagOptional ? false : !member.questionToken,
+      description: doc.description,
+    });
+  }
+  return optionParams;
+}
+
+function extractStaticMethods(componentName: string): ExtractedStaticMethod[] {
+  const config = STATIC_METHOD_SOURCES[componentName];
+  if (!config) return [];
+
+  const sourcePath = path.join(WORKSPACE_ROOT, config.source);
+  if (!fs.existsSync(sourcePath)) {
+    console.warn(`  static methods: source not found at ${config.source}`);
+    return [];
+  }
+
+  const content = fs.readFileSync(sourcePath, "utf-8");
+  const sourceFile = createTsSourceFile(sourcePath, content);
+
+  const methodNames = findNamespaceMethodNames(config.namespace, sourceFile);
+  if (methodNames.length === 0) {
+    console.warn(`  static methods: no exported object named ${config.namespace} in ${config.source}`);
+    return [];
+  }
+
+  const declaredFunctions = new Map<string, ts.FunctionDeclaration>();
+  for (const statement of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.name) {
+      declaredFunctions.set(statement.name.text, statement);
+    }
+  }
+
+  const methods: ExtractedStaticMethod[] = [];
+  for (const methodName of methodNames) {
+    const fn = declaredFunctions.get(methodName);
+    if (!fn) {
+      console.warn(
+        `  static methods: ${config.namespace}.${methodName} has no function declaration`,
+      );
+      continue;
+    }
+
+    const doc = readNodeJSDoc(fn);
+    // An @internal tag hides a method from the docs even when the namespace object exports it.
+    if (doc.internal) continue;
+
+    const params: ExtractedStaticMethodParam[] = [];
+    const signatureArgs: string[] = [];
+
+    for (const param of fn.parameters) {
+      if (!ts.isIdentifier(param.name)) continue;
+      const paramName = param.name.text;
+      signatureArgs.push(paramName);
+
+      const optionParams = expandOptionsBagParam(paramName, param, sourceFile);
+      if (optionParams) {
+        params.push(...optionParams);
+        continue;
+      }
+
+      const rawType = cleanType(param.type?.getText(sourceFile)?.trim() || "unknown");
+      const values = parseTypeAliasUnionValues(rawType, sourceFile);
+      const paramDescription = doc.paramDocs.get(paramName);
+      if (paramDescription === undefined) {
+        console.warn(
+          `  static methods: ${config.namespace}.${methodName} param "${paramName}" has no @param JSDoc`,
+        );
+      }
+      params.push({
+        name: paramName,
+        type: rawType,
+        ...(values ? { values } : {}),
+        required: !param.questionToken && !param.initializer,
+        description: paramDescription ?? "",
+      });
+    }
+
+    methods.push({
+      name: methodName,
+      signature: `${config.namespace}.${methodName}(${signatureArgs.join(", ")})`,
+      returnType: fn.type ? cleanType(fn.type.getText(sourceFile).trim()) : "void",
+      description: doc.description,
+      params,
+    });
+  }
+  return methods;
+}
+
+// =============================================================================
 // Main Extraction
 // =============================================================================
 
@@ -2265,6 +2530,8 @@ function extractComponentAPI(componentName: string): ExtractedComponentAPI | nul
   // Relative path from workspace root
   const relativePath = path.relative(WORKSPACE_ROOT, svelteFilePath);
 
+  const staticMethods = extractStaticMethods(componentName);
+
   return {
     componentSlug: toKebabCase(componentName),
     extractedFrom: relativePath,
@@ -2285,6 +2552,7 @@ function extractComponentAPI(componentName: string): ExtractedComponentAPI | nul
         slots: webComponentSlots,
       },
     },
+    ...(staticMethods.length > 0 ? { staticMethods } : {}),
   };
 }
 

--- a/libs/common/src/lib/temporary-notification-controller/temporary-notification-controller.ts
+++ b/libs/common/src/lib/temporary-notification-controller/temporary-notification-controller.ts
@@ -8,42 +8,83 @@ export type GoabTemporaryNotificationType =
   | "progress";
 
 export type GoabNotificationOptions = {
+  /**
+   * The type of notification, which determines its styling and icon. Use
+   * "indeterminate" to show an animated progress bar while work of unknown
+   * length runs, or "progress" to show a progress bar you update with
+   * setProgress(). Defaults to "basic".
+   */
   type: GoabTemporaryNotificationType;
-  uuid: string;
-  cancelUUID?: string;
+  /**
+   * How long the notification stays before it auto-dismisses: "short" (about
+   * 3 seconds), "medium" (about 4 seconds), "long" (about 6 seconds), or a
+   * number of milliseconds. Only "basic", "success", and "failure"
+   * notifications auto-dismiss (default "short"). "indeterminate" and
+   * "progress" notifications have no default duration and stay until you
+   * dismiss them.
+   */
   duration?: "long" | "medium" | "short" | number;
+  /**
+   * Text for an action button. When set, the notification shows a button the
+   * user can select.
+   */
   actionText?: string;
+  /** Function to run when the action button is selected. */
   action?: () => void;
+  /** UUID of an existing notification to cancel when this one is shown. */
+  cancelUUID?: string;
+  /** @internal Assigned by show(); not a public option. */
+  uuid: string;
+  /** @internal Managed by the notification controller. */
   visible: boolean;
 };
 
 const TypesRequiringDuration: GoabTemporaryNotificationType[] = ["basic", "success", "failure"];
 
-function show(message: string, opts?: Partial<GoabNotificationOptions>): string {
+/**
+ * Displays a temporary notification from your component. Returns the
+ * notification's UUID, which you can use to dismiss it or update its progress.
+ * @param message The message to display in the notification.
+ * @param options Settings for the notification's type, duration, and action.
+ * @returns The UUID of the notification.
+ */
+function show(message: string, options?: Partial<GoabNotificationOptions>): string {
   const uuid = crypto.randomUUID();
-  opts = { uuid, type: "basic", ...(opts || {}) };
+  options = { uuid, type: "basic", ...(options || {}) };
 
   // set default duration for certain notification types
-  if (!opts.duration && opts.type && TypesRequiringDuration.includes(opts.type)) {
-    opts.duration = "short";
+  if (!options.duration && options.type && TypesRequiringDuration.includes(options.type)) {
+    options.duration = "short";
   }
 
   relay(
     document.body,
     "goa:temp-notification",
-    { message: message, ...opts },
+    { message: message, ...options },
     { bubbles: true },
   );
 
   return uuid;
 }
 
+/**
+ * Hides a notification, using the UUID that show() returns.
+ * @param uuid The UUID of the notification to dismiss. This is the value that
+ * show() returns.
+ */
 function dismiss(uuid: string) {
   relay(
     document.body, "goa:temp-notification:dismiss", uuid, { bubbles: true }
   );
 }
 
+/**
+ * Updates the progress shown on a progress notification, using the UUID that
+ * show() returns.
+ * @param uuid The UUID of the progress notification to update. This is the
+ * value that show() returns.
+ * @param progress The progress to display, from 0 to 100.
+ */
 function setProgress(uuid: string, progress: number) {
   relay(
     document.body,


### PR DESCRIPTION
Closes #4020.

The Temporary Notification page documented the wrong thing. `temporary-notification/` has two custom elements: the notification (`goa-temp-notification`) and the controller (`goa-temp-notification-ctrl`). Only the controller has React and Angular wrappers, so it's the only element that exists across all three frameworks. And the notification's content (message, type, duration, and so on) isn't set through element props at all. It's set imperatively through `TemporaryNotification.show(message, options)`, which a props table can't express.

This PR does two things:

1. **Keeps all three element tabs on the controller** so React, Angular, and Web Components stay consistent. (An earlier attempt surfaced the notification element's props on the Web Components tab, which made it diverge from the other two. That's been reverted.)

2. **Documents the imperative API** in a new section under Properties: `show(message, options)`, `dismiss(uuid)`, and `setProgress(uuid, progress)`. `extract-api` now parses the controller source and emits a `staticMethods` block, rendered as a signature plus a params table per method. The method list, signatures, and descriptions all come from the controller itself (JSDoc on the functions and on `GoabNotificationOptions`, with `uuid` and `visible` tagged `@internal` to keep them out of the docs). `show()`'s options table covers `type`, `duration`, `actionText`, `action`, and `cancelUUID`.

Regenerating all 69 component JSONs confirms `temporary-notification` is the only one affected. The docs build passes and the new section renders on the preview.

