### PR TITLE
feat(#4022): add skills/ folder

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,39 @@
+# GoA Design System skills
+
+AI skills for building Government of Alberta services with the design system. Each one is a `SKILL.md` folder following the [Agent Skills open standard](https://agentskills.io), so it works across Claude Code, Cursor, GitHub Copilot, and other tools that read the format.
+
+A skill is plain-Markdown guidance your AI loads on its own when the work matches. It rides on top of the GoA design system MCP, which supplies the live component facts.
+
+## Skills
+
+| Skill | What it does |
+|---|---|
+| [`using-goa-design-system`](./using-goa-design-system/) | Turns "I'm building X for users" into the right product type, templates, and components. The navigator. |
+| [`content-design`](./content-design/) | Designs user-facing words for their reader, a citizen or a worker. The writer. |
+
+Each skill folder has a `SKILL.md` (the instructions your AI reads) and a `README.md` (what it is, for humans).
+
+## Install
+
+Add a skill, pointed at this repo:
+
+```
+npx skills add GovAlta/ui-components --skill using-goa-design-system
+npx skills add GovAlta/ui-components --skill content-design
+```
+
+It loads on its own when your work matches. Pair it with the GoA design system MCP for the live component facts.
+
+## Stay current
+
+The skills track this repo's `dev` branch, so you can keep them up to date:
+
+```
+npx skills update
+```
+
+To update automatically, add `npx skills update -g -y` to a SessionStart hook in your AI tool and they refresh every session. An update only lands when a skill's own files change, so everyday repo activity won't churn what you have.
+
+## Contributing
+
+Edit skills here; consuming teams pull from this folder. Skill updates reach teams on the skill's own cadence, independent of component releases.

--- a/skills/content-design/README.md
+++ b/skills/content-design/README.md
@@ -1,0 +1,50 @@
+# content-design
+
+The skill that designs user-facing service words for the specific person reading them: a citizen or a worker. It names the reader first, because the same message is two different designs for the two of them, not one lightly reworded.
+
+## In a sentence
+
+For anyone writing with the design system: when you're working on any words in a service (a button label, an error, a status message, guidance, an empty state), tell your AI who reads it, a citizen or a worker, and it shapes the wording to fit that reader, then explains each change.
+
+Under the hood: it is the prose counterpart to the design system's User Types foundation. The foundation owns the interaction layer (components, density, layout); this skill owns the words. Both are grounded in the same citizen-vs-worker model.
+
+## What it does
+
+1. Names the reader: citizen or worker, the service task and lifecycle stage, and the surface (a button, an error, an empty state). It asks if the audience is unclear, it does not guess, because a wrong audience invalidates everything downstream.
+2. Applies the six "busy reader" principles (Rogers & Lasky-Fink, *Writing for Busy Readers*), dialed to that reader. The principles hold for everyone; their settings change. A citizen gets plain language, low density, a calm tone, and one obvious action. A worker gets domain vocabulary, density, efficiency, and an action-first shape.
+3. Holds three things non-negotiable for both readers (not dials): accessibility (WCAG 2.2 AA), government voice, and no citizen PII (roles, never people).
+4. Emits the content-designed text first, paste-ready, then a short rationale that maps each change to its principle and its dial.
+
+## The master switch: citizen or worker
+
+Naming the reader is the master switch, because "good" means opposite things to each:
+
+- **Citizen:** accessing a service from outside government, maybe once in their life. They need clarity and confidence. Plain language, around grade 9, minimal density, calm and reassuring, one step at a time.
+- **Worker:** internal staff using a tool every day; it is their job and they know it. They need a power tool. Density is fine, domain vocabulary is precision not jargon, efficient and direct.
+- **Frequency can outrank role.** The mode is the reader's relationship to the task, not their title. A contractor filing daily permits is a citizen who wants worker-terse content; a caseworker handling a once-in-a-career exception wants citizen-style guidance.
+
+The clearest illustration: one service status, said two ways. To a citizen it *adds* orientation and *drops* the legal program name ("We're reviewing your application. You don't need to do anything."). To a worker it *removes* orientation and *keeps* the working vocabulary ("Stage 3, awaiting medical eligibility, 6 days in queue. Next: review docs, set eligibility."). Opposite moves, same source state.
+
+## What makes it distinctive
+
+- Reader-first, not draft-first. It refuses to reword until it knows who reads the copy, because citizen and worker writing pull in opposite directions.
+- Dials, not rules. The principles are constant; their settings change per reader. Accessibility, voice, and no-PII are the only true constants.
+- Self-contained. Unlike a component navigator, it barely needs live lookups: the principles and a plain-wording lookup are bundled in the skill. It works for any service content, whatever components are used.
+- Shows its work. It outputs the designed text, then maps each change to a principle and a dial, so the reasoning is reviewable.
+
+## Using it
+
+Install it, pointed at our repo:
+
+```
+npx skills add GovAlta/ui-components --skill content-design
+```
+
+Then tell your AI who the copy is for and what surface it lives on, and the skill loads on its own when the work matches. Run `npx skills update` to pull the latest.
+
+## Good to know
+
+- It is the prose counterpart to the User Types foundation (served through the MCP). The foundation owns the interaction layer; this skill owns the words. When one moves, check the other.
+- The bundled `content-design-succinct-alternatives.md` is a roughly 860-entry "wordy phrase to plain wording" lookup. Use it reader-awarely: most entries cut padding and help everyone, but some swap a formal word for an everyday one, which suits a citizen and can wrongly strip a worker's precise vocabulary. Never blanket-replace.
+- No component dependency. This skill is about words, not UI, so it stands on its own regardless of which components a service uses.
+- Best hardened by evaluation: run it on a few real pieces of content with a fresh agent and refine where the output misses, rather than trusting it on first write.

--- a/skills/content-design/SKILL.md
+++ b/skills/content-design/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: content-design
+description: "Designs user-facing service content (service names, descriptions, guidance, microcopy, button labels, status messages, errors, empty states) for its specific reader: a citizen (public, plain language, grade-9) or a worker (internal, dense, domain-expert). Use when writing or editing any citizen-facing or worker-facing copy for a Government of Alberta service, or when checking whether existing copy fits the reader it is actually for."
+---
+
+# Designing content for its reader: citizen or worker
+
+Given a piece of content (or a brief to write one), design it for whoever reads it. **Name the reader first.** It is the master switch: the same state said to a citizen and to a worker is two different designs, not one lightly reworded, because "good" means opposite things to them.
+
+## When to use it
+
+- Writing or editing any user-facing words in a Government of Alberta service: service names, descriptions, guidance, button and link labels, status messages, empty states, errors, confirmations, notifications.
+- Stress-testing existing copy against its actual reader. The two recurring failures: citizen copy written at a policy reading level, and worker copy padded with hand-holding that slows an expert down.
+
+Not for your team's own internal docs in your own voice (those follow your team's voice guide), though the worker profile is a fair lens for any fluent internal audience.
+
+## Step 1 — Name the reader (first, every time)
+
+Fix three things before writing a word:
+
+1. **Audience: citizen or worker?** Grounded in the design system's own user-type model (the **User Types** foundation, also served through the MCP):
+   - **Citizen** — accessing a service from outside government, maybe once in their life, once a year, or rarely. They didn't choose to be here; they need something. The experience should feel like a clear, considered path: slow on purpose, one step at a time, hard to make a mistake. Plain language, ~grade 9, minimal density. Values clarity over speed, confidence over efficiency.
+   - **Worker** — internal staff using a tool to deliver or administer a service from inside, every day; it's their job and they know it. The experience should feel like a power tool: fast, dense, information-rich, built for repetition and scale. Density fine, efficiency-focused, trusts expertise. Splits into an intake worker (deciding on a submission) and an ongoing case worker ("what needs me on this file").
+   - **Frequency can outrank role.** The mode is the reader's relationship to the task, not their title. A contractor filing daily permits is a citizen but wants worker-terse content; a caseworker handling a once-in-a-career exception wants citizen-style guidance. When the two disagree, frequency usually wins for content too.
+   - **Can't tell? Ask. Do not guess.** A wrong audience invalidates everything downstream.
+2. **Service task and lifecycle stage.** A service is a verb; *apply*, *check status*, and *report a change* read differently. The same stage often has a citizen-facing and a worker-facing track, said two different ways.
+3. **Surface and moment** — a button, page intro, error, empty state, confirmation, notification. The moment sets the job the words do.
+
+## Step 2 — Apply the busy-reader base, dialed to the reader
+
+The six principles (Rogers & Lasky-Fink, *Writing for Busy Readers*) hold for everyone: enough formatting, design for navigation, less is more, make reading easy, tell readers why they should care, make responding easy.
+
+What changes is their settings. **"Make reading easy" and "use enough" are defined relative to the reader's expertise and frequency.**
+
+| Dimension | Citizen (public, occasional, novice) | Worker (internal, frequent, expert) |
+|---|---|---|
+| Reading level | Plain language, ~grade 9 | Domain-fluent; precise terms are precision, not jargon |
+| Density | Minimal; one idea at a time; whitespace | Dense is fine; completeness and scannability over hand-holding |
+| Vocabulary | Everyday words; **verbs, not program names** ("report a change", not "Income Reporting Module"); expand acronyms, unless one is more familiar to this reader than its expansion (SIN, AISH on a recipient's own portal) | Real domain terms, program names, case states, stage labels |
+| Orientation | High — what is this, what's next, why it matters to me | Low — orient to *this file or task*, not the system |
+| Tone | Calm, reassuring, human | Efficient, direct, action-first |
+| Job | Help one person do one thing, confidently | Help an expert decide and move work |
+| "Less is more" → | Cut everything non-essential | Cut noise, not data; the bar for "needed" is higher |
+| "Responding easy" → | One obvious action, no dead ends | Quick actions, batch where it fits; don't over-confirm |
+
+Stakes amplify the tone dial: the higher the consequence to the reader (money, health, legal standing), the more a citizen needs calm and reassurance, and the less a worker wants anything slowing them down.
+
+Both readers, non-negotiable (not dials): WCAG 2.2 AA, government voice, and **no citizen PII** — roles, never people.
+
+**Cutting wordiness has a lookup.** For the "less is more" and "everyday words" dials, a companion reference lists ~860 common wordy or formal phrases and their plain replacements (`content-design-succinct-alternatives.md`). Use it reader-awarely: most entries cut padding ("due to the fact that" → "because") and help every reader; some swap a formal word for a plain one ("terminate" → "stop"), which suits a citizen but can wrongly strip a worker's precise vocabulary. Match the substitution to the reader; never blanket-replace.
+
+### Surface-specific moves
+
+A few patterns the dial table doesn't spell out, surfaced by real use:
+
+- **Errors (citizen):** state the fix as a positive instruction with an example of valid input ("Enter your 9-digit SIN, for example 123456789"), not a description of what went wrong. The field's own error styling already says "error"; don't repeat it in words.
+- **Empty states:** give the next action, not just the diagnosis ("No clients match these filters. Clear filters to see all.").
+- **Notifications:** they truncate. Front-load the point in the first few words; a citizen notification should answer "does this affect me, and do I need to do anything?".
+- **Handheld (mobile):** citizens are often on a phone, so tighten further. Front-load the one thing that matters, keep it short, and assume labels and notifications truncate. Anything that needs scrolling to reach is at risk of being missed.
+
+## Steps
+
+1. Name the reader (audience, task and stage, surface). Ask if the audience is unclear.
+2. Read the draft (or brief) for what it must do *for that reader*. Set aside anything that is a quality or NFR, not content (the component's own error styling, icon, or layout is its job; you own the words).
+3. Apply the principles, dialed to the audience profile.
+4. Emit the content-designed text, then the rationale.
+
+## Output
+
+- **The content-designed text first**, paste-ready: no markdown blockquote (the bar breaks copying), no em or en dashes (use periods or commas). Match formatting to the surface.
+- **The rationale**: name the audience, then map each concrete change to its principle and its dial. Skip what already worked. Keep it skimmable; it should follow the principles too.
+- Preserve meaning and intent; invent nothing. If a cut would drop real information, flag it rather than delete it.
+- **Audience unknown?** Don't ship one hedged version. Ask which reader it is for; if useful, show a provisional design per candidate audience so the decision is concrete.
+
+## Worked example
+
+One AISH file at lifecycle Stage 3 (awaiting medical eligibility). Same state, two readers.
+
+Undesigned draft (policy voice, no reader in mind):
+
+```
+Your application is currently being processed. The assessment of your medical eligibility for
+the Assured Income for the Severely Handicapped (AISH) program is pending and has been in the
+review queue for 6 days. Processing typically takes approximately 8 weeks from the date of
+submission. You will be contacted by email and text message in due course once a determination
+has been made. No further action is required at this time.
+```
+
+**Citizen** (recipient's portal, "where is my file"):
+
+```
+We're reviewing your application
+
+Right now we're checking your medical eligibility. You don't need to do anything.
+
+We'll text and email you as soon as there's a decision. Most take about 8 weeks.
+```
+
+Why: leads with status and "you don't need to do anything" (the anxious reader's real question); grade-9, dropped "in due course", "determination", and the legal program name; four lines, one idea each; ends on what's next and when.
+
+**Worker** (case worker's file view, "what needs me on this file"):
+
+```
+Stage 3 · Awaiting medical eligibility · 6 days in queue
+Next: review medical docs, set eligibility, assign reviewer
+```
+
+Why: keeps the working vocabulary ("Stage 3", "eligibility", "assign"); surfaces queue age for triage and the explicit next action; cuts reassurance an expert doesn't need. No reading-level softening, which would only slow them down.
+
+The citizen version *adds* orientation and *removes* domain language; the worker version *removes* orientation and *keeps* it. Opposite moves, same source state.
+
+## Common mistakes
+
+- **Skipping Step 1.** Writing before naming the reader. The dominant failure: copy that is simple where it should be dense, or dense where it should be simple.
+- **Over-simplifying worker copy.** Plain language is not the worker goal; stripping their vocabulary slows them down. Precision is the courtesy.
+- **Padding citizen copy with system orientation.** Citizens don't need the org chart or the legal program name; they need their next step.
+- **Treating accessibility or voice as an audience dial.** They apply to both readers at full strength, always.
+
+## Extending it (a first foundation)
+
+The base is one set of principles; audiences are profiles, so it grows without restructuring:
+
+- More **profiles** as they earn it: a delegated third party (trustee, POA); a screen-reader-first reader named explicitly rather than treated as an afterthought.
+- More **principles**: deepen the surface-specific moves (errors, empty states, notifications), plus service-language conventions.
+- Stay **aligned with the code side**: this is the prose counterpart to the design system's User Types foundation. When one moves, check the other.
+
+## Related
+
+- DS **User Types** foundation — the canonical source this mirrors (served through the MCP). The interaction layer (components, density, layouts) lives there; this skill owns the words, not the layout.
+- `content-design-succinct-alternatives.md` — the wordy-phrase-to-plain-wording lookup wired into Step 2.
+- Source for the six principles: Todd Rogers & Jessica Lasky-Fink, *Writing for Busy Readers*.

--- a/skills/content-design/content-design-succinct-alternatives.md
+++ b/skills/content-design/content-design-succinct-alternatives.md
@@ -1,0 +1,870 @@
+# Succinct alternatives: wordy phrase to plainer wording
+
+A lookup of common wordy or formal phrases and their shorter, plain-language replacements, for use with the content-design skill. Adapted from Todd Rogers & Jessica Lasky-Fink, *Writing for Busy Readers*. Curated to drop entries irrelevant to government service content.
+
+**Use it reader-awarely.** Most entries cut padding ("due to the fact that" to "because") and help every reader. Some swap a formal word for an everyday one ("terminate" to "stop"), which suits a citizen but can wrongly strip a worker's precise vocabulary. Match the substitution to the reader (see the citizen/worker dial in the skill); never blanket-replace.
+
+| Wordy phrase | Plainer alternative |
+| --- | --- |
+| (a) large number of | many, most (or say how many) |
+| (an) absence of | no, none |
+| (have) regard to | take into account |
+| (it is) compulsory | (you) must |
+| (it is) mandatory | (you) must |
+| (it is) obligatory | (you) must |
+| (please find) enclosed | I enclose |
+| (the) tenant | you |
+| 12 midnight | midnight |
+| 12 noon | noon |
+| a man/woman by the name of | named |
+| a number of | several, many |
+| a percentage of | some |
+| a sufficient number of | enough |
+| absence of | no |
+| absolutely certain | certain |
+| absolutely essential | essential |
+| abundance | enough, plenty, a lot (or say how many) |
+| accede to | allow, agree to |
+| accelerate | speed up |
+| accentuate | stress |
+| accommodation | where you live, home |
+| accompanying | with |
+| accomplish | do, finish |
+| according to our records | our records show |
+| accordingly | in line with this, so |
+| acknowledge | thank you for |
+| acquaint | tell |
+| acquaint yourself with | find out about, read |
+| acquiesce | agree |
+| acquire | buy, get |
+| actual experience | experience |
+| add an additional | add |
+| add up | add |
+| added bonus | bonus |
+| additional | extra, more |
+| adjacent | next to |
+| adjacent to | near |
+| adjustment | change, alteration |
+| admissible | allowed, acceptable |
+| advance forward | advance |
+| advance planning | planning |
+| advance reservations | reservations |
+| advance warning | warning |
+| advantageous | useful, helpful |
+| advise | tell, say (unless you are giving advice) |
+| affirmative yes | yes |
+| affix | add, write, fasten, stick on, fix to |
+| afford an opportunity | let, allow |
+| afforded | given |
+| aforesaid | this, earlier in this document |
+| aggregate | total |
+| ahead of schedule | early |
+| aligned | lined up, in line |
+| all meet together | all meet |
+| alleviate | ease, reduce |
+| allocate | divide, share, give |
+| along the lines of | like, as in |
+| alternative | (a) choice, (the) other |
+| alternative choice | choice |
+| alternatively | or, on the other hand |
+| ameliorate | improve, help |
+| amendment | change |
+| an adequate number of | enough |
+| anonymous stranger | stranger |
+| anticipate | expect |
+| any particular | any |
+| apparent | clear, plain, obvious, seeming |
+| applicant (the) | you |
+| application | use |
+| appreciable | large, great |
+| apprise | inform, tell |
+| appropriate | proper, right, suitable |
+| appropriate to | suitable for |
+| approximately | about, roughly |
+| arrangements are in the hands of | arranged by |
+| artificial prosthesis | prosthesis |
+| as a consequence of | because |
+| as far as... is concerned | as for |
+| as of the date of | from |
+| as per | per |
+| as regards | about, on the subject of |
+| ascertain | find out |
+| ask the question | ask |
+| assemble | build, gather, put together |
+| assemble together | assemble |
+| assistance | help |
+| at an early date | soon (or say when) |
+| at an early time | early |
+| at its discretion | can, may (or edit out) |
+| at the moment | now (or edit out) |
+| at the present time | now (or edit out) |
+| at this point in time | now |
+| ATM machine | ATM |
+| attach together | attach |
+| attempt | try |
+| attend | come to, go to, be at |
+| attired in | wore |
+| attributable to | due to, because of |
+| authorise | allow, let |
+| authority | right, power, may (as in 'have the authority to') |
+| autobiography of my life | autobiography |
+| awkward predicament | awkward |
+| axiomatic | obvious, goes without saying |
+| basic fundamentals | fundamentals |
+| beat out | beat |
+| belated | late |
+| beneficial | helpful, useful |
+| best of health | well/healthy |
+| bestow | give, award |
+| blend together | blend |
+| both agree | agree |
+| both of them | both |
+| bouquet of flowers | bouquet |
+| breach | break |
+| brief in duration | brief |
+| brief moment | moment |
+| brief summary | summary |
+| by means of | by |
+| cacophony of sound | cacophony |
+| calculate | work out, decide |
+| call your attention to the fact that | remind you, notify you |
+| called a halt | stopped |
+| cancel out | cancel |
+| careful scrutiny | scrutiny |
+| carry out the work | do the work |
+| caused injuries to | injured |
+| cease | finish, stop, end |
+| circle around | circle |
+| circulate around | circulate |
+| circumvent | get round, avoid, skirt, circle |
+| clarification | explanation, help |
+| classify into groups | classify |
+| clean up | clean |
+| close proximity | proximity |
+| closed fist | fist |
+| cold temperature | cold |
+| colder temperature | colder |
+| collaborate together | collaborate |
+| collide into each other | collide |
+| combine | mix |
+| combine together | combine |
+| combined | together |
+| commence | start, begin |
+| communicate | talk, write, telephone (be specific) |
+| compete with each other | compete |
+| competent | able, can |
+| compile | make, collect |
+| complete | fill in, finish |
+| completely annihilate | annihilate |
+| completely destroy | destroy |
+| completely eliminate | eliminate |
+| completely engulf | engulf |
+| completely fill | fill |
+| completely surround | surrounded |
+| completion | end |
+| comply with | keep to, meet |
+| component | part |
+| component parts | parts |
+| comprises | is made up of, includes |
+| conceal | hide |
+| concerning | about, on |
+| concerning the matter of | about |
+| conclusion | end |
+| concur | agree |
+| condition | rule |
+| confer together | confer |
+| confused state | confused |
+| connect together | connect |
+| consensus of opinion | consensus |
+| consequently | so |
+| considerable | great, important |
+| constantly maintained | maintained |
+| constitutes | makes up, forms, is |
+| construe | interpret |
+| consult | talk to, meet, ask |
+| consumption | amount used |
+| contemplate | think about |
+| continue on | continue |
+| continue to remain | stay |
+| contrary to | against, despite |
+| correct | put right |
+| correspond | write |
+| costs the sum of | costs |
+| could possibly | could |
+| counter | against |
+| courteous | polite |
+| crammed close together | crammed |
+| crisis situation | crisis |
+| crystal clear | clear |
+| cumulative | added up, added together |
+| curative process | curative |
+| current incumbent | incumbent |
+| current trend | trend |
+| currently | now (or edit out) |
+| customary | usual, normal |
+| deceptive lie | lie |
+| deduct | take off, take away |
+| deem to be | treat as |
+| defer | put off, delay |
+| deficiency | lack of |
+| delete | cross out |
+| demonstrate | show, prove |
+| denote | show |
+| depart from | depart |
+| depict | show |
+| depreciated in value | depreciated |
+| descend down | descend |
+| described as | called |
+| designate | point out, show, name |
+| desirable benefits | benefits |
+| desire | wish, want |
+| despatch or dispatch | send, post |
+| despite the fact that | though, although |
+| despite… nonetheless | despite OR nonetheless |
+| determine | decide, work out, set, end |
+| detrimental | harmful, damaging |
+| different kinds | kinds |
+| difficult dilemma | dilemma |
+| difficulties | problems |
+| diminish | lessen, reduce |
+| direct confrontation | confrontation |
+| disappear from sight | disappear |
+| disburse | pay, pay out |
+| discharge | carry out |
+| disclose | tell, show |
+| disconnect | cut off, unplug |
+| discontinue | stop, end |
+| discrete | separate |
+| discuss | talk about |
+| disseminate | spread |
+| documentation | papers, documents |
+| domiciled in | living in |
+| dominant | main |
+| draw the attention of | show/remind/point out |
+| drop down | drop |
+| due to the fact that | because, as |
+| duration | time, life |
+| during the course of | during |
+| during the time that | during |
+| during which time | while |
+| dwelling | home |
+| dwindle down | dwindle |
+| each and every | each |
+| each individual ____ | each ___ |
+| earlier in time | earlier |
+| economical | cheap, good value |
+| economics field | economics |
+| eligible | allowed, qualified |
+| eliminate altogether | eliminate |
+| elucidate | explain, make clear |
+| emergency situation | emergency |
+| emphasise | stress |
+| empower | allow, let |
+| empty hole | hole |
+| empty out | empty |
+| empty space | space |
+| enable | allow |
+| enclosed | inside, with |
+| enclosed herein | enclosed |
+| enclosed herewith | enclosed |
+| encounter | meet |
+| end product | product |
+| end result | result |
+| endeavour | try |
+| enquire | ask |
+| enquiry | question |
+| ensure | make sure |
+| enter in | enter |
+| entirely eliminate | eliminate |
+| entitlement | right |
+| envisage | expect, imagine |
+| equal to one another | equal |
+| equally as | equally OR as (one or the other, not both) |
+| equivalent | equal, the same |
+| eradicate completely | eradicate |
+| erroneous | wrong |
+| erupt (or explode) violently | erupt or explode |
+| escape from | escape |
+| establish | show, find out, set up |
+| estimate roughly | estimate |
+| estimated at about | estimated at |
+| evaluate | test, check |
+| evince | show, prove |
+| evolve over time | evolve |
+| ex officio | because of his or her position |
+| exact same | same |
+| exceeding the speed limit | speeding |
+| exceptionally | only when, in this case |
+| excessive | too many, too much |
+| exclude | leave out |
+| excluding | apart from, except |
+| exclusively | only |
+| exempt from | free from |
+| exit out of | exit |
+| expedite | hurry, speed up |
+| expeditiously | as soon as possible, quickly |
+| expenditure | spending |
+| expire | run out |
+| exposed opening | opening |
+| extant | current, in force |
+| extradite back | extradite |
+| extreme in degree | extreme |
+| extremity | limit |
+| fabricate | make, make up |
+| face mask | mask |
+| facilitate | help, make possible |
+| facilitate the effort | ease/help |
+| factor | reason |
+| failure to | if you do not |
+| fall down | fall |
+| favorable approval | approval |
+| fellow classmates | classmates |
+| fellow colleague | colleague |
+| fellow countryman | countryman |
+| fetch back | fetch |
+| few in number | few |
+| filled to capacity | filled |
+| final conclusion | conclusion |
+| final outcome | outcome |
+| finalise | end, finish |
+| finish up | finish |
+| first and foremost | foremost |
+| first conceived | conceived |
+| first of all | first |
+| flee from | flee |
+| fly through the air | fly |
+| follow after | follow |
+| following | after |
+| for the duration of | during, while |
+| for the purpose of | to, for |
+| for the reason of | because |
+| for the reason that | because |
+| foreign imports | imports |
+| former graduate | graduate |
+| former veteran | veteran |
+| formulate | plan, devise |
+| forthwith | now, at once |
+| forward | send |
+| free gift | gift |
+| frequently | often |
+| from out of the | out of/from |
+| from the point of view of | for |
+| from whence | whence |
+| frontispiece illustration | frontispiece |
+| frozen ice | ice |
+| full gamut | gamut |
+| fundamental | basic |
+| furnish | give |
+| further to | after, following |
+| furthermore | then, also, and |
+| fuse together | fuse |
+| future plans | plans |
+| gained entrance to | got in |
+| gather together | gather |
+| gathered together | met |
+| general consensus | consensus |
+| generate | produce, give, make |
+| give consideration to | consider, think about |
+| give rise to | cause |
+| glance briefly | glance |
+| goes under the name of | is called/known as |
+| grant | give |
+| green in color | green |
+| grow in size | grow |
+| had done previously | had done |
+| harmful injuries | injuries |
+| he is a man who | he |
+| head up | head |
+| heat up | heat |
+| heavy in weight | heavy |
+| hence why | why |
+| henceforth | from now on, from today |
+| hereby | now, by this (or edit out) |
+| herein | here (or edit out) |
+| hereinafter | after this (or edit out) |
+| hereof | of this |
+| hereto | to this |
+| heretofore | until now, previously |
+| hereunder | below |
+| herewith | with this (or edit out) |
+| hitherto | until now |
+| HIV virus | HIV |
+| hoist up | hoist |
+| hold in abeyance | wait, postpone |
+| hollow tube | tube |
+| honest in character | honest |
+| hope and trust | hope, trust (but not both) |
+| hotter temperature | hotter |
+| hourly basis | hourly |
+| hurry up | hurry |
+| I am hopeful that | I hope |
+| I was unaware of the fact that | I was unaware that, I did not know that |
+| if and when | if, when (but not both) |
+| illustrate | show, explain |
+| immediately | at once, now |
+| implement | carry out, do |
+| imply | suggest, hint at |
+| important essentials | essentials |
+| impossible to discover | cannot be found |
+| in a confused state | confused |
+| in a hasty manner | hastily |
+| in a number of cases | some (or say how many) |
+| in a satisfactory manner | satisfactorily |
+| in accordance with | as under, in line with, because of |
+| in addition | also |
+| in addition (to) | and, as well as, also |
+| in advance | before |
+| in advance of our meeting | before we meet |
+| in attendance | present/there |
+| in case of | if |
+| in conjunction with | and, with |
+| in connection with | for, about |
+| in consequence | because, as a result |
+| in consequence of | because of |
+| in excess of | more than |
+| in isolation | by itself/alone |
+| in large measure | largely |
+| in lieu of | instead of |
+| in many cases | often |
+| in order that | so that |
+| in order to | to |
+| in receipt of | get, have, receive |
+| in recognition of the fact that | recognizing that |
+| in relation to | about |
+| in respect of | about, for |
+| in spite of the fact that | though, although |
+| in succession | running |
+| in the absence of | without |
+| in the case of/in terms of | off |
+| in the course of | while, during |
+| in the direction of | toward |
+| in the event of | in/if |
+| in the event of/that | if |
+| in the field of | in/with |
+| in the majority of instances | most, mostly |
+| in the near future | soon |
+| in the neighbourhood of | about, around |
+| in the possession of | has/have |
+| in the vicinity/region/neighborhood of | about/near/around |
+| in view of the fact that | as, because |
+| inappropriate | wrong, unsuitable |
+| inasmuch as | since, because |
+| inception | start, beginning |
+| incorporating | which includes |
+| incredible to believe | incredible |
+| incur | have to pay, owe |
+| indicate | show, suggest |
+| indicted on a charge | indicted |
+| inform | tell |
+| initially | at first |
+| initiate | begin, start |
+| initiate, institute | start |
+| input into | input |
+| insert | put in |
+| insist adamantly | insist |
+| instances | cases |
+| integrate together | integrate |
+| integrate with each other | integrate |
+| intend to | will |
+| interdependent upon each other | interdependent |
+| intimate | say, hint |
+| introduced a new | introduced |
+| introduced for the first time | introduced |
+| irrespective of | despite, even if |
+| is of the opinion | thinks |
+| ISBN number | ISBN |
+| issue | give, send |
+| it cannot be denied that | undeniably |
+| it is known that | I/we know that |
+| it is often the case that | often |
+| jeopardise | risk, threaten |
+| join together | join |
+| joint collaboration | collaboration |
+| jump up | jump |
+| kneel down | kneel |
+| knots per hour | knots |
+| knowledgeable expert | expert |
+| lag behind | lag |
+| laptop computer | laptop |
+| large in size | large |
+| large volume of | many |
+| last of all | last |
+| later time | later |
+| LCD display | LCD |
+| leaving much to be desired | unsatisfactory/bad |
+| lesbian woman | lesbian |
+| less expensive | cheaper |
+| lift up | lift |
+| live witness | witness |
+| local residents | residents |
+| locality | place, area |
+| locate | find, put |
+| look ahead to the future | look to the future |
+| look back in retrospect | look back |
+| low degree of interest | little interest |
+| low ebb | ebb |
+| made an approach to | approached |
+| made good their escape | escaped |
+| made out of | made of |
+| magnitude | size |
+| major breakthrough | breakthrough |
+| major feat | feat |
+| manner | way |
+| manually by hand | manually |
+| manufacture | make |
+| marginal | small, slight |
+| match up | match |
+| material | relevant |
+| materialise | happen, occur |
+| may in the future | may, might, could |
+| may possibly | may |
+| measure up to | fit/reach/match |
+| meet up with | meet |
+| merchandise | goods |
+| merge together | merge |
+| might possibly | might |
+| mislay | lose |
+| modification | change |
+| moment in time | moment |
+| more superior | superior |
+| moreover | and, also, as well |
+| mutual cooperation | cooperation |
+| mutual respect for each other | mutual respect |
+| natural instinct | instinct |
+| nearly almost | nearly OR almost |
+| negligible | very small |
+| never at any time | never |
+| nevertheless | but, however, even so |
+| new beginning | beginning |
+| new construction | construction |
+| new innovation | innovation |
+| new invention | invention |
+| new recruit | recruit |
+| none at all | none |
+| nostalgia for the past | nostalgia |
+| notify | tell, let us (or you) know |
+| notwithstanding | even if, despite, still, yet |
+| notwithstanding the fact that | although |
+| now pending | pending |
+| null and void | void |
+| numerous | many (or say how many) |
+| objective | aim, goal |
+| obtain | get, receive |
+| occasioned by | caused by, because of |
+| of a bright color | bright |
+| of a strange type | strange |
+| of cheap quality | cheap |
+| of the order of | about |
+| off of | off |
+| often times | often |
+| old adage | adage |
+| old cliché | cliché |
+| old custom | custom |
+| old proverb | proverb |
+| on a daily basis | daily |
+| on a regular basis | regularly |
+| on account of the fact that | because |
+| on behalf of | for |
+| on numerous occasions | often |
+| on request | if you ask |
+| on the grounds that | because |
+| on the occasion that | when, if |
+| on the part of | by |
+| once used to | did, used to |
+| one of the purposes | one purpose |
+| one of the reasons | one reason |
+| operate | work, run |
+| optimum | best, ideal |
+| option | choice |
+| orbit around | orbit |
+| ordinarily | normally, usually |
+| originally created | created |
+| otherwise | or |
+| outside of | outside |
+| outstanding | unpaid |
+| overexaggerate | exaggerate |
+| owing to | because of |
+| owing to the fact that | since, because |
+| pair of twins | twins |
+| palm of the hand | palm |
+| partially | partly |
+| participate | join in, take part |
+| particulars | details, facts |
+| passing fad | fad |
+| past experience | experience |
+| past history | history |
+| past memories | memories |
+| pay tribute to | thank/praise/honor |
+| penetrate into | penetrate |
+| per annum | a year |
+| per capita | per person |
+| perform | do |
+| performs the function of | functions as |
+| period in time | period |
+| permeate through | permeate |
+| permissible | allowed |
+| permit | let, allow |
+| personal friend | friend |
+| personal opinion | opinion |
+| personnel | people, staff |
+| persons | people, anyone |
+| peruse | read, read carefully, look at |
+| pick and choose | pick |
+| PIN number | PIN |
+| place | put |
+| placed under arrest | arrested |
+| plan ahead | plan |
+| plan in advance | plan |
+| plunge down | plunge |
+| point in time | point, time, or then |
+| positive identification | identification |
+| possess | have, own |
+| possessions | belongings |
+| postpone until later | postpone |
+| practically | almost, nearly |
+| pre-recorded | recorded |
+| predominant | main |
+| preplan | plan |
+| prescribe | set, fix |
+| present time | time |
+| preserve | keep, protect |
+| previous | earlier, before, last |
+| previously listed above | previously listed |
+| principal | main |
+| prior to | before |
+| prior/preparatory/previous to | before we meet |
+| private industry | industry |
+| proceed | go ahead |
+| proceed ahead | proceed |
+| procure | get, obtain, arrange |
+| profusion of | plenty, too many (or say how many) |
+| prohibit | ban, stop |
+| projected | estimated |
+| prolonged | long |
+| promptly | quickly, at once |
+| promulgate | advertise, announce |
+| proportion | part |
+| proposed plan | plan |
+| protest against | protest |
+| prove beneficial | benefit |
+| provide | give |
+| provided that | if, as long as |
+| provisions | rules, terms |
+| proximity | closeness, nearness |
+| purchase | buy |
+| pursuant to | under, because of, in line with |
+| pursue after | pursue |
+| put in an appearance | appear |
+| raise up | raise |
+| re-elect for another term | re-elect |
+| reason is because | reason is |
+| reason why | reason (or "reason is") |
+| reconsider | think again about, look again at |
+| recur again | recur |
+| reduce | cut |
+| reduction | cut |
+| refer back | refer |
+| referred to as | called |
+| refers to | talks about, mentions |
+| reflect back | reflect |
+| regarding | about, on |
+| regular routine | routine |
+| regulation | rule |
+| reimburse | repay, pay back |
+| reiterate | repeat, restate |
+| relating to | about |
+| relative to the issue of | about |
+| remain | stay |
+| remainder | the rest, what is left |
+| remittance | payment |
+| remuneration | pay, wages, salary |
+| render | make, give, send |
+| rendered assistance to | helped |
+| repeat again | repeat |
+| reply back | reply |
+| report | tell |
+| represents | shows, stands for, is |
+| request | ask, question |
+| request the appropriation of | ask for (more) money |
+| require | need, want, force |
+| requirements | needs, rules |
+| reside | live |
+| residence | home, where you live |
+| restriction | limit |
+| retain | keep |
+| retain her position as | remain as |
+| retired for the night | went to bed |
+| retreat back | retreat |
+| return back | return |
+| revert back | revert |
+| review | look at (again) |
+| revised | new, changed |
+| rise up | rise |
+| round in shape | round |
+| safe haven | haven |
+| safe sanctuary | sanctuary |
+| said/such/same | the, this, that |
+| sand dune | dune |
+| scrutinise | read (look at) carefully |
+| scrutinize in detail | scrutinize |
+| select | choose |
+| self-____ yourself | self-_____ |
+| serious danger | danger |
+| serves the function of | serves as |
+| settle | pay |
+| share the same | share |
+| share together | share |
+| sharp point | point |
+| shiny in appearance | shiny |
+| short in length | short |
+| shortfall in supplies | shortage |
+| shout out | shout |
+| shuttle back and forth | shuttle |
+| similarly | also, in the same way |
+| single unit | unit |
+| sink down | sink |
+| sit down | sit |
+| skipped over | skipped |
+| skirt around | skirt |
+| slightly ajar | ajar |
+| small speck | speck |
+| so far as x is concerned | as for x |
+| soft to the touch | soft |
+| sole of the foot | sole |
+| solely | only |
+| special ceremonies marking the event were held | ceremonies marked the event |
+| specified | given, written, set |
+| spell out in detail | spell out |
+| spliced together | spliced |
+| start off | start |
+| start out | start |
+| state | say, tell us, write down |
+| statutory | legal, by law |
+| still persists | persists |
+| still remains | remains |
+| subject to | depending on, under, keeping to |
+| submit | send, give |
+| submitted his resignation | resigned |
+| subsequent to | after |
+| subsequent to/upon | after |
+| subsequently | later |
+| substantial | large, great, a lot of |
+| substantially | more or less |
+| substantiate | prove |
+| succeeded in defeating | defeated |
+| succumbed to his injuries | died |
+| sudden crisis | crisis |
+| sudden impulse | impulse |
+| suddenly exploded | exploded |
+| sufficient | enough |
+| sufficient consideration | enough thought |
+| sum total | total |
+| supplement | go with, add to |
+| supplementary | extra, more |
+| supply | give, sell, deliver |
+| surrounded on all sides | surrounded |
+| sustained injuries | was hurt |
+| swoop down | swoop |
+| sworn affidavit | affidavit |
+| take action on the issue | act |
+| tall in height | tall |
+| tall in stature | tall |
+| tall skyscraper | skyscraper |
+| temper tantrum | tantrum |
+| terminate | stop, end |
+| terrible tragedy | tragedy |
+| that being the case | if so |
+| the fact that he had not succeeded | his failure |
+| the fact that I had arrived | my arrival |
+| the question as to whether | whether |
+| the results so far achieved | the results |
+| the tools they employed | their tools |
+| there is no doubt but that | no doubt, doubtless |
+| there is no doubt that | clearly |
+| thereafter | then, afterwards |
+| thereby | by that, because of that |
+| therein | in that, there |
+| thereof | of that |
+| thereto | to that |
+| this day and age | today/nowadays |
+| this is a subject which | this subject |
+| thus | so, therefore |
+| tiny bit | bit |
+| to date | so far, up to now |
+| to the extent that | if, when |
+| took into consideration | considered |
+| tragically sad | tragic |
+| transfer | change, move |
+| transmit | send |
+| true facts | facts |
+| truly sincere | sincere |
+| two equal halves | halves |
+| ultimately | in the end, finally |
+| unavailability | lack of |
+| under active consideration | considered |
+| under preparation | being prepared |
+| under the circumstances | in this/that case |
+| undergraduate student | undergraduate |
+| underground subway | subway |
+| undernoted | the following |
+| undersigned | I, we |
+| undertake | agree, promise, do |
+| unexpected emergency | emergency |
+| unexpected surprise | surprise |
+| uniform | same, similar |
+| unilateral | one-sided, one-way |
+| unintentional mistake | mistake |
+| universal panacea | panacea |
+| unoccupied | empty |
+| unsolved mystery | mystery |
+| unthaw | thaw |
+| until such time | until |
+| until such time as | until |
+| unusual in nature | unusual |
+| used for fuel purposes | used for fuel |
+| used to at one time | used to |
+| used to in the past | used to |
+| usual custom | custom |
+| utilisation | use |
+| utilise | use |
+| vacillate back and forth | vacillate |
+| variation | change |
+| various differences | differences |
+| veiled ambush | ambush |
+| virtually | almost (or edit out) |
+| visible to the eye | visible |
+| visualise | see, predict |
+| voiced approval | approved |
+| wall mural | mural |
+| wall sconce | sconce |
+| wander around aimlessly | wander, roam |
+| warn in advance | warn |
+| was a witness of | saw |
+| was suffering from | had |
+| ways and means | ways |
+| we are in receipt of | we received |
+| we are of the opinion | we think |
+| we have pleasure in | we are glad to |
+| weather conditions | weather |
+| wend one's way | go |
+| whatsoever | whatever, what, any |
+| when and if | when |
+| whensoever | when |
+| whereas | but |
+| whether or not | whether |
+| who is, which was | [often superfluous; omit entirely] |
+| will be the speaker at | will speak |
+| with a view to | to, so that |
+| with effect from | from |
+| with reference to | about |
+| with regard to | about, for |
+| with respect to | about, for |
+| with the exception of | except |
+| with the minimum of delay | quickly (or say when) |
+| with the result that | so, so that |
+| worked their way | went |
+| write down | write |
+| x o'clock A.M. in the morning | x o'clock A.M. (ditto for "P.M. in the evening") |
+| you are requested | please |
+| your attention is drawn to | please see, please note |
+| zone | area, region |

--- a/skills/using-goa-design-system/README.md
+++ b/skills/using-goa-design-system/README.md
@@ -1,0 +1,62 @@
+# using-goa-design-system
+
+The skill that turns "I'm building X for users" into the right Government of Alberta product type, templates, and components. It is the "how should I approach this" layer. The GoA design system MCP is the "what is this" layer underneath it.
+
+## In a sentence
+
+For anyone building with the design system: tell your AI what you're making in plain terms ("a renewal form for citizens", "a case queue for workers") and it works out the right GoA product type, the matching page and section templates, and the exact components with their props and gotchas, before it writes any code.
+
+Under the hood: it is the composition layer to the MCP's knowledge layer. The MCP answers "what is this component"; this skill answers "I'm building this, how should I approach it," following the design system's service-first method so an AI tool uses our conventions by default.
+
+## What it does
+
+When you describe what you're building in user-facing terms, the skill walks the design system's structure top-down instead of jumping to a component:
+
+1. Names the service type: what the user is trying to accomplish, in service language ("getting permission", "requesting information", "getting financial support"). This uses Kate Tarling's Common Service Types vocabulary.
+2. Maps that to a product type: workspace (worker-facing) or public-form (citizen-facing), saying the translation out loud, and naming a gap if it does not fit cleanly.
+3. Pulls the matching templates by size (interaction, section, page, task, product) from the MCP.
+4. Pulls each component's real props, token references, and embedded guidance (the do's and don'ts) from the MCP, before any code is written.
+5. Hands back the plan and the known gotchas first, names what it assumed, and flags decisions a person should make.
+
+A guided descent: service, to product type, to template, to component, to tokens, with the MCP supplying the facts at each step.
+
+## How it works
+
+The MCP is the knowledge layer (facts, through its `search` and `get` tools). This skill is the composition layer (method: which questions to ask, in what order, and how to read the answers). It uses the MCP and never duplicates it. It carries no component specs, only the judgment for navigating to them. That is why it stays small, and why its facts stay current: they come live from the MCP.
+
+The structure it walks:
+
+- Service type: what the user is trying to accomplish (vocabulary layer)
+- Product type: workspace (worker) or public-form (citizen)
+- Example by size: interaction, section, page, task, product
+- Components: the atomic UI building blocks
+- Guidance atoms: the do's, don'ts, and tips tied to a component
+- Tokens: spacing, color, and sizing values
+
+## What makes it distinctive
+
+- Service-first, not component-first. It establishes product type and template before reaching for a component, so the result follows the system's conventions instead of being correct-looking code that ignores them.
+- Derives, does not interrogate. It infers worker-vs-citizen from the product type instead of asking.
+- Advisory and transparent. It names its defaults ("I'll scaffold in React, the same works in Angular") and escalates real decisions to people.
+- Same content, different lens. A designer gets design language; a developer gets technical language. It reframes, it does not withhold.
+- Gotchas before code. It surfaces known failure modes up front, not at review time.
+- Names gaps honestly. If no template captures the job, it says so and offers the closest pieces rather than forcing a near-miss.
+
+## The shorthand: a librarian
+
+You arrive with a fuzzy need ("I'm building an intake tool for caseworkers"). A component library hands you a pile of parts. This skill is the librarian: it works out what kind of thing you are really making, walks you to the right shelf, pulls the exact references with their specs, and warns you about the known pitfalls before you start.
+
+## Using it
+
+Install it, pointed at our repo:
+
+```
+npx skills add GovAlta/ui-components --skill using-goa-design-system
+```
+
+Then describe what you are building in plain terms, and the skill loads on its own when the work matches. Run `npx skills update` to pull the latest. It works alongside the GoA design system MCP, which supplies the live component facts.
+
+## Good to know
+
+- The service-type layer is vocabulary, not data yet. The skill leads with the Kate Tarling service types as a navigation lens; they are not a queryable layer in the MCP. As the service-mapping work formalizes them, the skill will get more opinionated about the building blocks each type expects.
+- The bundled `taxonomy.md` is a cache. It is a fast lookup of sizes, product types, and current templates, and it can drift from the docs site. The docs site and the MCP are the source of truth. Keep `taxonomy.md` in sync when product types or templates change.

--- a/skills/using-goa-design-system/SKILL.md
+++ b/skills/using-goa-design-system/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: using-goa-design-system
+description: Use when building or scoping a screen, page, or feature with the Government of Alberta Design System starting from a user-facing intent ("worker tool for case management", "public form for licence renewal", "error page for payment failure") rather than from a specific component or token.
+---
+
+# Using the GoA Design System
+
+## Overview
+
+The GoA design system has a layered structure: **product types** (workspace, public-form) → **examples by size** (interaction, section, page, task, product) → **components**, **guidance atoms**, **tokens**. This skill navigates from a user-facing intent down to the right artifacts. The MCP tools (`goa-design-system:search`, `goa-design-system:get`) are the knowledge layer; this skill is the composition layer — it walks the layered structure, surfaces guidance, and confirms specs by reading entries with `goa-design-system:get`.
+
+**Prerequisite:** this skill drives the `goa-design-system` MCP (`search`, `get`) at every step. If it isn't connected, tell the user and point them to install it (Claude Code: `claude mcp add --transport http goa-design-system https://mcp.design.alberta.ca/mcp --scope user`). Without it, the skill can't navigate.
+
+## When to use
+
+- A developer describes what they're building in user terms ("intake process", "case-management tool", "renewal form")
+- A team is scoping a new screen and needs to know what product type and templates apply
+- A reviewer is checking whether a screen uses the right layered structure
+
+When NOT to use:
+- The developer already names a specific component (`goa-button`, `goa-form-item`) → go straight to MCP `goa-design-system:get`
+- Purely token math (sizing, color values) → `goa-design-system:get` the component to see its token references
+- A single guidance-atom question → `goa-design-system:search` and `goa-design-system:get` directly
+
+## The layered structure
+
+| Layer | What it is | Examples |
+|---|---|---|
+| Service type | What the user is trying to accomplish (Kate Tarling Common Service Types) | "Getting permission" (permit), "Requesting/sharing information" (case lookup), "Getting financial support" (benefit claim) |
+| Product type | The kind of digital product the service is realized as (its own content collection) | `workspace` (worker), `public-form` (citizen) |
+| Example by size | Scale of artifact | `interaction` → `section` → `page` → `task` → `product` |
+| Components | Atomic UI building blocks | `goa-button`, `goa-form-item`, `goa-table` |
+| Guidance atoms | Do/don't/tip/warning/info linked to component + topic | "use goa-block for spacing, not goa-container" |
+| Tokens | Sizing, color, spacing values | `--goa-space-m`, `--goa-color-text-default` |
+
+Service type is the vocabulary layer (Kate Tarling), not a schema layer yet. The skill leads with it when recognizable, then narrates the mapping to product type. See `taxonomy.md` for the full framework.
+
+Public services typically have two sides: one to **provide and manage** (worker), and one to **receive** (citizen). When the intent names one side, name it. When the intent could apply to either, name both. The product type follows from which side the developer is building for.
+
+`task` is the unit for a complete user job — between a single page and a full product. When an intent is task-shaped (a complete job the user is trying to do), look for it in the tasks collection before composing from pages and components alone.
+
+For full enumeration of sizes, product types, and aliases, see `taxonomy.md`.
+
+## Navigation pattern
+
+1. Read the intent. Recognize the **service type**: what is the user trying to accomplish in service terms? If recognizable, name it using Kate Tarling's Common Service Types vocabulary (see `taxonomy.md`): "Getting permission," "Requesting/sharing information," "Getting financial support," etc.
+2. Map the service type to a product type. Narrate the translation explicitly: "this is a [service type], most often expressed as a [productType] in the GoA system today." If the service doesn't map cleanly to today's product types (workspace, public-form), name the gap rather than forcing a fit.
+3. `goa-design-system:get` the product type from the productTypes collection to surface its summary, demo URL, and listed components.
+4. `goa-design-system:search` filtered by `size` and `productType` for sections, non-canonical pages, or filtered queries (step 3 already lists the canonical pages).
+5. For each template, `goa-design-system:get` the entry to surface its components, source URLs, preview, and embedded guidance. For each component, `goa-design-system:get` to confirm props, types, and token references before generating code.
+6. If a task entry matches the intent, surface it. If no task captures it, name the gap and offer the closest pages so the developer can compose the job themselves.
+7. Surface result and gotchas to the developer before generating code. Apply the Decision calibration principles below: name what was defaulted (transparency) and frame through the developer's lens.
+
+## When to use which MCP tool
+
+The MCP is intentionally narrow. Guidance and specs are not separate tools; the skill surfaces them by reading component and template entries with `goa-design-system:get`.
+
+| Tool | Use for |
+|---|---|
+| `goa-design-system:search` | Open-ended discovery across the layered structure; supports filters on `size`, `productType`, `status`, etc. |
+| `goa-design-system:get` | Fetching a known entity by ID, alias, or name. Returns the entry's full record — components, sources, props, token references, embedded guidance. |
+
+## Decision calibration
+
+Two principles when responding:
+
+**1. Default transparently, not silently.** When making a choice on the user's behalf (file scaffolding, default props, framework selection), name what was defaulted with a short explanation and a way to override. The line between "matters to decide" and "doesn't matter" is too blurry without full user context, so transparency is the safer floor. Example: "I'll use React for the scaffold; the same patterns work in Angular if you'd prefer."
+
+For consequential choices that warrant team coordination (state-management architecture, content patterns, conventions that affect the whole project), don't default at all. Name the decision and point to who should make it. Example: "this is a state-management architecture decision worth talking through with a developer on your team" or "this is a content-pattern decision worth aligning with a designer."
+
+**2. Frame through the user's lens, but show both layers.** A designer asking sees the full picture (design intent AND a basic sketch of implementation), framed in design language: user goals, interactions, accessibility, patterns. A developer asking sees the full picture too (implementation intent AND the design rationale behind it), framed in technical language: implementation paths, integration, types. Same content, different lens. Don't withhold one layer because the question signals the other; do reframe the language so it lands in the user's perspective.
+
+## Common mistakes
+
+- **Skipping the service type.** Service language ("intake service", "permit application service") deserves explicit acknowledgment, not silent translation to product type. Name the service type, then narrate the mapping to product type.
+- **Skipping the product type layer.** Going straight to components produces correct-looking code that ignores the system's layered conventions.
+- **Asking for user type.** Don't. Derive from product type.
+- **Inventing tokens.** Always reference the actual token; never hardcode a value. If a value doesn't fit, use a component-level override; tokens themselves are referenced, not modified by teams.
+- **Treating guidance atoms as optional.** They encode known failure modes; surface them before code, not after review.
+- **Returning "not found" on an old slug.** Old slugs live in the `aliases` array on entries; treat aliases as additional lookup keys. See `taxonomy.md` for examples.
+- **Pretending every job has a task entry.** Many do, but not all. When no task matches, surface the closest pages and name the gap, rather than approximating from a near-miss task.
+
+## Cross-references
+
+The MCP tools are documented by the design system MCP server. This skill **uses** them; it does not duplicate them.

--- a/skills/using-goa-design-system/taxonomy.md
+++ b/skills/using-goa-design-system/taxonomy.md
@@ -1,0 +1,112 @@
+# GoA Design System: Layered Taxonomy
+
+A fast lookup for this skill. Treat the docs site as the source of truth; this file is a cache for orientation.
+
+## Contents
+
+- Sizes
+- Product types
+- User type
+- Service types (vocabulary layer)
+- Aliases (slugs)
+- Pages within each product (today)
+- What this file is NOT
+
+## Sizes
+
+The five-value `size` enum, smallest to biggest:
+
+| Size | Definition | Has page-like fields? |
+|---|---|---|
+| `interaction` | A single control or affordance behaving correctly | No |
+| `section` | A composed region of a page | No |
+| `page` | One full screen | Yes |
+| `task` | A complete user job from intent to completion. Lives in the tasks collection | Yes |
+| `product` | End-to-end digital product | Yes |
+
+"Page-like fields" means the entry can carry: `previewUrl`, `reactSourceUrl`, `angularSourceUrl`, `sourceUrl`, `stackblitzUrl`, `frameworks: ("react" | "angular" | "web-components")[]`.
+
+## Product types
+
+Product types are a **content collection** (not just a field on examples). Each one has an introductory narrative, a hero image, demo URL, and listed components. Examples link to a product type via the `productType` field, constrained today to:
+
+| Product type | Audience | Use for |
+|---|---|---|
+| `workspace` | Internal workers | Case management, dashboards, queues |
+| `public-form` | Citizens | Form-first flows like applications and renewals |
+
+Other product types (e.g. `error-pages`) may exist as example overviews without yet being a productTypes collection entry. When in doubt, query the productTypes collection via `goa-design-system:get`.
+
+## User type
+
+**Don't ask the developer for user type. Derive it.**
+
+| Product type | User type |
+|---|---|
+| `workspace` | worker |
+| `public-form` | citizen |
+| (none / interaction-only) | both |
+
+This derivation replaces the previous `userType` field on examples.
+
+## Service types (vocabulary layer)
+
+A service type names what a citizen or worker is trying to accomplish in service terms. The Kate Tarling "Common Service Types" framework names nine:
+
+1. Registering, providing, or reporting information
+2. Requesting, sharing, or checking information
+3. Paying for something
+4. Getting financial support or claiming something
+5. Getting permission to do something
+6. Scheduling something
+7. Buying or ordering something
+8. Becoming something
+9. Protecting something
+
+**They are not modelled in the design system schema yet, but the skill leads with this framing.** When intent is recognizable in service-type terms, name it explicitly using this vocabulary as the first navigation step, then map to a `productType` as the next explicit step. When the framework is formalized in the schema (likely via a separate service-mapping data source), the skill will become more opinionated about expected building blocks per type.
+
+Map intent to productType:
+
+| Intent shape | Service type (informal) | Likely productType |
+|---|---|---|
+| "case management", "intake", "review and decide", "queue" | Requesting / sharing information; sometimes Getting permission | `workspace` |
+| "apply for X", "register for Y" | Getting permission, Becoming something | `public-form` |
+| "renew", "report status" | Registering / providing information | `public-form` |
+| "claim", "request support" | Getting financial support | `public-form` |
+| "schedule X", "book a Y" | Scheduling something | `public-form` (booking) or `workspace` (queue) |
+
+Don't promote service types into a structured field; use them as intent vocabulary until the framework is formally adopted in the schema.
+
+## Aliases (slugs)
+
+Old slugs are preserved in the `aliases` array on entries for search continuity and URL redirects. When a developer references a slug that doesn't resolve directly, look up entries whose `aliases` contains that slug. Common cases include:
+
+- `confirm-that-an-application-was-submitted` → `result-page`
+- `ask-a-user-one-question-at-a-time` → `question-page` (one of the nine inline variants)
+- `give-more-information-before-asking-a-question-a` → `question-page`
+- 9 question-page variants now live as inline sections inside `/examples/question-page/`
+- 401, 404, 500 now live as inline sections inside `/examples/error-pages/`
+
+The MCP should treat aliases as additional searchable IDs.
+
+## Pages within each product (today)
+
+Workspace product:
+- `dashboard`
+- `index-page`
+- `case-detail`
+
+Public-form product:
+- `start-page`
+- `task-list-page`
+- `question-page` (with 9 inline variants)
+- `review-page`
+- `result-page`
+
+Each is `size: page` with `productType: <product>`.
+
+## What this file is NOT
+
+- Not the spec for any component. Use `goa-design-system:get` on the component entry.
+- Not the list of guidance atoms. Use `goa-design-system:search` and `goa-design-system:get`; the skill surfaces guidance during navigation.
+- Not a versioned source of truth. When in doubt, query the docs site or the MCP.


### PR DESCRIPTION
## What this does

Adds a public skills/ folder so consuming teams can install our AI skills the same way they install our package. Skills are an open standard now (SKILL.md), so these work across Claude Code, Cursor, Copilot, and other tools that read the format.

## What's in it

A skills/ folder at the repo root (modelled on apps/), with two skills:

- using-goa-design-system: the navigator. Turns "I'm building X for users" into the right product type, templates, and components, pulling live facts from the design system MCP.
- content-design: the writer. Designs user-facing copy for its reader, a citizen or a worker.

Each folder has a SKILL.md (what the AI reads) and a README.md (what it is, for people). A top-level README has the install commands and the skill index. No build wiring; it's a static folder teams fetch from.

## How teams use it

    npx skills add GovAlta/ui-components --skill using-goa-design-system
    npx skills add GovAlta/ui-components --skill content-design

The skill loads on its own when the work matches. `npx skills update` keeps it current.

## How to test

- Read the three READMEs (top-level plus one per skill) and check the framing lands.
- Optionally run an install command above in a scratch project and confirm the skill lands in your tool's skills folder.

## Notes

- Skills track dev, so updates reach teams on the skill's own cadence, separate from component releases.
- Pairs with the AI tools and resources page (#3981). Its skill install commands go live once this merges.
- Opening as a draft; I'll mark it ready after review.

Closes #4022