### PR TITLE
fix(#3763): size dropdown and date picker popover to measured width for percentage widths

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3763/bug3763.component.html
+++ b/apps/prs/angular/src/routes/bugs/3763/bug3763.component.html
@@ -1,0 +1,155 @@
+<div style="display: grid; gap: 1.5rem">
+  <div style="display: grid; gap: 0.5rem">
+    <h1 style="margin: 0">3763 - Percentage width expands open state too much</h1>
+    <p style="margin: 0">
+      When a Dropdown (or DatePicker) is given a percentage width, the closed input sizes
+      correctly, but the open menu expands far past the parent and the viewport. The
+      percentage is passed straight to the Popover container, where it no longer resolves
+      against the Dropdown's parent.
+    </p>
+    <p style="margin: 0 0 1rem">
+      Expected: the open width should match the closed width. Open each control below and
+      compare the open menu width to the dashed parent box.
+    </p>
+  </div>
+
+  <goab-container>
+    <div style="display: grid; gap: 1.5rem">
+      <h2 style="margin: 0">Dropdown with width="100%"</h2>
+      <p style="margin: 0 0 1rem">
+        The dropdown should be exactly as wide as the 320px dashed box, both closed and
+        open. Buggy behaviour: the open menu blows past the box.
+      </p>
+    </div>
+
+    <div style="width: 320px; border: 1px dashed var(--goa-color-greyscale-400); padding: 1rem">
+      <goab-dropdown
+        name="bug3763-province-full"
+        placeholder="Select a province"
+        width="100%"
+        [value]="province"
+        (onChange)="handleProvinceChange($event)"
+      >
+        <goab-dropdown-item value="alberta" label="Alberta"></goab-dropdown-item>
+        <goab-dropdown-item value="british-columbia" label="British Columbia"></goab-dropdown-item>
+        <goab-dropdown-item value="manitoba" label="Manitoba"></goab-dropdown-item>
+        <goab-dropdown-item value="ontario" label="Ontario"></goab-dropdown-item>
+        <goab-dropdown-item value="quebec" label="Quebec"></goab-dropdown-item>
+        <goab-dropdown-item
+          value="long"
+          label="Newfoundland and Labrador Provincial Vital Statistics and Records Registration Office"
+        ></goab-dropdown-item>
+      </goab-dropdown>
+    </div>
+  </goab-container>
+
+  <goab-container>
+    <div style="display: grid; gap: 1.5rem">
+      <h2 style="margin: 0">Dropdown with width="50%"</h2>
+      <p style="margin: 0 0 1rem">
+        Any percentage triggers the bug, not just 100%. The closed input is half the box;
+        the open menu should match it.
+      </p>
+    </div>
+
+    <div style="width: 320px; border: 1px dashed var(--goa-color-greyscale-400); padding: 1rem">
+      <goab-dropdown
+        name="bug3763-province-half"
+        placeholder="Select a province"
+        width="50%"
+        [value]="halfProvince"
+        (onChange)="handleHalfProvinceChange($event)"
+      >
+        <goab-dropdown-item value="alberta" label="Alberta"></goab-dropdown-item>
+        <goab-dropdown-item value="british-columbia" label="British Columbia"></goab-dropdown-item>
+        <goab-dropdown-item value="manitoba" label="Manitoba"></goab-dropdown-item>
+        <goab-dropdown-item value="ontario" label="Ontario"></goab-dropdown-item>
+        <goab-dropdown-item value="quebec" label="Quebec"></goab-dropdown-item>
+        <goab-dropdown-item
+          value="long"
+          label="Newfoundland and Labrador Provincial Vital Statistics and Records Registration Office"
+        ></goab-dropdown-item>
+      </goab-dropdown>
+    </div>
+  </goab-container>
+
+  <goab-container>
+    <div style="display: grid; gap: 1.5rem">
+      <h2 style="margin: 0">DatePicker with width="100%"</h2>
+      <p style="margin: 0 0 1rem">
+        Reported by Vidit: the same percentage-width problem affects the DatePicker. The
+        open calendar should not exceed the box width.
+      </p>
+    </div>
+
+    <div style="width: 320px; border: 1px dashed var(--goa-color-greyscale-400); padding: 1rem">
+      <goab-date-picker
+        name="bug3763-date"
+        width="100%"
+        [value]="date"
+        (onChange)="handleDateChange($event)"
+      ></goab-date-picker>
+    </div>
+  </goab-container>
+
+  <goab-container>
+    <div style="display: grid; gap: 1.5rem">
+      <h2 style="margin: 0">DatePicker with width="50%"</h2>
+      <p style="margin: 0 0 1rem">
+        Case from Benji: with a narrow percentage the input is much smaller than the
+        calendar's natural width, so the open calendar cannot match the input and
+        overflows the box. Expected: the open calendar should not exceed the maximum
+        width, not shrink to the tiny input.
+      </p>
+    </div>
+
+    <div style="width: 320px; border: 1px dashed var(--goa-color-greyscale-400); padding: 1rem">
+      <goab-date-picker
+        name="bug3763-date-half"
+        width="50%"
+        [value]="halfDate"
+        (onChange)="handleHalfDateChange($event)"
+      ></goab-date-picker>
+    </div>
+  </goab-container>
+
+  <goab-container>
+    <div style="display: grid; gap: 1.5rem">
+      <h2 style="margin: 0">DatePicker with width="100%" in a wide container</h2>
+      <p style="margin: 0 0 1rem">
+        Opposite case: the input is far wider than the calendar's natural width.
+        Expected: the open calendar stays at its natural width (left aligned under the
+        input), it should not stretch to fill the wide input.
+      </p>
+    </div>
+
+    <div style="width: 800px; border: 1px dashed var(--goa-color-greyscale-400); padding: 1rem">
+      <goab-date-picker
+        name="bug3763-date-wide"
+        width="100%"
+        [value]="wideDate"
+        (onChange)="handleWideDateChange($event)"
+      ></goab-date-picker>
+    </div>
+  </goab-container>
+
+  <goab-container>
+    <div style="display: grid; gap: 1.5rem">
+      <h2 style="margin: 0">DatePicker with an invalid width</h2>
+      <p style="margin: 0 0 1rem">
+        The width "5 0%" (note the stray space) is not a valid CSS dimension. Open the
+        browser console: the DatePicker should log an error explaining the width is
+        invalid, instead of failing silently.
+      </p>
+    </div>
+
+    <div style="width: 320px; border: 1px dashed var(--goa-color-greyscale-400); padding: 1rem">
+      <goab-date-picker
+        name="bug3763-date-invalid"
+        width="5 0%"
+        [value]="invalidDate"
+        (onChange)="handleInvalidDateChange($event)"
+      ></goab-date-picker>
+    </div>
+  </goab-container>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3763/bug3763.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3763/bug3763.component.ts
@@ -1,0 +1,57 @@
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+import {
+  GoabContainer,
+  GoabDatePicker,
+  GoabDropdown,
+  GoabDropdownItem,
+} from "@abgov/angular-components";
+import type {
+  GoabDatePickerOnChangeDetail,
+  GoabDropdownOnChangeDetail,
+} from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3763",
+  templateUrl: "./bug3763.component.html",
+  imports: [
+    CommonModule,
+    GoabContainer,
+    GoabDatePicker,
+    GoabDropdown,
+    GoabDropdownItem,
+  ],
+})
+export class Bug3763Component {
+  province = "";
+  halfProvince = "";
+  date = "";
+  halfDate = "";
+  wideDate = "";
+  invalidDate = "";
+
+  handleProvinceChange(detail: GoabDropdownOnChangeDetail): void {
+    this.province = detail.value || "";
+  }
+
+  handleHalfProvinceChange(detail: GoabDropdownOnChangeDetail): void {
+    this.halfProvince = detail.value || "";
+  }
+
+  handleDateChange(detail: GoabDatePickerOnChangeDetail): void {
+    this.date = detail.valueStr || "";
+  }
+
+  handleHalfDateChange(detail: GoabDatePickerOnChangeDetail): void {
+    this.halfDate = detail.valueStr || "";
+  }
+
+  handleWideDateChange(detail: GoabDatePickerOnChangeDetail): void {
+    this.wideDate = detail.valueStr || "";
+  }
+
+  handleInvalidDateChange(detail: GoabDatePickerOnChangeDetail): void {
+    this.invalidDate = detail.valueStr || "";
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3763/bug3763.route.json
+++ b/apps/prs/angular/src/routes/bugs/3763/bug3763.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3763",
+  "path": "bugs/3763",
+  "title": "Percentage width expands open state"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3763.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3763.route.ts
@@ -1,0 +1,10 @@
+import { Bug3763Route } from "../../../routes/bugs/bug3763";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3763",
+  path: "bugs/3763",
+  title: "Percentage width expands open state",
+  component: Bug3763Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3763.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3763.tsx
@@ -1,0 +1,236 @@
+import { useState } from "react";
+import {
+  GoabContainer,
+  GoabDatePicker,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabText,
+} from "@abgov/react-components";
+import type {
+  GoabDatePickerOnChangeDetail,
+  GoabDropdownOnChangeDetail,
+} from "@abgov/ui-components-common";
+
+const stackStyle = {
+  display: "grid",
+  gap: "1.5rem",
+};
+
+// Narrow parent so the open-state overflow is obvious against the viewport.
+const narrowParentStyle = {
+  width: "320px",
+  border: "1px dashed var(--goa-color-greyscale-400)",
+  padding: "1rem",
+};
+
+// Wide parent so the input ends up wider than the calendar's natural width.
+const wideParentStyle = {
+  width: "800px",
+  border: "1px dashed var(--goa-color-greyscale-400)",
+  padding: "1rem",
+};
+
+export function Bug3763Route() {
+  const [province, setProvince] = useState("");
+  const [halfProvince, setHalfProvince] = useState("");
+  const [date, setDate] = useState("");
+  const [halfDate, setHalfDate] = useState("");
+  const [wideDate, setWideDate] = useState("");
+  const [invalidDate, setInvalidDate] = useState("");
+
+  const handleProvinceChange = (detail: GoabDropdownOnChangeDetail) => {
+    setProvince(detail.value || "");
+  };
+
+  const handleHalfProvinceChange = (detail: GoabDropdownOnChangeDetail) => {
+    setHalfProvince(detail.value || "");
+  };
+
+  const handleDateChange = (detail: GoabDatePickerOnChangeDetail) => {
+    setDate(detail.valueStr || "");
+  };
+
+  const handleHalfDateChange = (detail: GoabDatePickerOnChangeDetail) => {
+    setHalfDate(detail.valueStr || "");
+  };
+
+  const handleWideDateChange = (detail: GoabDatePickerOnChangeDetail) => {
+    setWideDate(detail.valueStr || "");
+  };
+
+  const handleInvalidDateChange = (detail: GoabDatePickerOnChangeDetail) => {
+    setInvalidDate(detail.valueStr || "");
+  };
+
+  return (
+    <div style={stackStyle}>
+      <div style={stackStyle}>
+        <GoabText tag="h1">3763 - Percentage width expands open state too much</GoabText>
+        <GoabText>
+          When a Dropdown (or DatePicker) is given a percentage width, the closed input
+          sizes correctly, but the open menu expands far past the parent and the viewport.
+          The percentage is passed straight to the Popover container, where it no longer
+          resolves against the Dropdown's parent.
+        </GoabText>
+        <GoabText>
+          Expected: the open width should match the closed width. Open each control below
+          and compare the open menu width to the dashed parent box.
+        </GoabText>
+      </div>
+
+      <GoabContainer>
+        <div style={stackStyle}>
+          <GoabText tag="h2" mt="none">
+            Dropdown with width="100%"
+          </GoabText>
+          <GoabText>
+            The dropdown should be exactly as wide as the 320px dashed box, both closed and
+            open. Buggy behaviour: the open menu blows past the box.
+          </GoabText>
+        </div>
+
+        <div style={narrowParentStyle}>
+          <GoabDropdown
+            name="bug3763-province-full"
+            placeholder="Select a province"
+            width="100%"
+            value={province}
+            onChange={handleProvinceChange}
+          >
+            <GoabDropdownItem value="alberta" label="Alberta" />
+            <GoabDropdownItem value="british-columbia" label="British Columbia" />
+            <GoabDropdownItem value="manitoba" label="Manitoba" />
+            <GoabDropdownItem value="ontario" label="Ontario" />
+            <GoabDropdownItem value="quebec" label="Quebec" />
+            <GoabDropdownItem
+              value="long"
+              label="Newfoundland and Labrador Provincial Vital Statistics and Records Registration Office"
+            />
+          </GoabDropdown>
+        </div>
+      </GoabContainer>
+
+      <GoabContainer>
+        <div style={stackStyle}>
+          <GoabText tag="h2" mt="none">
+            Dropdown with width="50%"
+          </GoabText>
+          <GoabText>
+            Any percentage triggers the bug, not just 100%. The closed input is half the
+            box; the open menu should match it.
+          </GoabText>
+        </div>
+
+        <div style={narrowParentStyle}>
+          <GoabDropdown
+            name="bug3763-province-half"
+            placeholder="Select a province"
+            width="50%"
+            value={halfProvince}
+            onChange={handleHalfProvinceChange}
+          >
+            <GoabDropdownItem value="alberta" label="Alberta" />
+            <GoabDropdownItem value="british-columbia" label="British Columbia" />
+            <GoabDropdownItem value="manitoba" label="Manitoba" />
+            <GoabDropdownItem value="ontario" label="Ontario" />
+            <GoabDropdownItem value="quebec" label="Quebec" />
+            <GoabDropdownItem
+              value="long"
+              label="Newfoundland and Labrador Provincial Vital Statistics and Records Registration Office"
+            />
+          </GoabDropdown>
+        </div>
+      </GoabContainer>
+
+      <GoabContainer>
+        <div style={stackStyle}>
+          <GoabText tag="h2" mt="none">
+            DatePicker with width="100%"
+          </GoabText>
+          <GoabText>
+            Reported by Vidit: the same percentage-width problem affects the DatePicker.
+            The open calendar should not exceed the box width.
+          </GoabText>
+        </div>
+
+        <div style={narrowParentStyle}>
+          <GoabDatePicker
+            name="bug3763-date"
+            width="100%"
+            value={date}
+            onChange={handleDateChange}
+          />
+        </div>
+      </GoabContainer>
+
+      <GoabContainer>
+        <div style={stackStyle}>
+          <GoabText tag="h2" mt="none">
+            DatePicker with width="50%"
+          </GoabText>
+          <GoabText>
+            Case from Benji: with a narrow percentage the input is much smaller than the
+            calendar's natural width, so the open calendar cannot match the input and
+            overflows the box. Expected: the open calendar should not exceed the maximum
+            width, not shrink to the tiny input.
+          </GoabText>
+        </div>
+
+        <div style={narrowParentStyle}>
+          <GoabDatePicker
+            name="bug3763-date-half"
+            width="50%"
+            value={halfDate}
+            onChange={handleHalfDateChange}
+          />
+        </div>
+      </GoabContainer>
+
+      <GoabContainer>
+        <div style={stackStyle}>
+          <GoabText tag="h2" mt="none">
+            DatePicker with width="100%" in a wide container
+          </GoabText>
+          <GoabText>
+            Opposite case: the input is far wider than the calendar's natural width.
+            Expected: the open calendar stays at its natural width (left aligned under the
+            input), it should not stretch to fill the wide input.
+          </GoabText>
+        </div>
+
+        <div style={wideParentStyle}>
+          <GoabDatePicker
+            name="bug3763-date-wide"
+            width="100%"
+            value={wideDate}
+            onChange={handleWideDateChange}
+          />
+        </div>
+      </GoabContainer>
+
+      <GoabContainer>
+        <div style={stackStyle}>
+          <GoabText tag="h2" mt="none">
+            DatePicker with an invalid width
+          </GoabText>
+          <GoabText>
+            The width "5 0%" (note the stray space) is not a valid CSS dimension. Open the
+            browser console: the DatePicker should log an error explaining the width is
+            invalid, instead of failing silently.
+          </GoabText>
+        </div>
+
+        <div style={narrowParentStyle}>
+          <GoabDatePicker
+            name="bug3763-date-invalid"
+            width="5 0%"
+            value={invalidDate}
+            onChange={handleInvalidDateChange}
+          />
+        </div>
+      </GoabContainer>
+    </div>
+  );
+}
+
+export default Bug3763Route;

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -12,6 +12,7 @@
   import type { Spacing } from "../../common/styling";
   import { toBoolean } from "../../common/utils";
   import { receive, dispatch, relay } from "../../common/utils";
+  import { isValidDimension } from "../../common/validators";
   import {
     FieldsetSetValueMsg,
     FieldsetSetValueRelayDetail,
@@ -82,6 +83,12 @@
     addRelayListener();
     sendMountedMessage();
     showDeprecationWarnings();
+
+    if (width && !isValidDimension(width)) {
+      console.error(
+        "DatePicker width must be a valid CSS dimension (e.g. 50%, 320px, 16ch)",
+      );
+    }
   });
 
   function showDeprecationWarnings() {
@@ -266,7 +273,7 @@
         bind:this={_rootEl}
         tabindex="-1"
         data-testid="calendar-popover"
-        data-content-fits-width="true"
+        fitcontent="true"
         {testid}
         {mt}
         {mb}

--- a/libs/web-components/src/components/dropdown/Dropdown.spec.ts
+++ b/libs/web-components/src/components/dropdown/Dropdown.spec.ts
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
 import GoADropdown from "./Dropdown.svelte";
 import GoADropdownWrapper from "./DropdownWrapper.test.svelte";
-import { describe, it } from "vitest";
+import { describe, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import type { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 
@@ -1186,20 +1186,31 @@ describe("GoADropdown", () => {
         });
       });
 
-      it("should set popover max width to 100% for percentage widths", async () => {
-        const result = render(GoADropdownWrapper, {
-          name: "test",
-          items: ["1", "2", "3"],
-          width: "75%",
-        });
+      it("should set popover width to the measured pixel width for percentage widths", async () => {
+        // A percentage on the top-layer popover would resolve against the viewport
+        // and overflow, so the component measures the rendered width and passes
+        // pixels instead. jsdom has no layout, so stub the rendered width.
+        const rectSpy = vi
+          .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+          .mockReturnValue({ width: 240 } as DOMRect);
 
-        const dropdownIcon = result.container.querySelector("goa-icon");
-        dropdownIcon && (await fireEvent.click(dropdownIcon));
+        try {
+          const result = render(GoADropdownWrapper, {
+            name: "test",
+            items: ["1", "2", "3"],
+            width: "75%",
+          });
 
-        await waitFor(() => {
+          const dropdownIcon = result.container.querySelector("goa-icon");
+          dropdownIcon && (await fireEvent.click(dropdownIcon));
+
           const popover = result.container.querySelector("goa-popover");
-          expect(popover?.getAttribute("width")).toBe("100%");
-        });
+          await waitFor(() => {
+            expect(popover?.getAttribute("width")).toBe("240px");
+          });
+        } finally {
+          rectSpy.mockRestore();
+        }
       });
     });
 

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -28,6 +28,7 @@
     toBoolean,
   } from "../../common/utils";
   import { calculateMargin } from "../../common/styling";
+  import { isValidDimension } from "../../common/validators";
   import {
     FieldsetErrorRelayDetail,
     FieldsetResetErrorsMsg,
@@ -140,6 +141,12 @@
 
   $: calculateWidths(width, _options, _inputEl);
 
+  // Re-measure on open so the popover tracks the current rendered width after
+  // container resizes or layout that settled after mount.
+  $: if (_isMenuVisible && (width?.includes("%") || maxwidth?.includes("%"))) {
+    _popoverMaxWidth = getRenderedWidth();
+  }
+
   // TODO: Syed can you add a comment here describing what this does?
   $: {
     _error = toBoolean(error);
@@ -181,12 +188,11 @@
   ) {
     // Calculate the base width
     if (width) {
-      const unitPattern = /(px|%|ch|rem|em)$/; // Regex to detect valid units
-      if (unitPattern.test(width)) {
+      if (isValidDimension(width)) {
         _width = width; // Use the provided width with a valid unit
       } else {
         console.error(
-          "Dropdown width must be of an allowed unit. Falling back to `px`",
+          "Dropdown width must be a valid CSS dimension (e.g. 50%, 320px, 16ch). Falling back to `px`",
         );
         _width = `${width}px`; // Default to px if no unit is provided
       }
@@ -196,12 +202,17 @@
       _width = getLongestChildWidth(options); // Calculate based on the longest option
     }
 
-    // Set popover max width
     if (width?.includes("%") || maxwidth?.includes("%")) {
-      _popoverMaxWidth = "100%"; // let the parent's % width constraint handle it
+      // cannot use anchor size because chrome/edge < 124, firefox < 146, safari, safari iOS < 26 not supported
+      _popoverMaxWidth = getRenderedWidth();
     } else {
       _popoverMaxWidth = _width;
     }
+  }
+
+  function getRenderedWidth(): string {
+    const renderedWidth = _rootEl?.getBoundingClientRect().width;
+    return renderedWidth ? `${renderedWidth}px` : _width;
   }
 
   function setupPopoverListeners() {

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -63,6 +63,8 @@
   export let borderradius: string = "var(--goa-border-radius-m)";
   /** Indicates the popover is used within a filterable context like a combobox. */
   export let filterablecontext: string = "false";
+  /** @internal When true, the content sizes to its own width (fit-content) capped at maxwidth, instead of stretching to `width`. */
+  export let fitcontent: string = "false";
 
   // Private
   let _rootEl: HTMLElement;
@@ -82,6 +84,7 @@
   $: _disabled = toBoolean(disabled);
   $: _padded = toBoolean(padded);
   $: _filterableContext = toBoolean(filterablecontext);
+  $: _fitContent = toBoolean(fitcontent);
 
   $: syncPopoverOpenState(_popoverEl, open);
 
@@ -445,11 +448,13 @@
     class:use-anchor-based-positioning={!_needsManualPositioning}
     class:align-right={_alignment === "right"}
     style={styles(
-      position !== "right" && style("width", width),
+      position !== "right" && !_fitContent && style("width", width),
       style("min-width", minwidth),
       style(
         "max-width",
-        position !== "right" && width ? `max(${width}, ${maxwidth})` : maxwidth,
+        position !== "right" && width && !_fitContent
+          ? `max(${width}, ${maxwidth})`
+          : maxwidth,
       ),
       style("padding", _padded ? "var(--goa-space-m)" : "0"),
     )}


### PR DESCRIPTION
# Before (the change)
<img width="1391" height="480" alt="image" src="https://github.com/user-attachments/assets/70100889-93d3-4101-8ae7-59752b9729ad" />

# After (the change)

<img width="1305" height="872" alt="image" src="https://github.com/user-attachments/assets/9f5dc142-9442-42e3-82c8-90021f648f47" />


## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test
Angular link: https://govalta.github.io/ui-components/pr-preview-angular/pr-4029/bugs/3763
React link: https://govalta.github.io/ui-components/pr-preview-react/pr-4029/bugs/3763 