### PR TITLE
fix(#4030): Footer copyright text

### DIFF
--- a/apps/prs/angular/src/routes/bugs/4030/bug4030.component.html
+++ b/apps/prs/angular/src/routes/bugs/4030/bug4030.component.html
@@ -4,4 +4,4 @@
   The "This is a Government of Alberta Digital Service" span and "GoA" abbreviation should both be removed.
 </goab-text>
 
-<goab-app-footer version="2" />
+<goab-app-footer />

--- a/apps/prs/angular/src/routes/bugs/4030/bug4030.component.html
+++ b/apps/prs/angular/src/routes/bugs/4030/bug4030.component.html
@@ -1,0 +1,7 @@
+<goab-text tag="h1" mt="m" mb="s">Bug 4030 - Footer: copyright text</goab-text>
+<goab-text mb="l">
+  The V2 footer should show a single span "© 2026 Government of Alberta".
+  The "This is a Government of Alberta Digital Service" span and "GoA" abbreviation should both be removed.
+</goab-text>
+
+<goab-app-footer version="2" />

--- a/apps/prs/angular/src/routes/bugs/4030/bug4030.component.ts
+++ b/apps/prs/angular/src/routes/bugs/4030/bug4030.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabAppFooter, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug4030",
+  templateUrl: "./bug4030.component.html",
+  imports: [GoabAppFooter, GoabText],
+})
+export class Bug4030Component {}

--- a/apps/prs/angular/src/routes/bugs/4030/bug4030.route.json
+++ b/apps/prs/angular/src/routes/bugs/4030/bug4030.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "4030",
+  "path": "bugs/4030",
+  "title": "Footer copyright text"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug4030.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug4030.route.ts
@@ -1,0 +1,10 @@
+import { Bug4030Route } from "../../../routes/bugs/bug4030";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "4030",
+  path: "bugs/4030",
+  title: "Footer copyright text",
+  component: Bug4030Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug4030.tsx
+++ b/apps/prs/react/src/routes/bugs/bug4030.tsx
@@ -12,7 +12,7 @@ export function Bug4030Route() {
         should both be removed.
       </GoabText>
 
-      <GoabAppFooter version="2" />
+      <GoabAppFooter />
     </div>
   );
 }

--- a/apps/prs/react/src/routes/bugs/bug4030.tsx
+++ b/apps/prs/react/src/routes/bugs/bug4030.tsx
@@ -1,0 +1,20 @@
+import { GoabAppFooter, GoabText } from "@abgov/react-components";
+
+export function Bug4030Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m" mb="m">
+        Bug #4030: Footer copyright text
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        The V2 footer should show a single span "© 2026 Government of Alberta". The
+        "This is a Government of Alberta Digital Service" span and the "GoA" abbreviation
+        should both be removed.
+      </GoabText>
+
+      <GoabAppFooter version="2" />
+    </div>
+  );
+}
+
+export default Bug4030Route;

--- a/libs/web-components/src/components/footer/Footer.svelte
+++ b/libs/web-components/src/components/footer/Footer.svelte
@@ -85,8 +85,7 @@
             © {year} Government of Alberta
           </a>
         {:else if version === "2"}
-          <span>This is a Government of Alberta Digital Service</span>
-          <span class="goa-copyright">© {year} GoA</span>
+          <span class="goa-copyright">© {year} Government of Alberta</span>
         {/if}
       </div>
     </div>


### PR DESCRIPTION
## Description

Fixes #4030

The V2 footer bar rendered two spans: "This is a Government of Alberta Digital Service" and "© 2026 GoA". Communications confirmed "GoA" is an internal abbreviation, not a legal name. This PR simplifies the footer bar to a single span reading "© {year} Government of Alberta".

## Changes

- Removed the "This is a Government of Alberta Digital Service" span from the V2 footer.
- Replaced `© {year} GoA` with `© {year} Government of Alberta`, keeping the existing `goa-copyright` class.
- CSS-only adjacent layout: no React or Angular wrapper changes needed.

## Before / After

**Before:** Two spans: "This is a Government of Alberta Digital Service" + "© 2026 GoA"

**After:** Single span: "© 2026 Government of Alberta"

## Steps to test

1. Run `npm run serve:prs:react` and navigate to http://localhost:4201/bugs/4030.
2. Confirm the footer bar shows only "© 2026 Government of Alberta".
3. Confirm "This is a Government of Alberta Digital Service" is no longer present.
4. Confirm "GoA" no longer appears anywhere in the footer bar.

- [x] Setup steps read
- [x] Playground page created (React + Angular)
- [x] Tested in React playground