### PR TITLE
fix(#3837): prevent tab label horizontal shift on selection change

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3837/bug3837.component.html
+++ b/apps/prs/angular/src/routes/bugs/3837/bug3837.component.html
@@ -1,0 +1,19 @@
+<goab-text tag="h1" mt="m" mb="s">Bug 3837 - Tabs: label should not shift horizontally when selection changes</goab-text>
+<goab-text mb="m">
+  Click between tabs and observe that labels do not shift horizontally. The active tab bold treatment should be preserved.
+</goab-text>
+
+<goab-text tag="h3">Test 1: Default variant</goab-text>
+<goab-tabs>
+  <goab-tab heading="Short">Short tab content</goab-tab>
+  <goab-tab heading="Much longer label">Longer tab content</goab-tab>
+  <goab-tab heading="Medium label">Medium tab content</goab-tab>
+  <goab-tab heading="Another tab">Another tab content</goab-tab>
+</goab-tabs>
+
+<goab-text tag="h3">Test 2: Similar-length labels</goab-text>
+<goab-tabs>
+  <goab-tab heading="Information">Information content</goab-tab>
+  <goab-tab heading="Documents">Documents content</goab-tab>
+  <goab-tab heading="History">History content</goab-tab>
+</goab-tabs>

--- a/apps/prs/angular/src/routes/bugs/3837/bug3837.component.html
+++ b/apps/prs/angular/src/routes/bugs/3837/bug3837.component.html
@@ -3,7 +3,7 @@
   Click between tabs and observe that labels do not shift horizontally. The active tab bold treatment should be preserved.
 </goab-text>
 
-<goab-text tag="h3">Test 1: Default variant</goab-text>
+<goab-text tag="h3">Test 1: String headings (default)</goab-text>
 <goab-tabs>
   <goab-tab heading="Short">Short tab content</goab-tab>
   <goab-tab heading="Much longer label">Longer tab content</goab-tab>
@@ -11,9 +11,26 @@
   <goab-tab heading="Another tab">Another tab content</goab-tab>
 </goab-tabs>
 
-<goab-text tag="h3">Test 2: Similar-length labels</goab-text>
+<goab-text tag="h3">Test 2: Similar-length string headings</goab-text>
 <goab-tabs>
   <goab-tab heading="Information">Information content</goab-tab>
   <goab-tab heading="Documents">Documents content</goab-tab>
   <goab-tab heading="History">History content</goab-tab>
+</goab-tabs>
+
+<goab-text tag="h3">Test 3: Slot headings</goab-text>
+<goab-text mb="m">Tabs using the heading slot rather than a string prop. Verify no shift occurs.</goab-text>
+<goab-tabs>
+  <goab-tab>
+    <span slot="heading">Short</span>
+    Short tab content
+  </goab-tab>
+  <goab-tab>
+    <span slot="heading">Much longer label</span>
+    Longer tab content
+  </goab-tab>
+  <goab-tab>
+    <span slot="heading">Medium label</span>
+    Medium tab content
+  </goab-tab>
 </goab-tabs>

--- a/apps/prs/angular/src/routes/bugs/3837/bug3837.component.html
+++ b/apps/prs/angular/src/routes/bugs/3837/bug3837.component.html
@@ -34,3 +34,20 @@
     Medium tab content
   </goab-tab>
 </goab-tabs>
+
+<goab-text tag="h3">Test 4: Slot headings with badge</goab-text>
+<goab-text mb="m">Tabs with a badge alongside the label text in the slot. The ghost text only reserves space for the text portion, so a small shift may still occur here.</goab-text>
+<goab-tabs>
+  <goab-tab>
+    <span slot="heading">Notifications <goab-badge type="information" content="3" /></span>
+    Notifications content
+  </goab-tab>
+  <goab-tab>
+    <span slot="heading">Much longer label <goab-badge type="important" content="12" /></span>
+    Longer tab content
+  </goab-tab>
+  <goab-tab>
+    <span slot="heading">History</span>
+    History content
+  </goab-tab>
+</goab-tabs>

--- a/apps/prs/angular/src/routes/bugs/3837/bug3837.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3837/bug3837.component.ts
@@ -1,10 +1,10 @@
 import { Component } from "@angular/core";
-import { GoabTab, GoabTabs, GoabText } from "@abgov/angular-components";
+import { GoabBadge, GoabTab, GoabTabs, GoabText } from "@abgov/angular-components";
 
 @Component({
   standalone: true,
   selector: "abgov-bug3837",
   templateUrl: "./bug3837.component.html",
-  imports: [GoabTab, GoabTabs, GoabText],
+  imports: [GoabBadge, GoabTab, GoabTabs, GoabText],
 })
 export class Bug3837Component {}

--- a/apps/prs/angular/src/routes/bugs/3837/bug3837.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3837/bug3837.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabTab, GoabTabs, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3837",
+  templateUrl: "./bug3837.component.html",
+  imports: [GoabTab, GoabTabs, GoabText],
+})
+export class Bug3837Component {}

--- a/apps/prs/angular/src/routes/bugs/3837/bug3837.route.json
+++ b/apps/prs/angular/src/routes/bugs/3837/bug3837.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3837",
+  "path": "bugs/3837",
+  "title": "Tabs label shift on selection"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3837.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3837.route.ts
@@ -1,0 +1,10 @@
+import { Bug3837Route } from "../../../routes/bugs/bug3837";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3837",
+  path: "bugs/3837",
+  title: "Tabs label shift on selection",
+  component: Bug3837Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3837.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3837.tsx
@@ -35,12 +35,12 @@ export function Bug3837Route() {
 
       <GoabText tag="h2">Test Cases</GoabText>
 
-      <GoabText tag="h3">Test 1: V2 tabs (default variant)</GoabText>
+      <GoabText tag="h3">Test 1: String headings (default)</GoabText>
       <GoabText tag="p">
         Click between tabs and observe that the labels do not shift position. The active tab bold
         treatment should be preserved.
       </GoabText>
-      <GoabTabs version="2">
+      <GoabTabs>
         <GoabTab heading="Short">
           <GoabText tag="p">Short tab content</GoabText>
         </GoabTab>
@@ -55,12 +55,12 @@ export function Bug3837Route() {
         </GoabTab>
       </GoabTabs>
 
-      <GoabText tag="h3">Test 2: V2 tabs with similar-length labels</GoabText>
+      <GoabText tag="h3">Test 2: Similar-length string headings</GoabText>
       <GoabText tag="p">
         All tabs have similar-length labels to make any shift more visible. Verify no horizontal
         movement when switching tabs.
       </GoabText>
-      <GoabTabs version="2">
+      <GoabTabs>
         <GoabTab heading="Information">
           <GoabText tag="p">Information content</GoabText>
         </GoabTab>
@@ -72,19 +72,19 @@ export function Bug3837Route() {
         </GoabTab>
       </GoabTabs>
 
-      <GoabText tag="h3">Test 3: V1 tabs (should be unaffected)</GoabText>
+      <GoabText tag="h3">Test 3: Slot headings</GoabText>
       <GoabText tag="p">
-        V1 tabs are out of scope for this fix. Verify they still render correctly.
+        Tabs using the heading slot (ReactNode) rather than a string prop. Verify no shift occurs.
       </GoabText>
       <GoabTabs>
-        <GoabTab heading="Tab One">
-          <GoabText tag="p">Tab One content</GoabText>
+        <GoabTab heading={<span>Short</span>}>
+          <GoabText tag="p">Short tab content</GoabText>
         </GoabTab>
-        <GoabTab heading="Tab Two">
-          <GoabText tag="p">Tab Two content</GoabText>
+        <GoabTab heading={<span>Much longer label</span>}>
+          <GoabText tag="p">Longer tab content</GoabText>
         </GoabTab>
-        <GoabTab heading="Tab Three">
-          <GoabText tag="p">Tab Three content</GoabText>
+        <GoabTab heading={<span>Medium label</span>}>
+          <GoabText tag="p">Medium tab content</GoabText>
         </GoabTab>
       </GoabTabs>
     </div>

--- a/apps/prs/react/src/routes/bugs/bug3837.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3837.tsx
@@ -1,0 +1,94 @@
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabDetails,
+  GoabLink,
+  GoabTabs,
+  GoabTab,
+} from "@abgov/react-components";
+
+export function Bug3837Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug #3837: Tabs label should not shift horizontally when selection changes
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a href="https://github.com/GovAlta/ui-components/issues/3837" target="_blank" rel="noopener">
+            View on GitHub
+          </a>
+        </GoabLink>
+
+        <GoabDetails heading="Issue Description">
+          <GoabText tag="p">
+            When switching between tabs, the tab labels shift horizontally. This is caused by a bold
+            font weight being applied to the active tab, causing the text to take up more space and
+            nudging adjacent tabs out of position.
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      <GoabText tag="h3">Test 1: V2 tabs (default variant)</GoabText>
+      <GoabText tag="p">
+        Click between tabs and observe that the labels do not shift position. The active tab bold
+        treatment should be preserved.
+      </GoabText>
+      <GoabTabs version="2">
+        <GoabTab heading="Short">
+          <GoabText tag="p">Short tab content</GoabText>
+        </GoabTab>
+        <GoabTab heading="Much longer label">
+          <GoabText tag="p">Longer tab content</GoabText>
+        </GoabTab>
+        <GoabTab heading="Medium label">
+          <GoabText tag="p">Medium tab content</GoabText>
+        </GoabTab>
+        <GoabTab heading="Another tab">
+          <GoabText tag="p">Another tab content</GoabText>
+        </GoabTab>
+      </GoabTabs>
+
+      <GoabText tag="h3">Test 2: V2 tabs with similar-length labels</GoabText>
+      <GoabText tag="p">
+        All tabs have similar-length labels to make any shift more visible. Verify no horizontal
+        movement when switching tabs.
+      </GoabText>
+      <GoabTabs version="2">
+        <GoabTab heading="Information">
+          <GoabText tag="p">Information content</GoabText>
+        </GoabTab>
+        <GoabTab heading="Documents">
+          <GoabText tag="p">Documents content</GoabText>
+        </GoabTab>
+        <GoabTab heading="History">
+          <GoabText tag="p">History content</GoabText>
+        </GoabTab>
+      </GoabTabs>
+
+      <GoabText tag="h3">Test 3: V1 tabs (should be unaffected)</GoabText>
+      <GoabText tag="p">
+        V1 tabs are out of scope for this fix. Verify they still render correctly.
+      </GoabText>
+      <GoabTabs>
+        <GoabTab heading="Tab One">
+          <GoabText tag="p">Tab One content</GoabText>
+        </GoabTab>
+        <GoabTab heading="Tab Two">
+          <GoabText tag="p">Tab Two content</GoabText>
+        </GoabTab>
+        <GoabTab heading="Tab Three">
+          <GoabText tag="p">Tab Three content</GoabText>
+        </GoabTab>
+      </GoabTabs>
+    </div>
+  );
+}
+
+export default Bug3837Route;

--- a/apps/prs/react/src/routes/bugs/bug3837.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3837.tsx
@@ -6,6 +6,7 @@ import {
   GoabLink,
   GoabTabs,
   GoabTab,
+  GoabBadge,
 } from "@abgov/react-components";
 
 export function Bug3837Route() {
@@ -72,7 +73,7 @@ export function Bug3837Route() {
         </GoabTab>
       </GoabTabs>
 
-      <GoabText tag="h3">Test 3: Slot headings</GoabText>
+      <GoabText tag="h3">Test 3: Slot headings (text only)</GoabText>
       <GoabText tag="p">
         Tabs using the heading slot (ReactNode) rather than a string prop. Verify no shift occurs.
       </GoabText>
@@ -85,6 +86,23 @@ export function Bug3837Route() {
         </GoabTab>
         <GoabTab heading={<span>Medium label</span>}>
           <GoabText tag="p">Medium tab content</GoabText>
+        </GoabTab>
+      </GoabTabs>
+
+      <GoabText tag="h3">Test 4: Slot headings with badge</GoabText>
+      <GoabText tag="p">
+        Tabs with a badge alongside the label text in the slot. The ghost text only reserves space
+        for the text portion, so a small shift may still occur here.
+      </GoabText>
+      <GoabTabs>
+        <GoabTab heading={<>Notifications <GoabBadge type="information" content="3" /></>}>
+          <GoabText tag="p">Notifications content</GoabText>
+        </GoabTab>
+        <GoabTab heading={<>Much longer label <GoabBadge type="important" content="12" /></>}>
+          <GoabText tag="p">Longer tab content</GoabText>
+        </GoabTab>
+        <GoabTab heading={<>History</>}>
+          <GoabText tag="p">History content</GoabText>
         </GoabTab>
       </GoabTabs>
     </div>

--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -208,7 +208,7 @@
       link.setAttribute("aria-controls", `tabpanel-${index + 1}`);
 
       // Store text content for CSS pseudo-element (prevents layout shift when font-weight changes)
-      if (variant === "segmented") {
+      if (variant === "segmented" || version === "2") {
         const textContent = headingEl.textContent?.trim() || "";
         if (textContent) {
           link.setAttribute("data-text", textContent);
@@ -763,6 +763,19 @@
         6px 6px 0 0
       );
     }
+  }
+
+  /* Prevent layout shift when bold font is applied to selected tab */
+  .v2:not(.segmented) :global([role="tab"][data-text]) {
+    flex-direction: column;
+  }
+
+  .v2:not(.segmented) :global([role="tab"][data-text]::before) {
+    content: attr(data-text);
+    font: var(--goa-tab-typography-selected);
+    height: 0;
+    visibility: hidden;
+    overflow: hidden;
   }
 
   /* ========================================


### PR DESCRIPTION
## Summary

- Extends the existing ghost text technique (already used by the segmented variant) to V2 default tabs
- Sets `data-text` on tab links when `version === "2"`, then uses a `::before` pseudo-element at bold weight with `height: 0; visibility: hidden; overflow: hidden` to pre-reserve the bold text width
- No changes to React or Angular wrappers. CSS-only fix in the Svelte component

## Before / After

**Before:** Switching tabs causes a ~3px horizontal shift in adjacent tab labels as the selected tab grows to accommodate bold text.

**After:** All tab labels stay at the same position. The bold treatment on the active tab is preserved.

## Known limitation

Slot headings that mix text and a badge (or other inline element) may still exhibit a small shift. The ghost text only captures the text content of the heading, not the full slot width. This is documented in Test 4 of the playground page.

## Steps to test

1. `npm run serve:prs:react`
2. Navigate to **Bugs > 3837 Tabs label shift on selection**
3. Click between tabs in each test case and verify labels do not shift
4. Repeat in the Angular playground: `npm run serve:prs:angular`

- [x] Setup steps read
- [x] Unit tests pass (`npx vitest run libs/web-components/src/components/tabs/`)
- [x] Tested in React playground
- [x] Angular playground page included

Fixes #3837