### PR TITLE
chore(#4038): add CI gate to keep generated docs files in sync

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -113,7 +113,9 @@ jobs:
             echo "source and are overwritten on regeneration, so don't hand-edit these files."
             echo ""
             git status --short -- "${outputs[@]}"
+            git add --intent-to-add -- "${outputs[@]}"
             git diff --stat -- "${outputs[@]}"
+            git diff -- "${outputs[@]}"
             exit 1
           fi
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,3 +55,66 @@ jobs:
           if [ -d "./dist" ]; then
             npm run test:pr
           fi
+
+  docs-freshness:
+    name: Docs Freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    env:
+      # The generators don't need browsers; skip the Playwright download in npm ci.
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            docs/package-lock.json
+
+      - name: Install npm 11
+        run: npm install -g npm@11
+
+      - run: npm ci
+
+      - name: Check committed docs generated files match source
+        shell: bash
+        run: |
+          # Regenerate the docs outputs from source. npm ci ran the root postinstall
+          # (npm install --prefix docs), so tsx and the docs deps are available here.
+          ( cd docs && npm run extract-api && npm run build:search-index )
+
+          # The committed generated files are the single source of truth for the docs
+          # build, so fail if regeneration changed a tracked file (drift) or produced a
+          # new untracked one (a component whose JSON was never committed). This mirrors
+          # the .githooks/pre-commit check so local and CI tell the same story.
+          outputs=(docs/generated/component-apis docs/public/search-index.json)
+          stale=0
+          if ! git diff --quiet -- "${outputs[@]}"; then stale=1; fi
+          if [ -n "$(git ls-files --others --exclude-standard -- "${outputs[@]}")" ]; then stale=1; fi
+
+          if [ "$stale" -ne 0 ]; then
+            echo "::error::Generated docs files are out of date."
+            echo "The committed files do not match what the generators produce from source."
+            echo ""
+            echo "To fix, from the repo root run:"
+            echo "    npm install"
+            echo "    cd docs && npm run extract-api && npm run build:search-index"
+            echo "then commit the updated files under:"
+            echo "    docs/generated/component-apis/   docs/public/search-index.json"
+            echo ""
+            echo "Note: extracted fields (types, JSDoc descriptions) come from the component"
+            echo "source and are overwritten on regeneration, so don't hand-edit these files."
+            echo ""
+            git status --short -- "${outputs[@]}"
+            git diff --stat -- "${outputs[@]}"
+            exit 1
+          fi
+
+          echo "Generated docs files are up to date."

--- a/docs/src/scripts/extract-api.ts
+++ b/docs/src/scripts/extract-api.ts
@@ -2411,6 +2411,12 @@ function main() {
   console.log("\n" + "═".repeat(50));
   console.log(`Complete: ${successCount} succeeded, ${failCount} failed`);
   console.log(`Output: ${OUTPUT_PATH}\n`);
+
+  // Exit non-zero if any component failed to extract. Without this the process
+  // exits 0 on partial failure, leaving the failed component's committed JSON
+  // untouched, which the docs freshness check (and the pre-commit hook) would
+  // then see as a clean, in-sync diff while extraction is actually broken.
+  process.exitCode = failCount > 0 ? 1 : 0;
 }
 
 main();


### PR DESCRIPTION
## What

Adds a "Docs Freshness" check to the PR workflow. On every PR it regenerates the docs API files and search index from source and fails if the committed files don't match. It's the CI counterpart to the pre-commit hook from #3980, so local and CI enforce the same thing and what you review is what the docs site ships.

It also makes extract-api exit non-zero when a component fails to extract. Without that, a failed extraction leaves the old committed JSON untouched, so the check (and the hook, and the build) would pass while extraction is actually broken.

## Why

The docs build used to regenerate these files during the build, so the deployed site stayed fresh while the committed files could quietly drift. The hook gives fast local feedback; this check is the unskippable backstop. Together they make the committed files the single source of truth. Removing the build-time regeneration is a small separate follow-up, held until this check is green and required.

## Testing

Locally against dev: passes on clean dev, fails on a stale committed output, fails on a new untracked output (a component whose JSON was never committed), and fails when a component can't extract. Generators sort their output, so no cross-machine false-fails. actionlint clean.

Closes #4038
