### PR TITLE
fix(#3665): prevent page jump when switching tabs

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3665/bug3665.component.html
+++ b/apps/prs/angular/src/routes/bugs/3665/bug3665.component.html
@@ -1,0 +1,30 @@
+<goab-text tag="h1" mt="m" mb="m">Bug 3665 - Tabs: page jumps when switching tabs</goab-text>
+<goab-text mb="l">
+  Switching tabs should not move the viewport. Previously setCurrentTab() called el.focus()
+  on the selected tab, which triggered the browser's scroll-into-view behavior and jumped the
+  page. Scroll down so the tabs are partially visible, then switch the framework tab. The page
+  should now stay in place.
+</goab-text>
+
+<!-- Tall spacer so the tabs sit below the fold and a jump would be obvious. -->
+<div style="height: 80vh; display: flex; align-items: flex-end;">
+  <goab-text>Scroll down to the tabs below.</goab-text>
+</div>
+
+<goab-tabs>
+  <goab-tab heading="React">
+    <div style="height: 60vh;">
+      <goab-text>React content. Switch to Angular or Web Components.</goab-text>
+    </div>
+  </goab-tab>
+  <goab-tab heading="Angular">
+    <div style="height: 60vh;">
+      <goab-text>Angular content. The page should not jump.</goab-text>
+    </div>
+  </goab-tab>
+  <goab-tab heading="Web Components">
+    <div style="height: 60vh;">
+      <goab-text>Web Components content. The page should not jump.</goab-text>
+    </div>
+  </goab-tab>
+</goab-tabs>

--- a/apps/prs/angular/src/routes/bugs/3665/bug3665.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3665/bug3665.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabTab, GoabTabs, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3665",
+  templateUrl: "./bug3665.component.html",
+  imports: [GoabTab, GoabTabs, GoabText],
+})
+export class Bug3665Component {}

--- a/apps/prs/angular/src/routes/bugs/3665/bug3665.route.json
+++ b/apps/prs/angular/src/routes/bugs/3665/bug3665.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3665",
+  "path": "bugs/3665",
+  "title": "Tabs page jump on switch"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3665.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3665.route.ts
@@ -1,0 +1,10 @@
+import { Bug3665Route } from "../../../routes/bugs/bug3665";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3665",
+  path: "bugs/3665",
+  title: "Tabs page jump on switch",
+  component: Bug3665Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3665.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3665.tsx
@@ -1,0 +1,49 @@
+import { GoabTab, GoabTabs, GoabText } from "@abgov/react-components";
+
+export function Bug3665Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m" mb="m">
+        Bug #3665: Tabs page jumps when switching tabs
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        Switching tabs should not move the viewport. Previously, setCurrentTab() called
+        el.focus() on the selected tab, which triggered the browser's scroll-into-view
+        behavior and jumped the page. To reproduce the old behavior: scroll down so the
+        tabs are partially visible, then switch the framework tab. The page should now
+        stay in place.
+      </GoabText>
+
+      {/* Tall spacer so the tabs sit below the fold and a jump would be obvious. */}
+      <div
+        style={{
+          height: "80vh",
+          display: "flex",
+          alignItems: "flex-end",
+        }}
+      >
+        <GoabText tag="p">Scroll down to the tabs below.</GoabText>
+      </div>
+
+      <GoabTabs>
+        <GoabTab heading="React">
+          <div style={{ height: "60vh" }}>
+            <GoabText tag="p">React content. Switch to Angular or Web Components.</GoabText>
+          </div>
+        </GoabTab>
+        <GoabTab heading="Angular">
+          <div style={{ height: "60vh" }}>
+            <GoabText tag="p">Angular content. The page should not jump.</GoabText>
+          </div>
+        </GoabTab>
+        <GoabTab heading="Web Components">
+          <div style={{ height: "60vh" }}>
+            <GoabText tag="p">Web Components content. The page should not jump.</GoabText>
+          </div>
+        </GoabTab>
+      </GoabTabs>
+    </div>
+  );
+}
+
+export default Bug3665Route;

--- a/libs/react-components/specs/tabs.browser.spec.tsx
+++ b/libs/react-components/specs/tabs.browser.spec.tsx
@@ -812,4 +812,55 @@ describe("Tabs Browser Tests", () => {
       expect(borderLeft).toBe("none");
     });
   });
+
+  // Placed last: this test scrolls the shared page far down to exercise the
+  // scroll-jump fix. Earlier tests rely on history/popstate timing that this
+  // scrolling perturbs, so keep it after them to avoid cross-test interference.
+  describe("bug-3665", () => {
+    it("should not change scroll position when switching tabs", async () => {
+      /**
+       * setCurrentTab() focused the selected tab, which triggered the browser's
+       * scroll-into-view and jumped the page. The fix passes { preventScroll: true }.
+       * With tall content above and below and the tabs only just in view, clicking a
+       * tab must leave window.scrollY unchanged.
+       */
+      const Component = () => {
+        return (
+          <>
+            <div style={{ height: "2000px" }}>Tall content above tabs</div>
+            <GoabTabs testId="test-tabs">
+              <GoabTab heading="Tab 1">Content 1</GoabTab>
+              <GoabTab heading="Tab 2">Content 2</GoabTab>
+            </GoabTabs>
+            <div style={{ height: "2000px" }}>Tall content below tabs</div>
+          </>
+        );
+      };
+
+      const { getByRole } = render(<Component />);
+      const tablist = getByRole("tab");
+
+      await vi.waitFor(() => {
+        expect(tablist.elements().length).toBe(2);
+      });
+
+      const tabs = tablist.elements();
+
+      // Scroll so the tab row sits just inside the bottom of the viewport.
+      const tabAbsoluteTop = tabs[0].getBoundingClientRect().top + window.scrollY;
+      window.scrollTo(0, tabAbsoluteTop - window.innerHeight + 30);
+
+      const scrollBeforeClick = window.scrollY;
+      expect(scrollBeforeClick).toBeGreaterThan(0);
+
+      // Switch tabs (native click does not auto-scroll the element into view).
+      tabs[1].click();
+
+      await vi.waitFor(() => {
+        expect(tabs[1].getAttribute("aria-selected")).toBe("true");
+      });
+
+      expect(window.scrollY).toBe(scrollBeforeClick);
+    });
+  });
 });

--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -351,7 +351,7 @@
       if (isCurrent) {
         currentLocation = (el as HTMLLinkElement).href;
         if (!skipFocus) {
-          el.focus();
+          el.focus({ preventScroll: true });
         }
       }
     });

--- a/libs/web-components/src/components/tabs/tabs.spec.ts
+++ b/libs/web-components/src/components/tabs/tabs.spec.ts
@@ -109,6 +109,24 @@ describe("Tabs", () => {
     });
   });
 
+  it("should focus the selected tab with preventScroll to avoid page jump", async () => {
+    const { container } = render(Tabs);
+
+    const tab2Link = (await waitFor(() => {
+      const link = container.querySelector("a#tab-2") as HTMLElement;
+      expect(link).toBeTruthy();
+      return link;
+    })) as HTMLElement;
+
+    const focusSpy = vi.spyOn(tab2Link, "focus");
+
+    await fireEvent.click(tab2Link);
+
+    await waitFor(() => {
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+  });
+
   it("should select the last tab if the tab exceeds the number of tabs", async () => {
     const result = render(Tabs, { initialtab: 3 });
 


### PR DESCRIPTION
# Before (the change)

Switching tabs moved the viewport. `setCurrentTab()` in `Tabs.svelte` called `el.focus()` on the selected tab, which triggers the browser's default scroll-into-view behavior. On the docs site this is especially noticeable with the framework switcher tabs: switching React / Angular / Web Components while reading code jumped the page.

# After (the change)

`el.focus({ preventScroll: true })` keeps focus on the selected tab for keyboard accessibility, but the browser no longer scrolls the tab into view. The viewport stays put when switching tabs.

One line change in the Svelte source. No prop, event, or type changes, so the React and Angular wrappers did not need updates.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the setup steps
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Run the React playground: `npm run serve:prs:react`
2. Go to `/bugs/3665`
3. Scroll down so the framework tabs are partially in view
4. Switch between React / Angular / Web Components
5. The page should stay in place (no jump). The tab content should still update.
6. Repeat in the Angular playground: `npm run serve:prs:angular`, then `/bugs/3665`

Fixes #3665
