### PR TITLE
chore: collapse generated docs files in PR diffs (linguist-generated)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Generated docs files: collapse by default in GitHub PR diffs (linguist-generated).
+# Deterministic build outputs (see docs/ARCHITECTURE.md). They stay fully diffable,
+# searchable, and in history; this only hides them by default in the Files Changed tab.
+docs/generated/** linguist-generated=true
+docs/public/search-index.json linguist-generated=true


### PR DESCRIPTION
## What this does
Marks the committed generated docs files as `linguist-generated` so GitHub collapses them by default in the Files Changed tab. They stay fully diffable, searchable, and in history. They're just hidden behind a one-click expand so real changes are easier to spot in review.

Two entries in a new `.gitattributes`:
- `docs/generated/** linguist-generated=true`: covers the committed component API JSON today, plus any future generator that commits output under `docs/generated/`.
- `docs/public/search-index.json linguist-generated=true`: the search index, which lives outside `docs/generated/`.

## Scope
Display metadata only. No merge-driver or text/eol attributes. The merge driver stays parked until parallel PRs actually start conflicting on these files.

## When you'll see it
GitHub applies `linguist-generated` from the repo's default branch (`dev`), so it takes effect once this merges. You won't see any collapse on this PR; it shows up on later PRs whose diffs include a generated file. This PR just adds the rule.
