### PR TITLE
docs(#3742): add breakpoints to layout documentation

### DIFF
--- a/docs/src/pages/foundations/style-guide/layout.astro
+++ b/docs/src/pages/foundations/style-guide/layout.astro
@@ -52,6 +52,66 @@ import FoundationsSupportCallout from "../../../components/FoundationsSupportCal
 
   <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
 
+  <h2 id="design-for-responsiveness">Design for responsiveness</h2>
+  <goa-text size="body-m" mt="none" mb="m">
+    Layouts should adapt across screen sizes without losing clarity.
+  </goa-text>
+
+  <h3 id="breakpoints">Breakpoints</h3>
+  <goa-text size="body-m" mt="none" mb="m">
+    Most GoA components handle responsive behaviour internally. Many components use
+    container queries rather than viewport media queries, so they respond to the size of
+    their container rather than the size of the window. A component placed in a narrow
+    sidebar adapts to that sidebar even on a wide screen.
+  </goa-text>
+  <goa-text size="body-m" mt="none" mb="m">
+    When you do need to think about screen size explicitly, the Design System uses 3
+    breakpoints:
+  </goa-text>
+  <goa-text size="body-m" mt="none" mb="m">
+    <ul>
+      <li><strong>Mobile:</strong> under 624px. Phones and small devices.</li>
+      <li><strong>Tablet:</strong> 624px to 1023px. Tablets and medium devices.</li>
+      <li><strong>Desktop:</strong> 1024px and above. Desktop and larger screens.</li>
+    </ul>
+  </goa-text>
+  <goa-text size="body-m" mt="none" mb="m">
+    These align with how the components adapt, so custom layouts built around GoA
+    components work together at the same breakpoints. On mobile in particular:
+  </goa-text>
+  <goa-text size="body-m" mt="none" mb="m">
+    <ul>
+      <li>Buttons go full-width by default, and can be overridden</li>
+      <li>Form layouts stack labels above inputs</li>
+      <li>Navigation collapses</li>
+      <li>Block direction switches to column regardless of the direction prop</li>
+    </ul>
+  </goa-text>
+
+  <h3 id="public-form-considerations">Public form considerations</h3>
+  <goa-text size="body-m" mt="none" mb="m">
+    <ul>
+      <li>Use a single-column layout to support a clear reading flow</li>
+      <li>Keep the main task and primary actions in a predictable location</li>
+      <li>Avoid adding secondary regions that compete for attention</li>
+    </ul>
+  </goa-text>
+
+  <h3 id="workspace-considerations">Workspace considerations</h3>
+  <goa-text size="body-m" mt="none" mb="m">
+    <ul>
+      <li>Keep the main content area as the focus</li>
+      <li>
+        Let supporting panels and secondary regions move below or hide as space becomes
+        limited
+      </li>
+      <li>Ensure secondary content is still easy to access</li>
+      <li>Maintain a clear and predictable page structure across screen sizes</li>
+    </ul>
+  </goa-text>
+
+  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
+
   <h2 id="service-type">Service type</h2>
   <goa-text size="body-m" mt="none" mb="m">
     Choose a layout that matches the type of service you are building.
@@ -190,35 +250,6 @@ import FoundationsSupportCallout from "../../../components/FoundationsSupportCal
       <li>Use spacing tokens to add consistent space throughout the interface</li>
       <li>Use a single-column layout when it supports the task</li>
       <li>Start with an existing template before creating a custom structure</li>
-    </ul>
-  </goa-text>
-
-  <goa-divider version="2" mt="xl" mb="xl"></goa-divider>
-
-  <h2 id="design-for-responsiveness">Design for responsiveness</h2>
-  <goa-text size="body-m" mt="none" mb="m">
-    Layouts should adapt across screen sizes without losing clarity.
-  </goa-text>
-
-  <h3 id="public-form-considerations">Public form considerations</h3>
-  <goa-text size="body-m" mt="none" mb="m">
-    <ul>
-      <li>Use a single-column layout to support a clear reading flow</li>
-      <li>Keep the main task and primary actions in a predictable location</li>
-      <li>Avoid adding secondary regions that compete for attention</li>
-    </ul>
-  </goa-text>
-
-  <h3 id="workspace-considerations">Workspace considerations</h3>
-  <goa-text size="body-m" mt="none" mb="none">
-    <ul>
-      <li>Keep the main content area as the focus</li>
-      <li>
-        Let supporting panels and secondary regions move below or hide as space becomes
-        limited
-      </li>
-      <li>Ensure secondary content is still easy to access</li>
-      <li>Maintain a clear and predictable page structure across screen sizes</li>
     </ul>
   </goa-text>
 


### PR DESCRIPTION
# Before (the change)

The Foundations > Style guide > Layout page did not document the design system breakpoints. The breakpoint values (`MOBILE_BP = 624`, `TABLET_BP = 1024`) lived only in code with no site-facing reference.

# After (the change)

The Layout page now documents the breakpoints:

- Moved the "Design for responsiveness" section up so it follows directly after "Start with the user".
- Added a "Breakpoints" subsection under "Design for responsiveness" covering: components handle responsive behaviour internally, container queries, the three breakpoints (Mobile under 624px, Tablet 624px to 1023px, Desktop 1024px and above), and mobile behaviour notes.
- Content adapted from the existing `docs/src/content/foundations/responsive.mdx` and rewritten to match the site's page style.

Docs-only change. No Svelte, wrapper, or test changes.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Run `npx nx dev docs`.
2. Navigate to Foundations > Style guide > Layout (`/foundations/style-guide/layout`).
3. Confirm "Design for responsiveness" appears after "Start with the user".
4. Confirm the "Breakpoints" subsection lists the three breakpoints and responsive guidance.

Fixes #3742

🤖 Generated with [Claude Code](https://claude.com/claude-code)