### PR TITLE
chore: Updating release build to use built in GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Release libs
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx nx affected --target release --parallel=false --base=${{ steps.last_successful_commit.outputs.base }}
 


### PR DESCRIPTION
This is to change our token usage to instead use the built in GITHUB_TOKEN. This token gets created every job and only exists as long as the job is running, and is then deleted. The token inherently only has create and read permissions on the repo it's running from, and if run from a fork only has read permissions, which should be enough I think.

I don't know if this will fix the issue, but it's worth a shot and gets us away from using yet another personal access token.
