### PR TITLE
fix(#3921): update segmented tab indicator on resize

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3921/bug3921.component.html
+++ b/apps/prs/angular/src/routes/bugs/3921/bug3921.component.html
@@ -1,0 +1,21 @@
+<h1>3921 - Segmented tab dynamic indicator</h1>
+<p>Resize the browser window. The active tab indicator background should follow the selected tab as the layout reflows.</p>
+
+<h2>Many tabs including a long heading</h2>
+<goab-tabs variant="segmented" testId="bug3921-tabs">
+  <goab-tab heading="Day">Daily view</goab-tab>
+  <goab-tab heading="Week">Weekly view</goab-tab>
+  <goab-tab heading="Month">Monthly view</goab-tab>
+  <goab-tab heading="Quarter">Quarterly view</goab-tab>
+  <goab-tab heading="Year">Yearly view</goab-tab>
+  <goab-tab heading="Custom reporting period with a very long heading">Custom reporting period view</goab-tab>
+  <goab-tab heading="Archive">Archived view</goab-tab>
+  <goab-tab heading="Forecast">Forecast view</goab-tab>
+</goab-tabs>
+
+<h2>Simple three-tab example</h2>
+<goab-tabs variant="segmented">
+  <goab-tab heading="Tab one">Content one</goab-tab>
+  <goab-tab heading="Tab two">Content two</goab-tab>
+  <goab-tab heading="Tab three">Content three</goab-tab>
+</goab-tabs>

--- a/apps/prs/angular/src/routes/bugs/3921/bug3921.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3921/bug3921.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabTab, GoabTabs } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3921",
+  templateUrl: "./bug3921.component.html",
+  imports: [GoabTab, GoabTabs],
+})
+export class Bug3921Component {}

--- a/apps/prs/angular/src/routes/bugs/3921/bug3921.route.json
+++ b/apps/prs/angular/src/routes/bugs/3921/bug3921.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3921",
+  "path": "bugs/3921",
+  "title": "Segmented tab dynamic indicator"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3921.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3921.route.ts
@@ -1,0 +1,10 @@
+import { Bug3921Route } from "../../../routes/bugs/bug3921";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3921",
+  path: "bugs/3921",
+  title: "Segmented tab dynamic indicator",
+  component: Bug3921Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3921.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3921.tsx
@@ -1,0 +1,46 @@
+import { GoabTab, GoabTabs, GoabText } from "@abgov/react-components";
+
+export function Bug3921Route() {
+  return (
+    <div style={{ display: "grid", gap: "2rem" }}>
+      <div>
+        <GoabText tag="h1" mt="none">
+          3921 - Segmented tab dynamic indicator
+        </GoabText>
+        <GoabText>
+          Resize the browser window. The active tab indicator background should follow the
+          selected tab as the layout reflows.
+        </GoabText>
+      </div>
+
+      <div>
+        <GoabText tag="h2" mt="none">
+          Many tabs including a long heading
+        </GoabText>
+        <GoabTabs variant="segmented" testId="bug3921-tabs">
+          <GoabTab heading="Day">Daily view</GoabTab>
+          <GoabTab heading="Week">Weekly view</GoabTab>
+          <GoabTab heading="Month">Monthly view</GoabTab>
+          <GoabTab heading="Quarter">Quarterly view</GoabTab>
+          <GoabTab heading="Year">Yearly view</GoabTab>
+          <GoabTab heading="Custom reporting period with a very long heading">
+            Custom reporting period view
+          </GoabTab>
+          <GoabTab heading="Archive">Archived view</GoabTab>
+          <GoabTab heading="Forecast">Forecast view</GoabTab>
+        </GoabTabs>
+      </div>
+
+      <div>
+        <GoabText tag="h2" mt="none">
+          Simple three-tab example
+        </GoabText>
+        <GoabTabs variant="segmented">
+          <GoabTab heading="Tab one">Content one</GoabTab>
+          <GoabTab heading="Tab two">Content two</GoabTab>
+          <GoabTab heading="Tab three">Content three</GoabTab>
+        </GoabTabs>
+      </div>
+    </div>
+  );
+}

--- a/libs/react-components/specs/tabs.browser.spec.tsx
+++ b/libs/react-components/specs/tabs.browser.spec.tsx
@@ -1,7 +1,6 @@
 import { render } from "vitest-browser-react";
 
 import { GoabTabs, GoabTab } from "../src";
-import { GoabTabs, GoabTab } from "../src";
 import { expect, describe, it, vi } from "vitest";
 import { page } from "@vitest/browser/context";
 import { GoabBadge } from "../src/lib/badge/badge";
@@ -810,6 +809,71 @@ describe("Tabs Browser Tests", () => {
       const tabsDiv = tabs.elements()[0].parentElement!;
       const borderLeft = getComputedStyle(tabsDiv).borderLeftStyle;
       expect(borderLeft).toBe("none");
+    });
+  });
+
+  describe("bug-3921", () => {
+    it("should keep segmented indicator aligned when a long heading wraps on resize", async () => {
+      // Wide enough that the long heading fits on a single line.
+      await page.viewport(1024, 600);
+
+      // Mirrors the playground: a long heading that wraps when the container narrows.
+      const Component = () => (
+        <GoabTabs variant="segmented" testId="test-tabs">
+          <GoabTab heading="Day">Daily view</GoabTab>
+          <GoabTab heading="Week">Weekly view</GoabTab>
+          <GoabTab heading="Month">Monthly view</GoabTab>
+          <GoabTab heading="Quarter">Quarterly view</GoabTab>
+          <GoabTab heading="Year">Yearly view</GoabTab>
+          <GoabTab heading="Custom reporting period with a very long heading">
+            Custom reporting period view
+          </GoabTab>
+          <GoabTab heading="Archive">Archived view</GoabTab>
+          <GoabTab heading="Forecast">Forecast view</GoabTab>
+        </GoabTabs>
+      );
+
+      const { getByRole } = render(<Component />);
+      const tablist = getByRole("tab");
+
+      await vi.waitFor(() => {
+        expect(tablist.elements().length).toBe(8);
+      });
+
+      const tabs = tablist.elements();
+      // Select the long-heading tab so its size changes when the heading wraps.
+      const longHeadingTab = tabs[5];
+      await longHeadingTab.click();
+
+      const tabsContainer = tabs[0].parentElement!;
+
+      const getIndicatorLeft = () =>
+        parseFloat(tabsContainer.style.getPropertyValue("--segmented-indicator-left"));
+      const getIndicatorWidth = () =>
+        parseFloat(tabsContainer.style.getPropertyValue("--segmented-indicator-width"));
+
+      await vi.waitFor(() => {
+        expect(getIndicatorWidth()).toBeGreaterThan(0);
+      });
+
+      const heightBeforeResize = longHeadingTab.getBoundingClientRect().height;
+
+      // Narrow the viewport so the long heading wraps to multiple lines,
+      // growing the tab's height and shifting its position.
+      await page.viewport(480, 600);
+
+      await vi.waitFor(() => {
+        // Confirm the heading actually wrapped, otherwise this would not
+        // exercise the dynamic-resize behavior the fix targets.
+        expect(longHeadingTab.getBoundingClientRect().height).toBeGreaterThan(
+          heightBeforeResize,
+        );
+
+        const containerRect = tabsContainer.getBoundingClientRect();
+        const tabRect = longHeadingTab.getBoundingClientRect();
+        expect(getIndicatorLeft()).toBeCloseTo(tabRect.left - containerRect.left - 1, 0);
+        expect(getIndicatorWidth()).toBeCloseTo(tabRect.width, 0);
+      });
     });
   });
 

--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -36,6 +36,7 @@
   let _segmentedTransitionDuration: number = 0;
   let _previousTabIndex: number = 1;
   let _visibilityObserver: IntersectionObserver | null = null;
+  let _resizeObserver: ResizeObserver | null = null;
 
   const MIN_TRANSITION_DURATION = 200;
   const DURATION_PER_PIXEL = 0.2;
@@ -62,6 +63,10 @@
     if (_visibilityObserver) {
       _visibilityObserver.disconnect();
       _visibilityObserver = null;
+    }
+    if (_resizeObserver) {
+      _resizeObserver.disconnect();
+      _resizeObserver = null;
     }
   });
 
@@ -244,6 +249,16 @@
             }
           });
           _visibilityObserver.observe(_tabsEl);
+        }
+
+        // The indicator is positioned absolutely from a one-time measurement, so it
+        // drifts out of alignment when the tabs reflow (long heading wraps, window
+        // resize). Re-measure whenever the container's size changes.
+        if (_tabsEl && !_resizeObserver) {
+          _resizeObserver = new ResizeObserver(() => {
+            updateSegmentedIndicatorPosition({ withAnimation: false });
+          });
+          _resizeObserver.observe(_tabsEl);
         }
       });
     }


### PR DESCRIPTION
# Before (the change)

With `variant="segmented"`, the active tab background indicator only recalculated its position on tab click and initial bind. When the tabs container reflowed (a long heading, or a window resize), the indicator drifted out of alignment with the selected tab. Clicking the tab snapped it back into place.

# After (the change)

A `ResizeObserver` on the tabs container recalculates the indicator position (without animation) whenever the container resizes, so the background stays aligned with the selected tab through reflows and window resizing. The observer is disconnected in `onDestroy`.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Open the 3921 playground page in the React or Angular PRS playground.
2. On the segmented tabs, select the tab with the long heading ("Custom reporting period with a very long heading").
3. Resize the browser window narrower and wider.
4. Confirm the white background indicator stays aligned with the selected tab as the layout reflows, without needing to click.

This is a CSS-adjacent behavior fix in the Svelte source only. React and Angular wrappers pass attributes through and needed no changes. A browser test was added that resizes the viewport and asserts the indicator tracks the selected tab.

Fixes #3921