### PR TITLE
fix(#3964): mark Angular input/textarea as touched on blur only

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3964/bug3964.component.html
+++ b/apps/prs/angular/src/routes/bugs/3964/bug3964.component.html
@@ -1,0 +1,71 @@
+<h1>3964 - Input marked as touched when user tabs in (Angular)</h1>
+<p>
+  Tab into a field and tab straight back out without typing: the required error should
+  appear, because the control was entered and then left. Tabbing in alone, or typing
+  without leaving, should NOT show the error. Before the fix, the error appeared as soon
+  as the field received focus.
+</p>
+
+<h2>Reactive form (FormControl)</h2>
+<form [formGroup]="form">
+  <goab-form-item label="Last name" [error]="lastNameError">
+    <goab-input
+      formControlName="lastName"
+      name="lastName"
+      width="100%"
+      [error]="!!lastNameError"
+    />
+  </goab-form-item>
+
+  <goab-form-item label="Bio" [error]="bioError">
+    <goab-textarea formControlName="bio" name="bio" width="100%" [error]="!!bioError" />
+  </goab-form-item>
+</form>
+
+<dl>
+  <dt>lastName.touched</dt>
+  <dd>{{ form.get("lastName")?.touched }}</dd>
+  <dt>bio.touched</dt>
+  <dd>{{ form.get("bio")?.touched }}</dd>
+</dl>
+
+<h2>Template-driven form (ngModel)</h2>
+<p>Same behavior should hold for the ngModel binding.</p>
+<form>
+  <goab-form-item
+    label="Last name"
+    [error]="
+      tdLastName.touched && tdLastName.invalid ? 'Enter a last name.' : undefined
+    "
+  >
+    <goab-input
+      name="ngModelLastName"
+      width="100%"
+      required
+      [(ngModel)]="ngModelLastName"
+      #tdLastName="ngModel"
+      [error]="tdLastName.touched && tdLastName.invalid"
+    />
+  </goab-form-item>
+
+  <goab-form-item
+    label="Bio"
+    [error]="tdBio.touched && tdBio.invalid ? 'Enter a bio.' : undefined"
+  >
+    <goab-textarea
+      name="ngModelBio"
+      width="100%"
+      required
+      [(ngModel)]="ngModelBio"
+      #tdBio="ngModel"
+      [error]="tdBio.touched && tdBio.invalid"
+    />
+  </goab-form-item>
+</form>
+
+<dl>
+  <dt>ngModelLastName.touched</dt>
+  <dd>{{ tdLastName.touched }}</dd>
+  <dt>ngModelBio.touched</dt>
+  <dd>{{ tdBio.touched }}</dd>
+</dl>

--- a/apps/prs/angular/src/routes/bugs/3964/bug3964.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3964/bug3964.component.ts
@@ -1,0 +1,40 @@
+import { Component } from "@angular/core";
+import {
+  ReactiveFormsModule,
+  FormsModule,
+  FormGroup,
+  FormControl,
+  Validators,
+} from "@angular/forms";
+import { GoabFormItem, GoabInput, GoabTextArea } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3964",
+  templateUrl: "./bug3964.component.html",
+  imports: [ReactiveFormsModule, FormsModule, GoabFormItem, GoabInput, GoabTextArea],
+})
+export class Bug3964Component {
+  form = new FormGroup({
+    lastName: new FormControl("", Validators.required),
+    bio: new FormControl("", Validators.required),
+  });
+
+  // Template-driven (ngModel) values
+  ngModelLastName = "";
+  ngModelBio = "";
+
+  get lastNameError() {
+    const control = this.form.get("lastName");
+    return control && !control.valid && control.touched && control.hasError("required")
+      ? "Enter a last name."
+      : undefined;
+  }
+
+  get bioError() {
+    const control = this.form.get("bio");
+    return control && !control.valid && control.touched && control.hasError("required")
+      ? "Enter a bio."
+      : undefined;
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3964/bug3964.route.json
+++ b/apps/prs/angular/src/routes/bugs/3964/bug3964.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3964",
+  "path": "bugs/3964",
+  "title": "Input touched on tab-in (Angular)"
+}

--- a/libs/angular-components/src/lib/components/input/input.spec.ts
+++ b/libs/angular-components/src/lib/components/input/input.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { GoabInput } from "./input";
-import { Component, CUSTOM_ELEMENTS_SCHEMA, TemplateRef } from "@angular/core";
+import { Component, CUSTOM_ELEMENTS_SCHEMA, TemplateRef, ViewChild } from "@angular/core";
 import {
   GoabIconType,
   GoabInputAutoCapitalize,
@@ -10,6 +10,13 @@ import {
 } from "@abgov/ui-components-common";
 import { By } from "@angular/platform-browser";
 import { fireEvent } from "@testing-library/dom";
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  NgModel,
+  ReactiveFormsModule,
+} from "@angular/forms";
 
 @Component({
   standalone: true,
@@ -323,6 +330,121 @@ describe("GoABInput", () => {
       inputComponent.writeValue(null);
       expect(inputComponent.value).toBe(null);
     });
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [GoabInput, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form">
+      <goab-input formControlName="lastName" name="lastName"></goab-input>
+    </form>
+  `,
+})
+class TestReactiveFormComponent {
+  form = new FormGroup({
+    lastName: new FormControl(""),
+  });
+}
+
+describe("GoabInput reactive form touched state", () => {
+  let fixture: ComponentFixture<TestReactiveFormComponent>;
+  let component: TestReactiveFormComponent;
+  let input: HTMLElement;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestReactiveFormComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestReactiveFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    input = fixture.debugElement.query(By.css("goa-input")).nativeElement;
+  }));
+
+  it("should not mark the control as touched on focus", () => {
+    fireEvent(input, new CustomEvent("_focus"));
+    expect(component.form.get("lastName")?.touched).toBe(false);
+  });
+
+  it("should not mark the control as touched on change", () => {
+    fireEvent(
+      input,
+      new CustomEvent("_change", { detail: { name: "lastName", value: "Doe" } }),
+    );
+    expect(component.form.get("lastName")?.touched).toBe(false);
+  });
+
+  it("should not mark the control as touched on key press", () => {
+    fireEvent(input, new CustomEvent("_keyPress"));
+    expect(component.form.get("lastName")?.touched).toBe(false);
+  });
+
+  it("should mark the control as touched on blur", () => {
+    fireEvent(input, new CustomEvent("_blur"));
+    expect(component.form.get("lastName")?.touched).toBe(true);
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [GoabInput, FormsModule],
+  template: `
+    <goab-input name="lastName" [(ngModel)]="lastName" #model="ngModel"></goab-input>
+  `,
+})
+class TestNgModelComponent {
+  lastName = "";
+  @ViewChild("model") model!: NgModel;
+}
+
+describe("GoabInput template-driven form touched state", () => {
+  let fixture: ComponentFixture<TestNgModelComponent>;
+  let component: TestNgModelComponent;
+  let input: HTMLElement;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestNgModelComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestNgModelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    input = fixture.debugElement.query(By.css("goa-input")).nativeElement;
+  }));
+
+  it("should not mark the control as touched on focus", () => {
+    fireEvent(input, new CustomEvent("_focus"));
+    expect(component.model.touched).toBe(false);
+  });
+
+  it("should not mark the control as touched on change", () => {
+    fireEvent(
+      input,
+      new CustomEvent("_change", { detail: { name: "lastName", value: "Doe" } }),
+    );
+    expect(component.model.touched).toBe(false);
+  });
+
+  it("should not mark the control as touched on key press", () => {
+    fireEvent(input, new CustomEvent("_keyPress"));
+    expect(component.model.touched).toBe(false);
+  });
+
+  it("should mark the control as touched on blur", () => {
+    fireEvent(input, new CustomEvent("_blur"));
+    expect(component.model.touched).toBe(true);
   });
 });
 

--- a/libs/angular-components/src/lib/components/input/input.ts
+++ b/libs/angular-components/src/lib/components/input/input.ts
@@ -199,7 +199,6 @@ export class GoabInput extends GoabControlValueAccessor implements OnInit {
   }
 
   _onChange(e: Event) {
-    this.markAsTouched();
     const detail = { ...(e as CustomEvent<GoabInputOnChangeDetail>).detail, event: e };
     this.onChange.emit(detail);
 
@@ -207,20 +206,17 @@ export class GoabInput extends GoabControlValueAccessor implements OnInit {
   }
 
   _onKeyPress(e: Event) {
-    this.markAsTouched();
     const detail = { ...(e as CustomEvent<GoabInputOnKeyPressDetail>).detail, event: e };
     this.onKeyPress.emit(detail);
-
-    this.fcTouched?.();
   }
 
   _onFocus(e: Event) {
-    this.markAsTouched();
     const detail = { ...(e as CustomEvent<GoabInputOnFocusDetail>).detail, event: e };
     this.onFocus.emit(detail);
   }
 
   _onBlur(e: Event) {
+    this.markAsTouched();
     const detail = { ...(e as CustomEvent<GoabInputOnBlurDetail>).detail, event: e };
     this.onBlur.emit(detail);
   }

--- a/libs/angular-components/src/lib/components/textarea/textarea.spec.ts
+++ b/libs/angular-components/src/lib/components/textarea/textarea.spec.ts
@@ -1,9 +1,16 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { GoabTextArea } from "./textarea";
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { Component, CUSTOM_ELEMENTS_SCHEMA, ViewChild } from "@angular/core";
 import { GoabTextAreaCountBy, Spacing } from "@abgov/ui-components-common";
 import { fireEvent } from "@testing-library/dom";
 import { By } from "@angular/platform-browser";
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  NgModel,
+  ReactiveFormsModule,
+} from "@angular/forms";
 
 @Component({
   standalone: true,
@@ -178,5 +185,110 @@ describe("GoABTextArea", () => {
       textareaComponent.writeValue(null);
       expect(textareaComponent.value).toBe(null);
     });
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [GoabTextArea, ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form">
+      <goab-textarea formControlName="bio" name="bio"></goab-textarea>
+    </form>
+  `,
+})
+class TestReactiveFormComponent {
+  form = new FormGroup({
+    bio: new FormControl(""),
+  });
+}
+
+describe("GoabTextArea reactive form touched state", () => {
+  let fixture: ComponentFixture<TestReactiveFormComponent>;
+  let component: TestReactiveFormComponent;
+  let el: HTMLElement;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestReactiveFormComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestReactiveFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    el = fixture.nativeElement.querySelector("goa-textarea");
+  }));
+
+  it("should not mark the control as touched on change", () => {
+    fireEvent(
+      el,
+      new CustomEvent("_change", { detail: { name: "bio", value: "hello" } }),
+    );
+    expect(component.form.get("bio")?.touched).toBe(false);
+  });
+
+  it("should not mark the control as touched on key press", () => {
+    fireEvent(el, new CustomEvent("_keyPress"));
+    expect(component.form.get("bio")?.touched).toBe(false);
+  });
+
+  it("should mark the control as touched on blur", () => {
+    fireEvent(el, new CustomEvent("_blur"));
+    expect(component.form.get("bio")?.touched).toBe(true);
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [GoabTextArea, FormsModule],
+  template: `
+    <goab-textarea name="bio" [(ngModel)]="bio" #model="ngModel"></goab-textarea>
+  `,
+})
+class TestNgModelComponent {
+  bio = "";
+  @ViewChild("model") model!: NgModel;
+}
+
+describe("GoabTextArea template-driven form touched state", () => {
+  let fixture: ComponentFixture<TestNgModelComponent>;
+  let component: TestNgModelComponent;
+  let el: HTMLElement;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestNgModelComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestNgModelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    el = fixture.nativeElement.querySelector("goa-textarea");
+  }));
+
+  it("should not mark the control as touched on change", () => {
+    fireEvent(
+      el,
+      new CustomEvent("_change", { detail: { name: "bio", value: "hello" } }),
+    );
+    expect(component.model.touched).toBe(false);
+  });
+
+  it("should not mark the control as touched on key press", () => {
+    fireEvent(el, new CustomEvent("_keyPress"));
+    expect(component.model.touched).toBe(false);
+  });
+
+  it("should mark the control as touched on blur", () => {
+    fireEvent(el, new CustomEvent("_blur"));
+    expect(component.model.touched).toBe(true);
   });
 });

--- a/libs/angular-components/src/lib/components/textarea/textarea.ts
+++ b/libs/angular-components/src/lib/components/textarea/textarea.ts
@@ -115,7 +115,6 @@ export class GoabTextArea extends GoabControlValueAccessor implements OnInit {
   _onChange(e: Event) {
     const detail = { ...(e as CustomEvent<GoabTextAreaOnChangeDetail>).detail, event: e };
     this.onChange.emit(detail);
-    this.markAsTouched();
     this.fcChange?.(detail.value);
   }
 
@@ -124,7 +123,6 @@ export class GoabTextArea extends GoabControlValueAccessor implements OnInit {
       ...(e as CustomEvent<GoabTextAreaOnKeyPressDetail>).detail,
       event: e,
     };
-    this.markAsTouched();
     this.onKeyPress.emit(detail);
   }
 


### PR DESCRIPTION
# Before (the change)

Using `.touched` on a reactive `FormControl` for validation triggered as soon as a user tabbed into a `goab-input` (or `goab-textarea`). The Angular wrappers called `markAsTouched` on focus, change, and keypress, so the error state appeared before the user had interacted and left the field.

# After (the change)

`markAsTouched` runs only on blur, matching the definition of touched: entered and then left.

- Input wrapper: removed `markAsTouched` from `_onChange`, `_onKeyPress`, and `_onFocus` (also removed the redundant `fcTouched` call in `_onKeyPress`); added it to `_onBlur`.
- Textarea wrapper: removed `markAsTouched` from `_onChange` and `_onKeyPress`; the existing `_onBlur` call remains.

This is an Angular wrapper only change. `markAsTouched` is part of the Angular `ControlValueAccessor` integration, so the Svelte source and React wrapper are unaffected.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Run the Angular playground and open the `3964` bug page.
2. Tab into the Last name field and tab straight out without typing. The required error appears, because the control was entered and then left.
3. Tab into the field and type without leaving. No error appears while focused.
4. Repeat for the Bio textarea.
5. Confirm `lastName.touched` / `bio.touched` stay `false` on focus, change, and keypress, and flip to `true` on blur.

Fixes #3964

🤖 Generated with [Claude Code](https://claude.com/claude-code)