### PR TITLE
Add heading-2xl size support to Text component

### DIFF
--- a/apps/prs/angular/src/routes/bugs/4077/bug4077.component.html
+++ b/apps/prs/angular/src/routes/bugs/4077/bug4077.component.html
@@ -1,0 +1,18 @@
+<goab-text tag="h1" mt="m" mb="m">Bug 4077 - Text component missing heading-2xl</goab-text>
+<goab-text mb="l">
+  GoabText now supports a size of "heading-2xl", the largest heading size. It should
+  render at least as large as "heading-xl". The visual size is driven by the
+  "--goa-typography-heading-2xl" design token and falls back to "heading-xl" until that
+  token is published.
+</goab-text>
+
+<goab-text tag="h2" mb="s">New size</goab-text>
+<goab-text size="heading-2xl" mt="none">Heading 2XL</goab-text>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<goab-text tag="h2" mb="s">Size scale comparison</goab-text>
+<goab-text size="heading-2xl" mt="none" mb="xs">Heading 2XL</goab-text>
+<goab-text size="heading-xl" mt="none" mb="xs">Heading XL</goab-text>
+<goab-text size="heading-l" mt="none" mb="xs">Heading L</goab-text>
+<goab-text size="heading-m" mt="none" mb="xs">Heading M</goab-text>

--- a/apps/prs/angular/src/routes/bugs/4077/bug4077.component.ts
+++ b/apps/prs/angular/src/routes/bugs/4077/bug4077.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabDivider, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug4077",
+  templateUrl: "./bug4077.component.html",
+  imports: [GoabDivider, GoabText],
+})
+export class Bug4077Component {}

--- a/apps/prs/angular/src/routes/bugs/4077/bug4077.route.json
+++ b/apps/prs/angular/src/routes/bugs/4077/bug4077.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "4077",
+  "path": "bugs/4077",
+  "title": "Text missing heading-2xl"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug4077.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug4077.route.ts
@@ -1,0 +1,10 @@
+import { Bug4077Route } from "../../../routes/bugs/bug4077";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "4077",
+  path: "bugs/4077",
+  title: "Text missing heading-2xl",
+  component: Bug4077Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug4077.tsx
+++ b/apps/prs/react/src/routes/bugs/bug4077.tsx
@@ -1,0 +1,44 @@
+import { GoabDivider, GoabText } from "@abgov/react-components";
+
+export function Bug4077Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m" mb="m">
+        Bug #4077: Text component missing heading-2xl
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        GoabText now supports a size of "heading-2xl", the largest heading size. It
+        should render at least as large as "heading-xl". The visual size is driven by
+        the "--goa-typography-heading-2xl" design token and falls back to "heading-xl"
+        until that token is published.
+      </GoabText>
+
+      <GoabText tag="h2" mb="s">
+        New size
+      </GoabText>
+      <GoabText size="heading-2xl" mt="none">
+        Heading 2XL
+      </GoabText>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2" mb="s">
+        Size scale comparison
+      </GoabText>
+      <GoabText size="heading-2xl" mt="none" mb="xs">
+        Heading 2XL
+      </GoabText>
+      <GoabText size="heading-xl" mt="none" mb="xs">
+        Heading XL
+      </GoabText>
+      <GoabText size="heading-l" mt="none" mb="xs">
+        Heading L
+      </GoabText>
+      <GoabText size="heading-m" mt="none" mb="xs">
+        Heading M
+      </GoabText>
+    </div>
+  );
+}
+
+export default Bug4077Route;

--- a/docs/generated/component-apis/text.json
+++ b/docs/generated/component-apis/text.json
@@ -223,8 +223,9 @@
         },
         {
           "name": "size",
-          "type": "\"heading-xl\" | \"heading-l\" | \"heading-m\" | \"heading-s\" | \"heading-xs\" | \"heading-2xs\" | \"body-l\" | \"body-m\" | \"body-s\" | \"body-xs\"",
+          "type": "\"heading-2xl\" | \"heading-xl\" | \"heading-l\" | \"heading-m\" | \"heading-s\" | \"heading-xs\" | \"heading-2xs\" | \"body-l\" | \"body-m\" | \"body-s\" | \"body-xs\"",
           "values": [
+            "heading-2xl",
             "heading-xl",
             "heading-l",
             "heading-m",

--- a/docs/src/data/configurations/text.ts
+++ b/docs/src/data/configurations/text.ts
@@ -28,6 +28,8 @@ export const textConfigurations: ComponentConfigurations = {
       description: "All heading text sizes",
       code: {
         react: `<GoabDivider mb="none" mt="none" />
+<GoabText size="heading-2xl">Heading 2XL</GoabText>
+<GoabDivider mb="none" mt="none" />
 <GoabText size="heading-xl">Heading XL</GoabText>
 <GoabDivider mb="none" mt="none" />
 <GoabText size="heading-l">Heading L</GoabText>
@@ -41,6 +43,8 @@ export const textConfigurations: ComponentConfigurations = {
 <GoabText size="heading-2xs">Heading 2XS</GoabText>
 <GoabDivider mb="none" mt="none" />`,
         angular: `<goab-divider mb="none" mt="none"></goab-divider>
+<goab-text size="heading-2xl">Heading 2XL</goab-text>
+<goab-divider mb="none" mt="none"></goab-divider>
 <goab-text size="heading-xl">Heading XL</goab-text>
 <goab-divider mb="none" mt="none"></goab-divider>
 <goab-text size="heading-l">Heading L</goab-text>
@@ -54,6 +58,8 @@ export const textConfigurations: ComponentConfigurations = {
 <goab-text size="heading-2xs">Heading 2XS</goab-text>
 <goab-divider mb="none" mt="none"></goab-divider>`,
         webComponents: `<goa-divider mb="none" mt="none"></goa-divider>
+<goa-text size="heading-2xl">Heading 2XL</goa-text>
+<goa-divider mb="none" mt="none"></goa-divider>
 <goa-text size="heading-xl">Heading XL</goa-text>
 <goa-divider mb="none" mt="none"></goa-divider>
 <goa-text size="heading-l">Heading L</goa-text>

--- a/libs/angular-components/src/lib/components/text/text.spec.ts
+++ b/libs/angular-components/src/lib/components/text/text.spec.ts
@@ -58,6 +58,16 @@ describe("GoabText", () => {
     expect(element.getAttribute("ml")).toBe("xl");
   }));
 
+  it("should pass heading-2xl size through to the web component", fakeAsync(() => {
+    component.size = "heading-2xl";
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement.querySelector("goa-text");
+    expect(element.getAttribute("size")).toBe("heading-2xl");
+  }));
+
   it("should handle undefined properties", fakeAsync(() => {
     fixture.detectChanges();
     tick();

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -1247,6 +1247,7 @@ export type GoabTextMaxWidth = string | "none";
 export type GoabTextHeadingElement = "h1" | "h2" | "h3" | "h4" | "h5";
 export type GoabTextTextElement = "span" | "div" | "p";
 export type GoabTextHeadingSize =
+  | "heading-2xl"
   | "heading-xl"
   | "heading-l"
   | "heading-m"

--- a/libs/react-components/src/lib/text/text.spec.tsx
+++ b/libs/react-components/src/lib/text/text.spec.tsx
@@ -55,6 +55,13 @@ describe('GoabText', () => {
     expect(element?.getAttribute('mb')).toBe('l');
   });
 
+  it('should pass heading-2xl size through to the web component', () => {
+    const { container } = render(<GoabText size="heading-2xl">Largest heading</GoabText>);
+    const element = container.querySelector('goa-text');
+
+    expect(element?.getAttribute('size')).toBe('heading-2xl');
+  });
+
   it('should handle different tag values', () => {
     const cases = [
       { tag: 'p', name: 'paragraph' },

--- a/libs/web-components/src/components/text/Text.svelte
+++ b/libs/web-components/src/components/text/Text.svelte
@@ -5,6 +5,7 @@
   export type TextElement = "span" | "div" | "p";
 
   type HeadingSize =
+    | "heading-2xl"
     | "heading-xl"
     | "heading-l"
     | "heading-m"
@@ -77,6 +78,8 @@
     }
 
     switch (effectiveSize) {
+      case "heading-2xl":
+        return "l";
       case "heading-xl":
         return "l";
       case "heading-l":
@@ -106,6 +109,7 @@
     }
 
     switch (effectiveSize) {
+      case "heading-2xl":
       case "heading-xl":
       case "heading-l":
       case "heading-m":
@@ -155,6 +159,13 @@
     margin: 0;
   }
 
+  .heading-2xl {
+    font: var(--goa-typography-heading-2xl, var(--goa-typography-heading-xl));
+    letter-spacing: var(
+      --goa-typography-heading-2xl-letter-spacing,
+      var(--goa-typography-heading-xl-letter-spacing)
+    );
+  }
   .heading-xl {
     font: var(--goa-typography-heading-xl);
     letter-spacing: var(--goa-typography-heading-xl-letter-spacing);
@@ -193,6 +204,13 @@
   }
 
   @media (--mobile) {
+    .heading-2xl {
+      font: var(--goa-typography-mobile-heading-2xl, var(--goa-typography-mobile-heading-xl));
+      letter-spacing: var(
+        --goa-typography-mobile-heading-2xl-letter-spacing,
+        var(--goa-typography-mobile-heading-xl-letter-spacing)
+      );
+    }
     .heading-xl {
       font: var(--goa-typography-mobile-heading-xl);
       letter-spacing: var(--goa-typography-mobile-heading-xl-letter-spacing);

--- a/libs/web-components/src/components/text/Text.svelte
+++ b/libs/web-components/src/components/text/Text.svelte
@@ -159,6 +159,13 @@
     margin: 0;
   }
 
+  /*
+   * heading-2xl (like heading-2xs) exists only in the V2 token set. When a
+   * consumer has only V1 tokens loaded the token is undefined, so it falls back
+   * to the nearest size that exists in V1 (heading-xl) rather than collapsing to
+   * unstyled text. Sizes that exist in both token sets (heading-xl through
+   * heading-xs) reference their token directly and need no fallback.
+   */
   .heading-2xl {
     font: var(--goa-typography-heading-2xl, var(--goa-typography-heading-xl));
     letter-spacing: var(
@@ -204,6 +211,7 @@
   }
 
   @media (--mobile) {
+    /* V2-only size; falls back to the nearest V1 size. See the note on the desktop .heading-2xl rule above. */
     .heading-2xl {
       font: var(--goa-typography-mobile-heading-2xl, var(--goa-typography-mobile-heading-xl));
       letter-spacing: var(


### PR DESCRIPTION
# Before (the change)

The GoabText component supported heading sizes from `heading-xl` down to `heading-2xs`, but was missing the largest heading size `heading-2xl`.

# After (the change)

Added `heading-2xl` as a new size option for the GoabText component across all frameworks:

- **Web Component (Svelte)**: Added `heading-2xl` to the `HeadingSize` type and implemented styling with design token fallback to `heading-xl`
- **React Wrapper**: Updated type definitions and added unit test for the new size
- **Angular Wrapper**: Updated type definitions and added unit test for the new size
- **Shared Types**: Added `heading-2xl` to `GoabTextHeadingSize` type in common library
- **Documentation**: Updated generated component API documentation
- **Test Routes**: Added bug demonstration routes for both React and Angular playgrounds

The new size uses the `--goa-typography-heading-2xl` design token with a fallback to `--goa-typography-heading-xl` until the token is published. Mobile styles are also included with appropriate fallbacks.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Run `npm run test:pr` to verify all unit tests pass
2. Serve the React playground: `npm run serve:prs:react` and navigate to bugs/4077 to see the new heading-2xl size in action
3. Serve the Angular playground: `npm run serve:prs:angular` and navigate to bugs/4077 to verify Angular implementation
4. Verify the new size renders at least as large as heading-xl in both playgrounds

https://claude.ai/code/session_01S2KHt61RZD1RNrKKZFmKkm