### PR TITLE
fix(#4027): hide number spinner on DatePicker day and year inputs

### DIFF
--- a/apps/prs/angular/src/routes/bugs/4027/bug4027.component.html
+++ b/apps/prs/angular/src/routes/bugs/4027/bug4027.component.html
@@ -1,0 +1,22 @@
+<goab-text tag="h1" mt="m" mb="s">Bug 4027 - DatePicker: day and year hide number spinner</goab-text>
+<goab-text mb="l">
+  The Day (DD) and Year (YYYY) fields in the input-type DatePicker stay as type="number"
+  (numeric keypad on mobile, native validation), but the up/down spinner arrows are now
+  hidden via CSS. Other type="number" inputs elsewhere keep their spinner buttons. The
+  emitted value is unchanged.
+</goab-text>
+
+<goab-date-picker name="dob" type="input" [value]="value" (onChange)="onChange($event)" />
+
+<goab-text mt="l">Selected value: {{ value || "(none)" }}</goab-text>
+
+<goab-text tag="h2" mt="2xl" mb="m">Comparison: plain type="number" input</goab-text>
+<goab-text mb="l">
+  This is an unrelated GoabInputNumber. It should still show its up/down spinner arrows,
+  confirming the fix above is scoped to DatePicker's Day and Year fields only.
+</goab-text>
+<goab-input-number
+  name="comparison-number"
+  [value]="comparisonValue"
+  (onChange)="onComparisonChange($event)"
+/>

--- a/apps/prs/angular/src/routes/bugs/4027/bug4027.component.ts
+++ b/apps/prs/angular/src/routes/bugs/4027/bug4027.component.ts
@@ -1,0 +1,25 @@
+import { Component } from "@angular/core";
+import { GoabDatePicker, GoabInputNumber, GoabText } from "@abgov/angular-components";
+import {
+  GoabDatePickerOnChangeDetail,
+  GoabInputOnChangeDetail,
+} from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug4027",
+  templateUrl: "./bug4027.component.html",
+  imports: [GoabDatePicker, GoabInputNumber, GoabText],
+})
+export class Bug4027Component {
+  value = "2025-06-15";
+  comparisonValue = 42;
+
+  onChange(detail: GoabDatePickerOnChangeDetail) {
+    this.value = detail.valueStr;
+  }
+
+  onComparisonChange(detail: GoabInputOnChangeDetail) {
+    this.comparisonValue = parseFloat(detail.value);
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/4027/bug4027.route.json
+++ b/apps/prs/angular/src/routes/bugs/4027/bug4027.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "4027",
+  "path": "bugs/4027",
+  "title": "DatePicker day/year number spinner"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug4027.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug4027.route.ts
@@ -1,0 +1,10 @@
+import { Bug4027Route } from "../../../routes/bugs/bug4027";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "4027",
+  path: "bugs/4027",
+  title: "DatePicker day/year number spinner",
+  component: Bug4027Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug4027.tsx
+++ b/apps/prs/react/src/routes/bugs/bug4027.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { GoabDatePicker, GoabInputNumber, GoabText } from "@abgov/react-components";
+
+export function Bug4027Route() {
+  const [value, setValue] = useState<string>("2025-06-15");
+  const [comparisonValue, setComparisonValue] = useState<number>(42);
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m" mb="m">
+        Bug #4027: Day and Year number inputs should hide the spinner arrows
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        The Day (DD) and Year (YYYY) fields in the input-type DatePicker stay as
+        type="number" (numeric keypad on mobile, native validation), but the up/down
+        spinner arrows are now hidden via CSS. Other type="number" inputs elsewhere keep
+        their spinner buttons. The emitted value is unchanged.
+      </GoabText>
+
+      <GoabDatePicker
+        name="dob"
+        type="input"
+        value={value}
+        onChange={(detail) => setValue(detail.valueStr)}
+      />
+
+      <GoabText tag="p" mt="l">
+        Selected value: {value || "(none)"}
+      </GoabText>
+
+      <GoabText tag="h2" mt="2xl" mb="m">
+        Comparison: plain type="number" input
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        This is an unrelated GoabInputNumber. It should still show its up/down spinner
+        arrows, confirming the fix above is scoped to DatePicker's Day and Year fields
+        only.
+      </GoabText>
+      <GoabInputNumber
+        name="comparison-number"
+        value={comparisonValue}
+        onChange={(detail) => setComparisonValue(detail.value)}
+      />
+    </div>
+  );
+}
+
+export default Bug4027Route;

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -379,9 +379,10 @@
         <goa-input
           name="day"
           type="number"
+          class="no-spinner"
           testid="input-day"
           on:_change={onInputChange}
-          width="4ch"
+          width="2ch"
           value={_date.day || ""}
           min="1"
           max="31"
@@ -395,9 +396,10 @@
         <goa-input
           name="year"
           type="number"
+          class="no-spinner"
           testid="input-year"
           on:_change={onInputChange}
-          width="6ch"
+          width="4ch"
           value={_date.year || ""}
           min="1800"
           max="2200"

--- a/libs/web-components/src/components/date-picker/date-picker.spec.ts
+++ b/libs/web-components/src/components/date-picker/date-picker.spec.ts
@@ -105,3 +105,49 @@ describe("placeholder property", () => {
     expect(monthInput?.getAttribute("value")).toBe("0");
   });
 });
+
+describe("day and year inputs", () => {
+  it("renders day and year as number inputs with the spinner hidden", async () => {
+    const { container } = render(DatePicker, {
+      type: "input",
+    });
+
+    const dayInput = container.querySelector("[testid='input-day']");
+    const yearInput = container.querySelector("[testid='input-year']");
+
+    expect(dayInput?.getAttribute("type")).toBe("number");
+    expect(dayInput?.classList.contains("no-spinner")).toBe(true);
+    expect(yearInput?.getAttribute("type")).toBe("number");
+    expect(yearInput?.classList.contains("no-spinner")).toBe(true);
+  });
+
+  it("emits a string date value when typed digits form a valid date", async () => {
+    const { container } = render(DatePicker, { type: "input" });
+
+    const handler = vi.fn();
+    container.addEventListener("_change", handler);
+
+    const fields: Record<string, string> = {
+      year: "2025",
+      month: "6",
+      day: "15",
+    };
+    for (const [name, value] of Object.entries(fields)) {
+      const el = container.querySelector(`[testid='input-${name}']`);
+      el?.dispatchEvent(
+        new CustomEvent("_change", {
+          detail: { name, value },
+          bubbles: true,
+        }),
+      );
+    }
+
+    await waitFor(() => {
+      expect(handler).toHaveBeenCalled();
+    });
+
+    const { value } = handler.mock.calls.at(-1)[0].detail;
+    expect(typeof value).toBe("string");
+    expect(value).toBe("2025-06-15");
+  });
+});

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -639,6 +639,18 @@
     text-overflow: initial;
   }
 
+  /* Hides the native number spinner. Scoped to .no-spinner (set internally by DatePicker)
+     so other type="number" inputs keep the increment/decrement buttons. */
+  :host(.no-spinner) input[type="number"]::-webkit-outer-spin-button,
+  :host(.no-spinner) input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  :host(.no-spinner) input[type="number"] {
+    -moz-appearance: textfield;
+  }
+
   .leading-icon + input {
     padding-left: var(--goa-text-input-space-btw-icon-text);
   }


### PR DESCRIPTION
Fixes #4027

# Before

The Day (DD) and Year (YYYY) fields in the input-type DatePicker used `type="number"`, so the browser drew native up/down spinner arrows. Those arrows are easy to miss and meaningless for a date, and the value changes if you accidentally scroll over the field.

# After

Day and Year stay as `type="number"` (numeric keypad on mobile, native `min`/`max` validation), but the up/down spinner arrows are now hidden via CSS. The fix is scoped to a `no-spinner` class applied only to these two DatePicker fields, so other `type="number"` inputs elsewhere (for example `GoabInputNumber`) are unaffected and keep their spinner buttons, since incrementing by 1 can make more sense in those contexts. The emitted value is unchanged.

Notes:
- An earlier version of this PR moved Day/Year to `type="text"` with `inputmode="numeric"` and added a new `inputmode` prop to `Input`/`GoabInput`/`goab-input`. After discussion with the team we reverted that approach in favor of the CSS-only fix above, since it keeps native number validation and avoids a new prop with broader surface area than this fix needs.
- Added a comparison example to the bugs/4027 playground page (a plain `GoabInputNumber`) so a reviewer can confirm the spinner buttons are still present elsewhere.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the setup steps
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Run the React playground: `npm run serve:prs:react` and open `bugs/4027`.
2. Confirm the Day and Year fields have no up/down arrows.
3. Confirm the comparison number input below still shows its up/down arrows.
4. On a mobile device (or emulator), confirm focusing Day/Year shows the numeric keypad.
5. Enter a full date and confirm the selected value updates correctly.
6. Repeat in the Angular playground: `npm run serve:prs:angular`, open `bugs/4027`.