### PR TITLE
feat(#3917): add public form reference demo (Step 1)

### DIFF
--- a/apps/prs/react/src/app/app.tsx
+++ b/apps/prs/react/src/app/app.tsx
@@ -183,6 +183,13 @@ export function App() {
             label="Everything"
             url={`${baseUrl}everything`}
           />
+          {/* Opens full page, outside this shell, since the examples are whole
+              public form pages with their own layout. Browser back returns here. */}
+          <GoabWorkSideMenuItem
+            icon="document-text"
+            label="Public form"
+            url={`${baseUrl}public-form`}
+          />
         </>
       }
     />

--- a/apps/prs/react/src/main.tsx
+++ b/apps/prs/react/src/main.tsx
@@ -8,6 +8,7 @@ import App from "./app/app";
 import { EverythingRoute } from "./routes/everything";
 import { EverythingBRoute } from "./routes/everything-b";
 import { prRouteDefinitions } from "./app/route-manifest";
+import { PublicFormApp } from "./routes/public-form/public-form-app";
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 
 root.render(
@@ -16,6 +17,7 @@ root.render(
       <GoabThemeProvider>
         <Routes>
           <Route path="/everything/b" element={<EverythingBRoute />} />
+          <Route path="/public-form/*" element={<PublicFormApp />} />
           <Route path="/" element={<App />}>
             <Route path="everything" element={<EverythingRoute />} />
             {prRouteDefinitions.map((route) => {

--- a/apps/prs/react/src/routes/public-form/children-summary.tsx
+++ b/apps/prs/react/src/routes/public-form/children-summary.tsx
@@ -1,0 +1,63 @@
+import { ReactNode } from "react";
+import { SummarySection } from "./form-summary";
+
+type ChildItem = {
+  /** Stable id (React key). */
+  id: string;
+  /** The key identifying field shown on review (e.g. a name). */
+  label: string;
+  /** Optional secondary detail, shown muted under the label. */
+  detail?: ReactNode;
+};
+
+type ChildrenSummaryProps = {
+  /** Group title (e.g. "Emergency contacts"). */
+  title: string;
+  /** The collected items. */
+  items: ChildItem[];
+  /** Text shown when there are no items. */
+  emptyText?: string;
+  /** One Change/manage action for the whole group, as an action... */
+  onChange?: () => void;
+  /** ...or as a route. */
+  changeTo?: string;
+  changeLabel?: string;
+};
+
+/**
+ * Children summary (= goab-children-form-summary): the review-side representation
+ * of a REPEATING group (items added via modal / drawer / new page). Per the
+ * 2026-06-19 notes, a child loop collapses on the review to each item's key
+ * identifying field (a name), not every sub-field, with one Change back to the
+ * page where the items are managed. The full detail lives there.
+ *
+ * Composes SummarySection (the same card + title + one Change), with a list of
+ * children by key label as its body instead of Q/A rows.
+ */
+export function ChildrenSummary({
+  title,
+  items,
+  emptyText = "None added",
+  onChange,
+  changeTo,
+  changeLabel,
+}: ChildrenSummaryProps) {
+  return (
+    <SummarySection heading={title} onChange={onChange} changeTo={changeTo} changeLabel={changeLabel}>
+      {items.length === 0 ? (
+        <span style={{ color: "var(--goa-color-text-secondary)" }}>{emptyText}</span>
+      ) : (
+        items.map((it) => (
+          <div key={it.id} style={{ padding: "var(--goa-space-2xs) 0" }}>
+            <div>
+              <strong>{it.label}</strong>
+            </div>
+            {it.detail != null && (
+              <div style={{ color: "var(--goa-color-text-secondary)" }}>{it.detail}</div>
+            )}
+          </div>
+        ))
+      )}
+    </SummarySection>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/error-summary.tsx
+++ b/apps/prs/react/src/routes/public-form/error-summary.tsx
@@ -1,0 +1,110 @@
+import { forwardRef } from "react";
+import { GoabIcon, GoabText } from "@abgov/react-components";
+
+export type FieldError = {
+  /** id of the GoabFormItem this error belongs to, used to jump/scroll to the field. */
+  fieldId: string;
+  /** The message shown both in the summary and (by the page) on the field itself. */
+  text: string;
+};
+
+const FOCUSABLE = "input, select, textarea, button, [tabindex]:not([tabindex='-1'])";
+
+// Depth-first walk of light DOM and any open shadow roots, returning the first
+// focusable control. GoA form controls render their real input inside the web
+// component's shadow DOM (the date picker nests a dropdown one level deeper), so
+// a normal querySelector on the form item never reaches it.
+function findFocusable(node: ParentNode): HTMLElement | null {
+  for (const child of Array.from(node.children)) {
+    const el = child as HTMLElement;
+    if (el.matches(FOCUSABLE)) return el;
+    const inLight = findFocusable(el);
+    if (inLight) return inLight;
+    if (el.shadowRoot) {
+      const inShadow = findFocusable(el.shadowRoot);
+      if (inShadow) return inShadow;
+    }
+  }
+  return null;
+}
+
+/**
+ * Error summary for a question page ("There is a problem").
+ *
+ * The GOV.UK-style pattern the public form needs and the DS does not yet ship as
+ * a component: a box listing each field error as a link that jumps to the field.
+ * Pairs with per-field inline errors (GoabFormItem `error`). Deliberately NOT a
+ * Callout (guidance: callout-not-for-validation). This hand-built piece is a
+ * Step-2 component candidate to raise with Vanessa.
+ *
+ * Rendered and focus-managed by QuestionPage; pages only supply the errors.
+ */
+export const ErrorSummary = forwardRef<HTMLDivElement, { errors: FieldError[] }>(
+  function ErrorSummary({ errors }, ref) {
+    if (errors.length === 0) return null;
+
+    const jumpToField = (fieldId: string) => (e: React.MouseEvent) => {
+      e.preventDefault();
+      const formItem = document.getElementById(fieldId);
+      if (!formItem) return;
+      formItem.scrollIntoView({ behavior: "smooth", block: "center" });
+      // GoA inputs render their real control inside the web component's (open)
+      // shadow DOM, sometimes two levels deep (date picker), so a plain
+      // querySelector can't reach it. Walk light DOM + shadow roots for the
+      // first focusable control.
+      findFocusable(formItem)?.focus({ preventScroll: true });
+    };
+
+    return (
+      <div
+        ref={ref}
+        tabIndex={-1}
+        role="alert"
+        aria-labelledby="error-summary-title"
+        style={{
+          backgroundColor: "var(--goa-color-emergency-background)",
+          border: "1px solid var(--goa-color-emergency-default)",
+          borderRadius: "var(--goa-border-radius-m)",
+          padding: "var(--goa-space-l)",
+          marginBottom: "var(--goa-space-xl)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--goa-space-xs)",
+            marginBottom: "var(--goa-space-s)",
+          }}
+        >
+          <GoabIcon
+            type="warning"
+            theme="filled"
+            fillColor="var(--goa-color-emergency-default)"
+            ariaLabel=""
+          />
+          <GoabText id="error-summary-title" tag="h2" size="heading-s" mt="none" mb="none">
+            There is a problem
+          </GoabText>
+        </div>
+
+        <ul style={{ margin: 0, paddingLeft: "var(--goa-space-l)" }}>
+          {errors.map((err) => (
+            <li key={err.fieldId} style={{ marginBottom: "var(--goa-space-2xs)" }}>
+              <a
+                href={`#${err.fieldId}`}
+                onClick={jumpToField(err.fieldId)}
+                style={{
+                  color: "var(--goa-color-emergency-dark)",
+                  textDecoration: "underline",
+                }}
+              >
+                {err.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  },
+);

--- a/apps/prs/react/src/routes/public-form/error-summary.tsx
+++ b/apps/prs/react/src/routes/public-form/error-summary.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, useEffect, useRef } from "react";
 import { GoabIcon, GoabText } from "@abgov/react-components";
 
 export type FieldError = {
@@ -108,3 +108,19 @@ export const ErrorSummary = forwardRef<HTMLDivElement, { errors: FieldError[] }>
     );
   },
 );
+
+/**
+ * Focus the error summary when it first appears (an empty -> non-empty transition),
+ * so keyboard and screen-reader users land on it after a failed submit. Returns the
+ * ref to put on <ErrorSummary>. Shared by FormSet and the modal/drawer item forms.
+ */
+export function useErrorSummaryFocus(errors: FieldError[]) {
+  const ref = useRef<HTMLDivElement>(null);
+  const had = useRef(false);
+  useEffect(() => {
+    const has = errors.length > 0;
+    if (has && !had.current) ref.current?.focus();
+    had.current = has;
+  }, [errors]);
+  return ref;
+}

--- a/apps/prs/react/src/routes/public-form/examples/content-before.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/content-before.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { GoabFormItem, GoabCheckboxList, GoabCheckbox, GoabInput } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { Schema, required, minSelected, useFormValidation } from "../validation";
 
 type Values = {
   agreements: string[];
@@ -18,16 +18,11 @@ const FOIP =
   "application. This collection is authorized under section 33(c) of the Freedom of " +
   "Information and Protection of Privacy Act.";
 
-function validate(v: Values): FieldError[] {
-  const errors: FieldError[] = [];
-  if (v.agreements.length < 2)
-    errors.push({ fieldId: "agreements", text: "Select both statements to agree before continuing" });
-  if (!v.legalName.trim())
-    errors.push({ fieldId: "legalName", text: "Enter your full legal name" });
-  if (!v.signature.trim())
-    errors.push({ fieldId: "signature", text: "Type your full name to sign" });
-  return errors;
-}
+const schema: Schema = {
+  agreements: minSelected(2, "Select both statements to agree before continuing"),
+  legalName: required("Enter your full legal name"),
+  signature: required("Type your full name to sign"),
+};
 
 /**
  * Content before the question.
@@ -41,25 +36,19 @@ function validate(v: Values): FieldError[] {
 export function ContentBefore() {
   const navigate = useNavigate();
   const [values, setValues] = useState<Values>(EMPTY);
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors, submit, revalidate } = useFormValidation(schema);
 
   const update = (patch: Partial<Values>) =>
     setValues((prev) => {
       const next = { ...prev, ...patch };
-      if (submitted) setErrors(validate(next));
+      revalidate(next);
       return next;
     });
 
   const errorFor = (id: string) => errors.find((e) => e.fieldId === id)?.text;
   const has = (id: string) => errors.some((e) => e.fieldId === id);
 
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(values);
-    setErrors(found);
-    if (found.length === 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit(values, () => navigate("/public-form"));
 
   return (
     <PublicFormLayout back="/public-form">

--- a/apps/prs/react/src/routes/public-form/examples/content-before.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/content-before.tsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { GoabFormItem, GoabCheckbox, GoabInput } from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+type Values = {
+  agreeCheck: boolean;
+  agreeTrue: boolean;
+  legalName: string;
+  signature: string;
+};
+
+const EMPTY: Values = { agreeCheck: false, agreeTrue: false, legalName: "", signature: "" };
+
+const FOIP =
+  "The personal information collected through this service is used to process your " +
+  "application. This collection is authorized under section 33(c) of the Freedom of " +
+  "Information and Protection of Privacy Act.";
+
+function validate(v: Values): FieldError[] {
+  const errors: FieldError[] = [];
+  if (!(v.agreeCheck && v.agreeTrue))
+    errors.push({ fieldId: "agreements", text: "Select both statements to agree before continuing" });
+  if (!v.legalName.trim())
+    errors.push({ fieldId: "legalName", text: "Enter your full legal name" });
+  if (!v.signature.trim())
+    errors.push({ fieldId: "signature", text: "Type your full name to sign" });
+  return errors;
+}
+
+/**
+ * Content before the question.
+ *
+ * Explanatory / legal text before the inputs (the spec's consent example: a FOIP
+ * statement, then agreement checkboxes, legal name, and signature). The FOIP
+ * statement uses the FormSet `description` slot (content below the heading,
+ * before the fields). Validates on submit.
+ */
+export function ContentBefore() {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<Values>(EMPTY);
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const update = (patch: Partial<Values>) =>
+    setValues((prev) => {
+      const next = { ...prev, ...patch };
+      if (submitted) setErrors(validate(next));
+      return next;
+    });
+
+  const errorFor = (id: string) => errors.find((e) => e.fieldId === id)?.text;
+  const has = (id: string) => errors.some((e) => e.fieldId === id);
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(values);
+    setErrors(found);
+    if (found.length === 0) navigate("/public-form");
+  };
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet
+        heading="Confirm and sign"
+        description={FOIP}
+        continueLabel="Save and continue"
+        onContinue={handleContinue}
+        errors={errors}
+      >
+        <GoabFormItem
+          label="Read and agree to the following statements"
+          id="agreements"
+          error={errorFor("agreements")}
+        >
+          <GoabCheckbox
+            name="agreeCheck"
+            text="I consent to a background check being completed on me"
+            checked={values.agreeCheck}
+            error={has("agreements")}
+            onChange={(e) => update({ agreeCheck: e.checked })}
+          />
+          <GoabCheckbox
+            name="agreeTrue"
+            text="I confirm the information I have provided is true and accurate"
+            checked={values.agreeTrue}
+            error={has("agreements")}
+            mt="xs"
+            onChange={(e) => update({ agreeTrue: e.checked })}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem
+          label="Full legal name"
+          helpText="As it appears on your ID"
+          id="legalName"
+          error={errorFor("legalName")}
+          mt="l"
+        >
+          <GoabInput
+            name="legalName"
+            ariaLabel="Full legal name"
+            width="100%"
+            error={has("legalName")}
+            value={values.legalName}
+            onChange={(e) => update({ legalName: e.value })}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem
+          label="Signature"
+          helpText="Type your full name as your electronic signature"
+          id="signature"
+          error={errorFor("signature")}
+          mt="l"
+        >
+          <GoabInput
+            name="signature"
+            ariaLabel="Signature"
+            width="100%"
+            error={has("signature")}
+            value={values.signature}
+            onChange={(e) => update({ signature: e.value })}
+          />
+        </GoabFormItem>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/content-before.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/content-before.tsx
@@ -1,18 +1,17 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { GoabFormItem, GoabCheckbox, GoabInput } from "@abgov/react-components";
+import { GoabFormItem, GoabCheckboxList, GoabCheckbox, GoabInput } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
 import { FieldError } from "../error-summary";
 
 type Values = {
-  agreeCheck: boolean;
-  agreeTrue: boolean;
+  agreements: string[];
   legalName: string;
   signature: string;
 };
 
-const EMPTY: Values = { agreeCheck: false, agreeTrue: false, legalName: "", signature: "" };
+const EMPTY: Values = { agreements: [], legalName: "", signature: "" };
 
 const FOIP =
   "The personal information collected through this service is used to process your " +
@@ -21,7 +20,7 @@ const FOIP =
 
 function validate(v: Values): FieldError[] {
   const errors: FieldError[] = [];
-  if (!(v.agreeCheck && v.agreeTrue))
+  if (v.agreements.length < 2)
     errors.push({ fieldId: "agreements", text: "Select both statements to agree before continuing" });
   if (!v.legalName.trim())
     errors.push({ fieldId: "legalName", text: "Enter your full legal name" });
@@ -35,8 +34,9 @@ function validate(v: Values): FieldError[] {
  *
  * Explanatory / legal text before the inputs (the spec's consent example: a FOIP
  * statement, then agreement checkboxes, legal name, and signature). The FOIP
- * statement uses the FormSet `description` slot (content below the heading,
- * before the fields). Validates on submit.
+ * statement uses the FormSet `description` slot. The two consent statements are a
+ * GoabCheckboxList (a grouped multi-select), not standalone checkboxes. Validates
+ * on submit.
  */
 export function ContentBefore() {
   const navigate = useNavigate();
@@ -75,21 +75,23 @@ export function ContentBefore() {
           id="agreements"
           error={errorFor("agreements")}
         >
-          <GoabCheckbox
-            name="agreeCheck"
-            text="I consent to a background check being completed on me"
-            checked={values.agreeCheck}
+          <GoabCheckboxList
+            name="agreements"
+            value={values.agreements}
             error={has("agreements")}
-            onChange={(e) => update({ agreeCheck: e.checked })}
-          />
-          <GoabCheckbox
-            name="agreeTrue"
-            text="I confirm the information I have provided is true and accurate"
-            checked={values.agreeTrue}
-            error={has("agreements")}
-            mt="xs"
-            onChange={(e) => update({ agreeTrue: e.checked })}
-          />
+            onChange={(e) => update({ agreements: e.value })}
+          >
+            <GoabCheckbox
+              name="background-check"
+              value="background-check"
+              text="I consent to a background check being completed on me"
+            />
+            <GoabCheckbox
+              name="accurate"
+              value="accurate"
+              text="I confirm the information I have provided is true and accurate"
+            />
+          </GoabCheckboxList>
         </GoabFormItem>
 
         <GoabFormItem

--- a/apps/prs/react/src/routes/public-form/examples/drawer.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/drawer.tsx
@@ -11,7 +11,7 @@ import {
 } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { ErrorSummary, FieldError, useErrorSummaryFocus } from "../error-summary";
 import { Schema, required, pattern, minSelected, runSchema, useFormValidation } from "../validation";
 
 type Address = {
@@ -66,6 +66,7 @@ export function DrawerExample() {
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [draft, setDraft] = useState<Address>(EMPTY);
   const [drawerErrors, setDrawerErrors] = useState<FieldError[]>([]);
+  const drawerSummaryRef = useErrorSummaryFocus(drawerErrors);
 
   const openAdd = () => {
     setEditingIndex(null);
@@ -176,7 +177,9 @@ export function DrawerExample() {
           </GoabButtonGroup>
         }
       >
-        <GoabFormItem label="Street address" error={errorFor("street")}>
+        <ErrorSummary ref={drawerSummaryRef} errors={drawerErrors} />
+
+        <GoabFormItem label="Street address" id="street" error={errorFor("street")}>
           <GoabInput
             name="street"
             width="100%"
@@ -195,7 +198,7 @@ export function DrawerExample() {
           />
         </GoabFormItem>
 
-        <GoabFormItem label="City or town" mt="l" error={errorFor("city")}>
+        <GoabFormItem label="City or town" id="city" mt="l" error={errorFor("city")}>
           <GoabInput
             name="city"
             width="100%"
@@ -205,7 +208,7 @@ export function DrawerExample() {
           />
         </GoabFormItem>
 
-        <GoabFormItem label="Province or territory" mt="l" error={errorFor("province")}>
+        <GoabFormItem label="Province or territory" id="province" mt="l" error={errorFor("province")}>
           <GoabDropdown
             name="province"
             width="100%"
@@ -219,7 +222,7 @@ export function DrawerExample() {
           </GoabDropdown>
         </GoabFormItem>
 
-        <GoabFormItem label="Postal code" mt="l" error={errorFor("postal")}>
+        <GoabFormItem label="Postal code" id="postal" mt="l" error={errorFor("postal")}>
           <GoabInput
             name="postal"
             width="130px"
@@ -231,6 +234,7 @@ export function DrawerExample() {
 
         <GoabFormItem
           label="How long did you live here?"
+          id="years"
           mt="l"
           helpText="For example, 2 years"
           error={errorFor("years")}

--- a/apps/prs/react/src/routes/public-form/examples/drawer.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/drawer.tsx
@@ -12,6 +12,7 @@ import {
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
 import { FieldError } from "../error-summary";
+import { Schema, required, pattern, minSelected, runSchema, useFormValidation } from "../validation";
 
 type Address = {
   street: string;
@@ -42,28 +43,24 @@ const PROVINCES: ReadonlyArray<[string, string]> = [
 
 const POSTAL_CODE = /^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d$/;
 
-function validateAddress(a: Address): FieldError[] {
-  const errors: FieldError[] = [];
-  if (!a.street.trim()) errors.push({ fieldId: "street", text: "Enter the street address" });
-  if (!a.city.trim()) errors.push({ fieldId: "city", text: "Enter the city or town" });
-  if (!a.province) errors.push({ fieldId: "province", text: "Select the province or territory" });
-  if (!POSTAL_CODE.test(a.postal.trim()))
-    errors.push({ fieldId: "postal", text: "Enter a valid postal code, such as T3R 8Y2" });
-  if (!a.years.trim()) errors.push({ fieldId: "years", text: "Enter how long you lived there" });
-  return errors;
-}
+const addressSchema: Schema = {
+  street: required("Enter the street address"),
+  city: required("Enter the city or town"),
+  province: required("Select the province or territory"),
+  postal: pattern(POSTAL_CODE, "Enter a valid postal code, such as T3R 8Y2"),
+  years: required("Enter how long you lived there"),
+};
+const pageSchema: Schema = { addresses: minSelected(1, "Add at least one previous address") };
 
 /**
- * Drawer variant of the add-in-an-overlay pattern: same as the modal version,
- * but in a full-height side drawer because the item has more fields (a previous
- * address: six fields vs the modal example's three). The modal-vs-drawer choice
- * is the spec's "size choice." Validates the item inside the overlay; the page
- * requires at least one item.
+ * Drawer variant of the add-in-an-overlay pattern: same as the modal version, but
+ * in a full-height side drawer because the item has more fields. Validates the
+ * item inside the overlay (runSchema); the page requires at least one item (the hook).
  */
 export function DrawerExample() {
   const navigate = useNavigate();
   const [addresses, setAddresses] = useState<Address[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors: pageErrors, submit, revalidate } = useFormValidation(pageSchema);
 
   const [open, setOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
@@ -87,33 +84,32 @@ export function DrawerExample() {
   const updateDraft = (patch: Partial<Address>) => {
     const next = { ...draft, ...patch };
     setDraft(next);
-    if (drawerErrors.length > 0) setDrawerErrors(validateAddress(next));
+    if (drawerErrors.length > 0) setDrawerErrors(runSchema(addressSchema, next));
   };
 
   const save = () => {
-    const found = validateAddress(draft);
+    const found = runSchema(addressSchema, draft);
     setDrawerErrors(found);
     if (found.length > 0) return;
-    setAddresses((prev) =>
-      editingIndex === null ? [...prev, draft] : prev.map((a, i) => (i === editingIndex ? draft : a)),
-    );
+    const next =
+      editingIndex === null
+        ? [...addresses, draft]
+        : addresses.map((a, i) => (i === editingIndex ? draft : a));
+    setAddresses(next);
+    revalidate({ addresses: next });
     setOpen(false);
   };
 
-  const removeAddress = (i: number) => setAddresses((prev) => prev.filter((_, idx) => idx !== i));
+  const removeAddress = (i: number) => {
+    const next = addresses.filter((_, idx) => idx !== i);
+    setAddresses(next);
+    revalidate({ addresses: next });
+  };
 
   const errorFor = (id: string) => drawerErrors.find((e) => e.fieldId === id)?.text;
   const has = (id: string) => drawerErrors.some((e) => e.fieldId === id);
 
-  const pageErrors: FieldError[] =
-    submitted && addresses.length === 0
-      ? [{ fieldId: "addresses", text: "Add at least one previous address" }]
-      : [];
-
-  const handleContinue = () => {
-    setSubmitted(true);
-    if (addresses.length > 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit({ addresses }, () => navigate("/public-form"));
 
   return (
     <PublicFormLayout back="/public-form">

--- a/apps/prs/react/src/routes/public-form/examples/drawer.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/drawer.tsx
@@ -1,0 +1,253 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  GoabButton,
+  GoabButtonGroup,
+  GoabDrawer,
+  GoabFormItem,
+  GoabInput,
+  GoabDropdown,
+  GoabDropdownItem,
+} from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+type Address = {
+  street: string;
+  suite: string;
+  city: string;
+  province: string;
+  postal: string;
+  years: string;
+};
+
+const EMPTY: Address = { street: "", suite: "", city: "", province: "", postal: "", years: "" };
+
+const PROVINCES: ReadonlyArray<[string, string]> = [
+  ["AB", "Alberta"],
+  ["BC", "British Columbia"],
+  ["MB", "Manitoba"],
+  ["NB", "New Brunswick"],
+  ["NL", "Newfoundland and Labrador"],
+  ["NS", "Nova Scotia"],
+  ["NT", "Northwest Territories"],
+  ["NU", "Nunavut"],
+  ["ON", "Ontario"],
+  ["PE", "Prince Edward Island"],
+  ["QC", "Quebec"],
+  ["SK", "Saskatchewan"],
+  ["YT", "Yukon"],
+];
+
+const POSTAL_CODE = /^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d$/;
+
+function validateAddress(a: Address): FieldError[] {
+  const errors: FieldError[] = [];
+  if (!a.street.trim()) errors.push({ fieldId: "street", text: "Enter the street address" });
+  if (!a.city.trim()) errors.push({ fieldId: "city", text: "Enter the city or town" });
+  if (!a.province) errors.push({ fieldId: "province", text: "Select the province or territory" });
+  if (!POSTAL_CODE.test(a.postal.trim()))
+    errors.push({ fieldId: "postal", text: "Enter a valid postal code, such as T3R 8Y2" });
+  if (!a.years.trim()) errors.push({ fieldId: "years", text: "Enter how long you lived there" });
+  return errors;
+}
+
+/**
+ * Drawer variant of the add-in-an-overlay pattern: same as the modal version,
+ * but in a full-height side drawer because the item has more fields (a previous
+ * address: six fields vs the modal example's three). The modal-vs-drawer choice
+ * is the spec's "size choice." Validates the item inside the overlay; the page
+ * requires at least one item.
+ */
+export function DrawerExample() {
+  const navigate = useNavigate();
+  const [addresses, setAddresses] = useState<Address[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const [open, setOpen] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [draft, setDraft] = useState<Address>(EMPTY);
+  const [drawerErrors, setDrawerErrors] = useState<FieldError[]>([]);
+
+  const openAdd = () => {
+    setEditingIndex(null);
+    setDraft(EMPTY);
+    setDrawerErrors([]);
+    setOpen(true);
+  };
+
+  const openEdit = (i: number) => {
+    setEditingIndex(i);
+    setDraft(addresses[i]);
+    setDrawerErrors([]);
+    setOpen(true);
+  };
+
+  const updateDraft = (patch: Partial<Address>) => {
+    const next = { ...draft, ...patch };
+    setDraft(next);
+    if (drawerErrors.length > 0) setDrawerErrors(validateAddress(next));
+  };
+
+  const save = () => {
+    const found = validateAddress(draft);
+    setDrawerErrors(found);
+    if (found.length > 0) return;
+    setAddresses((prev) =>
+      editingIndex === null ? [...prev, draft] : prev.map((a, i) => (i === editingIndex ? draft : a)),
+    );
+    setOpen(false);
+  };
+
+  const removeAddress = (i: number) => setAddresses((prev) => prev.filter((_, idx) => idx !== i));
+
+  const errorFor = (id: string) => drawerErrors.find((e) => e.fieldId === id)?.text;
+  const has = (id: string) => drawerErrors.some((e) => e.fieldId === id);
+
+  const pageErrors: FieldError[] =
+    submitted && addresses.length === 0
+      ? [{ fieldId: "addresses", text: "Add at least one previous address" }]
+      : [];
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    if (addresses.length > 0) navigate("/public-form");
+  };
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet
+        heading="Previous addresses"
+        description="Add any addresses you have lived at in the past 5 years."
+        continueLabel="Save and continue"
+        onContinue={handleContinue}
+        errors={pageErrors}
+      >
+        <div id="addresses">
+          {addresses.length > 0 && (
+            <div style={{ marginBottom: "var(--goa-space-l)" }}>
+              {addresses.map((a, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: "var(--goa-space-m)",
+                    padding: "var(--goa-space-m) 0",
+                    borderTop: "1px solid var(--goa-color-greyscale-200)",
+                  }}
+                >
+                  <div>
+                    <div style={{ fontWeight: 700 }}>{a.street}</div>
+                    <div style={{ color: "var(--goa-color-text-secondary)" }}>
+                      {a.city}, {a.province} {a.postal} &middot; {a.years}
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: "var(--goa-space-m)", flexShrink: 0 }}>
+                    <GoabButton type="tertiary" size="compact" onClick={() => openEdit(i)}>
+                      Edit
+                    </GoabButton>
+                    <GoabButton type="tertiary" size="compact" onClick={() => removeAddress(i)}>
+                      Remove
+                    </GoabButton>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <GoabButton type="tertiary" leadingIcon="add" onClick={openAdd}>
+            {addresses.length === 0 ? "Add a previous address" : "Add another address"}
+          </GoabButton>
+        </div>
+      </FormSet>
+
+      <GoabDrawer
+        position="right"
+        open={open}
+        onClose={() => setOpen(false)}
+        heading={editingIndex === null ? "Add a previous address" : "Edit previous address"}
+        actions={
+          <GoabButtonGroup alignment="end">
+            <GoabButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
+              Cancel
+            </GoabButton>
+            <GoabButton type="primary" size="compact" onClick={save}>
+              {editingIndex === null ? "Add address" : "Save changes"}
+            </GoabButton>
+          </GoabButtonGroup>
+        }
+      >
+        <GoabFormItem label="Street address" error={errorFor("street")}>
+          <GoabInput
+            name="street"
+            width="100%"
+            error={has("street")}
+            value={draft.street}
+            onChange={(e) => updateDraft({ street: e.value })}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem label="Suite or unit number" requirement="optional" mt="l">
+          <GoabInput
+            name="suite"
+            width="100%"
+            value={draft.suite}
+            onChange={(e) => updateDraft({ suite: e.value })}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem label="City or town" mt="l" error={errorFor("city")}>
+          <GoabInput
+            name="city"
+            width="100%"
+            error={has("city")}
+            value={draft.city}
+            onChange={(e) => updateDraft({ city: e.value })}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem label="Province or territory" mt="l" error={errorFor("province")}>
+          <GoabDropdown
+            name="province"
+            width="100%"
+            error={has("province")}
+            value={draft.province}
+            onChange={(e) => updateDraft({ province: e.value ?? "" })}
+          >
+            {PROVINCES.map(([value, label]) => (
+              <GoabDropdownItem key={value} value={value} label={label} />
+            ))}
+          </GoabDropdown>
+        </GoabFormItem>
+
+        <GoabFormItem label="Postal code" mt="l" error={errorFor("postal")}>
+          <GoabInput
+            name="postal"
+            width="130px"
+            error={has("postal")}
+            value={draft.postal}
+            onChange={(e) => updateDraft({ postal: e.value })}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem
+          label="How long did you live here?"
+          mt="l"
+          helpText="For example, 2 years"
+          error={errorFor("years")}
+        >
+          <GoabInput
+            name="years"
+            width="200px"
+            error={has("years")}
+            value={draft.years}
+            onChange={(e) => updateDraft({ years: e.value })}
+          />
+        </GoabFormItem>
+      </GoabDrawer>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/eligibility-review.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/eligibility-review.tsx
@@ -1,50 +1,38 @@
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { GoabText, GoabButton, GoabButtonGroup } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
-import { FormSet } from "../form-set";
+import { SummarySection, SummaryItem } from "../form-summary";
 
 const ROOT = "/public-form/eligibility";
 const yesNo = (v: string) => (v === "yes" ? "Yes" : v === "no" ? "No" : "Not answered");
 
-// Minimal answer row. A real form summary (label / value / Change, grouped) is a
-// Step-2 component the DS doesn't ship yet, hand-built here as a placeholder.
-function Row({ label, value, changeTo }: { label: string; value: string; changeTo: string }) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "baseline",
-        gap: "var(--goa-space-m)",
-        padding: "var(--goa-space-s) 0",
-        borderTop: "1px solid var(--goa-color-greyscale-200)",
-      }}
-    >
-      <span style={{ flex: "0 0 40%", color: "var(--goa-color-text-secondary)" }}>{label}</span>
-      <span style={{ flex: 1 }}>{yesNo(value)}</span>
-      <Link to={changeTo}>Change</Link>
-    </div>
-  );
-}
-
 /**
- * Section review ("check your answers") for the eligibility task. Lets the user
- * confirm or change each answer, then completes the section and returns to the
- * task list.
+ * Section review ("check your answers") for the eligibility task. Composed from
+ * the form-summary pieces: each answer is its own SummarySection (a single
+ * SummaryItem) with its own Change target back to that question page, since the
+ * two answers change in different places. Editable state, ending in Save and
+ * continue. (Replaces the earlier hand-built placeholder Row.)
  */
 export function EligibilityReview({ answers }: { answers: { age: string; residency: string } }) {
   const navigate = useNavigate();
   return (
     <PublicFormLayout back={`${ROOT}/residency`}>
-      <FormSet
-        heading="Check your answers"
-        continueLabel="Save and continue"
-        onContinue={() => navigate("/public-form")}
-      >
-        <div>
-          <Row label="18 or older?" value={answers.age} changeTo={`${ROOT}/age`} />
-          <Row label="Live in Alberta?" value={answers.residency} changeTo={`${ROOT}/residency`} />
-        </div>
-      </FormSet>
+      <GoabText tag="h1" mt="none" mb="xl">
+        Check your answers
+      </GoabText>
+
+      <SummarySection changeTo={`${ROOT}/age`}>
+        <SummaryItem question="Are you 18 or older?">{yesNo(answers.age)}</SummaryItem>
+      </SummarySection>
+      <SummarySection changeTo={`${ROOT}/residency`}>
+        <SummaryItem question="Do you live in Alberta?">{yesNo(answers.residency)}</SummaryItem>
+      </SummarySection>
+
+      <GoabButtonGroup alignment="start" mt="2xl">
+        <GoabButton type="primary" onClick={() => navigate("/public-form")}>
+          Save and continue
+        </GoabButton>
+      </GoabButtonGroup>
     </PublicFormLayout>
   );
 }

--- a/apps/prs/react/src/routes/public-form/examples/eligibility-review.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/eligibility-review.tsx
@@ -1,0 +1,50 @@
+import { Link, useNavigate } from "react-router-dom";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+
+const ROOT = "/public-form/eligibility";
+const yesNo = (v: string) => (v === "yes" ? "Yes" : v === "no" ? "No" : "Not answered");
+
+// Minimal answer row. A real form summary (label / value / Change, grouped) is a
+// Step-2 component the DS doesn't ship yet, hand-built here as a placeholder.
+function Row({ label, value, changeTo }: { label: string; value: string; changeTo: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "baseline",
+        gap: "var(--goa-space-m)",
+        padding: "var(--goa-space-s) 0",
+        borderTop: "1px solid var(--goa-color-greyscale-200)",
+      }}
+    >
+      <span style={{ flex: "0 0 40%", color: "var(--goa-color-text-secondary)" }}>{label}</span>
+      <span style={{ flex: 1 }}>{yesNo(value)}</span>
+      <Link to={changeTo}>Change</Link>
+    </div>
+  );
+}
+
+/**
+ * Section review ("check your answers") for the eligibility task. Lets the user
+ * confirm or change each answer, then completes the section and returns to the
+ * task list.
+ */
+export function EligibilityReview({ answers }: { answers: { age: string; residency: string } }) {
+  const navigate = useNavigate();
+  return (
+    <PublicFormLayout back={`${ROOT}/residency`}>
+      <FormSet
+        heading="Check your answers"
+        continueLabel="Save and continue"
+        onContinue={() => navigate("/public-form")}
+      >
+        <div>
+          <Row label="18 or older?" value={answers.age} changeTo={`${ROOT}/age`} />
+          <Row label="Live in Alberta?" value={answers.residency} changeTo={`${ROOT}/residency`} />
+        </div>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/eligibility-review.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/eligibility-review.tsx
@@ -4,29 +4,47 @@ import { PublicFormLayout } from "../public-form-layout";
 import { SummarySection, SummaryItem } from "../form-summary";
 
 const ROOT = "/public-form/eligibility";
-const yesNo = (v: string) => (v === "yes" ? "Yes" : v === "no" ? "No" : "Not answered");
+const yesNo = (v?: string) => (v === "yes" ? "Yes" : v === "no" ? "No" : "Not answered");
 
 /**
- * Section review ("check your answers") for the eligibility task. Composed from
- * the form-summary pieces: each answer is its own SummarySection (a single
- * SummaryItem) with its own Change target back to that question page, since the
- * two answers change in different places. Editable state, ending in Save and
- * continue. (Replaces the earlier hand-built placeholder Row.)
+ * Section review ("check your answers") for the eligibility task. Each answer is
+ * its own SummarySection; Change uses the action form (onChange) to enter the
+ * change-from-review flow, where the question pre-fills and Save returns here
+ * (re-walking any newly-opened questions first). The benefits-detail row only
+ * shows when benefits is "yes".
  */
-export function EligibilityReview({ answers }: { answers: { age: string; residency: string } }) {
+export function EligibilityReview({
+  answers,
+  onChange,
+}: {
+  answers: Record<string, string | undefined>;
+  onChange: (step: string) => void;
+}) {
   const navigate = useNavigate();
   return (
-    <PublicFormLayout back={`${ROOT}/residency`}>
+    <PublicFormLayout back={`${ROOT}/benefits`}>
       <GoabText tag="h1" mt="none" mb="xl">
         Check your answers
       </GoabText>
 
-      <SummarySection changeTo={`${ROOT}/age`}>
+      <SummarySection onChange={() => onChange("age")}>
         <SummaryItem question="Are you 18 or older?">{yesNo(answers.age)}</SummaryItem>
       </SummarySection>
-      <SummarySection changeTo={`${ROOT}/residency`}>
+      <SummarySection onChange={() => onChange("residency")}>
         <SummaryItem question="Do you live in Alberta?">{yesNo(answers.residency)}</SummaryItem>
       </SummarySection>
+      <SummarySection onChange={() => onChange("benefits")}>
+        <SummaryItem question="Are you receiving other benefits?">
+          {yesNo(answers.benefits)}
+        </SummaryItem>
+      </SummarySection>
+      {answers.benefits === "yes" && (
+        <SummarySection onChange={() => onChange("benefits-detail")}>
+          <SummaryItem question="Which benefits are you receiving?">
+            {answers["benefits-detail"] || "Not answered"}
+          </SummaryItem>
+        </SummarySection>
+      )}
 
       <GoabButtonGroup alignment="start" mt="2xl">
         <GoabButton type="primary" onClick={() => navigate("/public-form")}>

--- a/apps/prs/react/src/routes/public-form/examples/eligibility-task.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/eligibility-task.tsx
@@ -10,6 +10,7 @@ import {
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
 import { FieldError } from "../error-summary";
+import { required, runSchema } from "../validation";
 import { EligibilityReview } from "./eligibility-review";
 import { Ineligible } from "./ineligible";
 
@@ -199,7 +200,7 @@ function Question({
   const [submitted, setSubmitted] = useState(false);
 
   const validate = (v: string): FieldError[] =>
-    v && v.trim() ? [] : [{ fieldId: id, text: cfg.requiredError }];
+    runSchema({ [id]: required(cfg.requiredError) }, { [id]: v });
 
   const handleChange = (v: string) => {
     setDraft(v);

--- a/apps/prs/react/src/routes/public-form/examples/eligibility-task.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/eligibility-task.tsx
@@ -1,6 +1,12 @@
 import { useState } from "react";
 import { Routes, Route, Navigate, useNavigate } from "react-router-dom";
-import { GoabFormItem, GoabRadioGroup, GoabRadioItem } from "@abgov/react-components";
+import {
+  GoabFormItem,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabInput,
+  GoabCallout,
+} from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
 import { FieldError } from "../error-summary";
@@ -9,119 +15,244 @@ import { Ineligible } from "./ineligible";
 
 const ROOT = "/public-form/eligibility";
 
-type Answers = { age: string; residency: string };
+type StepId = "age" | "residency" | "benefits" | "benefits-detail";
+type Answers = Partial<Record<StepId, string>>;
+type Outcome = "review" | "ineligible";
 
 /**
- * A single Yes/No eligibility question. Validates (an answer is required) on
- * submit, then runs `next` to branch to the following page. Reuses the shared
- * PublicFormLayout + FormSet, so a flow page is the same shape as any other
- * question page.
+ * The flow graph: given the answers, where each step leads. Branch logic lives
+ * here, not in the JSX, so the resolver can walk it for the change-from-review
+ * flow. This hand-coded graph is the demo stand-in for the V2 data-driven runtime.
  */
-function YesNoQuestion({
-  heading,
-  back,
-  value,
-  onChange,
-  next,
-  requiredError,
-}: {
-  heading: string;
-  back: string;
-  value: string;
-  onChange: (v: string) => void;
-  next: (v: string) => string;
-  requiredError: string;
-}) {
-  const navigate = useNavigate();
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+const NEXT: Record<StepId, (a: Answers) => StepId | Outcome> = {
+  age: (a) => (a.age === "yes" ? "residency" : "ineligible"),
+  residency: (a) => (a.residency === "yes" ? "benefits" : "ineligible"),
+  benefits: (a) => (a.benefits === "yes" ? "benefits-detail" : "review"),
+  "benefits-detail": () => "review",
+};
 
-  const validate = (v: string): FieldError[] =>
-    v ? [] : [{ fieldId: "answer", text: requiredError }];
+type StepConfig = { heading: string; requiredError: string; field: "yesno" | "text"; back: string };
+const STEPS: Record<StepId, StepConfig> = {
+  age: {
+    heading: "Are you 18 or older?",
+    requiredError: "Select yes if you are 18 or older",
+    field: "yesno",
+    back: "/public-form",
+  },
+  residency: {
+    heading: "Do you live in Alberta?",
+    requiredError: "Select yes if you live in Alberta",
+    field: "yesno",
+    back: `${ROOT}/age`,
+  },
+  benefits: {
+    heading: "Are you receiving other benefits?",
+    requiredError: "Select yes if you are receiving other benefits",
+    field: "yesno",
+    back: `${ROOT}/residency`,
+  },
+  "benefits-detail": {
+    heading: "Which benefits are you receiving?",
+    requiredError: "Enter the benefits you receive",
+    field: "text",
+    back: `${ROOT}/benefits`,
+  },
+};
 
-  const handleChange = (v: string) => {
-    onChange(v);
-    if (submitted) setErrors(validate(v));
-  };
+const isOutcome = (s: StepId | Outcome): s is Outcome => s === "review" || s === "ineligible";
+const isAnswered = (id: StepId, a: Answers) => Boolean(a[id] && a[id] !== "");
 
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(value);
-    setErrors(found);
-    if (found.length === 0) navigate(next(value));
-  };
+/**
+ * Walk forward from `from`, skipping already-answered questions, to the first
+ * unanswered question or a terminal outcome. The same walk serves the first pass
+ * and the change-from-review flow: in the first pass nothing ahead is answered, so
+ * it lands on the immediate next question; in change mode it skips what's already
+ * answered and stops at the first newly-opened question (or the outcome).
+ */
+function resolveNext(from: StepId, a: Answers): { question: StepId } | { outcome: Outcome } {
+  let cur = NEXT[from](a);
+  while (!isOutcome(cur)) {
+    if (!isAnswered(cur, a)) return { question: cur };
+    cur = NEXT[cur](a);
+  }
+  return { outcome: cur };
+}
 
-  return (
-    <PublicFormLayout back={back}>
-      <FormSet onContinue={handleContinue} errors={errors}>
-        <GoabFormItem
-          label={heading}
-          labelSize="large"
-          id="answer"
-          error={errors.find((e) => e.fieldId === "answer")?.text}
-        >
-          <GoabRadioGroup
-            name="answer"
-            ariaLabel={heading}
-            value={value}
-            onChange={(e) => handleChange(e.value)}
-          >
-            <GoabRadioItem value="yes" label="Yes" />
-            <GoabRadioItem value="no" label="No" />
-          </GoabRadioGroup>
-        </GoabFormItem>
-      </FormSet>
-    </PublicFormLayout>
-  );
+/** Steps reachable from the start along the answered path. Anything answered but not reachable is an abandoned branch and gets discarded. */
+function reachable(a: Answers): Set<StepId> {
+  const set = new Set<StepId>();
+  let cur: StepId | Outcome = "age";
+  while (!isOutcome(cur)) {
+    set.add(cur);
+    if (!isAnswered(cur, a)) break;
+    cur = NEXT[cur](a);
+  }
+  return set;
+}
+
+/** Count the unanswered questions from `from` to the terminal — the "N more questions". */
+function remainingNew(from: StepId, a: Answers): number {
+  let cur: StepId | Outcome = from;
+  let n = 0;
+  while (!isOutcome(cur)) {
+    if (!isAnswered(cur, a)) n++;
+    cur = NEXT[cur](a);
+  }
+  return n;
 }
 
 /**
- * Eligibility task: a real multi-page task (an organized section), not a single
- * question. Shows what the gallery's isolated pages don't: a task is a sequence
- * of question pages with branching/next-logic, an ineligible outcome, a section
- * review, and a round trip back to the task list.
- *
- * Each question page owns its next-logic (the spec's core primitive: "question
- * page + optional branching to the next page"), and the whole flow is visible
- * here. Pages are real routes, so the browser back button works across the
- * section.
+ * Eligibility task: a real multi-page task with branching, plus the change-from-
+ * review flow. A review-change re-runs the branch logic and lands in one of three
+ * places: straight back to review (no structural change), through newly-opened
+ * questions then review (the rewalk), or a different outcome entirely (a gate
+ * flipped to "No" routes to ineligible).
  */
 export function EligibilityTask() {
-  const [answers, setAnswers] = useState<Answers>({ age: "", residency: "" });
-  const set = (key: keyof Answers) => (value: string) =>
-    setAnswers((a) => ({ ...a, [key]: value }));
+  const navigate = useNavigate();
+  const [answers, setAnswers] = useState<Answers>({});
+  // Change-from-review state: the question the user clicked "Change" on, plus a
+  // snapshot to restore on cancel. null = the normal first pass.
+  const [change, setChange] = useState<{ entry: StepId; snapshot: Answers } | null>(null);
+
+  const startChange = (step: string) => {
+    setChange({ entry: step as StepId, snapshot: answers });
+    navigate(`${ROOT}/${step}`);
+  };
+
+  // "Back to review" in change mode: restore the snapshot (discarding the whole
+  // in-progress change, including any partial rewalk answers) and return to review.
+  const cancelChange = () => {
+    if (change) setAnswers(change.snapshot);
+    setChange(null);
+    navigate(`${ROOT}/review`);
+  };
+
+  const save = (step: StepId, value: string) => {
+    const updated: Answers = { ...answers, [step]: value };
+    // Discard answers on branches no longer taken.
+    const keep = reachable(updated);
+    const pruned: Answers = {};
+    (Object.keys(updated) as StepId[]).forEach((k) => {
+      if (keep.has(k)) pruned[k] = updated[k];
+    });
+    setAnswers(pruned);
+
+    const next = resolveNext(step, pruned);
+    if ("outcome" in next) {
+      setChange(null); // change flow complete (or first pass done)
+      navigate(next.outcome === "review" ? `${ROOT}/review` : `${ROOT}/ineligible`);
+    } else {
+      navigate(`${ROOT}/${next.question}`);
+    }
+  };
+
+  const renderStep = (id: StepId) => {
+    const inChange = change !== null;
+    // The "N more questions" callout shows on a newly-opened question during a
+    // change (not the question the user actually clicked Change on).
+    const isRewalk = inChange && id !== change!.entry;
+    return (
+      <Question
+        key={id}
+        id={id}
+        value={answers[id] ?? ""}
+        inChange={inChange}
+        calloutCount={isRewalk ? remainingNew(id, answers) : 0}
+        onSave={(v) => save(id, v)}
+        onCancel={cancelChange}
+      />
+    );
+  };
 
   return (
     <Routes>
       <Route index element={<Navigate to="age" replace />} />
-      <Route
-        path="age"
-        element={
-          <YesNoQuestion
-            heading="Are you 18 or older?"
-            back="/public-form"
-            value={answers.age}
-            onChange={set("age")}
-            next={(v) => (v === "yes" ? `${ROOT}/residency` : `${ROOT}/ineligible`)}
-            requiredError="Select yes if you are 18 or older"
-          />
-        }
-      />
-      <Route
-        path="residency"
-        element={
-          <YesNoQuestion
-            heading="Do you live in Alberta?"
-            back={`${ROOT}/age`}
-            value={answers.residency}
-            onChange={set("residency")}
-            next={(v) => (v === "yes" ? `${ROOT}/review` : `${ROOT}/ineligible`)}
-            requiredError="Select yes if you live in Alberta"
-          />
-        }
-      />
-      <Route path="review" element={<EligibilityReview answers={answers} />} />
+      <Route path="age" element={renderStep("age")} />
+      <Route path="residency" element={renderStep("residency")} />
+      <Route path="benefits" element={renderStep("benefits")} />
+      <Route path="benefits-detail" element={renderStep("benefits-detail")} />
+      <Route path="review" element={<EligibilityReview answers={answers} onChange={startChange} />} />
       <Route path="ineligible" element={<Ineligible />} />
     </Routes>
+  );
+}
+
+function Question({
+  id,
+  value,
+  inChange,
+  calloutCount,
+  onSave,
+  onCancel,
+}: {
+  id: StepId;
+  value: string;
+  inChange: boolean;
+  calloutCount: number;
+  onSave: (value: string) => void;
+  onCancel: () => void;
+}) {
+  const cfg = STEPS[id];
+  const [draft, setDraft] = useState(value);
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const validate = (v: string): FieldError[] =>
+    v && v.trim() ? [] : [{ fieldId: id, text: cfg.requiredError }];
+
+  const handleChange = (v: string) => {
+    setDraft(v);
+    if (submitted) setErrors(validate(v));
+  };
+
+  const handleSave = () => {
+    setSubmitted(true);
+    const found = validate(draft);
+    setErrors(found);
+    if (found.length === 0) onSave(draft);
+  };
+
+  // First pass: back goes to the previous question. Change mode: "Back to review" cancels.
+  const layoutProps = inChange
+    ? { backLabel: "Back to review", onBack: onCancel }
+    : { back: cfg.back };
+
+  return (
+    <PublicFormLayout {...layoutProps}>
+      {calloutCount > 0 && (
+        <GoabCallout type="important" heading="You changed an answer" mb="l">
+          Based on your change, there {calloutCount === 1 ? "is" : "are"} {calloutCount} more{" "}
+          {calloutCount === 1 ? "question" : "questions"} to confirm.
+        </GoabCallout>
+      )}
+      <FormSet onContinue={handleSave} continueLabel="Save and continue" errors={errors}>
+        <GoabFormItem
+          label={cfg.heading}
+          labelSize="large"
+          id={id}
+          error={errors.find((e) => e.fieldId === id)?.text}
+        >
+          {cfg.field === "yesno" ? (
+            <GoabRadioGroup
+              name={id}
+              ariaLabel={cfg.heading}
+              value={draft}
+              onChange={(e) => handleChange(e.value)}
+            >
+              <GoabRadioItem value="yes" label="Yes" />
+              <GoabRadioItem value="no" label="No" />
+            </GoabRadioGroup>
+          ) : (
+            <GoabInput
+              name={id}
+              value={draft}
+              width="100%"
+              onChange={(e) => handleChange(e.value)}
+            />
+          )}
+        </GoabFormItem>
+      </FormSet>
+    </PublicFormLayout>
   );
 }

--- a/apps/prs/react/src/routes/public-form/examples/eligibility-task.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/eligibility-task.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { Routes, Route, Navigate, useNavigate } from "react-router-dom";
+import { GoabFormItem, GoabRadioGroup, GoabRadioItem } from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+import { EligibilityReview } from "./eligibility-review";
+import { Ineligible } from "./ineligible";
+
+const ROOT = "/public-form/eligibility";
+
+type Answers = { age: string; residency: string };
+
+/**
+ * A single Yes/No eligibility question. Validates (an answer is required) on
+ * submit, then runs `next` to branch to the following page. Reuses the shared
+ * PublicFormLayout + FormSet, so a flow page is the same shape as any other
+ * question page.
+ */
+function YesNoQuestion({
+  heading,
+  back,
+  value,
+  onChange,
+  next,
+  requiredError,
+}: {
+  heading: string;
+  back: string;
+  value: string;
+  onChange: (v: string) => void;
+  next: (v: string) => string;
+  requiredError: string;
+}) {
+  const navigate = useNavigate();
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const validate = (v: string): FieldError[] =>
+    v ? [] : [{ fieldId: "answer", text: requiredError }];
+
+  const handleChange = (v: string) => {
+    onChange(v);
+    if (submitted) setErrors(validate(v));
+  };
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(value);
+    setErrors(found);
+    if (found.length === 0) navigate(next(value));
+  };
+
+  return (
+    <PublicFormLayout back={back}>
+      <FormSet onContinue={handleContinue} errors={errors}>
+        <GoabFormItem
+          label={heading}
+          labelSize="large"
+          id="answer"
+          error={errors.find((e) => e.fieldId === "answer")?.text}
+        >
+          <GoabRadioGroup
+            name="answer"
+            ariaLabel={heading}
+            value={value}
+            onChange={(e) => handleChange(e.value)}
+          >
+            <GoabRadioItem value="yes" label="Yes" />
+            <GoabRadioItem value="no" label="No" />
+          </GoabRadioGroup>
+        </GoabFormItem>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}
+
+/**
+ * Eligibility task: a real multi-page task (an organized section), not a single
+ * question. Shows what the gallery's isolated pages don't: a task is a sequence
+ * of question pages with branching/next-logic, an ineligible outcome, a section
+ * review, and a round trip back to the task list.
+ *
+ * Each question page owns its next-logic (the spec's core primitive: "question
+ * page + optional branching to the next page"), and the whole flow is visible
+ * here. Pages are real routes, so the browser back button works across the
+ * section.
+ */
+export function EligibilityTask() {
+  const [answers, setAnswers] = useState<Answers>({ age: "", residency: "" });
+  const set = (key: keyof Answers) => (value: string) =>
+    setAnswers((a) => ({ ...a, [key]: value }));
+
+  return (
+    <Routes>
+      <Route index element={<Navigate to="age" replace />} />
+      <Route
+        path="age"
+        element={
+          <YesNoQuestion
+            heading="Are you 18 or older?"
+            back="/public-form"
+            value={answers.age}
+            onChange={set("age")}
+            next={(v) => (v === "yes" ? `${ROOT}/residency` : `${ROOT}/ineligible`)}
+            requiredError="Select yes if you are 18 or older"
+          />
+        }
+      />
+      <Route
+        path="residency"
+        element={
+          <YesNoQuestion
+            heading="Do you live in Alberta?"
+            back={`${ROOT}/age`}
+            value={answers.residency}
+            onChange={set("residency")}
+            next={(v) => (v === "yes" ? `${ROOT}/review` : `${ROOT}/ineligible`)}
+            requiredError="Select yes if you live in Alberta"
+          />
+        }
+      />
+      <Route path="review" element={<EligibilityReview answers={answers} />} />
+      <Route path="ineligible" element={<Ineligible />} />
+    </Routes>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/file-upload.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/file-upload.tsx
@@ -8,13 +8,13 @@ import {
 } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { Schema, required, useFormValidation } from "../validation";
 
 type UploadedFile = { name: string; size: number; type: string };
 
-function validate(file: UploadedFile | null): FieldError[] {
-  return file ? [] : [{ fieldId: "idDocument", text: "Upload a copy of your ID" }];
-}
+const schema: Schema = {
+  idDocument: required("Upload a copy of your ID"),
+};
 
 /**
  * File upload.
@@ -24,32 +24,26 @@ function validate(file: UploadedFile | null): FieldError[] {
  * action. Validates on submit (a file is required).
  *
  * Note: GoabFileUploadInput has no `error` prop, so the required-file error can
- * only surface via the form item message + summary, not a red dropzone. Minor
- * gap for Vanessa.
+ * only surface via the form item message + summary, not a red dropzone. Minor gap
+ * for Vanessa.
  */
 export function FileUpload() {
   const navigate = useNavigate();
   const [file, setFile] = useState<UploadedFile | null>(null);
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors, submit, revalidate } = useFormValidation(schema);
 
   const handleSelect = (detail: { file: File }) => {
     const next = { name: detail.file.name, size: detail.file.size, type: detail.file.type };
     setFile(next);
-    if (submitted) setErrors(validate(next));
+    revalidate({ idDocument: next });
   };
 
   const handleDelete = () => {
     setFile(null);
-    if (submitted) setErrors(validate(null));
+    revalidate({ idDocument: null });
   };
 
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(file);
-    setErrors(found);
-    if (found.length === 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit({ idDocument: file }, () => navigate("/public-form"));
 
   return (
     <PublicFormLayout back="/public-form">

--- a/apps/prs/react/src/routes/public-form/examples/file-upload.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/file-upload.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  GoabFormItem,
+  GoabFileUploadInput,
+  GoabFileUploadCard,
+  GoabDetails,
+} from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+type UploadedFile = { name: string; size: number; type: string };
+
+function validate(file: UploadedFile | null): FieldError[] {
+  return file ? [] : [{ fieldId: "idDocument", text: "Upload a copy of your ID" }];
+}
+
+/**
+ * File upload.
+ *
+ * Drag-and-drop upload with constraints (max 10MB; JPG, PNG, PDF) and a Details
+ * for help. Selecting a file swaps the dropzone for a file card with a remove
+ * action. Validates on submit (a file is required).
+ *
+ * Note: GoabFileUploadInput has no `error` prop, so the required-file error can
+ * only surface via the form item message + summary, not a red dropzone. Minor
+ * gap for Vanessa.
+ */
+export function FileUpload() {
+  const navigate = useNavigate();
+  const [file, setFile] = useState<UploadedFile | null>(null);
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSelect = (detail: { file: File }) => {
+    const next = { name: detail.file.name, size: detail.file.size, type: detail.file.type };
+    setFile(next);
+    if (submitted) setErrors(validate(next));
+  };
+
+  const handleDelete = () => {
+    setFile(null);
+    if (submitted) setErrors(validate(null));
+  };
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(file);
+    setErrors(found);
+    if (found.length === 0) navigate("/public-form");
+  };
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet
+        heading="Upload your ID"
+        continueLabel="Save and continue"
+        onContinue={handleContinue}
+        errors={errors}
+      >
+        <GoabFormItem
+          label=""
+          id="idDocument"
+          helpText="Maximum file size is 10MB. Accepted formats: JPG, PNG, PDF"
+          error={errors.find((e) => e.fieldId === "idDocument")?.text}
+        >
+          {file ? (
+            <GoabFileUploadCard
+              filename={file.name}
+              size={file.size}
+              type={file.type}
+              onDelete={handleDelete}
+            />
+          ) : (
+            <GoabFileUploadInput
+              variant="dragdrop"
+              accept=".jpg,.jpeg,.png,.pdf"
+              maxFileSize="10MB"
+              onSelectFile={handleSelect}
+            />
+          )}
+        </GoabFormItem>
+
+        <GoabDetails heading="What can I use as ID?" mt="l">
+          <p>You can upload any government-issued photo ID, such as:</p>
+          <ul>
+            <li>Driver's licence</li>
+            <li>Passport</li>
+            <li>Provincial ID card</li>
+            <li>Permanent resident card</li>
+          </ul>
+          <p>Make sure the image is clear and all the text is readable.</p>
+        </GoabDetails>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/grouped-fields.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/grouped-fields.tsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  GoabFormItem,
+  GoabInput,
+  GoabDropdown,
+  GoabDropdownItem,
+} from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+const PROVINCES: ReadonlyArray<[string, string]> = [
+  ["AB", "Alberta"],
+  ["BC", "British Columbia"],
+  ["MB", "Manitoba"],
+  ["NB", "New Brunswick"],
+  ["NL", "Newfoundland and Labrador"],
+  ["NS", "Nova Scotia"],
+  ["NT", "Northwest Territories"],
+  ["NU", "Nunavut"],
+  ["ON", "Ontario"],
+  ["PE", "Prince Edward Island"],
+  ["QC", "Quebec"],
+  ["SK", "Saskatchewan"],
+  ["YT", "Yukon"],
+];
+
+const POSTAL_CODE = /^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d$/;
+
+type Values = {
+  street: string;
+  suite: string;
+  city: string;
+  province: string;
+  postal: string;
+};
+
+const EMPTY: Values = { street: "", suite: "", city: "", province: "", postal: "" };
+
+// Required-field + postal-format checks, in field order so the summary reads
+// top to bottom. Each error's fieldId matches a GoabFormItem id, which links
+// the summary entry to the field and drives the inline error.
+function validate(values: Values): FieldError[] {
+  const errors: FieldError[] = [];
+  if (!values.street.trim())
+    errors.push({ fieldId: "street", text: "Enter your street address" });
+  if (!values.city.trim())
+    errors.push({ fieldId: "city", text: "Enter your city or town" });
+  if (!values.province)
+    errors.push({ fieldId: "province", text: "Select your province or territory" });
+  if (!POSTAL_CODE.test(values.postal.trim()))
+    errors.push({ fieldId: "postal", text: "Enter a valid postal code, such as T3R 8Y2" });
+  return errors;
+}
+
+/**
+ * Grouped fields, one topic: a home address.
+ *
+ * Several inputs that make up one thing, grouped under one heading (the
+ * goa-form-set "Multiple questions = True" shape: a section heading plus fields
+ * with normal labels). Also the validation showcase: validates on Continue,
+ * surfaces the error summary plus per-field inline errors, and live-clears each
+ * error as it's fixed. Matches the "What is your address?" error-state screen
+ * in Figma.
+ */
+export function GroupedFields() {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<Values>(EMPTY);
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const set = (key: keyof Values) => (value: string) =>
+    setValues((prev) => {
+      const next = { ...prev, [key]: value };
+      // After the first submit, re-validate live so fixed fields clear as you go.
+      if (submitted) setErrors(validate(next));
+      return next;
+    });
+
+  const errorFor = (fieldId: string) => errors.find((e) => e.fieldId === fieldId)?.text;
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(values);
+    setErrors(found);
+    if (found.length === 0) navigate("/public-form");
+  };
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet
+        heading="What is your address?"
+        continueLabel="Save and continue"
+        onContinue={handleContinue}
+        errors={errors}
+      >
+        <GoabFormItem label="Street address" id="street" error={errorFor("street")}>
+          <GoabInput
+            name="street"
+            ariaLabel="Street address"
+            width="100%"
+            error={!!errorFor("street")}
+            value={values.street}
+            onChange={(e) => set("street")(e.value)}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem label="Suite or unit number" id="suite" requirement="optional" mt="l">
+          <GoabInput
+            name="suite"
+            ariaLabel="Suite or unit number"
+            width="100%"
+            value={values.suite}
+            onChange={(e) => set("suite")(e.value)}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem label="City or town" id="city" error={errorFor("city")} mt="l">
+          <GoabInput
+            name="city"
+            ariaLabel="City or town"
+            width="100%"
+            error={!!errorFor("city")}
+            value={values.city}
+            onChange={(e) => set("city")(e.value)}
+          />
+        </GoabFormItem>
+
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--goa-space-l)",
+            flexWrap: "wrap",
+            marginTop: "var(--goa-space-l)",
+          }}
+        >
+          <div style={{ width: "fit-content" }}>
+            <GoabFormItem
+              label="Province or territory"
+              id="province"
+              error={errorFor("province")}
+              mt="none"
+            >
+              <GoabDropdown
+                name="province"
+                ariaLabel="Province or territory"
+                error={!!errorFor("province")}
+                value={values.province}
+                onChange={(e) => set("province")(e.value ?? "")}
+              >
+                {PROVINCES.map(([value, label]) => (
+                  <GoabDropdownItem key={value} value={value} label={label} />
+                ))}
+              </GoabDropdown>
+            </GoabFormItem>
+          </div>
+
+          <div style={{ width: "130px" }}>
+            <GoabFormItem label="Postal code" id="postal" error={errorFor("postal")} mt="none">
+              <GoabInput
+                name="postal"
+                ariaLabel="Postal code"
+                width="100%"
+                error={!!errorFor("postal")}
+                value={values.postal}
+                onChange={(e) => set("postal")(e.value)}
+              />
+            </GoabFormItem>
+          </div>
+        </div>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/grouped-fields.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/grouped-fields.tsx
@@ -8,7 +8,7 @@ import {
 } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { Schema, required, pattern, useFormValidation } from "../validation";
 
 const PROVINCES: ReadonlyArray<[string, string]> = [
   ["AB", "Alberta"],
@@ -38,54 +38,38 @@ type Values = {
 
 const EMPTY: Values = { street: "", suite: "", city: "", province: "", postal: "" };
 
-// Required-field + postal-format checks, in field order so the summary reads
-// top to bottom. Each error's fieldId matches a GoabFormItem id, which links
-// the summary entry to the field and drives the inline error.
-function validate(values: Values): FieldError[] {
-  const errors: FieldError[] = [];
-  if (!values.street.trim())
-    errors.push({ fieldId: "street", text: "Enter your street address" });
-  if (!values.city.trim())
-    errors.push({ fieldId: "city", text: "Enter your city or town" });
-  if (!values.province)
-    errors.push({ fieldId: "province", text: "Select your province or territory" });
-  if (!POSTAL_CODE.test(values.postal.trim()))
-    errors.push({ fieldId: "postal", text: "Enter a valid postal code, such as T3R 8Y2" });
-  return errors;
-}
+// Rules in field order, so the summary reads top to bottom. Suite is optional, so
+// it has no rule. The postal rule folds required + format into one message.
+const schema: Schema = {
+  street: required("Enter your street address"),
+  city: required("Enter your city or town"),
+  province: required("Select your province or territory"),
+  postal: pattern(POSTAL_CODE, "Enter a valid postal code, such as T3R 8Y2"),
+};
 
 /**
  * Grouped fields, one topic: a home address.
  *
- * Several inputs that make up one thing, grouped under one heading (the
- * goa-form-set "Multiple questions = True" shape: a section heading plus fields
- * with normal labels). Also the validation showcase: validates on Continue,
- * surfaces the error summary plus per-field inline errors, and live-clears each
- * error as it's fixed. Matches the "What is your address?" error-state screen
- * in Figma.
+ * Several inputs that make up one thing, grouped under one heading. Also the
+ * validation showcase: validates on Continue, surfaces the error summary plus
+ * per-field inline errors, and live-clears each error as it's fixed. Matches the
+ * "What is your address?" error-state screen in Figma.
  */
 export function GroupedFields() {
   const navigate = useNavigate();
   const [values, setValues] = useState<Values>(EMPTY);
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors, submit, revalidate } = useFormValidation(schema);
 
   const set = (key: keyof Values) => (value: string) =>
     setValues((prev) => {
       const next = { ...prev, [key]: value };
-      // After the first submit, re-validate live so fixed fields clear as you go.
-      if (submitted) setErrors(validate(next));
+      revalidate(next);
       return next;
     });
 
   const errorFor = (fieldId: string) => errors.find((e) => e.fieldId === fieldId)?.text;
 
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(values);
-    setErrors(found);
-    if (found.length === 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit(values, () => navigate("/public-form"));
 
   return (
     <PublicFormLayout back="/public-form">

--- a/apps/prs/react/src/routes/public-form/examples/ineligible.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/ineligible.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+import { GoabText } from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+
+const ROOT = "/public-form/eligibility";
+
+/**
+ * Ineligible outcome: the dead-end branch of the eligibility task. Not a form
+ * set (no Continue), a result page reached when a gating question fails.
+ */
+export function Ineligible() {
+  return (
+    <PublicFormLayout back={`${ROOT}/age`}>
+      <GoabText tag="h1" mt="none" mb="m">
+        You are not eligible to apply
+      </GoabText>
+      <GoabText mt="none" mb="l">
+        Based on your answers, you do not meet the eligibility criteria for this service.
+      </GoabText>
+      <GoabText mt="none" mb="xl">
+        If you think this is a mistake, go back and check your answers.
+      </GoabText>
+      <Link to={`${ROOT}/age`}>Go back and change your answers</Link>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/ineligible.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/ineligible.tsx
@@ -1,26 +1,36 @@
-import { Link } from "react-router-dom";
-import { GoabText } from "@abgov/react-components";
-import { PublicFormLayout } from "../public-form-layout";
+import { useNavigate } from "react-router-dom";
+import { GoabButton, GoabButtonGroup } from "@abgov/react-components";
+import { ResultsPage, ResultContactSection } from "../results-page";
 
 const ROOT = "/public-form/eligibility";
 
 /**
- * Ineligible outcome: the dead-end branch of the eligibility task. Not a form
- * set (no Continue), a result page reached when a gating question fails.
+ * Ineligible outcome: the dead-end branch of the eligibility task, reached when a
+ * gating question fails. Uses the shared ResultsPage piece (not a FormSet, not a
+ * question page), with a flow-contextual primary action that sends the user back
+ * to the questions to change their answers. The standalone showcase of this
+ * pattern is examples/result-not-eligible.tsx.
  */
 export function Ineligible() {
+  const navigate = useNavigate();
   return (
-    <PublicFormLayout back={`${ROOT}/age`}>
-      <GoabText tag="h1" mt="none" mb="m">
-        You are not eligible to apply
-      </GoabText>
-      <GoabText mt="none" mb="l">
-        Based on your answers, you do not meet the eligibility criteria for this service.
-      </GoabText>
-      <GoabText mt="none" mb="xl">
-        If you think this is a mistake, go back and check your answers.
-      </GoabText>
-      <Link to={`${ROOT}/age`}>Go back and change your answers</Link>
-    </PublicFormLayout>
+    <ResultsPage
+      heading="You are not eligible to apply"
+      status="important"
+      statusHeading="Based on your answers, you do not meet the eligibility criteria"
+      statusBody="You can go back and change your answers if you think this is a mistake."
+      actions={
+        <GoabButtonGroup alignment="start">
+          <GoabButton type="primary" onClick={() => navigate(`${ROOT}/age`)}>
+            Go back and change your answers
+          </GoabButton>
+          <GoabButton type="secondary" onClick={() => navigate("/public-form")}>
+            Back to Alberta.ca
+          </GoabButton>
+        </GoabButtonGroup>
+      }
+    >
+      <ResultContactSection />
+    </ResultsPage>
   );
 }

--- a/apps/prs/react/src/routes/public-form/examples/inline-list.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/inline-list.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { GoabFormItem, GoabInput, GoabButton } from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+// At least one non-blank row required. A blank trailing row is fine (ignored on
+// save), so we only fail when nothing has been entered at all.
+function validate(rows: string[]): FieldError[] {
+  return rows.some((r) => r.trim())
+    ? []
+    : [{ fieldId: "dependant-0", text: "Enter at least one dependant" }];
+}
+
+/**
+ * Inline list: a single field repeated in identical rows ("+ Add another"), the
+ * V1 "add another dependant" pattern. Remove appears once there are 2+ rows.
+ * Unlimited rows; a blank trailing row is ignored on save. Validates on submit
+ * (at least one entry).
+ */
+export function InlineList() {
+  const navigate = useNavigate();
+  const [rows, setRows] = useState<string[]>([""]);
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const revalidate = (next: string[]) => {
+    if (submitted) setErrors(validate(next));
+  };
+
+  const updateRow = (i: number, value: string) => {
+    const next = rows.map((r, idx) => (idx === i ? value : r));
+    setRows(next);
+    revalidate(next);
+  };
+
+  const addRow = () => setRows([...rows, ""]);
+
+  const removeRow = (i: number) => {
+    const next = rows.filter((_, idx) => idx !== i);
+    setRows(next);
+    revalidate(next);
+  };
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(rows);
+    setErrors(found);
+    if (found.length === 0) {
+      // On save, blank rows are dropped (filter before submitting to a backend).
+      navigate("/public-form");
+    }
+  };
+
+  const firstError = errors.find((e) => e.fieldId === "dependant-0")?.text;
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet
+        heading="Your dependants"
+        description="Add the full name of each dependant under 18 in your care."
+        continueLabel="Save and continue"
+        onContinue={handleContinue}
+        errors={errors}
+      >
+        {rows.map((value, i) => (
+          <GoabFormItem
+            key={i}
+            label={`Dependant ${i + 1}`}
+            id={`dependant-${i}`}
+            error={i === 0 ? firstError : undefined}
+            mt={i > 0 ? "m" : undefined}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: "var(--goa-space-m)" }}>
+              <div style={{ flex: 1 }}>
+                <GoabInput
+                  name={`dependant-${i}`}
+                  ariaLabel={`Dependant ${i + 1} full name`}
+                  width="100%"
+                  error={i === 0 && !!firstError}
+                  value={value}
+                  onChange={(e) => updateRow(i, e.value)}
+                />
+              </div>
+              {rows.length > 1 && (
+                <GoabButton type="tertiary" onClick={() => removeRow(i)}>
+                  Remove
+                </GoabButton>
+              )}
+            </div>
+          </GoabFormItem>
+        ))}
+
+        <GoabButton type="tertiary" leadingIcon="add" mt="m" onClick={addRow}>
+          Add another dependant
+        </GoabButton>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/inline-list.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/inline-list.tsx
@@ -3,15 +3,17 @@ import { useNavigate } from "react-router-dom";
 import { GoabFormItem, GoabInput, GoabButton } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { Schema, useFormValidation } from "../validation";
 
-// At least one non-blank row required. A blank trailing row is fine (ignored on
-// save), so we only fail when nothing has been entered at all.
-function validate(rows: string[]): FieldError[] {
-  return rows.some((r) => r.trim())
-    ? []
-    : [{ fieldId: "dependant-0", text: "Enter at least one dependant" }];
-}
+// A collection rule: at least one non-blank row. Keyed to the first row so the
+// summary links there; the rule reads the whole list from `all`. (A blank trailing
+// row is fine, ignored on save.)
+const schema: Schema = {
+  "dependant-0": (_v, all) => {
+    const rows = (all.dependants as string[]) ?? [];
+    return rows.some((r) => typeof r === "string" && r.trim()) ? null : "Enter at least one dependant";
+  },
+};
 
 /**
  * Inline list: a single field repeated in identical rows ("+ Add another"), the
@@ -22,17 +24,12 @@ function validate(rows: string[]): FieldError[] {
 export function InlineList() {
   const navigate = useNavigate();
   const [rows, setRows] = useState<string[]>([""]);
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
-
-  const revalidate = (next: string[]) => {
-    if (submitted) setErrors(validate(next));
-  };
+  const { errors, submit, revalidate } = useFormValidation(schema);
 
   const updateRow = (i: number, value: string) => {
     const next = rows.map((r, idx) => (idx === i ? value : r));
     setRows(next);
-    revalidate(next);
+    revalidate({ dependants: next });
   };
 
   const addRow = () => setRows([...rows, ""]);
@@ -40,18 +37,14 @@ export function InlineList() {
   const removeRow = (i: number) => {
     const next = rows.filter((_, idx) => idx !== i);
     setRows(next);
-    revalidate(next);
+    revalidate({ dependants: next });
   };
 
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(rows);
-    setErrors(found);
-    if (found.length === 0) {
+  const handleContinue = () =>
+    submit({ dependants: rows }, () => {
       // On save, blank rows are dropped (filter before submitting to a backend).
       navigate("/public-form");
-    }
-  };
+    });
 
   const firstError = errors.find((e) => e.fieldId === "dependant-0")?.text;
 

--- a/apps/prs/react/src/routes/public-form/examples/modal-drawer.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/modal-drawer.tsx
@@ -12,6 +12,7 @@ import {
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
 import { FieldError } from "../error-summary";
+import { Schema, required, minSelected, runSchema, useFormValidation } from "../validation";
 
 type Contact = { name: string; relationship: string; phone: string };
 
@@ -19,31 +20,31 @@ const EMPTY_CONTACT: Contact = { name: "", relationship: "", phone: "" };
 
 const RELATIONSHIPS = ["Parent", "Spouse or partner", "Sibling", "Friend", "Other"];
 
-// Validates the item being added/edited inside the overlay.
-function validateContact(c: Contact): FieldError[] {
-  const errors: FieldError[] = [];
-  if (!c.name.trim()) errors.push({ fieldId: "name", text: "Enter a full name" });
-  if (!c.relationship) errors.push({ fieldId: "relationship", text: "Select a relationship" });
-
-  const digits = c.phone.replace(/\D/g, "");
-  if (!c.phone.trim()) errors.push({ fieldId: "phone", text: "Enter a phone number" });
-  else if (!(digits.length === 10 || (digits.length === 11 && digits.startsWith("1"))))
-    errors.push({ fieldId: "phone", text: "Enter a valid phone number, like 780 123 4567" });
-
-  return errors;
-}
+// The item rules (validated inside the overlay) and the page rule (at least one item).
+const contactSchema: Schema = {
+  name: required("Enter a full name"),
+  relationship: required("Select a relationship"),
+  phone: (v) => {
+    const s = typeof v === "string" ? v.trim() : "";
+    if (!s) return "Enter a phone number";
+    const digits = s.replace(/\D/g, "");
+    return digits.length === 10 || (digits.length === 11 && digits.startsWith("1"))
+      ? null
+      : "Enter a valid phone number, like 780 123 4567";
+  },
+};
+const pageSchema: Schema = { contacts: minSelected(1, "Add at least one emergency contact") };
 
 /**
  * Modal / drawer: multiple fields for one item, added in an overlay. Saved items
- * show as a list with Edit / Remove. Uses a modal here (a handful of fields, the
- * spec's modal-vs-drawer choice); the same pattern uses GoabDrawer when an item
- * has more fields. Validates the item inside the overlay; the page requires at
- * least one item on submit.
+ * show as a list with Edit / Remove. Validates the item inside the overlay
+ * (runSchema over the item rules); the page requires at least one item on submit
+ * (the validation hook).
  */
 export function ModalDrawer() {
   const navigate = useNavigate();
   const [contacts, setContacts] = useState<Contact[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors: pageErrors, submit, revalidate } = useFormValidation(pageSchema);
 
   // Overlay state: which item (null = adding new), the working draft, its errors.
   const [open, setOpen] = useState(false);
@@ -69,33 +70,32 @@ export function ModalDrawer() {
     const next = { ...draft, ...patch };
     setDraft(next);
     // Re-validate live only after a failed save in the overlay.
-    if (modalErrors.length > 0) setModalErrors(validateContact(next));
+    if (modalErrors.length > 0) setModalErrors(runSchema(contactSchema, next));
   };
 
   const saveContact = () => {
-    const found = validateContact(draft);
+    const found = runSchema(contactSchema, draft);
     setModalErrors(found);
     if (found.length > 0) return;
-    setContacts((prev) =>
-      editingIndex === null ? [...prev, draft] : prev.map((c, i) => (i === editingIndex ? draft : c)),
-    );
+    const next =
+      editingIndex === null
+        ? [...contacts, draft]
+        : contacts.map((c, i) => (i === editingIndex ? draft : c));
+    setContacts(next);
+    revalidate({ contacts: next });
     setOpen(false);
   };
 
-  const removeContact = (i: number) => setContacts((prev) => prev.filter((_, idx) => idx !== i));
+  const removeContact = (i: number) => {
+    const next = contacts.filter((_, idx) => idx !== i);
+    setContacts(next);
+    revalidate({ contacts: next });
+  };
 
   const errorFor = (id: string) => modalErrors.find((e) => e.fieldId === id)?.text;
   const has = (id: string) => modalErrors.some((e) => e.fieldId === id);
 
-  const pageErrors: FieldError[] =
-    submitted && contacts.length === 0
-      ? [{ fieldId: "contacts", text: "Add at least one emergency contact" }]
-      : [];
-
-  const handleContinue = () => {
-    setSubmitted(true);
-    if (contacts.length > 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit({ contacts }, () => navigate("/public-form"));
 
   return (
     <PublicFormLayout back="/public-form">

--- a/apps/prs/react/src/routes/public-form/examples/modal-drawer.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/modal-drawer.tsx
@@ -1,0 +1,200 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  GoabButton,
+  GoabButtonGroup,
+  GoabModal,
+  GoabFormItem,
+  GoabInput,
+  GoabDropdown,
+  GoabDropdownItem,
+} from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+type Contact = { name: string; relationship: string; phone: string };
+
+const EMPTY_CONTACT: Contact = { name: "", relationship: "", phone: "" };
+
+const RELATIONSHIPS = ["Parent", "Spouse or partner", "Sibling", "Friend", "Other"];
+
+// Validates the item being added/edited inside the overlay.
+function validateContact(c: Contact): FieldError[] {
+  const errors: FieldError[] = [];
+  if (!c.name.trim()) errors.push({ fieldId: "name", text: "Enter a full name" });
+  if (!c.relationship) errors.push({ fieldId: "relationship", text: "Select a relationship" });
+
+  const digits = c.phone.replace(/\D/g, "");
+  if (!c.phone.trim()) errors.push({ fieldId: "phone", text: "Enter a phone number" });
+  else if (!(digits.length === 10 || (digits.length === 11 && digits.startsWith("1"))))
+    errors.push({ fieldId: "phone", text: "Enter a valid phone number, like 780 123 4567" });
+
+  return errors;
+}
+
+/**
+ * Modal / drawer: multiple fields for one item, added in an overlay. Saved items
+ * show as a list with Edit / Remove. Uses a modal here (a handful of fields, the
+ * spec's modal-vs-drawer choice); the same pattern uses GoabDrawer when an item
+ * has more fields. Validates the item inside the overlay; the page requires at
+ * least one item on submit.
+ */
+export function ModalDrawer() {
+  const navigate = useNavigate();
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  // Overlay state: which item (null = adding new), the working draft, its errors.
+  const [open, setOpen] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [draft, setDraft] = useState<Contact>(EMPTY_CONTACT);
+  const [modalErrors, setModalErrors] = useState<FieldError[]>([]);
+
+  const openAdd = () => {
+    setEditingIndex(null);
+    setDraft(EMPTY_CONTACT);
+    setModalErrors([]);
+    setOpen(true);
+  };
+
+  const openEdit = (i: number) => {
+    setEditingIndex(i);
+    setDraft(contacts[i]);
+    setModalErrors([]);
+    setOpen(true);
+  };
+
+  const updateDraft = (patch: Partial<Contact>) => {
+    const next = { ...draft, ...patch };
+    setDraft(next);
+    // Re-validate live only after a failed save in the overlay.
+    if (modalErrors.length > 0) setModalErrors(validateContact(next));
+  };
+
+  const saveContact = () => {
+    const found = validateContact(draft);
+    setModalErrors(found);
+    if (found.length > 0) return;
+    setContacts((prev) =>
+      editingIndex === null ? [...prev, draft] : prev.map((c, i) => (i === editingIndex ? draft : c)),
+    );
+    setOpen(false);
+  };
+
+  const removeContact = (i: number) => setContacts((prev) => prev.filter((_, idx) => idx !== i));
+
+  const errorFor = (id: string) => modalErrors.find((e) => e.fieldId === id)?.text;
+  const has = (id: string) => modalErrors.some((e) => e.fieldId === id);
+
+  const pageErrors: FieldError[] =
+    submitted && contacts.length === 0
+      ? [{ fieldId: "contacts", text: "Add at least one emergency contact" }]
+      : [];
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    if (contacts.length > 0) navigate("/public-form");
+  };
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet
+        heading="Emergency contacts"
+        description="Add at least one person we can contact in an emergency."
+        continueLabel="Save and continue"
+        onContinue={handleContinue}
+        errors={pageErrors}
+      >
+        <div id="contacts">
+          {contacts.length > 0 && (
+            <div style={{ marginBottom: "var(--goa-space-l)" }}>
+              {contacts.map((c, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: "var(--goa-space-m)",
+                    padding: "var(--goa-space-m) 0",
+                    borderTop: "1px solid var(--goa-color-greyscale-200)",
+                  }}
+                >
+                  <div>
+                    <div style={{ fontWeight: 700 }}>{c.name}</div>
+                    <div style={{ color: "var(--goa-color-text-secondary)" }}>
+                      {c.relationship} &middot; {c.phone}
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: "var(--goa-space-m)", flexShrink: 0 }}>
+                    <GoabButton type="tertiary" size="compact" onClick={() => openEdit(i)}>
+                      Edit
+                    </GoabButton>
+                    <GoabButton type="tertiary" size="compact" onClick={() => removeContact(i)}>
+                      Remove
+                    </GoabButton>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <GoabButton type="tertiary" leadingIcon="add" onClick={openAdd}>
+            {contacts.length === 0 ? "Add an emergency contact" : "Add another contact"}
+          </GoabButton>
+        </div>
+      </FormSet>
+
+      <GoabModal
+        heading={editingIndex === null ? "Add an emergency contact" : "Edit emergency contact"}
+        open={open}
+        onClose={() => setOpen(false)}
+        actions={
+          <GoabButtonGroup alignment="end">
+            <GoabButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
+              Cancel
+            </GoabButton>
+            <GoabButton type="primary" size="compact" onClick={saveContact}>
+              {editingIndex === null ? "Add contact" : "Save changes"}
+            </GoabButton>
+          </GoabButtonGroup>
+        }
+      >
+        <GoabFormItem label="Full name" error={errorFor("name")}>
+          <GoabInput
+            name="name"
+            width="100%"
+            error={has("name")}
+            value={draft.name}
+            onChange={(e) => updateDraft({ name: e.value })}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem label="Relationship to you" mt="l" error={errorFor("relationship")}>
+          <GoabDropdown
+            name="relationship"
+            error={has("relationship")}
+            value={draft.relationship}
+            onChange={(e) => updateDraft({ relationship: e.value ?? "" })}
+          >
+            {RELATIONSHIPS.map((r) => (
+              <GoabDropdownItem key={r} value={r} label={r} />
+            ))}
+          </GoabDropdown>
+        </GoabFormItem>
+
+        <GoabFormItem label="Phone number" mt="l" helpText="Include the area code" error={errorFor("phone")}>
+          <GoabInput
+            name="phone"
+            type="tel"
+            width="100%"
+            error={has("phone")}
+            value={draft.phone}
+            onChange={(e) => updateDraft({ phone: e.value })}
+          />
+        </GoabFormItem>
+      </GoabModal>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/modal-drawer.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/modal-drawer.tsx
@@ -11,7 +11,7 @@ import {
 } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { ErrorSummary, FieldError, useErrorSummaryFocus } from "../error-summary";
 import { Schema, required, minSelected, runSchema, useFormValidation } from "../validation";
 
 type Contact = { name: string; relationship: string; phone: string };
@@ -51,6 +51,7 @@ export function ModalDrawer() {
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [draft, setDraft] = useState<Contact>(EMPTY_CONTACT);
   const [modalErrors, setModalErrors] = useState<FieldError[]>([]);
+  const modalSummaryRef = useErrorSummaryFocus(modalErrors);
 
   const openAdd = () => {
     setEditingIndex(null);
@@ -161,7 +162,9 @@ export function ModalDrawer() {
           </GoabButtonGroup>
         }
       >
-        <GoabFormItem label="Full name" error={errorFor("name")}>
+        <ErrorSummary ref={modalSummaryRef} errors={modalErrors} />
+
+        <GoabFormItem label="Full name" id="name" error={errorFor("name")}>
           <GoabInput
             name="name"
             width="100%"
@@ -171,7 +174,7 @@ export function ModalDrawer() {
           />
         </GoabFormItem>
 
-        <GoabFormItem label="Relationship to you" mt="l" error={errorFor("relationship")}>
+        <GoabFormItem label="Relationship to you" id="relationship" mt="l" error={errorFor("relationship")}>
           <GoabDropdown
             name="relationship"
             error={has("relationship")}
@@ -184,7 +187,7 @@ export function ModalDrawer() {
           </GoabDropdown>
         </GoabFormItem>
 
-        <GoabFormItem label="Phone number" mt="l" helpText="Include the area code" error={errorFor("phone")}>
+        <GoabFormItem label="Phone number" id="phone" mt="l" helpText="Include the area code" error={errorFor("phone")}>
           <GoabInput
             name="phone"
             type="tel"

--- a/apps/prs/react/src/routes/public-form/examples/multi-step.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/multi-step.tsx
@@ -1,0 +1,262 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  GoabButton,
+  GoabButtonGroup,
+  GoabModal,
+  GoabFormItem,
+  GoabInput,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabText,
+} from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+type Address = { street: string; city: string; province: string; postal: string };
+
+const EMPTY: Address = { street: "", city: "", province: "", postal: "" };
+
+const PROVINCES: ReadonlyArray<[string, string]> = [
+  ["AB", "Alberta"],
+  ["BC", "British Columbia"],
+  ["MB", "Manitoba"],
+  ["NB", "New Brunswick"],
+  ["NL", "Newfoundland and Labrador"],
+  ["NS", "Nova Scotia"],
+  ["NT", "Northwest Territories"],
+  ["NU", "Nunavut"],
+  ["ON", "Ontario"],
+  ["PE", "Prince Edward Island"],
+  ["QC", "Quebec"],
+  ["SK", "Saskatchewan"],
+  ["YT", "Yukon"],
+];
+
+const POSTAL_CODE = /^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d$/;
+
+function validateStep1(a: Address): FieldError[] {
+  const errors: FieldError[] = [];
+  if (!a.street.trim()) errors.push({ fieldId: "street", text: "Enter the street address" });
+  if (!a.city.trim()) errors.push({ fieldId: "city", text: "Enter the city or town" });
+  return errors;
+}
+
+function validateStep2(a: Address): FieldError[] {
+  const errors: FieldError[] = [];
+  if (!a.province) errors.push({ fieldId: "province", text: "Select the province or territory" });
+  if (!POSTAL_CODE.test(a.postal.trim()))
+    errors.push({ fieldId: "postal", text: "Enter a valid postal code, such as T3R 8Y2" });
+  return errors;
+}
+
+/**
+ * Multi-step entry: the same overlay-add pattern as modal/drawer, but the item's
+ * fields are split across steps (Step 1 -> Next -> Step 2) with a step indicator
+ * and Next/Back. Each step validates before advancing; the final step saves. Two
+ * steps, by design. Saved items show in a list with Edit / Remove.
+ */
+export function MultiStep() {
+  const navigate = useNavigate();
+  const [addresses, setAddresses] = useState<Address[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const [open, setOpen] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [step, setStep] = useState<1 | 2>(1);
+  const [draft, setDraft] = useState<Address>(EMPTY);
+  const [modalErrors, setModalErrors] = useState<FieldError[]>([]);
+
+  const openAdd = () => {
+    setEditingIndex(null);
+    setDraft(EMPTY);
+    setStep(1);
+    setModalErrors([]);
+    setOpen(true);
+  };
+
+  const openEdit = (i: number) => {
+    setEditingIndex(i);
+    setDraft(addresses[i]);
+    setStep(1);
+    setModalErrors([]);
+    setOpen(true);
+  };
+
+  const updateDraft = (patch: Partial<Address>) => {
+    const next = { ...draft, ...patch };
+    setDraft(next);
+    if (modalErrors.length > 0) setModalErrors(step === 1 ? validateStep1(next) : validateStep2(next));
+  };
+
+  const goNext = () => {
+    const found = validateStep1(draft);
+    setModalErrors(found);
+    if (found.length === 0) {
+      setStep(2);
+      setModalErrors([]);
+    }
+  };
+
+  const goBack = () => {
+    setStep(1);
+    setModalErrors([]);
+  };
+
+  const save = () => {
+    const found = validateStep2(draft);
+    setModalErrors(found);
+    if (found.length > 0) return;
+    setAddresses((prev) =>
+      editingIndex === null ? [...prev, draft] : prev.map((a, i) => (i === editingIndex ? draft : a)),
+    );
+    setOpen(false);
+  };
+
+  const removeAddress = (i: number) => setAddresses((prev) => prev.filter((_, idx) => idx !== i));
+
+  const errorFor = (id: string) => modalErrors.find((e) => e.fieldId === id)?.text;
+  const has = (id: string) => modalErrors.some((e) => e.fieldId === id);
+
+  const pageErrors: FieldError[] =
+    submitted && addresses.length === 0
+      ? [{ fieldId: "addresses", text: "Add at least one previous address" }]
+      : [];
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    if (addresses.length > 0) navigate("/public-form");
+  };
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet
+        heading="Previous addresses"
+        description="Add any addresses you have lived at in the past 5 years."
+        continueLabel="Save and continue"
+        onContinue={handleContinue}
+        errors={pageErrors}
+      >
+        <div id="addresses">
+          {addresses.length > 0 && (
+            <div style={{ marginBottom: "var(--goa-space-l)" }}>
+              {addresses.map((a, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: "var(--goa-space-m)",
+                    padding: "var(--goa-space-m) 0",
+                    borderTop: "1px solid var(--goa-color-greyscale-200)",
+                  }}
+                >
+                  <div>
+                    <div style={{ fontWeight: 700 }}>{a.street}</div>
+                    <div style={{ color: "var(--goa-color-text-secondary)" }}>
+                      {a.city}, {a.province} {a.postal}
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: "var(--goa-space-m)", flexShrink: 0 }}>
+                    <GoabButton type="tertiary" size="compact" onClick={() => openEdit(i)}>
+                      Edit
+                    </GoabButton>
+                    <GoabButton type="tertiary" size="compact" onClick={() => removeAddress(i)}>
+                      Remove
+                    </GoabButton>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <GoabButton type="tertiary" leadingIcon="add" onClick={openAdd}>
+            {addresses.length === 0 ? "Add a previous address" : "Add another address"}
+          </GoabButton>
+        </div>
+      </FormSet>
+
+      <GoabModal
+        heading={editingIndex === null ? "Add a previous address" : "Edit previous address"}
+        open={open}
+        onClose={() => setOpen(false)}
+        actions={
+          <GoabButtonGroup alignment="end">
+            {step === 1 ? (
+              <>
+                <GoabButton type="tertiary" size="compact" onClick={() => setOpen(false)}>
+                  Cancel
+                </GoabButton>
+                <GoabButton type="primary" size="compact" onClick={goNext}>
+                  Next
+                </GoabButton>
+              </>
+            ) : (
+              <>
+                <GoabButton type="tertiary" size="compact" onClick={goBack}>
+                  Back
+                </GoabButton>
+                <GoabButton type="primary" size="compact" onClick={save}>
+                  {editingIndex === null ? "Add address" : "Save changes"}
+                </GoabButton>
+              </>
+            )}
+          </GoabButtonGroup>
+        }
+      >
+        <GoabText size="body-s" color="secondary" mt="none" mb="m">
+          Step {step} of 2
+        </GoabText>
+
+        {step === 1 ? (
+          <>
+            <GoabFormItem label="Street address" error={errorFor("street")}>
+              <GoabInput
+                name="street"
+                width="100%"
+                error={has("street")}
+                value={draft.street}
+                onChange={(e) => updateDraft({ street: e.value })}
+              />
+            </GoabFormItem>
+            <GoabFormItem label="City or town" mt="l" error={errorFor("city")}>
+              <GoabInput
+                name="city"
+                width="100%"
+                error={has("city")}
+                value={draft.city}
+                onChange={(e) => updateDraft({ city: e.value })}
+              />
+            </GoabFormItem>
+          </>
+        ) : (
+          <>
+            <GoabFormItem label="Province or territory" error={errorFor("province")}>
+              <GoabDropdown
+                name="province"
+                error={has("province")}
+                value={draft.province}
+                onChange={(e) => updateDraft({ province: e.value ?? "" })}
+              >
+                {PROVINCES.map(([value, label]) => (
+                  <GoabDropdownItem key={value} value={value} label={label} />
+                ))}
+              </GoabDropdown>
+            </GoabFormItem>
+            <GoabFormItem label="Postal code" mt="l" error={errorFor("postal")}>
+              <GoabInput
+                name="postal"
+                width="130px"
+                error={has("postal")}
+                value={draft.postal}
+                onChange={(e) => updateDraft({ postal: e.value })}
+              />
+            </GoabFormItem>
+          </>
+        )}
+      </GoabModal>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/multi-step.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/multi-step.tsx
@@ -12,7 +12,7 @@ import {
 } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { ErrorSummary, FieldError, useErrorSummaryFocus } from "../error-summary";
 import { Schema, required, pattern, minSelected, runSchema, useFormValidation } from "../validation";
 
 type Address = { street: string; city: string; province: string; postal: string };
@@ -64,6 +64,7 @@ export function MultiStep() {
   const [step, setStep] = useState<1 | 2>(1);
   const [draft, setDraft] = useState<Address>(EMPTY);
   const [modalErrors, setModalErrors] = useState<FieldError[]>([]);
+  const modalSummaryRef = useErrorSummaryFocus(modalErrors);
 
   const openAdd = () => {
     setEditingIndex(null);
@@ -207,9 +208,11 @@ export function MultiStep() {
           Step {step} of 2
         </GoabText>
 
+        <ErrorSummary ref={modalSummaryRef} errors={modalErrors} />
+
         {step === 1 ? (
           <>
-            <GoabFormItem label="Street address" error={errorFor("street")}>
+            <GoabFormItem label="Street address" id="street" error={errorFor("street")}>
               <GoabInput
                 name="street"
                 width="100%"
@@ -218,7 +221,7 @@ export function MultiStep() {
                 onChange={(e) => updateDraft({ street: e.value })}
               />
             </GoabFormItem>
-            <GoabFormItem label="City or town" mt="l" error={errorFor("city")}>
+            <GoabFormItem label="City or town" id="city" mt="l" error={errorFor("city")}>
               <GoabInput
                 name="city"
                 width="100%"
@@ -230,7 +233,7 @@ export function MultiStep() {
           </>
         ) : (
           <>
-            <GoabFormItem label="Province or territory" error={errorFor("province")}>
+            <GoabFormItem label="Province or territory" id="province" error={errorFor("province")}>
               <GoabDropdown
                 name="province"
                 error={has("province")}
@@ -242,7 +245,7 @@ export function MultiStep() {
                 ))}
               </GoabDropdown>
             </GoabFormItem>
-            <GoabFormItem label="Postal code" mt="l" error={errorFor("postal")}>
+            <GoabFormItem label="Postal code" id="postal" mt="l" error={errorFor("postal")}>
               <GoabInput
                 name="postal"
                 width="130px"

--- a/apps/prs/react/src/routes/public-form/examples/multi-step.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/multi-step.tsx
@@ -13,6 +13,7 @@ import {
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
 import { FieldError } from "../error-summary";
+import { Schema, required, pattern, minSelected, runSchema, useFormValidation } from "../validation";
 
 type Address = { street: string; city: string; province: string; postal: string };
 
@@ -36,31 +37,27 @@ const PROVINCES: ReadonlyArray<[string, string]> = [
 
 const POSTAL_CODE = /^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d$/;
 
-function validateStep1(a: Address): FieldError[] {
-  const errors: FieldError[] = [];
-  if (!a.street.trim()) errors.push({ fieldId: "street", text: "Enter the street address" });
-  if (!a.city.trim()) errors.push({ fieldId: "city", text: "Enter the city or town" });
-  return errors;
-}
-
-function validateStep2(a: Address): FieldError[] {
-  const errors: FieldError[] = [];
-  if (!a.province) errors.push({ fieldId: "province", text: "Select the province or territory" });
-  if (!POSTAL_CODE.test(a.postal.trim()))
-    errors.push({ fieldId: "postal", text: "Enter a valid postal code, such as T3R 8Y2" });
-  return errors;
-}
+// One schema per step (validated before advancing / saving), plus the page rule.
+const step1Schema: Schema = {
+  street: required("Enter the street address"),
+  city: required("Enter the city or town"),
+};
+const step2Schema: Schema = {
+  province: required("Select the province or territory"),
+  postal: pattern(POSTAL_CODE, "Enter a valid postal code, such as T3R 8Y2"),
+};
+const pageSchema: Schema = { addresses: minSelected(1, "Add at least one previous address") };
 
 /**
  * Multi-step entry: the same overlay-add pattern as modal/drawer, but the item's
- * fields are split across steps (Step 1 -> Next -> Step 2) with a step indicator
- * and Next/Back. Each step validates before advancing; the final step saves. Two
- * steps, by design. Saved items show in a list with Edit / Remove.
+ * fields are split across steps (Step 1 -> Next -> Step 2) with Next/Back. Each
+ * step validates before advancing (runSchema per step); the page requires at least
+ * one item (the hook).
  */
 export function MultiStep() {
   const navigate = useNavigate();
   const [addresses, setAddresses] = useState<Address[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors: pageErrors, submit, revalidate } = useFormValidation(pageSchema);
 
   const [open, setOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
@@ -87,11 +84,12 @@ export function MultiStep() {
   const updateDraft = (patch: Partial<Address>) => {
     const next = { ...draft, ...patch };
     setDraft(next);
-    if (modalErrors.length > 0) setModalErrors(step === 1 ? validateStep1(next) : validateStep2(next));
+    if (modalErrors.length > 0)
+      setModalErrors(runSchema(step === 1 ? step1Schema : step2Schema, next));
   };
 
   const goNext = () => {
-    const found = validateStep1(draft);
+    const found = runSchema(step1Schema, draft);
     setModalErrors(found);
     if (found.length === 0) {
       setStep(2);
@@ -105,29 +103,28 @@ export function MultiStep() {
   };
 
   const save = () => {
-    const found = validateStep2(draft);
+    const found = runSchema(step2Schema, draft);
     setModalErrors(found);
     if (found.length > 0) return;
-    setAddresses((prev) =>
-      editingIndex === null ? [...prev, draft] : prev.map((a, i) => (i === editingIndex ? draft : a)),
-    );
+    const next =
+      editingIndex === null
+        ? [...addresses, draft]
+        : addresses.map((a, i) => (i === editingIndex ? draft : a));
+    setAddresses(next);
+    revalidate({ addresses: next });
     setOpen(false);
   };
 
-  const removeAddress = (i: number) => setAddresses((prev) => prev.filter((_, idx) => idx !== i));
+  const removeAddress = (i: number) => {
+    const next = addresses.filter((_, idx) => idx !== i);
+    setAddresses(next);
+    revalidate({ addresses: next });
+  };
 
   const errorFor = (id: string) => modalErrors.find((e) => e.fieldId === id)?.text;
   const has = (id: string) => modalErrors.some((e) => e.fieldId === id);
 
-  const pageErrors: FieldError[] =
-    submitted && addresses.length === 0
-      ? [{ fieldId: "addresses", text: "Add at least one previous address" }]
-      : [];
-
-  const handleContinue = () => {
-    setSubmitted(true);
-    if (addresses.length > 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit({ addresses }, () => navigate("/public-form"));
 
   return (
     <PublicFormLayout back="/public-form">

--- a/apps/prs/react/src/routes/public-form/examples/multiple-questions.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/multiple-questions.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { GoabFormItem, GoabInput } from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+type Values = { fullName: string; phone: string };
+
+const EMPTY: Values = { fullName: "", phone: "" };
+
+// Required + phone-format checks, in field order so the summary reads top to
+// bottom. Each fieldId matches a GoabFormItem id (links summary -> field + drives
+// the inline error).
+function validate(values: Values): FieldError[] {
+  const errors: FieldError[] = [];
+  if (!values.fullName.trim())
+    errors.push({ fieldId: "fullName", text: "Enter your full name" });
+
+  const digits = values.phone.replace(/\D/g, "");
+  if (!values.phone.trim())
+    errors.push({ fieldId: "phone", text: "Enter your phone number" });
+  else if (!(digits.length === 10 || (digits.length === 11 && digits.startsWith("1"))))
+    errors.push({ fieldId: "phone", text: "Enter a valid phone number, like 780 123 4567" });
+
+  return errors;
+}
+
+/**
+ * Multiple questions on a page.
+ *
+ * A few independent questions sharing one page, each with its own label and
+ * hint (the goa-form-set "Multiple questions = True" shape: a section heading
+ * plus normal-label fields). Distinct from grouped-fields, where the inputs are
+ * parts of one thing. Validates on submit.
+ */
+export function MultipleQuestions() {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<Values>(EMPTY);
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const set = (key: keyof Values) => (value: string) =>
+    setValues((prev) => {
+      const next = { ...prev, [key]: value };
+      if (submitted) setErrors(validate(next));
+      return next;
+    });
+
+  const errorFor = (fieldId: string) => errors.find((e) => e.fieldId === fieldId)?.text;
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(values);
+    setErrors(found);
+    if (found.length === 0) navigate("/public-form");
+  };
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet heading="Your contact details" onContinue={handleContinue} errors={errors}>
+        <GoabFormItem
+          label="Full name"
+          id="fullName"
+          helpText="Include any middle names"
+          error={errorFor("fullName")}
+        >
+          <GoabInput
+            name="fullName"
+            ariaLabel="Full name"
+            width="100%"
+            error={!!errorFor("fullName")}
+            value={values.fullName}
+            onChange={(e) => set("fullName")(e.value)}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem
+          label="Phone number"
+          id="phone"
+          helpText="Include the area code"
+          error={errorFor("phone")}
+          mt="l"
+        >
+          <GoabInput
+            name="phone"
+            type="tel"
+            ariaLabel="Phone number"
+            width="320px"
+            error={!!errorFor("phone")}
+            value={values.phone}
+            onChange={(e) => set("phone")(e.value)}
+          />
+        </GoabFormItem>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/multiple-questions.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/multiple-questions.tsx
@@ -3,58 +3,47 @@ import { useNavigate } from "react-router-dom";
 import { GoabFormItem, GoabInput } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { Schema, required, useFormValidation } from "../validation";
 
 type Values = { fullName: string; phone: string };
 
 const EMPTY: Values = { fullName: "", phone: "" };
 
-// Required + phone-format checks, in field order so the summary reads top to
-// bottom. Each fieldId matches a GoabFormItem id (links summary -> field + drives
-// the inline error).
-function validate(values: Values): FieldError[] {
-  const errors: FieldError[] = [];
-  if (!values.fullName.trim())
-    errors.push({ fieldId: "fullName", text: "Enter your full name" });
-
-  const digits = values.phone.replace(/\D/g, "");
-  if (!values.phone.trim())
-    errors.push({ fieldId: "phone", text: "Enter your phone number" });
-  else if (!(digits.length === 10 || (digits.length === 11 && digits.startsWith("1"))))
-    errors.push({ fieldId: "phone", text: "Enter a valid phone number, like 780 123 4567" });
-
-  return errors;
-}
+// Rules in field order, so the summary reads top to bottom.
+const schema: Schema = {
+  fullName: required("Enter your full name"),
+  phone: (v) => {
+    const s = typeof v === "string" ? v.trim() : "";
+    if (!s) return "Enter your phone number";
+    const digits = s.replace(/\D/g, "");
+    return digits.length === 10 || (digits.length === 11 && digits.startsWith("1"))
+      ? null
+      : "Enter a valid phone number, like 780 123 4567";
+  },
+};
 
 /**
  * Multiple questions on a page.
  *
- * A few independent questions sharing one page, each with its own label and
- * hint (the goa-form-set "Multiple questions = True" shape: a section heading
- * plus normal-label fields). Distinct from grouped-fields, where the inputs are
- * parts of one thing. Validates on submit.
+ * A few independent questions sharing one page, each with its own label and hint
+ * (the goa-form-set "Multiple questions = True" shape). Distinct from
+ * grouped-fields, where the inputs are parts of one thing. Validates on submit.
  */
 export function MultipleQuestions() {
   const navigate = useNavigate();
   const [values, setValues] = useState<Values>(EMPTY);
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors, submit, revalidate } = useFormValidation(schema);
 
   const set = (key: keyof Values) => (value: string) =>
     setValues((prev) => {
       const next = { ...prev, [key]: value };
-      if (submitted) setErrors(validate(next));
+      revalidate(next);
       return next;
     });
 
   const errorFor = (fieldId: string) => errors.find((e) => e.fieldId === fieldId)?.text;
 
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(values);
-    setErrors(found);
-    if (found.length === 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit(values, () => navigate("/public-form"));
 
   return (
     <PublicFormLayout back="/public-form">

--- a/apps/prs/react/src/routes/public-form/examples/new-page.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/new-page.tsx
@@ -1,0 +1,328 @@
+import { useState } from "react";
+import { Routes, Route, Navigate, useNavigate } from "react-router-dom";
+import {
+  GoabFormItem,
+  GoabInput,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabButton,
+} from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+const ROOT = "/public-form/new-page";
+
+type Child = { name: string; isAdult: string; inEducation: string };
+const EMPTY_CHILD: Child = { name: "", isAdult: "", inEducation: "" };
+
+const yesNo = (v: string) => (v === "yes" ? "Yes" : v === "no" ? "No" : "Not answered");
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        gap: "var(--goa-space-m)",
+        padding: "var(--goa-space-s) 0",
+        borderTop: "1px solid var(--goa-color-greyscale-200)",
+      }}
+    >
+      <span style={{ color: "var(--goa-color-text-secondary)" }}>{label}</span>
+      <span style={{ flex: 1 }}>{value}</span>
+    </div>
+  );
+}
+
+/** A lone Yes/No sub-flow page that branches on Continue (the spec's core primitive). */
+function YesNoStep({
+  heading,
+  back,
+  value,
+  onChange,
+  next,
+  requiredError,
+}: {
+  heading: string;
+  back: string;
+  value: string;
+  onChange: (v: string) => void;
+  next: (v: string) => string;
+  requiredError: string;
+}) {
+  const navigate = useNavigate();
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const validate = (v: string): FieldError[] => (v ? [] : [{ fieldId: "answer", text: requiredError }]);
+  const handleChange = (v: string) => {
+    onChange(v);
+    if (submitted) setErrors(validate(v));
+  };
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(value);
+    setErrors(found);
+    if (found.length === 0) navigate(next(value));
+  };
+
+  return (
+    <PublicFormLayout back={back}>
+      <FormSet onContinue={handleContinue} errors={errors}>
+        <GoabFormItem
+          label={heading}
+          labelSize="large"
+          id="answer"
+          error={errors.find((e) => e.fieldId === "answer")?.text}
+        >
+          <GoabRadioGroup
+            name="answer"
+            ariaLabel={heading}
+            value={value}
+            onChange={(e) => handleChange(e.value)}
+          >
+            <GoabRadioItem value="yes" label="Yes" />
+            <GoabRadioItem value="no" label="No" />
+          </GoabRadioGroup>
+        </GoabFormItem>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}
+
+/** Sub-flow page 1: the child's name. */
+function NameStep({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const navigate = useNavigate();
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const validate = (v: string): FieldError[] =>
+    v.trim() ? [] : [{ fieldId: "name", text: "Enter the child's full name" }];
+  const handleChange = (v: string) => {
+    onChange(v);
+    if (submitted) setErrors(validate(v));
+  };
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(value);
+    setErrors(found);
+    if (found.length === 0) navigate(`${ROOT}/add/age`);
+  };
+
+  return (
+    <PublicFormLayout back={ROOT}>
+      <FormSet onContinue={handleContinue} errors={errors}>
+        <GoabFormItem
+          label="What is the child's full name?"
+          labelSize="large"
+          id="name"
+          error={errors.find((e) => e.fieldId === "name")?.text}
+        >
+          <GoabInput
+            name="name"
+            width="100%"
+            error={errors.some((e) => e.fieldId === "name")}
+            value={value}
+            onChange={(e) => handleChange(e.value)}
+          />
+        </GoabFormItem>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}
+
+/** Final sub-flow page: confirm and add the child to the list. */
+function ConfirmStep({ draft, editing, onAdd }: { draft: Child; editing: boolean; onAdd: () => void }) {
+  const back = draft.isAdult === "yes" ? `${ROOT}/add/education` : `${ROOT}/add/age`;
+  return (
+    <PublicFormLayout back={back}>
+      <FormSet
+        heading={`Check ${draft.name || "the child"}'s details`}
+        continueLabel={editing ? "Save changes" : "Continue"}
+        onContinue={onAdd}
+      >
+        <div>
+          <SummaryRow label="Name" value={draft.name} />
+          <SummaryRow label="18 or older" value={yesNo(draft.isAdult)} />
+          {draft.isAdult === "yes" && (
+            <SummaryRow label="In full-time education" value={yesNo(draft.inEducation)} />
+          )}
+        </div>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}
+
+/** The main page: the collected list of children + Add + Save and continue. */
+function ChildrenList({
+  items,
+  onAdd,
+  onEdit,
+  onRemove,
+  errors,
+  onContinue,
+}: {
+  items: Child[];
+  onAdd: () => void;
+  onEdit: (i: number) => void;
+  onRemove: (i: number) => void;
+  errors: FieldError[];
+  onContinue: () => void;
+}) {
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet
+        heading="Your children"
+        description="Add each child who lives with you."
+        continueLabel="Save and continue"
+        onContinue={onContinue}
+        errors={errors}
+      >
+        <div id="children">
+          {items.length > 0 && (
+            <div style={{ marginBottom: "var(--goa-space-l)" }}>
+              {items.map((c, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: "var(--goa-space-m)",
+                    padding: "var(--goa-space-m) 0",
+                    borderTop: "1px solid var(--goa-color-greyscale-200)",
+                  }}
+                >
+                  <div>
+                    <div style={{ fontWeight: 700 }}>{c.name}</div>
+                    <div style={{ color: "var(--goa-color-text-secondary)" }}>
+                      18 or older: {yesNo(c.isAdult)}
+                      {c.isAdult === "yes" ? ` · In education: ${yesNo(c.inEducation)}` : ""}
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: "var(--goa-space-m)", flexShrink: 0 }}>
+                    <GoabButton type="tertiary" size="compact" onClick={() => onEdit(i)}>
+                      Change
+                    </GoabButton>
+                    <GoabButton type="tertiary" size="compact" onClick={() => onRemove(i)}>
+                      Remove
+                    </GoabButton>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <GoabButton type="tertiary" leadingIcon="add" onClick={onAdd}>
+            {items.length === 0 ? "Add a child" : "Add another child"}
+          </GoabButton>
+        </div>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}
+
+/**
+ * New page per item, with branches: the public form pattern itself, looped.
+ *
+ * "Add a child" walks a sub-flow of full pages (name -> 18-or-older -> [in
+ * education, if 18+] -> confirm), branching on the age answer, then collects the
+ * child into a list. Each page is a real route, so the browser back button and
+ * state carry across the sub-flow (the team's feasibility stress-test). The added
+ * children show as a list with Change / Remove, the loop reduced to a title.
+ */
+export function NewPageTask() {
+  const navigate = useNavigate();
+  const [children, setChildren] = useState<Child[]>([]);
+  const [draft, setDraft] = useState<Child>(EMPTY_CHILD);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const update = (patch: Partial<Child>) => setDraft((d) => ({ ...d, ...patch }));
+
+  const startAdd = () => {
+    setDraft(EMPTY_CHILD);
+    setEditingIndex(null);
+    navigate(`${ROOT}/add/name`);
+  };
+
+  const startEdit = (i: number) => {
+    setDraft(children[i]);
+    setEditingIndex(i);
+    navigate(`${ROOT}/add/name`);
+  };
+
+  const removeChild = (i: number) => setChildren((prev) => prev.filter((_, idx) => idx !== i));
+
+  const saveChild = () => {
+    setChildren((prev) =>
+      editingIndex === null ? [...prev, draft] : prev.map((c, i) => (i === editingIndex ? draft : c)),
+    );
+    setEditingIndex(null);
+    navigate(ROOT);
+  };
+
+  const pageErrors: FieldError[] =
+    submitted && children.length === 0
+      ? [{ fieldId: "children", text: "Add at least one child" }]
+      : [];
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    if (children.length > 0) navigate("/public-form");
+  };
+
+  return (
+    <Routes>
+      <Route
+        index
+        element={
+          <ChildrenList
+            items={children}
+            onAdd={startAdd}
+            onEdit={startEdit}
+            onRemove={removeChild}
+            errors={pageErrors}
+            onContinue={handleContinue}
+          />
+        }
+      />
+      <Route
+        path="add/name"
+        element={<NameStep value={draft.name} onChange={(v) => update({ name: v })} />}
+      />
+      <Route
+        path="add/age"
+        element={
+          <YesNoStep
+            heading="Is the child 18 or older?"
+            back={`${ROOT}/add/name`}
+            value={draft.isAdult}
+            onChange={(v) => update({ isAdult: v })}
+            next={(v) => (v === "yes" ? `${ROOT}/add/education` : `${ROOT}/add/confirm`)}
+            requiredError="Select yes if the child is 18 or older"
+          />
+        }
+      />
+      <Route
+        path="add/education"
+        element={
+          <YesNoStep
+            heading="Is the child in full-time education?"
+            back={`${ROOT}/add/age`}
+            value={draft.inEducation}
+            onChange={(v) => update({ inEducation: v })}
+            next={() => `${ROOT}/add/confirm`}
+            requiredError="Select yes if the child is in full-time education"
+          />
+        }
+      />
+      <Route
+        path="add/confirm"
+        element={<ConfirmStep draft={draft} editing={editingIndex !== null} onAdd={saveChild} />}
+      />
+      <Route path="*" element={<Navigate to={ROOT} replace />} />
+    </Routes>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/new-page.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/new-page.tsx
@@ -10,6 +10,7 @@ import {
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
 import { FieldError } from "../error-summary";
+import { Schema, required, minSelected, useFormValidation } from "../validation";
 
 const ROOT = "/public-form/new-page";
 
@@ -52,20 +53,14 @@ function YesNoStep({
   requiredError: string;
 }) {
   const navigate = useNavigate();
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors, submit, revalidate } = useFormValidation({ answer: required(requiredError) });
 
-  const validate = (v: string): FieldError[] => (v ? [] : [{ fieldId: "answer", text: requiredError }]);
   const handleChange = (v: string) => {
     onChange(v);
-    if (submitted) setErrors(validate(v));
+    revalidate({ answer: v });
   };
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(value);
-    setErrors(found);
-    if (found.length === 0) navigate(next(value));
-  };
+
+  const handleContinue = () => submit({ answer: value }, () => navigate(next(value)));
 
   return (
     <PublicFormLayout back={back}>
@@ -94,21 +89,16 @@ function YesNoStep({
 /** Sub-flow page 1: the child's name. */
 function NameStep({ value, onChange }: { value: string; onChange: (v: string) => void }) {
   const navigate = useNavigate();
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors, submit, revalidate } = useFormValidation({
+    name: required("Enter the child's full name"),
+  });
 
-  const validate = (v: string): FieldError[] =>
-    v.trim() ? [] : [{ fieldId: "name", text: "Enter the child's full name" }];
   const handleChange = (v: string) => {
     onChange(v);
-    if (submitted) setErrors(validate(v));
+    revalidate({ name: v });
   };
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(value);
-    setErrors(found);
-    if (found.length === 0) navigate(`${ROOT}/add/age`);
-  };
+
+  const handleContinue = () => submit({ name: value }, () => navigate(`${ROOT}/add/age`));
 
   return (
     <PublicFormLayout back={ROOT}>
@@ -223,21 +213,23 @@ function ChildrenList({
   );
 }
 
+const pageSchema: Schema = { children: minSelected(1, "Add at least one child") };
+
 /**
  * New page per item, with branches: the public form pattern itself, looped.
  *
  * "Add a child" walks a sub-flow of full pages (name -> 18-or-older -> [in
  * education, if 18+] -> confirm), branching on the age answer, then collects the
  * child into a list. Each page is a real route, so the browser back button and
- * state carry across the sub-flow (the team's feasibility stress-test). The added
- * children show as a list with Change / Remove, the loop reduced to a title.
+ * state carry across the sub-flow. The added children show as a list with
+ * Change / Remove, the loop reduced to a title.
  */
 export function NewPageTask() {
   const navigate = useNavigate();
   const [children, setChildren] = useState<Child[]>([]);
   const [draft, setDraft] = useState<Child>(EMPTY_CHILD);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors: pageErrors, submit, revalidate } = useFormValidation(pageSchema);
 
   const update = (patch: Partial<Child>) => setDraft((d) => ({ ...d, ...patch }));
 
@@ -253,25 +245,24 @@ export function NewPageTask() {
     navigate(`${ROOT}/add/name`);
   };
 
-  const removeChild = (i: number) => setChildren((prev) => prev.filter((_, idx) => idx !== i));
+  const removeChild = (i: number) => {
+    const next = children.filter((_, idx) => idx !== i);
+    setChildren(next);
+    revalidate({ children: next });
+  };
 
   const saveChild = () => {
-    setChildren((prev) =>
-      editingIndex === null ? [...prev, draft] : prev.map((c, i) => (i === editingIndex ? draft : c)),
-    );
+    const next =
+      editingIndex === null
+        ? [...children, draft]
+        : children.map((c, i) => (i === editingIndex ? draft : c));
+    setChildren(next);
+    revalidate({ children: next });
     setEditingIndex(null);
     navigate(ROOT);
   };
 
-  const pageErrors: FieldError[] =
-    submitted && children.length === 0
-      ? [{ fieldId: "children", text: "Add at least one child" }]
-      : [];
-
-  const handleContinue = () => {
-    setSubmitted(true);
-    if (children.length > 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit({ children }, () => navigate("/public-form"));
 
   return (
     <Routes>

--- a/apps/prs/react/src/routes/public-form/examples/question-with-details.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/question-with-details.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  GoabFormItem,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabDetails,
+} from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+const STATUSES: ReadonlyArray<[string, string]> = [
+  ["single", "Single"],
+  ["married", "Married"],
+  ["common-law", "Common-law"],
+  ["separated", "Separated"],
+  ["divorced", "Divorced"],
+  ["widowed", "Widowed"],
+];
+
+function validate(value: string): FieldError[] {
+  return value ? [] : [{ fieldId: "maritalStatus", text: "Select your marital status" }];
+}
+
+/**
+ * Question with Details.
+ *
+ * A lone question (large label) plus a GoabDetails "show more" expander for
+ * optional help, placed after the input (canonical help-details placement). The
+ * Details keeps the page uncluttered for users who don't need the explanation.
+ * Validates on submit.
+ */
+export function QuestionWithDetails() {
+  const navigate = useNavigate();
+  const [maritalStatus, setMaritalStatus] = useState("");
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleChange = (value: string) => {
+    setMaritalStatus(value);
+    if (submitted) setErrors(validate(value));
+  };
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(maritalStatus);
+    setErrors(found);
+    if (found.length === 0) navigate("/public-form");
+  };
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet onContinue={handleContinue} errors={errors}>
+        <GoabFormItem
+          label="What is your marital status?"
+          labelSize="large"
+          id="maritalStatus"
+          error={errors.find((e) => e.fieldId === "maritalStatus")?.text}
+        >
+          <GoabDropdown
+            name="maritalStatus"
+            ariaLabel="Marital status"
+            error={errors.some((e) => e.fieldId === "maritalStatus")}
+            value={maritalStatus}
+            onChange={(e) => handleChange(e.value ?? "")}
+          >
+            {STATUSES.map(([value, label]) => (
+              <GoabDropdownItem key={value} value={value} label={label} />
+            ))}
+          </GoabDropdown>
+        </GoabFormItem>
+
+        <GoabDetails heading="How do I know my marital status?" mt="l">
+          <p>
+            Your marital status is your legal relationship status. Choose the option that
+            best describes your current situation.
+          </p>
+          <ul>
+            <li>
+              <strong>Single:</strong> never been legally married
+            </li>
+            <li>
+              <strong>Married:</strong> currently legally married
+            </li>
+            <li>
+              <strong>Common-law:</strong> living with a partner in a marriage-like
+              relationship for at least 12 months
+            </li>
+            <li>
+              <strong>Separated:</strong> legally married but living apart
+            </li>
+            <li>
+              <strong>Divorced:</strong> legally ended a marriage
+            </li>
+            <li>
+              <strong>Widowed:</strong> your spouse or partner has died
+            </li>
+          </ul>
+        </GoabDetails>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/question-with-details.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/question-with-details.tsx
@@ -8,7 +8,7 @@ import {
 } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { Schema, required, useFormValidation } from "../validation";
 
 const STATUSES: ReadonlyArray<[string, string]> = [
   ["single", "Single"],
@@ -19,35 +19,28 @@ const STATUSES: ReadonlyArray<[string, string]> = [
   ["widowed", "Widowed"],
 ];
 
-function validate(value: string): FieldError[] {
-  return value ? [] : [{ fieldId: "maritalStatus", text: "Select your marital status" }];
-}
+const schema: Schema = {
+  maritalStatus: required("Select your marital status"),
+};
 
 /**
  * Question with Details.
  *
  * A lone question (large label) plus a GoabDetails "show more" expander for
- * optional help, placed after the input (canonical help-details placement). The
- * Details keeps the page uncluttered for users who don't need the explanation.
+ * optional help, placed after the input (canonical help-details placement).
  * Validates on submit.
  */
 export function QuestionWithDetails() {
   const navigate = useNavigate();
   const [maritalStatus, setMaritalStatus] = useState("");
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors, submit, revalidate } = useFormValidation(schema);
 
   const handleChange = (value: string) => {
     setMaritalStatus(value);
-    if (submitted) setErrors(validate(value));
+    revalidate({ maritalStatus: value });
   };
 
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(maritalStatus);
-    setErrors(found);
-    if (found.length === 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit({ maritalStatus }, () => navigate("/public-form"));
 
   return (
     <PublicFormLayout back="/public-form">
@@ -73,8 +66,8 @@ export function QuestionWithDetails() {
 
         <GoabDetails heading="How do I know my marital status?" mt="l">
           <p>
-            Your marital status is your legal relationship status. Choose the option that
-            best describes your current situation.
+            Your marital status is your legal relationship status. Choose the option that best
+            describes your current situation.
           </p>
           <ul>
             <li>
@@ -84,8 +77,8 @@ export function QuestionWithDetails() {
               <strong>Married:</strong> currently legally married
             </li>
             <li>
-              <strong>Common-law:</strong> living with a partner in a marriage-like
-              relationship for at least 12 months
+              <strong>Common-law:</strong> living with a partner in a marriage-like relationship for
+              at least 12 months
             </li>
             <li>
               <strong>Separated:</strong> legally married but living apart

--- a/apps/prs/react/src/routes/public-form/examples/result-eligible.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/result-eligible.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from "react-router-dom";
+import { GoabButton, GoabButtonGroup } from "@abgov/react-components";
+import { ResultsPage, ResultContactSection } from "../results-page";
+
+/**
+ * Result page — eligible outcome. Success (green) Callout, the standard contact
+ * block, then the forward action. Matches the Figma "eligible" result page.
+ */
+export function ResultEligible() {
+  const navigate = useNavigate();
+  // Demo actions return to the gallery home; in a real service "Continue" would
+  // go to the application form.
+  const home = () => navigate("/public-form");
+  return (
+    <ResultsPage
+      heading="You are eligible for this service"
+      status="success"
+      statusHeading="You are eligible for this service"
+      statusBody="Based on your answers, you can apply for this service."
+      actions={
+        <GoabButtonGroup alignment="start">
+          <GoabButton type="secondary" onClick={home}>
+            Continue your application
+          </GoabButton>
+        </GoabButtonGroup>
+      }
+    >
+      <ResultContactSection />
+    </ResultsPage>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/result-not-eligible.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/result-not-eligible.tsx
@@ -1,0 +1,34 @@
+import { useNavigate } from "react-router-dom";
+import { GoabButton, GoabButtonGroup } from "@abgov/react-components";
+import { ResultsPage, ResultContactSection } from "../results-page";
+
+/**
+ * Result page — not-eligible outcome. Important (yellow) Callout stating the
+ * reason, the contact block, then two exits. Matches the Figma "not eligible"
+ * result page. The in-flow eligibility dead-end (examples/ineligible.tsx) uses
+ * the same ResultsPage piece with a flow-contextual action instead.
+ */
+export function ResultNotEligible() {
+  const navigate = useNavigate();
+  const home = () => navigate("/public-form");
+  return (
+    <ResultsPage
+      heading="You are not eligible for this service"
+      status="important"
+      statusHeading="You must live in Alberta to be eligible for this service"
+      statusBody="Contact us if you think this does not apply to you."
+      actions={
+        <GoabButtonGroup alignment="start">
+          <GoabButton type="primary" onClick={home}>
+            Return to my applications
+          </GoabButton>
+          <GoabButton type="secondary" onClick={home}>
+            Back to Alberta.ca
+          </GoabButton>
+        </GoabButtonGroup>
+      }
+    >
+      <ResultContactSection />
+    </ResultsPage>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/result-submitted.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/result-submitted.tsx
@@ -1,0 +1,44 @@
+import { useNavigate } from "react-router-dom";
+import { GoabText, GoabLink, GoabButton, GoabButtonGroup } from "@abgov/react-components";
+import { ResultsPage, ResultContactSection } from "../results-page";
+
+/**
+ * Result page — submitted outcome. Success Callout, a "what happens next"
+ * section, the contact block, then a single exit. Matches the Figma "submitted"
+ * result page.
+ */
+export function ResultSubmitted() {
+  const navigate = useNavigate();
+  const home = () => navigate("/public-form");
+  return (
+    <ResultsPage
+      heading="You have submitted your application"
+      status="success"
+      statusHeading="Application submitted"
+      statusBody="We've received your application."
+      actions={
+        <GoabButtonGroup alignment="start">
+          <GoabButton type="secondary" onClick={home}>
+            Back to Alberta.ca
+          </GoabButton>
+        </GoabButtonGroup>
+      }
+    >
+      <GoabText tag="h2" mt="xl" mb="s">
+        What happens next
+      </GoabText>
+      <GoabText mt="none" mb="s">
+        We've sent your application for review. You will be contacted by email if we need any more
+        information from you. You can now close this window.
+      </GoabText>
+      <GoabText mt="none" mb="none">
+        What did you think of this service?{" "}
+        <GoabLink>
+          <a href="#">Give feedback</a>
+        </GoabLink>
+      </GoabText>
+
+      <ResultContactSection />
+    </ResultsPage>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/reveal.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/reveal.tsx
@@ -8,7 +8,7 @@ import {
 } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { Schema, required, when, useFormValidation } from "../validation";
 
 const METHODS: ReadonlyArray<{ value: string; label: string; field: string; type: "email" | "tel" }> = [
   { value: "email", label: "Email", field: "Email address", type: "email" },
@@ -16,61 +16,47 @@ const METHODS: ReadonlyArray<{ value: string; label: string; field: string; type
   { value: "text", label: "Text message", field: "Mobile phone number", type: "tel" },
 ];
 
-// Conditional validation: must pick a method, and the revealed field is required
-// only while it's shown. The fieldId is method-specific so the summary links to
-// whichever field is actually revealed.
-function validate(method: string, detail: string): FieldError[] {
-  if (!method)
-    return [{ fieldId: "contactMethod", text: "Select how you would like to be contacted" }];
-  if (!detail.trim()) {
-    const m = METHODS.find((x) => x.value === method);
-    return [
-      {
-        fieldId: `contactDetail-${method}`,
-        text: `Enter your ${m ? m.field.toLowerCase() : "contact details"}`,
-      },
-    ];
-  }
-  return [];
-}
+// Conditional rules: a method is required, and each revealed field is required only
+// while its method is selected (the `when` rule). The field id is method-specific,
+// so the summary links to whichever field is actually shown.
+const schema: Schema = {
+  contactMethod: required("Select how you would like to be contacted"),
+  "contactDetail-email": when((a) => a.contactMethod === "email", required("Enter your email address")),
+  "contactDetail-phone": when((a) => a.contactMethod === "phone", required("Enter your phone number")),
+  "contactDetail-text": when((a) => a.contactMethod === "text", required("Enter your mobile phone number")),
+};
+
+// The selected method's detail goes under its field id so the schema validates it.
+const valuesFor = (method: string, detail: string) => ({
+  contactMethod: method,
+  [`contactDetail-${method}`]: detail,
+});
 
 /**
  * Reveal: selecting an option reveals a follow-up input.
  *
  * Uses GoA's built-in `reveal` prop on GoabRadioItem (the canonical
  * reveal-input-based-on-a-selection example), which renders the connector line
- * natively. No custom CSS, unlike the old demo, which hand-built the reveal
- * because the public-form runtime broke the slot. Validates on submit, including
- * the revealed field while it's shown.
+ * natively. Validates on submit, including the revealed field while it's shown.
  */
 export function Reveal() {
   const navigate = useNavigate();
   const [method, setMethod] = useState("");
   const [detail, setDetail] = useState("");
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
-
-  const revalidate = (m: string, d: string) => {
-    if (submitted) setErrors(validate(m, d));
-  };
+  const { errors, submit, revalidate } = useFormValidation(schema);
 
   const handleMethod = (value: string) => {
     setMethod(value);
     setDetail("");
-    revalidate(value, "");
+    revalidate(valuesFor(value, ""));
   };
 
   const handleDetail = (value: string) => {
     setDetail(value);
-    revalidate(method, value);
+    revalidate(valuesFor(method, value));
   };
 
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(method, detail);
-    setErrors(found);
-    if (found.length === 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit(valuesFor(method, detail), () => navigate("/public-form"));
 
   return (
     <PublicFormLayout back="/public-form">

--- a/apps/prs/react/src/routes/public-form/examples/reveal.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/reveal.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  GoabFormItem,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabInput,
+} from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+const METHODS: ReadonlyArray<{ value: string; label: string; field: string; type: "email" | "tel" }> = [
+  { value: "email", label: "Email", field: "Email address", type: "email" },
+  { value: "phone", label: "Phone", field: "Phone number", type: "tel" },
+  { value: "text", label: "Text message", field: "Mobile phone number", type: "tel" },
+];
+
+// Conditional validation: must pick a method, and the revealed field is required
+// only while it's shown. The fieldId is method-specific so the summary links to
+// whichever field is actually revealed.
+function validate(method: string, detail: string): FieldError[] {
+  if (!method)
+    return [{ fieldId: "contactMethod", text: "Select how you would like to be contacted" }];
+  if (!detail.trim()) {
+    const m = METHODS.find((x) => x.value === method);
+    return [
+      {
+        fieldId: `contactDetail-${method}`,
+        text: `Enter your ${m ? m.field.toLowerCase() : "contact details"}`,
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Reveal: selecting an option reveals a follow-up input.
+ *
+ * Uses GoA's built-in `reveal` prop on GoabRadioItem (the canonical
+ * reveal-input-based-on-a-selection example), which renders the connector line
+ * natively. No custom CSS, unlike the old demo, which hand-built the reveal
+ * because the public-form runtime broke the slot. Validates on submit, including
+ * the revealed field while it's shown.
+ */
+export function Reveal() {
+  const navigate = useNavigate();
+  const [method, setMethod] = useState("");
+  const [detail, setDetail] = useState("");
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const revalidate = (m: string, d: string) => {
+    if (submitted) setErrors(validate(m, d));
+  };
+
+  const handleMethod = (value: string) => {
+    setMethod(value);
+    setDetail("");
+    revalidate(value, "");
+  };
+
+  const handleDetail = (value: string) => {
+    setDetail(value);
+    revalidate(method, value);
+  };
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(method, detail);
+    setErrors(found);
+    if (found.length === 0) navigate("/public-form");
+  };
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet onContinue={handleContinue} errors={errors}>
+        <GoabFormItem
+          label="How would you like to be contacted?"
+          labelSize="large"
+          id="contactMethod"
+          error={errors.find((e) => e.fieldId === "contactMethod")?.text}
+        >
+          <GoabRadioGroup name="contactMethod" value={method} onChange={(e) => handleMethod(e.value)}>
+            {METHODS.map((m) => (
+              <GoabRadioItem
+                key={m.value}
+                value={m.value}
+                label={m.label}
+                reveal={
+                  <GoabFormItem
+                    label={m.field}
+                    id={`contactDetail-${m.value}`}
+                    error={errors.find((e) => e.fieldId === `contactDetail-${m.value}`)?.text}
+                  >
+                    <GoabInput
+                      name={m.value}
+                      type={m.type}
+                      ariaLabel={m.field}
+                      width="320px"
+                      error={errors.some((e) => e.fieldId === `contactDetail-${m.value}`)}
+                      value={detail}
+                      onChange={(e) => handleDetail(e.value)}
+                    />
+                  </GoabFormItem>
+                }
+              />
+            ))}
+          </GoabRadioGroup>
+        </GoabFormItem>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/review-children-summary.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/review-children-summary.tsx
@@ -1,0 +1,49 @@
+import { useNavigate } from "react-router-dom";
+import { GoabText, GoabButton, GoabButtonGroup } from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { SummarySection, SummaryItem } from "../form-summary";
+import { ChildrenSummary } from "../children-summary";
+
+/**
+ * Review page — a repeating group (children summary). The contacts were added on a
+ * repeat page (modal / drawer); here the loop collapses to each contact's key field
+ * (the name), with one Change back to that manage page. Contrast with the
+ * "Personal details" section above, which shows individual answers in full.
+ */
+export function ReviewChildrenSummary() {
+  const navigate = useNavigate();
+  const home = () => navigate("/public-form");
+  const contacts = [
+    { id: "1", label: "Thomas Jeffery", detail: "Sibling · 1 (780) 935-8312" },
+    { id: "2", label: "Sam Smith", detail: "Friend · +1 780 555 0142" },
+  ];
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <GoabText tag="h1" mt="none" mb="m">
+        Review your answers
+      </GoabText>
+      <GoabText mt="none" mb="xl" color="secondary">
+        A repeating group collapses to each item's key field, with one Change back to the page where
+        the items were added.
+      </GoabText>
+
+      <SummarySection heading="Personal details" onChange={home}>
+        <SummaryItem question="Full name">Jane Smith</SummaryItem>
+        <SummaryItem question="Date of birth">1 January 1990</SummaryItem>
+      </SummarySection>
+
+      <ChildrenSummary
+        title="Emergency contacts"
+        items={contacts}
+        onChange={() => navigate("/public-form/modal-drawer")}
+      />
+
+      <GoabButtonGroup alignment="start" mt="2xl">
+        <GoabButton type="primary" onClick={home}>
+          Save and continue
+        </GoabButton>
+      </GoabButtonGroup>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/review-editable.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/review-editable.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  GoabText,
+  GoabLink,
+  GoabCheckbox,
+  GoabButton,
+  GoabButtonGroup,
+} from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSummary, SummarySection, SummaryItem } from "../form-summary";
+
+/**
+ * Review page — editable state. Change links per section, a confirm checkbox, and
+ * "Save and continue". Composed from the form-summary trio (FormSummary >
+ * SummarySection > SummaryItem). Shows the range from the Figma: grouped cards,
+ * single-row cards, a long answer, and a file answer, across two titled sections.
+ * (Change links point at gallery question pages so they navigate somewhere real.)
+ */
+export function ReviewEditable() {
+  const navigate = useNavigate();
+  const [confirmed, setConfirmed] = useState(false);
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <GoabText tag="h1" mt="none" mb="xl">
+        Review your answers
+      </GoabText>
+
+      <FormSummary title="My information">
+        <SummarySection heading="Personal details" changeTo="/public-form/multiple-questions">
+          <SummaryItem question="Full name">Jane Smith</SummaryItem>
+          <SummaryItem question="Date of birth">1 January 1990</SummaryItem>
+        </SummarySection>
+
+        <SummarySection changeTo="/public-form/single-question">
+          <SummaryItem question="Phone number">780 123 4567</SummaryItem>
+        </SummarySection>
+
+        <SummarySection heading="Your situation" changeTo="/public-form/reveal">
+          <SummaryItem question="Are you a current resident?">Yes</SummaryItem>
+          <SummaryItem question="Tell us more">
+            Lorem ipsum dolor sit amet consectetur. Ultricies at aliquet tellus diam. Odio velit
+            aenean nec at venenatis pretium. Eget dui aliquam sit pharetra duis arcu.
+          </SummaryItem>
+        </SummarySection>
+
+        <SummarySection changeTo="/public-form/file-upload">
+          <SummaryItem question="Proof of address">
+            <GoabLink>
+              <a href="#">utility-bill.pdf</a>
+            </GoabLink>
+          </SummaryItem>
+        </SummarySection>
+      </FormSummary>
+
+      <FormSummary title="My family">
+        <SummarySection heading="Dependants" changeTo="/public-form/inline-list">
+          <SummaryItem question="Number of children">2</SummaryItem>
+          <SummaryItem question="Names">Alex Smith, Sam Smith</SummaryItem>
+        </SummarySection>
+      </FormSummary>
+
+      <GoabCheckbox
+        name="confirm"
+        text="I confirm that the information above is correct"
+        checked={confirmed}
+        onChange={(e) => setConfirmed(e.checked)}
+        mt="l"
+        mb="xl"
+      />
+
+      <GoabButtonGroup alignment="start">
+        <GoabButton type="primary" onClick={() => navigate("/public-form")}>
+          Save and continue
+        </GoabButton>
+      </GoabButtonGroup>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/review-question-types.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/review-question-types.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { GoabText, GoabCheckbox } from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSummary, SummarySection, SummaryItem } from "../form-summary";
+
+/**
+ * Review page — how different question types collapse onto the summary, per
+ * review-page-spec.md. Demonstrates: a multi-select with a reveal (selected
+ * options as a list, the reveal as its own follow-up row), a field set with
+ * secondary fields (each its own row), and optional questions ("Not answered",
+ * with the showUnanswered toggle). An empty secondary sub-field is simply not
+ * passed in, so it never shows.
+ */
+export function ReviewQuestionTypes() {
+  const [showUnanswered, setShowUnanswered] = useState(true);
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <GoabText tag="h1" mt="none" mb="m">
+        Review your answers
+      </GoabText>
+      <GoabText mt="none" mb="xl" color="secondary">
+        How different question types read on the summary. Use the toggle to show or hide unanswered
+        optional questions.
+      </GoabText>
+
+      <GoabCheckbox
+        name="show-unanswered"
+        text="Show unanswered optional questions"
+        checked={showUnanswered}
+        onChange={(e) => setShowUnanswered(e.checked)}
+        mb="xl"
+      />
+
+      {/* Multi-select with a reveal: the selected options are listed, and the
+          revealed input becomes its own follow-up question below them. */}
+      <FormSummary title="Documents">
+        <SummarySection heading="Which documents did you use?" changeTo="/public-form/grouped-fields">
+          <SummaryItem question="Documents used">
+            <div>Tax return</div>
+            <div>Paystub</div>
+            <div>Other(s)</div>
+          </SummaryItem>
+          <SummaryItem question="What other documents?">A separation agreement</SummaryItem>
+          <SummaryItem question="Document year">2020</SummaryItem>
+        </SummarySection>
+      </FormSummary>
+
+      {/* Field set with secondary fields: phone and its extension are separate rows. */}
+      <FormSummary title="Authorized representative">
+        <SummarySection changeTo="/public-form/multiple-questions">
+          <SummaryItem question="Name">Bruno Mars</SummaryItem>
+          <SummaryItem question="Relationship to you">Parent</SummaryItem>
+          <SummaryItem question="Primary phone">+1 555 199 9761</SummaryItem>
+          <SummaryItem question="Primary phone extension">1234</SummaryItem>
+          <SummaryItem question="Email">bruno@example.com</SummaryItem>
+        </SummarySection>
+      </FormSummary>
+
+      {/* Optional questions: shown as "Not answered" so the user sees what they
+          skipped; the toggle above hides them instead. */}
+      <FormSummary title="Optional questions" showUnanswered={showUnanswered}>
+        <SummarySection changeTo="/public-form/single-question">
+          <SummaryItem question="Preferred name" optional>
+            Jay
+          </SummaryItem>
+          <SummaryItem question="Middle name" optional></SummaryItem>
+        </SummarySection>
+      </FormSummary>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/review-readonly.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/review-readonly.tsx
@@ -1,0 +1,45 @@
+import { useNavigate } from "react-router-dom";
+import { GoabText, GoabButton, GoabButtonGroup } from "@abgov/react-components";
+import { FormSummary, SummarySection, SummaryItem } from "../form-summary";
+
+/**
+ * Review page — read-only state. No Change links (a SummarySection renders
+ * read-only when given no change target), no confirm checkbox, and no back link;
+ * it exits with "Back to all tasks". Matches the Figma read-only "Review your
+ * answers", the state used once a submission can no longer be changed.
+ */
+export function ReviewReadonly() {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <GoabText tag="h1" mt="none" mb="xl">
+        Review your answers
+      </GoabText>
+
+      <FormSummary title="My information">
+        <SummarySection heading="Personal details">
+          <SummaryItem question="Full name">Jane Smith</SummaryItem>
+          <SummaryItem question="Date of birth">1 January 1990</SummaryItem>
+        </SummarySection>
+
+        <SummarySection>
+          <SummaryItem question="Phone number">780 123 4567</SummaryItem>
+        </SummarySection>
+      </FormSummary>
+
+      <FormSummary title="My family">
+        <SummarySection heading="Dependants">
+          <SummaryItem question="Number of children">2</SummaryItem>
+          <SummaryItem question="Names">Alex Smith, Sam Smith</SummaryItem>
+        </SummarySection>
+      </FormSummary>
+
+      <GoabButtonGroup alignment="start" mt="l">
+        <GoabButton type="secondary" leadingIcon="arrow-back" onClick={() => navigate("/public-form")}>
+          Back to all tasks
+        </GoabButton>
+      </GoabButtonGroup>
+    </>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/examples/single-question.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/single-question.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { GoabFormItem, GoabDatePicker } from "@abgov/react-components";
 import { PublicFormLayout } from "../public-form-layout";
 import { FormSet } from "../form-set";
-import { FieldError } from "../error-summary";
+import { Schema, useFormValidation } from "../validation";
 
 // Today as yyyy-MM-dd in local time. The picker emits dates in yyyy-MM-dd, which
 // sort chronologically as strings, so a string compare is a timezone-safe
@@ -15,53 +15,41 @@ function todayISO(): string {
   return `${now.getFullYear()}-${mm}-${dd}`;
 }
 
-function validate(value: string): FieldError[] {
-  const v = value.trim();
-  // The picker emits "" for missing, partial, AND invalid dates (day 0, day 50,
-  // Feb 30) alike, so they all share one message: it can't tell us which.
-  if (!v) return [{ fieldId: "dateOfBirth", text: "Enter a valid date of birth" }];
-  // The picker ignores `max` in input mode, so future dates come through and we
-  // catch them here.
-  if (v > todayISO())
-    return [{ fieldId: "dateOfBirth", text: "Date of birth must be in the past" }];
-  return [];
-}
+// The rules, declared. The picker emits "" for missing, partial, AND invalid
+// dates alike, so they share one message; it ignores `max` in input mode, so the
+// future check is done here.
+const schema: Schema = {
+  dateOfBirth: (v) => {
+    const s = typeof v === "string" ? v.trim() : "";
+    if (!s) return "Enter a valid date of birth";
+    if (s > todayISO()) return "Date of birth must be in the past";
+    return null;
+  },
+};
 
 /**
  * Single question: date of birth.
  *
  * A lone question with nothing else on the page, so the field's label doubles as
- * the page heading via labelSize="large" (the goa-form-set "Multiple questions =
- * False" shape). Uses the DatePicker in type="input" mode (month dropdown +
- * day/year text), the GoA pattern for known dates far in the past.
+ * the page heading via labelSize="large". Uses the DatePicker in type="input"
+ * mode, the GoA pattern for known dates far in the past.
  *
- * Validates three cases: missing, not a real date, and in the future. Two
- * component limitations surfaced here for Vanessa:
- *  1. The picker collapses missing / partial / invalid into one empty value, so
- *     a real date and a missing date can't carry different messages, and we
- *     can't point at the specific wrong box (no GOV.UK-style granular errors).
- *  2. The picker ignores `max` in input mode, so the future check is done by the
- *     consumer, not the component.
+ * Two component limitations surfaced here for Vanessa:
+ *  1. The picker collapses missing / partial / invalid into one empty value, so a
+ *     real date and a missing date can't carry different messages.
+ *  2. The picker ignores `max` in input mode, so the future check is the consumer's.
  */
 export function SingleQuestion() {
   const navigate = useNavigate();
   const [dateOfBirth, setDateOfBirth] = useState("");
-  const [errors, setErrors] = useState<FieldError[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+  const { errors, submit, revalidate } = useFormValidation(schema);
 
   const handleChange = (value: string) => {
     setDateOfBirth(value);
-    // After the first submit, re-validate live so the error clears once a
-    // complete, valid, in-range date is entered.
-    if (submitted) setErrors(validate(value));
+    revalidate({ dateOfBirth: value });
   };
 
-  const handleContinue = () => {
-    setSubmitted(true);
-    const found = validate(dateOfBirth);
-    setErrors(found);
-    if (found.length === 0) navigate("/public-form");
-  };
+  const handleContinue = () => submit({ dateOfBirth }, () => navigate("/public-form"));
 
   return (
     <PublicFormLayout back="/public-form">

--- a/apps/prs/react/src/routes/public-form/examples/single-question.tsx
+++ b/apps/prs/react/src/routes/public-form/examples/single-question.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { GoabFormItem, GoabDatePicker } from "@abgov/react-components";
+import { PublicFormLayout } from "../public-form-layout";
+import { FormSet } from "../form-set";
+import { FieldError } from "../error-summary";
+
+// Today as yyyy-MM-dd in local time. The picker emits dates in yyyy-MM-dd, which
+// sort chronologically as strings, so a string compare is a timezone-safe
+// "is this in the future" check with no Date parsing.
+function todayISO(): string {
+  const now = new Date();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  return `${now.getFullYear()}-${mm}-${dd}`;
+}
+
+function validate(value: string): FieldError[] {
+  const v = value.trim();
+  // The picker emits "" for missing, partial, AND invalid dates (day 0, day 50,
+  // Feb 30) alike, so they all share one message: it can't tell us which.
+  if (!v) return [{ fieldId: "dateOfBirth", text: "Enter a valid date of birth" }];
+  // The picker ignores `max` in input mode, so future dates come through and we
+  // catch them here.
+  if (v > todayISO())
+    return [{ fieldId: "dateOfBirth", text: "Date of birth must be in the past" }];
+  return [];
+}
+
+/**
+ * Single question: date of birth.
+ *
+ * A lone question with nothing else on the page, so the field's label doubles as
+ * the page heading via labelSize="large" (the goa-form-set "Multiple questions =
+ * False" shape). Uses the DatePicker in type="input" mode (month dropdown +
+ * day/year text), the GoA pattern for known dates far in the past.
+ *
+ * Validates three cases: missing, not a real date, and in the future. Two
+ * component limitations surfaced here for Vanessa:
+ *  1. The picker collapses missing / partial / invalid into one empty value, so
+ *     a real date and a missing date can't carry different messages, and we
+ *     can't point at the specific wrong box (no GOV.UK-style granular errors).
+ *  2. The picker ignores `max` in input mode, so the future check is done by the
+ *     consumer, not the component.
+ */
+export function SingleQuestion() {
+  const navigate = useNavigate();
+  const [dateOfBirth, setDateOfBirth] = useState("");
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleChange = (value: string) => {
+    setDateOfBirth(value);
+    // After the first submit, re-validate live so the error clears once a
+    // complete, valid, in-range date is entered.
+    if (submitted) setErrors(validate(value));
+  };
+
+  const handleContinue = () => {
+    setSubmitted(true);
+    const found = validate(dateOfBirth);
+    setErrors(found);
+    if (found.length === 0) navigate("/public-form");
+  };
+
+  return (
+    <PublicFormLayout back="/public-form">
+      <FormSet onContinue={handleContinue} errors={errors}>
+        <GoabFormItem
+          label="What is your date of birth?"
+          labelSize="large"
+          helpText="For example, March 27 2007"
+          id="dateOfBirth"
+          error={errors.find((e) => e.fieldId === "dateOfBirth")?.text}
+        >
+          <GoabDatePicker
+            name="dateOfBirth"
+            type="input"
+            max={new Date()}
+            error={errors.some((e) => e.fieldId === "dateOfBirth")}
+            value={dateOfBirth}
+            onChange={(detail) => handleChange(detail.valueStr)}
+          />
+        </GoabFormItem>
+      </FormSet>
+    </PublicFormLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/form-set.tsx
+++ b/apps/prs/react/src/routes/public-form/form-set.tsx
@@ -1,6 +1,6 @@
-import { ReactNode, useEffect, useRef } from "react";
+import { ReactNode } from "react";
 import { GoabText, GoabButton, GoabButtonGroup } from "@abgov/react-components";
-import { ErrorSummary, FieldError } from "./error-summary";
+import { ErrorSummary, FieldError, useErrorSummaryFocus } from "./error-summary";
 
 type FormSetProps = {
   /**
@@ -47,18 +47,9 @@ export function FormSet({
   onContinue,
   errors = [],
 }: FormSetProps) {
-  const summaryRef = useRef<HTMLDivElement>(null);
-  const hadErrors = useRef(false);
-
-  // Move focus to the summary only on an empty -> non-empty transition (a fresh
-  // failed submit), not while the user is live-clearing errors as they fix them.
-  useEffect(() => {
-    const hasErrors = errors.length > 0;
-    if (hasErrors && !hadErrors.current) {
-      summaryRef.current?.focus();
-    }
-    hadErrors.current = hasErrors;
-  }, [errors]);
+  // Focus the summary on a fresh failed submit (empty -> non-empty), not while the
+  // user is live-clearing errors as they fix them.
+  const summaryRef = useErrorSummaryFocus(errors);
 
   return (
     <>

--- a/apps/prs/react/src/routes/public-form/form-set.tsx
+++ b/apps/prs/react/src/routes/public-form/form-set.tsx
@@ -1,0 +1,87 @@
+import { ReactNode, useEffect, useRef } from "react";
+import { GoabText, GoabButton, GoabButtonGroup } from "@abgov/react-components";
+import { ErrorSummary, FieldError } from "./error-summary";
+
+type FormSetProps = {
+  /**
+   * Section name / question heading. Omit for a lone single question whose
+   * field uses labelSize="large" so its label doubles as the page heading.
+   */
+  heading?: string;
+  /** Supporting content shown below the heading (only rendered with a heading). */
+  description?: ReactNode;
+  /** The field(s). */
+  children: ReactNode;
+  /** Primary action label. Defaults to "Continue". */
+  continueLabel?: string;
+  /** Runs when the primary action is pressed (the page owns validation + navigation). */
+  onContinue?: () => void;
+  /**
+   * Validation errors. When non-empty, renders the error summary above the
+   * fields and moves focus to it on a fresh failed submit. The page owns the
+   * rules and sets matching field-level errors.
+   */
+  errors?: FieldError[];
+};
+
+/**
+ * Form set (the goa-form-set candidate): the form-content unit shared by every
+ * question page. Renders an optional section header, the error summary, the
+ * fields, and the Save-and-continue button, and owns:
+ *  - the within-form vertical rhythm (heading -> description -> fields -> button)
+ *  - the error summary's placement and focus-on-submit
+ *
+ * Two shapes, matching the component's "Multiple questions" variant:
+ *  - Lone single question: omit `heading`; the single field uses labelSize="large"
+ *    so its label is the heading.
+ *  - Section / multiple questions: pass `heading`; fields use normal labels.
+ *
+ * The back link and app shell are NOT here. They live in PublicFormLayout and
+ * PublicFormApp.
+ */
+export function FormSet({
+  heading,
+  description,
+  children,
+  continueLabel = "Continue",
+  onContinue,
+  errors = [],
+}: FormSetProps) {
+  const summaryRef = useRef<HTMLDivElement>(null);
+  const hadErrors = useRef(false);
+
+  // Move focus to the summary only on an empty -> non-empty transition (a fresh
+  // failed submit), not while the user is live-clearing errors as they fix them.
+  useEffect(() => {
+    const hasErrors = errors.length > 0;
+    if (hasErrors && !hadErrors.current) {
+      summaryRef.current?.focus();
+    }
+    hadErrors.current = hasErrors;
+  }, [errors]);
+
+  return (
+    <>
+      {heading && (
+        <GoabText tag="h1" mt="none" mb={description ? "m" : "xl"}>
+          {heading}
+        </GoabText>
+      )}
+      {heading && description && (
+        <GoabText mt="none" mb="xl">
+          {description}
+        </GoabText>
+      )}
+
+      <ErrorSummary ref={summaryRef} errors={errors} />
+
+      {children}
+
+      <GoabButtonGroup alignment="start" mt="2xl">
+        <GoabButton type="primary" onClick={onContinue}>
+          {continueLabel}
+        </GoabButton>
+      </GoabButtonGroup>
+    </>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/form-summary.tsx
+++ b/apps/prs/react/src/routes/public-form/form-summary.tsx
@@ -57,8 +57,10 @@ export function FormSummary({ title, showUnanswered = true, children }: FormSumm
 type SummarySectionProps = {
   /** Optional group heading (the grey "Heading for group of questions"). */
   heading?: string;
-  /** Where the section's Change link goes. Omit for a read-only section (no Change link). */
+  /** Where the section's Change link goes (a route). Omit for a read-only section. */
   changeTo?: string;
+  /** Change as an action instead of a route (e.g. to enter a change-from-review flow). */
+  onChange?: () => void;
   /** Change link label. */
   changeLabel?: string;
   /** SummaryItem rows. */
@@ -69,6 +71,7 @@ type SummarySectionProps = {
 export function SummarySection({
   heading,
   changeTo,
+  onChange,
   changeLabel = "Change",
   children,
 }: SummarySectionProps) {
@@ -100,9 +103,26 @@ export function SummarySection({
           )}
           {children}
         </div>
-        {changeTo && (
+        {(changeTo || onChange) && (
           <GoabLink mt="none" mb="none">
-            <Link to={changeTo}>{changeLabel}</Link>
+            {onChange ? (
+              <a
+                role="button"
+                tabIndex={0}
+                style={{ cursor: "pointer" }}
+                onClick={onChange}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onChange();
+                  }
+                }}
+              >
+                {changeLabel}
+              </a>
+            ) : (
+              <Link to={changeTo!}>{changeLabel}</Link>
+            )}
           </GoabLink>
         )}
       </div>

--- a/apps/prs/react/src/routes/public-form/form-summary.tsx
+++ b/apps/prs/react/src/routes/public-form/form-summary.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, createContext, useContext } from "react";
 import { Link } from "react-router-dom";
 import { GoabText, GoabLink } from "@abgov/react-components";
 
@@ -11,31 +11,46 @@ import { GoabText, GoabLink } from "@abgov/react-components";
  *   SummaryItem    (= goab-summary-item)    one Q/A row: question + answer slot
  *
  * V1 = slots: each piece owns structure/spacing/layout, the consumer passes the
- * content in (children). No internal data management. Read-only vs editable falls
- * out of whether a SummarySection is given a change target.
- *
- * These mirror the parent/child shape of the task list (task-list -> task-list-item),
- * so the demo reads as the spec Vanessa hardens into web components in Step 2.
+ * content in (children). No internal data management. See review-page-spec.md (in
+ * the conductor) for how each question type maps onto these pieces and the decisions.
  */
+
+// showUnanswered is set on FormSummary and read by SummaryItem — the React analog
+// of a parent web-component attribute shared down via the GoA context store.
+const FormSummaryContext = createContext<{ showUnanswered: boolean }>({ showUnanswered: true });
+
+function isEmptyAnswer(children: ReactNode): boolean {
+  if (children == null || children === false || children === "") return true;
+  if (typeof children === "string") return children.trim() === "";
+  if (Array.isArray(children)) return children.length === 0;
+  return false;
+}
 
 type FormSummaryProps = {
   /** Section title (e.g. "My information"). Optional. */
   title?: string;
+  /**
+   * Whether unanswered optional questions render as "Not answered" (default) or
+   * are hidden. The author toggle from review-page-spec.md.
+   */
+  showUnanswered?: boolean;
   /** SummarySection cards. */
   children: ReactNode;
 };
 
 /** Top level: a titled group of summary sections. */
-export function FormSummary({ title, children }: FormSummaryProps) {
+export function FormSummary({ title, showUnanswered = true, children }: FormSummaryProps) {
   return (
-    <div style={{ marginBottom: "var(--goa-space-l)" }}>
-      {title && (
-        <GoabText tag="h2" mt="none" mb="s" color="secondary">
-          {title}
-        </GoabText>
-      )}
-      {children}
-    </div>
+    <FormSummaryContext.Provider value={{ showUnanswered }}>
+      <div style={{ marginBottom: "var(--goa-space-l)" }}>
+        {title && (
+          <GoabText tag="h2" mt="none" mb="s" color="secondary">
+            {title}
+          </GoabText>
+        )}
+        {children}
+      </div>
+    </FormSummaryContext.Provider>
   );
 }
 
@@ -98,12 +113,31 @@ export function SummarySection({
 type SummaryItemProps = {
   /** The question / field label (left column). */
   question: string;
-  /** The answer (right column) — text, a long paragraph, a file link, etc. The V1 slot. */
-  children: ReactNode;
+  /**
+   * Marks an optional question. When its answer is empty it renders "Not answered"
+   * (or is hidden if the FormSummary's showUnanswered is off). Empty secondary
+   * sub-fields are simply not passed in (developer-controlled), not marked optional.
+   */
+  optional?: boolean;
+  /** The answer (right column) — text, a long paragraph, a selected-options list, a file link. The V1 slot. */
+  children?: ReactNode;
 };
 
 /** One row inside a section: question on the left, answer (slot) on the right. */
-export function SummaryItem({ question, children }: SummaryItemProps) {
+export function SummaryItem({ question, optional, children }: SummaryItemProps) {
+  const { showUnanswered } = useContext(FormSummaryContext);
+  const empty = isEmptyAnswer(children);
+
+  // Optional + empty: hidden when the form turns unanswered display off; otherwise
+  // a muted "Not answered" so the user sees what they chose to skip.
+  if (optional && empty && !showUnanswered) return null;
+  const answer =
+    optional && empty ? (
+      <span style={{ color: "var(--goa-color-text-secondary)" }}>Not answered</span>
+    ) : (
+      children
+    );
+
   return (
     <div
       style={{
@@ -116,7 +150,7 @@ export function SummaryItem({ question, children }: SummaryItemProps) {
       <span style={{ flex: "0 0 40%" }}>
         <strong>{question}</strong>
       </span>
-      <span style={{ flex: 1 }}>{children}</span>
+      <span style={{ flex: 1 }}>{answer}</span>
     </div>
   );
 }

--- a/apps/prs/react/src/routes/public-form/form-summary.tsx
+++ b/apps/prs/react/src/routes/public-form/form-summary.tsx
@@ -1,0 +1,122 @@
+import { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { GoabText, GoabLink } from "@abgov/react-components";
+
+/**
+ * Form summary (the "review your answers" pattern) — the slot-based V1 spec for
+ * the three components agreed with Vanessa (2026-06-18 component-planning meeting):
+ *
+ *   FormSummary    (= goab-form-summary)   section title + a group of sections
+ *   SummarySection (= goab-summary-section) the card: optional heading + Change action
+ *   SummaryItem    (= goab-summary-item)    one Q/A row: question + answer slot
+ *
+ * V1 = slots: each piece owns structure/spacing/layout, the consumer passes the
+ * content in (children). No internal data management. Read-only vs editable falls
+ * out of whether a SummarySection is given a change target.
+ *
+ * These mirror the parent/child shape of the task list (task-list -> task-list-item),
+ * so the demo reads as the spec Vanessa hardens into web components in Step 2.
+ */
+
+type FormSummaryProps = {
+  /** Section title (e.g. "My information"). Optional. */
+  title?: string;
+  /** SummarySection cards. */
+  children: ReactNode;
+};
+
+/** Top level: a titled group of summary sections. */
+export function FormSummary({ title, children }: FormSummaryProps) {
+  return (
+    <div style={{ marginBottom: "var(--goa-space-l)" }}>
+      {title && (
+        <GoabText tag="h2" mt="none" mb="s" color="secondary">
+          {title}
+        </GoabText>
+      )}
+      {children}
+    </div>
+  );
+}
+
+type SummarySectionProps = {
+  /** Optional group heading (the grey "Heading for group of questions"). */
+  heading?: string;
+  /** Where the section's Change link goes. Omit for a read-only section (no Change link). */
+  changeTo?: string;
+  /** Change link label. */
+  changeLabel?: string;
+  /** SummaryItem rows. */
+  children: ReactNode;
+};
+
+/** The card: one bordered group, an optional heading, one Change action for the group. */
+export function SummarySection({
+  heading,
+  changeTo,
+  changeLabel = "Change",
+  children,
+}: SummarySectionProps) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--goa-color-greyscale-200)",
+        borderRadius: "var(--goa-border-radius-xl)",
+        padding: "var(--goa-space-m) var(--goa-space-l)",
+        marginBottom: "var(--goa-space-m)",
+      }}
+    >
+      {/* Change sits beside the content (top-right), not on its own line above it,
+          so a single-row card reads as one line with no odd gap above the question.
+          Change is section-level, so it aligns to the top of the group. mt/mb none
+          zeroes GoabLink's default margins. */}
+      <div style={{ display: "flex", gap: "var(--goa-space-l)", alignItems: "flex-start" }}>
+        <div style={{ flex: 1 }}>
+          {heading && (
+            <span
+              style={{
+                display: "block",
+                color: "var(--goa-color-text-secondary)",
+                marginBottom: "var(--goa-space-xs)",
+              }}
+            >
+              {heading}
+            </span>
+          )}
+          {children}
+        </div>
+        {changeTo && (
+          <GoabLink mt="none" mb="none">
+            <Link to={changeTo}>{changeLabel}</Link>
+          </GoabLink>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type SummaryItemProps = {
+  /** The question / field label (left column). */
+  question: string;
+  /** The answer (right column) — text, a long paragraph, a file link, etc. The V1 slot. */
+  children: ReactNode;
+};
+
+/** One row inside a section: question on the left, answer (slot) on the right. */
+export function SummaryItem({ question, children }: SummaryItemProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: "var(--goa-space-l)",
+        alignItems: "baseline",
+        padding: "var(--goa-space-xs) 0",
+      }}
+    >
+      <span style={{ flex: "0 0 40%" }}>
+        <strong>{question}</strong>
+      </span>
+      <span style={{ flex: 1 }}>{children}</span>
+    </div>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/public-form-app.tsx
+++ b/apps/prs/react/src/routes/public-form/public-form-app.tsx
@@ -36,7 +36,7 @@ export function PublicFormApp() {
   return (
     <GoabOneColumnLayout>
       <section slot="header">
-        <GoabAppHeader url="https://www.alberta.ca" heading="Service name" maxContentWidth="704px">
+        <GoabAppHeader url="/public-form" heading="Service name" maxContentWidth="704px">
           <div slot="utilities">
             <GoabMenuButton text="Edna Mode" type="tertiary" size="compact">
               <GoabMenuAction text="My profile" action="profile" />

--- a/apps/prs/react/src/routes/public-form/public-form-app.tsx
+++ b/apps/prs/react/src/routes/public-form/public-form-app.tsx
@@ -5,11 +5,23 @@ import {
   GoabMenuButton,
   GoabMenuAction,
   GoabAppFooter,
-  GoabAppFooterNavSection,
   GoabAppFooterMetaSection,
   GoabPageBlock,
 } from "@abgov/react-components";
 import { TaskListHome } from "./task-list-home";
+import { SingleQuestion } from "./examples/single-question";
+import { GroupedFields } from "./examples/grouped-fields";
+import { MultipleQuestions } from "./examples/multiple-questions";
+import { QuestionWithDetails } from "./examples/question-with-details";
+import { Reveal } from "./examples/reveal";
+import { EligibilityTask } from "./examples/eligibility-task";
+import { ContentBefore } from "./examples/content-before";
+import { FileUpload } from "./examples/file-upload";
+import { InlineList } from "./examples/inline-list";
+import { ModalDrawer } from "./examples/modal-drawer";
+import { MultiStep } from "./examples/multi-step";
+import { NewPageTask } from "./examples/new-page";
+import { DrawerExample } from "./examples/drawer";
 
 /**
  * Public form template gallery (Step 1 demo).
@@ -39,20 +51,33 @@ export function PublicFormApp() {
         <div style={{ paddingTop: "var(--goa-space-2xl)", paddingBottom: "var(--goa-space-3xl)" }}>
           <Routes>
             <Route path="/" element={<TaskListHome />} />
+            <Route path="single-question" element={<SingleQuestion />} />
+            <Route path="grouped-fields" element={<GroupedFields />} />
+            <Route path="multiple-questions" element={<MultipleQuestions />} />
+            <Route path="details" element={<QuestionWithDetails />} />
+            <Route path="reveal" element={<Reveal />} />
+            <Route path="content-before" element={<ContentBefore />} />
+            <Route path="file-upload" element={<FileUpload />} />
+            <Route path="inline-list" element={<InlineList />} />
+            <Route path="modal-drawer" element={<ModalDrawer />} />
+            <Route path="drawer" element={<DrawerExample />} />
+            <Route path="multi-step" element={<MultiStep />} />
+            <Route path="new-page/*" element={<NewPageTask />} />
+            <Route path="eligibility/*" element={<EligibilityTask />} />
           </Routes>
         </div>
       </GoabPageBlock>
 
       <section slot="footer">
-        <GoabAppFooter maxContentWidth="704px">
-          <GoabAppFooterNavSection>
+        {/* Links go in the meta section so they lay out horizontally (the nav
+            section stacks them in columns). The footer auto-adds the copyright.
+            No maxContentWidth, so it spans full width to match the header. */}
+        <GoabAppFooter>
+          <GoabAppFooterMetaSection>
             <a href="#">My profile</a>
             <a href="#">Accessibility</a>
             <a href="#">Privacy</a>
             <a href="#">Terms and conditions</a>
-          </GoabAppFooterNavSection>
-          <GoabAppFooterMetaSection>
-            This is a Government of Alberta Digital Service. &copy; 2026 GoA
           </GoabAppFooterMetaSection>
         </GoabAppFooter>
       </section>

--- a/apps/prs/react/src/routes/public-form/public-form-app.tsx
+++ b/apps/prs/react/src/routes/public-form/public-form-app.tsx
@@ -25,6 +25,8 @@ import { DrawerExample } from "./examples/drawer";
 import { ResultEligible } from "./examples/result-eligible";
 import { ResultNotEligible } from "./examples/result-not-eligible";
 import { ResultSubmitted } from "./examples/result-submitted";
+import { ReviewEditable } from "./examples/review-editable";
+import { ReviewReadonly } from "./examples/review-readonly";
 
 /**
  * Public form template gallery (Step 1 demo).
@@ -70,6 +72,8 @@ export function PublicFormApp() {
             <Route path="result-eligible" element={<ResultEligible />} />
             <Route path="result-not-eligible" element={<ResultNotEligible />} />
             <Route path="result-submitted" element={<ResultSubmitted />} />
+            <Route path="review-editable" element={<ReviewEditable />} />
+            <Route path="review-readonly" element={<ReviewReadonly />} />
           </Routes>
         </div>
       </GoabPageBlock>

--- a/apps/prs/react/src/routes/public-form/public-form-app.tsx
+++ b/apps/prs/react/src/routes/public-form/public-form-app.tsx
@@ -1,0 +1,61 @@
+import { Routes, Route } from "react-router-dom";
+import {
+  GoabOneColumnLayout,
+  GoabAppHeader,
+  GoabMenuButton,
+  GoabMenuAction,
+  GoabAppFooter,
+  GoabAppFooterNavSection,
+  GoabAppFooterMetaSection,
+  GoabPageBlock,
+} from "@abgov/react-components";
+import { TaskListHome } from "./task-list-home";
+
+/**
+ * Public form template gallery (Step 1 demo).
+ *
+ * Mounted as its own top-level route at /public-form with its own GoA app shell,
+ * outside the react-prs side menu. Each example is a route under /public-form.
+ *
+ * Built from standard GoA (V2) components only -- no GoabPublicForm. The hand-built
+ * pieces (task list, form pages, summaries) are the spec for the Step 2 components.
+ */
+export function PublicFormApp() {
+  return (
+    <GoabOneColumnLayout>
+      <section slot="header">
+        <GoabAppHeader url="https://www.alberta.ca" heading="Service name" maxContentWidth="704px">
+          <div slot="utilities">
+            <GoabMenuButton text="Edna Mode" type="tertiary" size="compact">
+              <GoabMenuAction text="My profile" action="profile" />
+              <GoabMenuAction text="Settings" action="settings" />
+              <GoabMenuAction text="Sign out" action="sign-out" />
+            </GoabMenuButton>
+          </div>
+        </GoabAppHeader>
+      </section>
+
+      <GoabPageBlock width="640px">
+        <div style={{ paddingTop: "var(--goa-space-2xl)", paddingBottom: "var(--goa-space-3xl)" }}>
+          <Routes>
+            <Route path="/" element={<TaskListHome />} />
+          </Routes>
+        </div>
+      </GoabPageBlock>
+
+      <section slot="footer">
+        <GoabAppFooter maxContentWidth="704px">
+          <GoabAppFooterNavSection>
+            <a href="#">My profile</a>
+            <a href="#">Accessibility</a>
+            <a href="#">Privacy</a>
+            <a href="#">Terms and conditions</a>
+          </GoabAppFooterNavSection>
+          <GoabAppFooterMetaSection>
+            This is a Government of Alberta Digital Service. &copy; 2026 GoA
+          </GoabAppFooterMetaSection>
+        </GoabAppFooter>
+      </section>
+    </GoabOneColumnLayout>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/public-form-app.tsx
+++ b/apps/prs/react/src/routes/public-form/public-form-app.tsx
@@ -22,6 +22,9 @@ import { ModalDrawer } from "./examples/modal-drawer";
 import { MultiStep } from "./examples/multi-step";
 import { NewPageTask } from "./examples/new-page";
 import { DrawerExample } from "./examples/drawer";
+import { ResultEligible } from "./examples/result-eligible";
+import { ResultNotEligible } from "./examples/result-not-eligible";
+import { ResultSubmitted } from "./examples/result-submitted";
 
 /**
  * Public form template gallery (Step 1 demo).
@@ -64,6 +67,9 @@ export function PublicFormApp() {
             <Route path="multi-step" element={<MultiStep />} />
             <Route path="new-page/*" element={<NewPageTask />} />
             <Route path="eligibility/*" element={<EligibilityTask />} />
+            <Route path="result-eligible" element={<ResultEligible />} />
+            <Route path="result-not-eligible" element={<ResultNotEligible />} />
+            <Route path="result-submitted" element={<ResultSubmitted />} />
           </Routes>
         </div>
       </GoabPageBlock>

--- a/apps/prs/react/src/routes/public-form/public-form-app.tsx
+++ b/apps/prs/react/src/routes/public-form/public-form-app.tsx
@@ -29,6 +29,7 @@ import { ResultSubmitted } from "./examples/result-submitted";
 import { ReviewEditable } from "./examples/review-editable";
 import { ReviewReadonly } from "./examples/review-readonly";
 import { ReviewQuestionTypes } from "./examples/review-question-types";
+import { ReviewChildrenSummary } from "./examples/review-children-summary";
 
 /**
  * Reset scroll to the top on every route change. React Router keeps the previous
@@ -91,6 +92,7 @@ export function PublicFormApp() {
             <Route path="review-editable" element={<ReviewEditable />} />
             <Route path="review-readonly" element={<ReviewReadonly />} />
             <Route path="review-question-types" element={<ReviewQuestionTypes />} />
+            <Route path="review-children" element={<ReviewChildrenSummary />} />
           </Routes>
         </div>
       </GoabPageBlock>

--- a/apps/prs/react/src/routes/public-form/public-form-app.tsx
+++ b/apps/prs/react/src/routes/public-form/public-form-app.tsx
@@ -1,4 +1,5 @@
-import { Routes, Route } from "react-router-dom";
+import { useEffect } from "react";
+import { Routes, Route, useLocation } from "react-router-dom";
 import {
   GoabOneColumnLayout,
   GoabAppHeader,
@@ -27,6 +28,20 @@ import { ResultNotEligible } from "./examples/result-not-eligible";
 import { ResultSubmitted } from "./examples/result-submitted";
 import { ReviewEditable } from "./examples/review-editable";
 import { ReviewReadonly } from "./examples/review-readonly";
+import { ReviewQuestionTypes } from "./examples/review-question-types";
+
+/**
+ * Reset scroll to the top on every route change. React Router keeps the previous
+ * page's scroll position otherwise, so navigating to a new page can land partway
+ * down it. (A real public-form template/CSS layer would own this.)
+ */
+function ScrollToTop() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+  return null;
+}
 
 /**
  * Public form template gallery (Step 1 demo).
@@ -54,6 +69,7 @@ export function PublicFormApp() {
 
       <GoabPageBlock width="640px">
         <div style={{ paddingTop: "var(--goa-space-2xl)", paddingBottom: "var(--goa-space-3xl)" }}>
+          <ScrollToTop />
           <Routes>
             <Route path="/" element={<TaskListHome />} />
             <Route path="single-question" element={<SingleQuestion />} />
@@ -74,6 +90,7 @@ export function PublicFormApp() {
             <Route path="result-submitted" element={<ResultSubmitted />} />
             <Route path="review-editable" element={<ReviewEditable />} />
             <Route path="review-readonly" element={<ReviewReadonly />} />
+            <Route path="review-question-types" element={<ReviewQuestionTypes />} />
           </Routes>
         </div>
       </GoabPageBlock>

--- a/apps/prs/react/src/routes/public-form/public-form-layout.tsx
+++ b/apps/prs/react/src/routes/public-form/public-form-layout.tsx
@@ -3,10 +3,15 @@ import { Link } from "react-router-dom";
 import { GoabLink } from "@abgov/react-components";
 
 type PublicFormLayoutProps = {
-  /** Where the back link navigates. Defaults to the task list. */
+  /** Where the back link navigates (a route). Defaults to the task list. */
   back?: string;
   /** Back link text. Defaults to "Back". */
   backLabel?: string;
+  /**
+   * Back as an action instead of a route (e.g. "Back to review" cancelling a
+   * change-from-review flow). Takes precedence over `back` when set.
+   */
+  onBack?: () => void;
   /** The page content, typically a <FormSet>. */
   children: ReactNode;
 };
@@ -15,25 +20,40 @@ type PublicFormLayoutProps = {
  * Public-form page layout (the goa-public-form-layout candidate).
  *
  * Owns the page-shell concerns that sit OUTSIDE the form set: the back link and
- * the back-link -> content spacing. The form content (heading, fields, submit)
- * lives in <FormSet>, matching the boundary in the goa-form-set Figma component
- * (its only variant axis is "Multiple questions"; the back link is not part of
- * it). The GoA app shell (header / footer / single column) is provided one level
- * up by PublicFormApp.
+ * the back-link -> content spacing. The form content lives in <FormSet>; the GoA
+ * app shell is provided one level up by PublicFormApp.
  */
 export function PublicFormLayout({
   back = "/public-form",
   backLabel = "Back",
+  onBack,
   children,
 }: PublicFormLayoutProps) {
   return (
     <>
       <GoabLink leadingIcon="arrow-back" size="small" mb="none">
-        <Link to={back}>{backLabel}</Link>
+        {onBack ? (
+          <a
+            role="button"
+            tabIndex={0}
+            style={{ cursor: "pointer" }}
+            onClick={onBack}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onBack();
+              }
+            }}
+          >
+            {backLabel}
+          </a>
+        ) : (
+          <Link to={back}>{backLabel}</Link>
+        )}
       </GoabLink>
 
-      {/* xl gap is the canonical back-link -> heading rhythm; FormSet's first
-          element sits flush (mt none) so the gap is exactly this. */}
+      {/* xl gap is the canonical back-link -> heading rhythm; the first child sits
+          flush (mt none) so the gap is exactly this. */}
       <div style={{ marginTop: "var(--goa-space-xl)" }}>{children}</div>
     </>
   );

--- a/apps/prs/react/src/routes/public-form/public-form-layout.tsx
+++ b/apps/prs/react/src/routes/public-form/public-form-layout.tsx
@@ -1,0 +1,40 @@
+import { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { GoabLink } from "@abgov/react-components";
+
+type PublicFormLayoutProps = {
+  /** Where the back link navigates. Defaults to the task list. */
+  back?: string;
+  /** Back link text. Defaults to "Back". */
+  backLabel?: string;
+  /** The page content, typically a <FormSet>. */
+  children: ReactNode;
+};
+
+/**
+ * Public-form page layout (the goa-public-form-layout candidate).
+ *
+ * Owns the page-shell concerns that sit OUTSIDE the form set: the back link and
+ * the back-link -> content spacing. The form content (heading, fields, submit)
+ * lives in <FormSet>, matching the boundary in the goa-form-set Figma component
+ * (its only variant axis is "Multiple questions"; the back link is not part of
+ * it). The GoA app shell (header / footer / single column) is provided one level
+ * up by PublicFormApp.
+ */
+export function PublicFormLayout({
+  back = "/public-form",
+  backLabel = "Back",
+  children,
+}: PublicFormLayoutProps) {
+  return (
+    <>
+      <GoabLink leadingIcon="arrow-back" size="small" mb="none">
+        <Link to={back}>{backLabel}</Link>
+      </GoabLink>
+
+      {/* xl gap is the canonical back-link -> heading rhythm; FormSet's first
+          element sits flush (mt none) so the gap is exactly this. */}
+      <div style={{ marginTop: "var(--goa-space-xl)" }}>{children}</div>
+    </>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/public-form-layout.tsx
+++ b/apps/prs/react/src/routes/public-form/public-form-layout.tsx
@@ -31,7 +31,7 @@ export function PublicFormLayout({
 }: PublicFormLayoutProps) {
   return (
     <>
-      <GoabLink leadingIcon="arrow-back" size="small" mb="none">
+      <GoabLink leadingIcon="arrow-back" size="small" color="dark" mb="none">
         {onBack ? (
           <a
             role="button"

--- a/apps/prs/react/src/routes/public-form/results-page.tsx
+++ b/apps/prs/react/src/routes/public-form/results-page.tsx
@@ -1,0 +1,83 @@
+import { ReactNode } from "react";
+import { GoabText, GoabCallout, GoabLink } from "@abgov/react-components";
+
+type ResultsPageProps = {
+  /** The outcome statement (H1). */
+  heading: string;
+  /** Status colour: "success" for a positive outcome, "important" for a blocked one. */
+  status: "success" | "important";
+  /** The Callout heading — the headline status (often the specific reason). */
+  statusHeading: string;
+  /** Optional Callout body. */
+  statusBody?: ReactNode;
+  /** Content between the Callout and the actions (e.g. "what happens next", the contact block). */
+  children?: ReactNode;
+  /** The action button group. */
+  actions: ReactNode;
+};
+
+/**
+ * Results page (the goa-public-form result-page candidate): the terminal outcome
+ * screen for a service — eligible / not eligible / submitted.
+ *
+ * The inverse of FormSet. A question page leads with a form and sits inside
+ * PublicFormLayout (which renders the back link); a result page is terminal, so
+ * it has NO back link and leads with a status Callout. It is rendered directly
+ * inside the app shell (PublicFormApp), not wrapped by PublicFormLayout.
+ *
+ * Owns the result-page anatomy from the Figma: H1 outcome -> status Callout ->
+ * optional content -> action button group.
+ */
+export function ResultsPage({
+  heading,
+  status,
+  statusHeading,
+  statusBody,
+  children,
+  actions,
+}: ResultsPageProps) {
+  return (
+    <>
+      <GoabText tag="h1" mt="none" mb="xl">
+        {heading}
+      </GoabText>
+
+      {/* mb none: the next section's heading owns the gap (mt xl), so sections
+          sit on one consistent rhythm whether or not a Callout body is present. */}
+      <GoabCallout type={status} heading={statusHeading} mb="none">
+        {statusBody}
+      </GoabCallout>
+
+      {children}
+
+      <div style={{ marginTop: "var(--goa-space-2xl)" }}>{actions}</div>
+    </>
+  );
+}
+
+/**
+ * "If you have questions about your application" — the contact block that repeats
+ * on every result page in the Figma. Hand-built; a real contact-details block is
+ * a candidate Step-2 piece.
+ */
+export function ResultContactSection() {
+  return (
+    <>
+      <GoabText tag="h2" mt="xl" mb="s">
+        If you have questions about your application
+      </GoabText>
+      <GoabText mt="none" mb="s">
+        Contact the [ministry area].
+      </GoabText>
+      <GoabText mt="none" mb="2xs">
+        <strong>Email:</strong>{" "}
+        <GoabLink>
+          <a href="mailto:information@gov.ab.ca">information@gov.ab.ca</a>
+        </GoabLink>
+      </GoabText>
+      <GoabText mt="none" mb="none">
+        <strong>Phone:</strong> 780 123 4567
+      </GoabText>
+    </>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/task-list-home.tsx
+++ b/apps/prs/react/src/routes/public-form/task-list-home.tsx
@@ -1,3 +1,4 @@
+import { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import { GoabText, GoabBadge, GoabCallout, GoabButton } from "@abgov/react-components";
 
@@ -9,6 +10,12 @@ type Section = { title: string; tasks: Task[]; locked?: boolean; lockedNote?: st
 // Statuses are illustrative, to show the badge states. Everything unlocked is a link
 // (free-jump); the last section is locked to demo that state too.
 const sections: Section[] = [
+  {
+    // A real multi-page task (an organized section with branching), to contrast
+    // with the single-page pattern demos below.
+    title: "Before you apply",
+    tasks: [{ slug: "eligibility", name: "Confirm your eligibility", status: "not-started" }],
+  },
   {
     title: "Question types",
     tasks: [
@@ -25,7 +32,8 @@ const sections: Section[] = [
     title: "Repeating questions",
     tasks: [
       { slug: "inline-list", name: "Inline list", status: "not-started" },
-      { slug: "modal-drawer", name: "Modal / drawer", status: "not-started" },
+      { slug: "modal-drawer", name: "Add in a modal", status: "not-started" },
+      { slug: "drawer", name: "Add in a drawer", status: "not-started" },
       { slug: "multi-step", name: "Multi-step entry", status: "not-started" },
       { slug: "new-page", name: "New page per item, with branches", status: "not-started" },
     ],
@@ -62,22 +70,33 @@ function SectionCard({ section, index }: { section: Section; index: number }) {
       {section.locked ? (
         <GoabText mt="none" mb="none" color="secondary">{section.lockedNote}</GoabText>
       ) : (
-        section.tasks.map((task, i) => (
-          <div
-            key={task.slug ?? task.name}
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              gap: "var(--goa-space-m)",
-              padding: "var(--goa-space-s) 0",
-              borderTop: i > 0 ? "1px solid var(--goa-color-greyscale-100)" : "none",
-            }}
-          >
-            {task.slug ? <Link to={task.slug}>{task.name}</Link> : <span>{task.name}</span>}
-            <StatusBadge status={task.status} />
-          </div>
-        ))
+        section.tasks.map((task, i) => {
+          // Full-bleed clickable row: negative horizontal margin cancels the
+          // card's padding so the hover background spans the whole card width,
+          // and the whole row is the link target (click anywhere).
+          const rowStyle: CSSProperties = {
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: "var(--goa-space-m)",
+            padding: "var(--goa-space-m) var(--goa-space-xl)",
+            margin: "0 calc(-1 * var(--goa-space-xl))",
+            borderTop: i > 0 ? "1px solid var(--goa-color-greyscale-100)" : "none",
+            textDecoration: "none",
+            color: "inherit",
+          };
+          return task.slug ? (
+            <Link key={task.slug} to={task.slug} className="pf-task-row" style={rowStyle}>
+              <span className="pf-task-name">{task.name}</span>
+              <StatusBadge status={task.status} />
+            </Link>
+          ) : (
+            <div key={task.name} style={rowStyle}>
+              <span className="pf-task-name">{task.name}</span>
+              <StatusBadge status={task.status} />
+            </div>
+          );
+        })
       )}
     </div>
   );
@@ -86,6 +105,13 @@ function SectionCard({ section, index }: { section: Section; index: number }) {
 export function TaskListHome() {
   return (
     <div>
+      <style>{`
+        .pf-task-row { transition: background-color 0.12s ease; }
+        .pf-task-row:hover,
+        .pf-task-row:focus-visible { background-color: var(--goa-color-greyscale-100); }
+        .pf-task-row:hover .pf-task-name,
+        .pf-task-row:focus-visible .pf-task-name { text-decoration: underline; }
+      `}</style>
       <div
         style={{
           display: "flex",

--- a/apps/prs/react/src/routes/public-form/task-list-home.tsx
+++ b/apps/prs/react/src/routes/public-form/task-list-home.tsx
@@ -51,6 +51,7 @@ const sections: Section[] = [
     tasks: [
       { slug: "review-editable", name: "Editable", status: "not-started" },
       { slug: "review-readonly", name: "Read-only", status: "not-started" },
+      { slug: "review-question-types", name: "Question types", status: "not-started" },
     ],
   },
   {

--- a/apps/prs/react/src/routes/public-form/task-list-home.tsx
+++ b/apps/prs/react/src/routes/public-form/task-list-home.tsx
@@ -1,0 +1,125 @@
+import { Link } from "react-router-dom";
+import { GoabText, GoabBadge, GoabCallout, GoabButton } from "@abgov/react-components";
+
+type Status = "not-started" | "in-progress" | "completed";
+type Task = { slug?: string; name: string; status: Status };
+type Section = { title: string; tasks: Task[]; locked?: boolean; lockedNote?: string };
+
+// Gallery content, styled as a real task list (see step-1-demo-spec.md).
+// Statuses are illustrative, to show the badge states. Everything unlocked is a link
+// (free-jump); the last section is locked to demo that state too.
+const sections: Section[] = [
+  {
+    title: "Question types",
+    tasks: [
+      { slug: "single-question", name: "Single question", status: "completed" },
+      { slug: "multiple-questions", name: "Multiple questions on a page", status: "completed" },
+      { slug: "details", name: "Question with Details", status: "in-progress" },
+      { slug: "grouped-fields", name: "Grouped fields, one topic", status: "not-started" },
+      { slug: "reveal", name: "Reveal", status: "not-started" },
+      { slug: "content-before", name: "Content before the question", status: "not-started" },
+      { slug: "file-upload", name: "File upload", status: "not-started" },
+    ],
+  },
+  {
+    title: "Repeating questions",
+    tasks: [
+      { slug: "inline-list", name: "Inline list", status: "not-started" },
+      { slug: "modal-drawer", name: "Modal / drawer", status: "not-started" },
+      { slug: "multi-step", name: "Multi-step entry", status: "not-started" },
+      { slug: "new-page", name: "New page per item, with branches", status: "not-started" },
+    ],
+  },
+  {
+    title: "Locked example",
+    locked: true,
+    lockedNote: "You need to complete the previous section before you can start this task.",
+    tasks: [],
+  },
+];
+
+function StatusBadge({ status }: { status: Status }) {
+  if (status === "completed") return <GoabBadge type="success" content="Completed" />;
+  if (status === "in-progress") return <GoabBadge type="important" content="In progress" />;
+  return <GoabBadge type="information" content="Not started" />;
+}
+
+// Hand-built task-list section card -> the goab-task-list / task-list-item spec for Step 2.
+function SectionCard({ section, index }: { section: Section; index: number }) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--goa-color-greyscale-200)",
+        borderRadius: "var(--goa-border-radius-xl)",
+        padding: "var(--goa-space-l) var(--goa-space-xl)",
+        marginBottom: "var(--goa-space-l)",
+      }}
+    >
+      <GoabText tag="h2" mt="none" mb={section.locked ? "xs" : "s"}>
+        {index}. {section.title}
+      </GoabText>
+
+      {section.locked ? (
+        <GoabText mt="none" mb="none" color="secondary">{section.lockedNote}</GoabText>
+      ) : (
+        section.tasks.map((task, i) => (
+          <div
+            key={task.slug ?? task.name}
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: "var(--goa-space-m)",
+              padding: "var(--goa-space-s) 0",
+              borderTop: i > 0 ? "1px solid var(--goa-color-greyscale-100)" : "none",
+            }}
+          >
+            {task.slug ? <Link to={task.slug}>{task.name}</Link> : <span>{task.name}</span>}
+            <StatusBadge status={task.status} />
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+export function TaskListHome() {
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--goa-space-s)",
+          marginBottom: "var(--goa-space-2xs)",
+        }}
+      >
+        <GoabText tag="h1" mt="none" mb="none">
+          Apply for a [service]
+        </GoabText>
+        <GoabBadge type="information" content="Draft" />
+      </div>
+      <GoabText mt="xs" mb="xl" color="secondary">
+        Your progress is saved automatically. You can return to complete this application at any time.
+      </GoabText>
+
+      <GoabCallout type="information" heading="2 sections left to complete" mb="xl">
+        <div style={{ marginBottom: "var(--goa-space-xs)", color: "var(--goa-color-text-secondary)" }}>
+          You have completed 1 of 3 sections
+        </div>
+        <Link to="single-question">Continue</Link>
+      </GoabCallout>
+
+      {sections.map((section, i) => (
+        <SectionCard key={section.title} section={section} index={i + 1} />
+      ))}
+
+      <GoabText mt="l" mb="s" color="secondary">
+        Complete all sections above to submit your application.
+      </GoabText>
+      <GoabButton type="primary" disabled>
+        Submit application
+      </GoabButton>
+    </div>
+  );
+}

--- a/apps/prs/react/src/routes/public-form/task-list-home.tsx
+++ b/apps/prs/react/src/routes/public-form/task-list-home.tsx
@@ -39,6 +39,14 @@ const sections: Section[] = [
     ],
   },
   {
+    title: "Result pages",
+    tasks: [
+      { slug: "result-eligible", name: "Eligible", status: "not-started" },
+      { slug: "result-not-eligible", name: "Not eligible", status: "not-started" },
+      { slug: "result-submitted", name: "Submitted", status: "not-started" },
+    ],
+  },
+  {
     title: "Locked example",
     locked: true,
     lockedNote: "You need to complete the previous section before you can start this task.",

--- a/apps/prs/react/src/routes/public-form/task-list-home.tsx
+++ b/apps/prs/react/src/routes/public-form/task-list-home.tsx
@@ -52,6 +52,7 @@ const sections: Section[] = [
       { slug: "review-editable", name: "Editable", status: "not-started" },
       { slug: "review-readonly", name: "Read-only", status: "not-started" },
       { slug: "review-question-types", name: "Question types", status: "not-started" },
+      { slug: "review-children", name: "Repeating group", status: "not-started" },
     ],
   },
   {

--- a/apps/prs/react/src/routes/public-form/task-list-home.tsx
+++ b/apps/prs/react/src/routes/public-form/task-list-home.tsx
@@ -47,6 +47,13 @@ const sections: Section[] = [
     ],
   },
   {
+    title: "Review pages",
+    tasks: [
+      { slug: "review-editable", name: "Editable", status: "not-started" },
+      { slug: "review-readonly", name: "Read-only", status: "not-started" },
+    ],
+  },
+  {
     title: "Locked example",
     locked: true,
     lockedNote: "You need to complete the previous section before you can start this task.",

--- a/apps/prs/react/src/routes/public-form/validation.ts
+++ b/apps/prs/react/src/routes/public-form/validation.ts
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { FieldError } from "./error-summary";
+
+/**
+ * The validation piece — declarative rules separated from the lifecycle.
+ *
+ * A page declares its rules as a schema (field id -> rule). The schema is the
+ * framework-neutral artifact: it's what an intentional template or a generator
+ * would emit, and it reads the same in any framework. `useFormValidation` is the
+ * React binding that owns the lifecycle (validate-on-submit, error state, live
+ * clearing after the first submit); FormSet still renders the error summary and
+ * moves focus. Angular would get an equivalent binding over the same schema shape.
+ *
+ * This replaces the per-page hand-rolled validate() + submitted + errors plumbing.
+ */
+
+/** A rule: given a field's value and all values, return an error message or null. */
+export type Rule = (value: unknown, all: Record<string, unknown>) => string | null;
+/** Declarative rules per field id. The field id matches the GoabFormItem id. */
+export type Schema = Record<string, Rule>;
+
+export const required =
+  (message: string): Rule =>
+  (v) => {
+    if (typeof v === "string") return v.trim() ? null : message;
+    if (Array.isArray(v)) return v.length ? null : message;
+    return v ? null : message;
+  };
+
+export const minSelected =
+  (n: number, message: string): Rule =>
+  (v) =>
+    Array.isArray(v) && v.length >= n ? null : message;
+
+export const pattern =
+  (re: RegExp, message: string): Rule =>
+  (v) =>
+    typeof v === "string" && re.test(v.trim()) ? null : message;
+
+/** Only apply `rule` when `when(all)` is true; otherwise the field is valid. For reveals / conditional fields. */
+export const when =
+  (predicate: (all: Record<string, unknown>) => boolean, rule: Rule): Rule =>
+  (v, all) =>
+    predicate(all) ? rule(v, all) : null;
+
+/**
+ * Run a schema against values, in declaration order, so the error summary lists
+ * errors top-to-bottom matching the field order on the page.
+ */
+export function runSchema(schema: Schema, values: Record<string, unknown>): FieldError[] {
+  const errors: FieldError[] = [];
+  for (const [fieldId, rule] of Object.entries(schema)) {
+    const message = rule(values[fieldId], values);
+    if (message) errors.push({ fieldId, text: message });
+  }
+  return errors;
+}
+
+/** The validation lifecycle. Owns error state and validate-on-submit; FormSet renders the rest. */
+export function useFormValidation(schema: Schema) {
+  const [errors, setErrors] = useState<FieldError[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  /** Validate now; run `onValid` only if the form is valid. Call from the submit handler. */
+  const submit = (values: Record<string, unknown>, onValid: () => void) => {
+    setSubmitted(true);
+    const found = runSchema(schema, values);
+    setErrors(found);
+    if (found.length === 0) onValid();
+  };
+
+  /** After the first submit, re-validate as the user edits (live clear). Call from onChange. */
+  const revalidate = (values: Record<string, unknown>) => {
+    if (submitted) setErrors(runSchema(schema, values));
+  };
+
+  return { errors, submit, revalidate };
+}


### PR DESCRIPTION
# Before (the change)

#3917 asked which components the public form needs. The plan out of that spike makes Step 1 a coded reference demo, then Step 2 builds the real components against it. There's no such reference today: the current demo rides on an unmerged fork of the form runtime that only lives on a separate branch, and the page-scale starters (start, review, result) are generic for other scenarios.

# After (the change)

The Step 1 reference demo: a self-contained public form gallery built entirely from standard GoA components, with no form-runtime fork. It lives in the React example app under `apps/prs/react/src/routes/public-form/`, and you get to it from Public form in the playground side menu. It opens as its own full page rather than inside the playground layout, since these are whole public form pages with their own header and footer. Browser back returns to the playground. The task-list page is the home, and everything is reachable from it.

The gallery, by section:

- **Question types:** single question, multiple questions on a page, question with details, grouped fields, reveal, content before the question, file upload.
- **Repeating questions:** inline list, add in a modal, add in a drawer, multi-step entry, new page per item with branches. (Table is the one repeater pattern from the spike I didn't build, since it's the overkill-for-simple-cases case.)
- **Before you apply:** a real multi-page eligibility task with next-logic and branching, plus a change-from-review flow that rewalks any newly-opened questions.
- **Review pages:** editable, read-only, per-question-type, and a repeating-group summary, built from a form summary, section, and item hierarchy.
- **Result pages:** eligible, not eligible, submitted.

It's all additive and isolated to the example app, so it doesn't touch any shipped component.

This is the reference for the component list in the spike. Most of those pieces are hand-built here because they don't exist as components yet: the error summary, the task list, the parent and child form summaries, the inline repeater layout, and the public-form page layout. Building by hand also turned up a few smaller DX gaps (form item error not reddening its control, date picker losing partial and invalid states, file upload having no error prop), captured separately for Step 2.

One accessibility note for the Form page component: the single-question pattern uses the field label as the page heading, but Form Item can't render its label as a heading, so those pages have no programmatic h1. That's filed as #4096, along with the other findings for Step 2.

One thing left for later: the task-list completion statuses are decorative right now, they don't update when you come back to a task. That needs app-level state.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the setup steps
- [ ] I have created necessary unit tests (this is a reference demo, verified in-browser rather than unit-tested)
- [ ] I have tested the functionality in both React and Angular (React-only example app; the Angular reference comes in Step 2)

## Steps needed to test

The preview link is the quickest way in. Open it and choose Public form in the side menu.

To run it locally instead, in a fresh checkout of this branch:

1. `npm ci --legacy-peer-deps`
2. `npm run build`
3. `npm run serve:prs:react`

From the task-list home: submit a form with empty required fields (the error summary appears and moves focus to the field), walk the eligibility task and change an answer from the review page, and add a few items through the modal, drawer, and new-page patterns.


