### PR TITLE
fix(#3986): GoabButton doesn't take 100% width inside GoabButtonGroup on mobile

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3986/bug3986.component.html
+++ b/apps/prs/angular/src/routes/bugs/3986/bug3986.component.html
@@ -1,0 +1,39 @@
+<goab-text tag="h1" mt="m" mb="m">
+  Bug 3986 - GoabButton doesn't take 100% width inside GoabButtonGroup on mobile
+</goab-text>
+<goab-text mb="l">
+  GoabButton normally takes 100% width of the parent container on mobile. However, if
+  you place the button inside a GoabButtonGroup, it no longer takes up 100% width,
+  instead fitting to content. Resize the viewport below 624px wide to test.
+</goab-text>
+
+<goab-text tag="h2" mb="s">Test 1: ButtonGroup in normal flow</goab-text>
+<goab-button-group alignment="end" gap="relaxed" mb="l">
+  <goab-button type="secondary">Cancel</goab-button>
+  <goab-button type="primary">Confirm</goab-button>
+</goab-button-group>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<goab-text tag="h2" mb="s">Test 2: ButtonGroup inside a flex row container</goab-text>
+<goab-text mb="s">
+  This was the main repro: a flex-row parent (a common page/footer layout) shrinks
+  GoabButtonGroup to its content width, so the buttons' 100% width was 100% of the
+  shrunk group, not the viewport. Buttons should still stack and take 100% width below
+  the mobile breakpoint.
+</goab-text>
+<div style="display: flex; flex-direction: row;">
+  <goab-button-group alignment="end" gap="relaxed">
+    <goab-button type="secondary">Cancel</goab-button>
+    <goab-button type="primary">Confirm</goab-button>
+  </goab-button-group>
+</div>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<goab-text tag="h2" mb="s">Test 3: Three buttons, compact gap</goab-text>
+<goab-button-group alignment="start" gap="compact">
+  <goab-button type="primary">Primary</goab-button>
+  <goab-button type="secondary">Secondary</goab-button>
+  <goab-button type="tertiary">Tertiary</goab-button>
+</goab-button-group>

--- a/apps/prs/angular/src/routes/bugs/3986/bug3986.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3986/bug3986.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabButton, GoabButtonGroup, GoabText, GoabDivider } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3986",
+  templateUrl: "./bug3986.component.html",
+  imports: [GoabButton, GoabButtonGroup, GoabText, GoabDivider],
+})
+export class Bug3986Component {}

--- a/apps/prs/angular/src/routes/bugs/3986/bug3986.route.json
+++ b/apps/prs/angular/src/routes/bugs/3986/bug3986.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3986",
+  "path": "bugs/3986",
+  "title": "ButtonGroup mobile width"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3986.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3986.route.ts
@@ -1,0 +1,10 @@
+import { Bug3986Route } from "../../../routes/bugs/bug3986";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3986",
+  path: "bugs/3986",
+  title: "ButtonGroup mobile width",
+  component: Bug3986Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3986.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3986.tsx
@@ -1,0 +1,72 @@
+import {
+  GoabButton,
+  GoabButtonGroup,
+  GoabText,
+  GoabBlock,
+  GoabDivider,
+  GoabDetails,
+  GoabLink,
+} from "@abgov/react-components";
+
+export function Bug3986Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug #3986: GoabButton doesn't take 100% width inside GoabButtonGroup on mobile
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a href="https://github.com/GovAlta/ui-components/issues/3986" target="_blank" rel="noopener">
+            View on GitHub
+          </a>
+        </GoabLink>
+
+        <GoabDetails heading="Issue Description">
+          <GoabText tag="p">
+            GoabButton normally takes 100% width of the parent container on mobile.
+            However, if you place the button inside a GoabButtonGroup, it no longer
+            takes up 100% width, instead fitting to content. Resize the viewport below
+            624px wide to test.
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      <GoabText tag="h3">Test 1: ButtonGroup in normal flow</GoabText>
+      <GoabText tag="p">
+        Buttons should stack and take 100% width below the mobile breakpoint.
+      </GoabText>
+      <GoabButtonGroup alignment="end" gap="relaxed">
+        <GoabButton type="secondary">Cancel</GoabButton>
+        <GoabButton type="primary">Confirm</GoabButton>
+      </GoabButtonGroup>
+
+      <GoabText tag="h3">Test 2: ButtonGroup inside a flex row container</GoabText>
+      <GoabText tag="p">
+        This was the main repro: a flex-row parent (a common page/footer layout)
+        shrinks GoabButtonGroup to its content width, so the buttons&apos; 100% width
+        was 100% of the shrunk group, not the viewport. Buttons should still stack and
+        take 100% width below the mobile breakpoint.
+      </GoabText>
+      <div style={{ display: "flex", flexDirection: "row" }}>
+        <GoabButtonGroup alignment="end" gap="relaxed">
+          <GoabButton type="secondary">Cancel</GoabButton>
+          <GoabButton type="primary">Confirm</GoabButton>
+        </GoabButtonGroup>
+      </div>
+
+      <GoabText tag="h3">Test 3: Three buttons, compact gap</GoabText>
+      <GoabButtonGroup alignment="start" gap="compact">
+        <GoabButton type="primary">Primary</GoabButton>
+        <GoabButton type="secondary">Secondary</GoabButton>
+        <GoabButton type="tertiary">Tertiary</GoabButton>
+      </GoabButtonGroup>
+    </div>
+  );
+}
+
+export default Bug3986Route;

--- a/libs/angular-components/src/lib/components/button-group/button-group.ts
+++ b/libs/angular-components/src/lib/components/button-group/button-group.ts
@@ -33,6 +33,13 @@ import { GoabBaseComponent } from "../base.component";
     }
   `,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  styles: [
+    `
+      :host {
+        display: contents;
+      }
+    `,
+  ],
 })
 /** Display multiple related actions stacked or in a horizontal row to help with arrangement and spacing. */
 export class GoabButtonGroup extends GoabBaseComponent implements OnInit {

--- a/libs/web-components/src/components/button-group/ButtonGroup.svelte
+++ b/libs/web-components/src/components/button-group/ButtonGroup.svelte
@@ -77,4 +77,15 @@
     padding: 3px 0; /* prevent button box shadow from being cut off */
     line-height: 100%;
   }
+
+  @media (--mobile) {
+    :host {
+      display: block;
+      width: 100%;
+    }
+    div {
+      flex-direction: column;
+      align-items: stretch;
+    }
+  }
 </style>


### PR DESCRIPTION
# Before (the change)

Buttons inside a GoabButtonGroup do not take 100% width on mobile. The group's shadow host has no explicit display rule, so it defaults to inline. When the button group sits inside a flex row parent (a common layout, such as a page actions row), it shrinks to its content width instead of filling the row, so each button's mobile width:100% resolves against that shrunk width rather than the real available space.

The Angular wrapper has a second, related issue: GoabButtonGroup (Angular) wraps the underlying goa-button-group element in its own host element with no display override. When that wrapper is itself a flex item in a row, the wrapper shrinks to content width, which prevents the web component level fix from taking effect for Angular consumers even after the Svelte fix.

# After (the change)

The button group's host is explicitly set to display:block and width:100% on mobile, and the inner flex container switches to flex-direction:column with align-items:stretch. Buttons inside the group now reliably stack and span 100% width on mobile regardless of the parent layout context.

The Angular wrapper now sets display:contents on its own host, matching the existing pattern used by the Spacer and Badge wrappers, so the wrapper element disappears from layout and the underlying web component participates directly in the parent's flex layout.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the setup steps
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Open the React playground at bugs/3986 or Angular playground at bugs/3986.
2. Resize the viewport below 624px wide.
3. Confirm the buttons in each test case stack and take 100% width, including Test 2, which places the button group inside a flex row container.

Fixes #3986