### PR TITLE
fix(#3495): resize tooltip width when content changes while visible

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3495/bug3495.component.html
+++ b/apps/prs/angular/src/routes/bugs/3495/bug3495.component.html
@@ -1,0 +1,17 @@
+<goab-text tag="h1" mt="m" mb="m">Bug 3495 - Tooltip width issue when text changes</goab-text>
+<goab-text mb="l">
+  Clicking the copy button changes the tooltip content from "Copy" to "Copied" while
+  the tooltip stays open. Expected: the tooltip resizes to fit the new text. Actual
+  (before fix): the tooltip kept the narrower width measured for "Copy", squeezing the
+  "Copied" text.
+</goab-text>
+
+<goab-block gap="m" direction="row" alignment="center">
+  <goab-tooltip [content]="label()">
+    <goab-button type="tertiary" leadingIcon="copy" (onClick)="markCopied()">
+      456 789 0123
+    </goab-button>
+  </goab-tooltip>
+
+  <goab-button type="secondary" (onClick)="reset()">Reset tooltip text</goab-button>
+</goab-block>

--- a/apps/prs/angular/src/routes/bugs/3495/bug3495.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3495/bug3495.component.ts
@@ -1,0 +1,20 @@
+import { Component, signal } from "@angular/core";
+import { GoabBlock, GoabButton, GoabText, GoabTooltip } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3495",
+  templateUrl: "./bug3495.component.html",
+  imports: [GoabBlock, GoabButton, GoabText, GoabTooltip],
+})
+export class Bug3495Component {
+  label = signal("Copy");
+
+  markCopied() {
+    this.label.set("Copied");
+  }
+
+  reset() {
+    this.label.set("Copy");
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3495/bug3495.route.json
+++ b/apps/prs/angular/src/routes/bugs/3495/bug3495.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3495",
+  "path": "bugs/3495",
+  "title": "Tooltip width issue when text changes"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3495.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3495.route.ts
@@ -1,0 +1,10 @@
+import { Bug3495Route } from "../../../routes/bugs/bug3495";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3495",
+  path: "bugs/3495",
+  title: "Tooltip width issue when text changes",
+  component: Bug3495Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3495.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3495.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { GoabBlock, GoabButton, GoabText, GoabTooltip } from "@abgov/react-components";
+
+export function Bug3495Route() {
+  const [label, setLabel] = useState("Copy");
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m" mb="m">
+        Bug #3495: Tooltip width issue when text changes
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        Clicking the copy button changes the tooltip content from "Copy" to "Copied"
+        while the tooltip stays open. Expected: the tooltip resizes to fit the new
+        text. Actual (before fix): the tooltip kept the narrower width measured for
+        "Copy", squeezing the "Copied" text.
+      </GoabText>
+
+      <GoabBlock gap="m" direction="row" alignment="center">
+        <GoabTooltip content={label}>
+          <GoabButton
+            type="tertiary"
+            leadingIcon="copy"
+            onClick={() => setLabel("Copied")}
+          >
+            456 789 0123
+          </GoabButton>
+        </GoabTooltip>
+
+        <GoabButton type="secondary" onClick={() => setLabel("Copy")}>
+          Reset tooltip text
+        </GoabButton>
+      </GoabBlock>
+    </div>
+  );
+}
+
+export default Bug3495Route;

--- a/libs/react-components/specs/tooltip.browser.spec.tsx
+++ b/libs/react-components/specs/tooltip.browser.spec.tsx
@@ -598,6 +598,9 @@ describe("Tooltip Browser Tests", () => {
               Copy ID
             </GoabButton>
           </GoabTooltip>
+          <GoabButton testId="reset" onClick={() => setLabel("Copy")}>
+            Reset
+          </GoabButton>
         </div>
       );
     };
@@ -605,7 +608,10 @@ describe("Tooltip Browser Tests", () => {
     const result = render(<Component />);
     const container = result.getByTestId("container");
     const trigger = result.getByTestId("trigger");
+    const reset = result.getByTestId("reset");
     const host = container.element().querySelector("goa-tooltip") as HTMLElement | null;
+
+    await document.fonts.ready;
 
     vi.useFakeTimers();
     try {
@@ -645,6 +651,21 @@ describe("Tooltip Browser Tests", () => {
         // "Copied" is longer than "Copy", so the tooltip should grow to fit
         // it instead of keeping the narrower width measured for "Copy".
         expect(copiedWidth).toBeGreaterThan(copyWidth);
+      });
+
+      // Change back to the shorter content while the tooltip stays open.
+      await reset.click();
+
+      await vi.waitFor(() => {
+        expect(tooltipTextEl?.textContent?.trim()).toBe("Copy");
+      });
+
+      await vi.waitFor(() => {
+        const resetWidth = parseFloat(tooltipTextEl?.style.width ?? "0");
+        // The tooltip should shrink back down to fit "Copy" instead of
+        // keeping the wider width measured for "Copied".
+        expect(resetWidth).toBeLessThan(copiedWidth);
+        expect(resetWidth).toBe(copyWidth);
       });
     } finally {
       vi.useRealTimers();

--- a/libs/react-components/specs/tooltip.browser.spec.tsx
+++ b/libs/react-components/specs/tooltip.browser.spec.tsx
@@ -1,5 +1,6 @@
 import { render } from "vitest-browser-react";
 import { page } from "@vitest/browser/context";
+import { useState } from "react";
 
 import { GoabTooltip, GoabButton } from "../src";
 import { expect, describe, it, vi } from "vitest";
@@ -579,6 +580,71 @@ describe("Tooltip Browser Tests", () => {
 
         expect(renderedWidth).toBeGreaterThan(200);
         expect(renderedWidth).toBeLessThanOrEqual(401);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("should resize to fit content that changes while the tooltip is visible", async () => {
+    await page.viewport(1280, 800);
+
+    const Component = () => {
+      const [label, setLabel] = useState("Copy");
+      return (
+        <div data-testid="container">
+          <GoabTooltip content={label} testId="test-tooltip">
+            <GoabButton testId="trigger" onClick={() => setLabel("Copied")}>
+              Copy ID
+            </GoabButton>
+          </GoabTooltip>
+        </div>
+      );
+    };
+
+    const result = render(<Component />);
+    const container = result.getByTestId("container");
+    const trigger = result.getByTestId("trigger");
+    const host = container.element().querySelector("goa-tooltip") as HTMLElement | null;
+
+    vi.useFakeTimers();
+    try {
+      expect(host).toBeTruthy();
+
+      await vi.waitFor(() => {
+        const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+        expect(hoverTarget).toBeTruthy();
+      });
+
+      const hoverTarget = host?.shadowRoot?.querySelector<HTMLElement>(".tooltip");
+      hoverTarget?.dispatchEvent(new MouseEvent("mouseenter"));
+
+      await vi.advanceTimersByTimeAsync(350);
+
+      const tooltipTextEl = host?.shadowRoot?.querySelector(
+        ".tooltip-text",
+      ) as HTMLElement | null;
+
+      await vi.waitFor(() => {
+        expect(tooltipTextEl?.classList.contains("show")).toBe(true);
+      });
+
+      const copyWidth = parseFloat(tooltipTextEl?.style.width ?? "0");
+
+      // Change the content while the tooltip stays open, simulating
+      // the Copy -> Copied transition after clicking a copy button.
+      await trigger.click();
+
+      await vi.waitFor(() => {
+        expect(tooltipTextEl?.textContent?.trim()).toBe("Copied");
+      });
+
+      let copiedWidth = 0;
+      await vi.waitFor(() => {
+        copiedWidth = parseFloat(tooltipTextEl?.style.width ?? "0");
+        // "Copied" is longer than "Copy", so the tooltip should grow to fit
+        // it instead of keeping the narrower width measured for "Copy".
+        expect(copiedWidth).toBeGreaterThan(copyWidth);
       });
     } finally {
       vi.useRealTimers();

--- a/libs/web-components/src/components/tooltip/Tooltip.svelte
+++ b/libs/web-components/src/components/tooltip/Tooltip.svelte
@@ -308,6 +308,12 @@
       return;
     }
 
+    // Clear any width/white-space set by a previous reconcile so the
+    // natural size for the current content is measured, not a size left
+    // over from earlier content (e.g. "Copy" -> "Copied").
+    _tooltipEl.style.width = "";
+    _tooltipEl.style.whiteSpace = "";
+
     // determine the bounding rectangle of the tooltip and target element
     let tooltipRect = _tooltipEl.getBoundingClientRect();
     const targetRect = _targetEl.getBoundingClientRect();

--- a/libs/web-components/src/components/tooltip/Tooltip.svelte
+++ b/libs/web-components/src/components/tooltip/Tooltip.svelte
@@ -308,9 +308,6 @@
       return;
     }
 
-    // Clear any width/white-space set by a previous reconcile so the
-    // natural size for the current content is measured, not a size left
-    // over from earlier content (e.g. "Copy" -> "Copied").
     _tooltipEl.style.width = "";
     _tooltipEl.style.whiteSpace = "";
 


### PR DESCRIPTION
# Before (the change)

When a Tooltip's content prop changes while the tooltip is already visible (e.g. a Copy button's tooltip switching from "Copy" to "Copied" after a click), the tooltip kept the explicit width measured for the previous content. The new, longer text got squeezed into the old narrower box instead of resizing.

# After (the change)

`reconcileTooltipLayout` now clears the tooltip's explicit width and white-space styles before re-measuring, so the natural size is calculated for the current content every time, not a size left over from earlier content.

Fixes #3495

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the setup steps
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Run `npm run serve:prs:react` (or `serve:prs:angular`).
2. Go to Bugs, 3495, Tooltip width issue when text changes.
3. Hover the copy button so the "Copy" tooltip shows, then click it.
4. Confirm the tooltip resizes to fit "Copied" instead of staying at the narrower "Copy" width.