### PR TITLE
fix(#4004): forward heading slot to internal push drawer

### DIFF
--- a/apps/prs/angular/src/routes/bugs/4004/bug4004.component.html
+++ b/apps/prs/angular/src/routes/bugs/4004/bug4004.component.html
@@ -42,11 +42,37 @@
   </goab-push-drawer>
 </div>
 
+<goab-text tag="h2" mt="2xl" mb="m">Test 3: Long slotted heading (wrapping)</goab-text>
+<goab-text mb="l">
+  When slotted heading content is longer than the available width, it should wrap onto
+  multiple lines while the close button stays pinned to the top right.
+</goab-text>
+<div style="display: flex; min-height: 320px">
+  <div style="flex: 1; min-width: 0">
+    <goab-button (onClick)="openLong()">Open long heading</goab-button>
+  </div>
+  <goab-push-drawer
+    [heading]="longHeading"
+    width="320px"
+    [open]="longOpen"
+    (onClose)="closeLong()"
+  >
+    <goab-text mt="none">Drawer body content.</goab-text>
+  </goab-push-drawer>
+</div>
+
 <ng-template #customHeading>
   <goab-block gap="s" alignment="center" direction="row">
     <span>Custom heading</span>
     <goab-badge type="important" content="New"></goab-badge>
   </goab-block>
+</ng-template>
+
+<ng-template #longHeading>
+  <span>
+    A longer custom heading that should wrap onto multiple lines
+    <goab-badge type="important" content="New"></goab-badge>
+  </span>
 </ng-template>
 
 <ng-template #slotActions>

--- a/apps/prs/angular/src/routes/bugs/4004/bug4004.component.html
+++ b/apps/prs/angular/src/routes/bugs/4004/bug4004.component.html
@@ -1,0 +1,56 @@
+<goab-text tag="h1" mt="m" mb="s">Bug 4004 - PushDrawer heading doesn't work with slotted content</goab-text>
+<goab-text mb="l">
+  The PushDrawer documents support for slotted content in the heading, but only string
+  headings rendered. PushDrawer.svelte forwarded heading only as a prop and never
+  forwarded the heading slot to its internal drawer. Both drawers should now render custom
+  slotted heading content.
+</goab-text>
+
+<goab-text tag="h2" mt="2xl" mb="m">Test 1: String heading (control)</goab-text>
+<goab-text mb="l">A plain string heading should still render as before.</goab-text>
+<div style="display: flex; min-height: 320px">
+  <div style="flex: 1; min-width: 0">
+    <goab-button (onClick)="openString()">Open string heading</goab-button>
+  </div>
+  <goab-push-drawer
+    heading="Plain string heading"
+    width="320px"
+    [open]="stringOpen"
+    (onClose)="closeString()"
+  >
+    <goab-text mt="none">Drawer body content.</goab-text>
+  </goab-push-drawer>
+</div>
+
+<goab-text tag="h2" mt="2xl" mb="m">Test 2: Slotted heading content</goab-text>
+<goab-text mb="l">
+  Passing a template as the heading should render the custom content (here, text plus a
+  badge). Before the fix this rendered nothing.
+</goab-text>
+<div style="display: flex; min-height: 320px">
+  <div style="flex: 1; min-width: 0">
+    <goab-button (onClick)="openSlot()">Open slotted heading</goab-button>
+  </div>
+  <goab-push-drawer
+    [heading]="customHeading"
+    width="320px"
+    [open]="slotOpen"
+    (onClose)="closeSlot()"
+    [actions]="slotActions"
+  >
+    <goab-text mt="none">Drawer body content.</goab-text>
+  </goab-push-drawer>
+</div>
+
+<ng-template #customHeading>
+  <goab-block gap="s" alignment="center" direction="row">
+    <span>Custom heading</span>
+    <goab-badge type="important" content="New"></goab-badge>
+  </goab-block>
+</ng-template>
+
+<ng-template #slotActions>
+  <goab-button-group alignment="start">
+    <goab-button (onClick)="closeSlot()">Close</goab-button>
+  </goab-button-group>
+</ng-template>

--- a/apps/prs/angular/src/routes/bugs/4004/bug4004.component.ts
+++ b/apps/prs/angular/src/routes/bugs/4004/bug4004.component.ts
@@ -1,0 +1,43 @@
+import { Component } from "@angular/core";
+import {
+  GoabBadge,
+  GoabBlock,
+  GoabButton,
+  GoabButtonGroup,
+  GoabPushDrawer,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug4004",
+  templateUrl: "./bug4004.component.html",
+  imports: [
+    GoabBadge,
+    GoabBlock,
+    GoabButton,
+    GoabButtonGroup,
+    GoabPushDrawer,
+    GoabText,
+  ],
+})
+export class Bug4004Component {
+  stringOpen = false;
+  slotOpen = false;
+
+  openString(): void {
+    this.stringOpen = true;
+  }
+
+  closeString(): void {
+    this.stringOpen = false;
+  }
+
+  openSlot(): void {
+    this.slotOpen = true;
+  }
+
+  closeSlot(): void {
+    this.slotOpen = false;
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/4004/bug4004.component.ts
+++ b/apps/prs/angular/src/routes/bugs/4004/bug4004.component.ts
@@ -24,6 +24,7 @@ import {
 export class Bug4004Component {
   stringOpen = false;
   slotOpen = false;
+  longOpen = false;
 
   openString(): void {
     this.stringOpen = true;
@@ -39,5 +40,13 @@ export class Bug4004Component {
 
   closeSlot(): void {
     this.slotOpen = false;
+  }
+
+  openLong(): void {
+    this.longOpen = true;
+  }
+
+  closeLong(): void {
+    this.longOpen = false;
   }
 }

--- a/apps/prs/angular/src/routes/bugs/4004/bug4004.route.json
+++ b/apps/prs/angular/src/routes/bugs/4004/bug4004.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "4004",
+  "path": "bugs/4004",
+  "title": "PushDrawer slotted heading"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug4004.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug4004.route.ts
@@ -1,0 +1,10 @@
+import { Bug4004Route } from "../../../routes/bugs/bug4004";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "4004",
+  path: "bugs/4004",
+  title: "PushDrawer slotted heading",
+  component: Bug4004Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug4004.tsx
+++ b/apps/prs/react/src/routes/bugs/bug4004.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import {
+  GoabButton,
+  GoabButtonGroup,
+  GoabPushDrawer,
+  GoabBadge,
+  GoabBlock,
+  GoabText,
+} from "@abgov/react-components";
+
+export function Bug4004Route() {
+  const [stringOpen, setStringOpen] = useState(false);
+  const [slotOpen, setSlotOpen] = useState(false);
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m" mb="m">
+        Bug #4004: PushDrawer heading doesn't work with slotted content
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        The PushDrawer documents support for slotted content in the heading, but only
+        string headings rendered. PushDrawer.svelte forwarded heading only as a prop and
+        never forwarded the heading slot to its internal drawer. Both drawers should now
+        render custom slotted heading content.
+      </GoabText>
+
+      <GoabText tag="h2" mt="2xl" mb="m">
+        Test 1: String heading (control)
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        A plain string heading should still render as before.
+      </GoabText>
+      <div style={{ display: "flex", minHeight: "320px" }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <GoabButton onClick={() => setStringOpen(true)}>
+            Open string heading
+          </GoabButton>
+        </div>
+        <GoabPushDrawer
+          open={stringOpen}
+          heading="Plain string heading"
+          width="320px"
+          onClose={() => setStringOpen(false)}
+        >
+          <GoabText tag="p">Drawer body content.</GoabText>
+        </GoabPushDrawer>
+      </div>
+
+      <GoabText tag="h2" mt="2xl" mb="m">
+        Test 2: Slotted heading content
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        Passing a ReactNode as the heading should render the custom content (here, text
+        plus a badge). Before the fix this rendered nothing.
+      </GoabText>
+      <div style={{ display: "flex", minHeight: "320px" }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <GoabButton onClick={() => setSlotOpen(true)}>
+            Open slotted heading
+          </GoabButton>
+        </div>
+        <GoabPushDrawer
+          open={slotOpen}
+          width="320px"
+          heading={
+            <GoabBlock gap="s" alignment="center" direction="row">
+              <span>Custom heading</span>
+              <GoabBadge type="important" content="New" />
+            </GoabBlock>
+          }
+          onClose={() => setSlotOpen(false)}
+          actions={
+            <GoabButtonGroup alignment="start">
+              <GoabButton onClick={() => setSlotOpen(false)}>Close</GoabButton>
+            </GoabButtonGroup>
+          }
+        >
+          <GoabText tag="p">Drawer body content.</GoabText>
+        </GoabPushDrawer>
+      </div>
+    </div>
+  );
+}
+
+export default Bug4004Route;

--- a/apps/prs/react/src/routes/bugs/bug4004.tsx
+++ b/apps/prs/react/src/routes/bugs/bug4004.tsx
@@ -11,6 +11,7 @@ import {
 export function Bug4004Route() {
   const [stringOpen, setStringOpen] = useState(false);
   const [slotOpen, setSlotOpen] = useState(false);
+  const [longOpen, setLongOpen] = useState(false);
 
   return (
     <div>
@@ -74,6 +75,34 @@ export function Bug4004Route() {
               <GoabButton onClick={() => setSlotOpen(false)}>Close</GoabButton>
             </GoabButtonGroup>
           }
+        >
+          <GoabText tag="p">Drawer body content.</GoabText>
+        </GoabPushDrawer>
+      </div>
+
+      <GoabText tag="h2" mt="2xl" mb="m">
+        Test 3: Long slotted heading (wrapping)
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        When slotted heading content is longer than the available width, it should wrap
+        onto multiple lines while the close button stays pinned to the top right.
+      </GoabText>
+      <div style={{ display: "flex", minHeight: "320px" }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <GoabButton onClick={() => setLongOpen(true)}>
+            Open long heading
+          </GoabButton>
+        </div>
+        <GoabPushDrawer
+          open={longOpen}
+          width="320px"
+          heading={
+            <span>
+              A longer custom heading that should wrap onto multiple lines{" "}
+              <GoabBadge type="important" content="New" />
+            </span>
+          }
+          onClose={() => setLongOpen(false)}
         >
           <GoabText tag="p">Drawer body content.</GoabText>
         </GoabPushDrawer>

--- a/docs/generated/component-apis/push-drawer.json
+++ b/docs/generated/component-apis/push-drawer.json
@@ -53,6 +53,12 @@
           "type": "ReactNode",
           "description": "Content rendered in the actions slot, typically action buttons.",
           "required": false
+        },
+        {
+          "name": "heading",
+          "type": "ReactNode",
+          "description": "Sets the heading text or custom heading content.",
+          "required": false
         }
       ]
     },
@@ -106,6 +112,12 @@
           "name": "actions",
           "type": "TemplateRef",
           "description": "Content rendered in the actions slot, typically action buttons.",
+          "required": false
+        },
+        {
+          "name": "heading",
+          "type": "TemplateRef",
+          "description": "Sets the heading text or custom heading content.",
           "required": false
         }
       ]
@@ -162,6 +174,11 @@
         {
           "name": "actions",
           "description": "Content rendered in the actions slot, typically action buttons.",
+          "required": false
+        },
+        {
+          "name": "heading",
+          "description": "Sets the heading text or custom heading content.",
           "required": false
         }
       ]

--- a/docs/src/data/configurations/push-drawer.ts
+++ b/docs/src/data/configurations/push-drawer.ts
@@ -114,6 +114,73 @@ export const pushDrawerConfigurations: ComponentConfigurations = {
       },
     },
     {
+      id: "custom-heading",
+      name: "Custom heading",
+      description: "Push drawer with custom heading content, such as a status badge",
+      code: {
+        react: {
+          ts: reactDrawerSetup,
+          jsx: `<div style={{ display: "flex", minHeight: "320px" }}>
+  <div style={{ flex: 1, minWidth: 0 }}>
+    <GoabButton onClick={() => setIsOpen(true)}>Open push drawer</GoabButton>
+  </div>
+  <GoabPushDrawer
+    heading={
+      <GoabBlock gap="s" alignment="center" direction="row">
+        <span>Cases</span>
+        <GoabBadge type="success" content="Approved" />
+      </GoabBlock>
+    }
+    width="320px"
+    open={isOpen}
+    onClose={handleClose}
+  >
+    <GoabText size="body-m" mt="none">Applicant name</GoabText>
+    <GoabText size="body-m" mt="none">Jane Smith</GoabText>
+  </GoabPushDrawer>
+</div>`,
+        },
+        angular: {
+          ts: angularDrawerSetup,
+          template: `<div style="display: flex; min-height: 320px">
+  <div style="flex: 1; min-width: 0">
+    <goab-button (onClick)="openDrawer()">Open push drawer</goab-button>
+  </div>
+  <goab-push-drawer
+    [heading]="customHeading"
+    width="320px"
+    [open]="isOpen"
+    (onClose)="handleClose()"
+  >
+    <goab-text size="body-m" mt="none">Applicant name</goab-text>
+    <goab-text size="body-m" mt="none">Jane Smith</goab-text>
+  </goab-push-drawer>
+</div>
+
+<ng-template #customHeading>
+  <goab-block gap="s" alignment="center" direction="row">
+    <span>Cases</span>
+    <goab-badge type="success" content="Approved"></goab-badge>
+  </goab-block>
+</ng-template>`,
+        },
+        webComponents: `<div style="display: flex; min-height: 320px;">
+  <div style="flex: 1; min-width: 0; display: flex; align-items: center; justify-content: center;">
+    <goa-button version="2" id="open-push-drawer">Open push drawer</goa-button>
+  </div>
+  <goa-push-drawer version="2" id="demo-push-drawer" width="320px">
+    <goa-block slot="heading" gap="s" alignment="center" direction="row">
+      <span>Cases</span>
+      <goa-badge version="2" type="success" content="Approved"></goa-badge>
+    </goa-block>
+    <goa-text size="body-m" mt="none">Applicant name</goa-text>
+    <goa-text size="body-m" mt="none">Jane Smith</goa-text>
+  </goa-push-drawer>
+</div>
+<script>${pushDrawerScript}</script>`,
+      },
+    },
+    {
       id: "custom-width",
       name: "Custom width",
       description: "Push drawer with a custom width",

--- a/libs/web-components/src/components/push-drawer/PushDrawer.spec.ts
+++ b/libs/web-components/src/components/push-drawer/PushDrawer.spec.ts
@@ -1,5 +1,6 @@
 import { render, waitFor } from "@testing-library/svelte";
 import GoAPushDrawer from "./PushDrawer.svelte";
+import PushDrawerWrapper from "./PushDrawerWrapper.test.svelte";
 import { it, describe, beforeEach, afterEach, vi, expect } from "vitest";
 
 describe("GoAPushDrawer", () => {
@@ -64,6 +65,42 @@ describe("GoAPushDrawer", () => {
 
       expect(drawer).toBeTruthy();
       expect(pushDrawerInternal).toBeNull();
+    });
+  });
+
+  it("forwards slotted heading content to goa-push-drawer-internal on desktop", async () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+
+    const { container } = render(PushDrawerWrapper, {
+      props: { open: true },
+    });
+
+    const internal = container.querySelector("goa-push-drawer-internal");
+    await waitFor(() => {
+      const forwarded = internal?.querySelector('span[slot="heading"]');
+      expect(forwarded?.textContent).toContain("Custom Heading Content");
+    });
+  });
+
+  it("forwards slotted heading content to goa-drawer on mobile", async () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: 1023,
+    });
+
+    const { container } = render(PushDrawerWrapper, {
+      props: { open: true },
+    });
+
+    const drawer = container.querySelector("goa-drawer");
+    await waitFor(() => {
+      const forwarded = drawer?.querySelector('span[slot="heading"]');
+      expect(forwarded?.textContent).toContain("Custom Heading Content");
     });
   });
 });

--- a/libs/web-components/src/components/push-drawer/PushDrawer.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawer.svelte
@@ -44,6 +44,11 @@
     {heading}
     {version}
   >
+    {#if $$slots.heading}
+      <span slot="heading">
+        <slot name="heading" />
+      </span>
+    {/if}
     {#if $$slots.actions}
       <span slot="actions">
         <slot name="actions" />
@@ -60,6 +65,11 @@
     {heading}
     {version}
   >
+    {#if $$slots.heading}
+      <span slot="heading">
+        <slot name="heading" />
+      </span>
+    {/if}
     {#if $$slots.actions}
       <span slot="actions">
         <slot name="actions" />

--- a/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
@@ -332,6 +332,12 @@
     font: var(--goa-push-drawer-heading-typography);
   }
 
+  /* V2: minimum separation so wide slotted heading content never butts
+     up against the close button */
+  .v2 .drawer-default-header {
+    column-gap: var(--goa-space-s);
+  }
+
   .drawer-actions {
     width: 100%;
     padding: var(--goa-push-drawer-actions-padding-top)

--- a/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
@@ -145,26 +145,28 @@
     <div id="goa-drawer-heading" slot="header" class="drawer-header">
       <div class="drawer-default-header">
         {#if heading || $$slots.heading}
-          {#if heading}
-            {#if version === "2"}
-              <goa-text
-                size={_scrollPos === "middle" || _scrollPos === "bottom"
-                  ? "heading-xs"
-                  : "heading-s"}
-                as="h3"
-                mt="2xs"
-                mb="none"
-              >
-                {heading}
-              </goa-text>
+          <div class="drawer-heading-content">
+            {#if heading}
+              {#if version === "2"}
+                <goa-text
+                  size={_scrollPos === "middle" || _scrollPos === "bottom"
+                    ? "heading-xs"
+                    : "heading-s"}
+                  as="h3"
+                  mt="2xs"
+                  mb="none"
+                >
+                  {heading}
+                </goa-text>
+              {:else}
+                <goa-text size="heading-m" as="h3" mt="none" mb="none">
+                  {heading}
+                </goa-text>
+              {/if}
             {:else}
-              <goa-text size="heading-m" as="h3" mt="none" mb="none">
-                {heading}
-              </goa-text>
+              <slot name="heading" />
             {/if}
-          {:else}
-            <slot name="heading" />
-          {/if}
+          </div>
         {/if}
 
         <goa-icon-button
@@ -333,9 +335,26 @@
   }
 
   /* V2: minimum separation so wide slotted heading content never butts
-     up against the close button */
+     up against the close button. Top-align so heading content that wraps
+     onto multiple lines flows downward while the close button stays
+     pinned top-right (matches the regular Drawer header). */
   .v2 .drawer-default-header {
+    align-items: flex-start;
     column-gap: var(--goa-space-s);
+  }
+
+  /* V2: let the heading content shrink so long content wraps onto the
+     next line instead of pushing the close button past the header's
+     right padding */
+  .v2 .drawer-heading-content {
+    min-width: 0;
+  }
+
+  /* V2: keep the close button at its intrinsic size, nudged to align with
+     the heading's first line (matches the regular Drawer) */
+  .v2 .drawer-default-header goa-icon-button {
+    flex-shrink: 0;
+    margin-top: -0.1875rem;
   }
 
   .drawer-actions {

--- a/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawerInternal.svelte
@@ -334,24 +334,15 @@
     font: var(--goa-push-drawer-heading-typography);
   }
 
-  /* V2: minimum separation so wide slotted heading content never butts
-     up against the close button. Top-align so heading content that wraps
-     onto multiple lines flows downward while the close button stays
-     pinned top-right (matches the regular Drawer header). */
   .v2 .drawer-default-header {
     align-items: flex-start;
     column-gap: var(--goa-space-s);
   }
 
-  /* V2: let the heading content shrink so long content wraps onto the
-     next line instead of pushing the close button past the header's
-     right padding */
   .v2 .drawer-heading-content {
     min-width: 0;
   }
 
-  /* V2: keep the close button at its intrinsic size, nudged to align with
-     the heading's first line (matches the regular Drawer) */
   .v2 .drawer-default-header goa-icon-button {
     flex-shrink: 0;
     margin-top: -0.1875rem;

--- a/libs/web-components/src/components/push-drawer/PushDrawerWrapper.test.svelte
+++ b/libs/web-components/src/components/push-drawer/PushDrawerWrapper.test.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import PushDrawer from "./PushDrawer.svelte";
+
+  export let open: boolean = true;
+</script>
+
+<PushDrawer {open}>
+  <div slot="heading" data-testid="custom-heading">Custom Heading Content</div>
+  <p>Body content</p>
+</PushDrawer>


### PR DESCRIPTION
Fixes #4004
Related: #2941

# Before (the change)

`GoabPushDrawer` documents support for slotted `heading` content, but only string headings rendered. `PushDrawer.svelte` forwarded `heading` only as a prop and never forwarded the `heading` slot to its internal drawer, so custom heading content was silently dropped.

# After (the change)

`PushDrawer.svelte` now forwards the `heading` slot into both `goa-drawer` (mobile) and `goa-push-drawer-internal` (desktop), the same way `actions` is already forwarded. Both internal components already rendered `<slot name="heading" />`, they just never received it. No wrapper changes were needed: the React and Angular wrappers already pass `<div slot="heading">` through.

**Reviewer note (header layout):** While testing the slotted heading, the V2 header in `PushDrawerInternal.svelte` needed alignment work, so this PR also tidies the `.drawer-default-header` row to match the regular `Drawer` header:

- Top-align the row (`align-items: flex-start`) with the same close-button nudge the `Drawer` uses, so the close button stays pinned top-right and aligns to the heading's first line.
- Let the heading content shrink (`min-width: 0`) so long, wrappable heading content flows onto the next line instead of pushing the close button past the header's right padding.
- Keep the close button at its intrinsic size (`flex-shrink: 0`) and add `column-gap: var(--goa-space-s)` for a minimum gap before the close button.

`Drawer.svelte` already has its own header layout, so it was left untouched.

**Known limitation (tracked by #2941):** `GoabBlock` has no wrapping support (its `direction: row` is a non-wrapping flex row). A block-based heading containing a badge will overflow in a narrow drawer because the block itself cannot wrap. This fits fine at the default drawer width and wraps correctly for plain wrappable content (see Test 3). Once #2941 lands and `GoabBlock` gains a `wrap` prop, a block heading with a badge can wrap as well.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Run the React playground: `npm run serve:prs:react`
2. Open `http://localhost:4201/bugs/4004`
3. Under Test 2, click "Open slotted heading" and confirm the heading renders custom content (text plus a "New" badge).
4. Under Test 3, click "Open long heading" and confirm the long heading wraps onto multiple lines while the close button stays pinned top-right.
5. Narrow the window below ~1023px and reopen: it switches to the overlay drawer and still shows the slotted heading.
6. Repeat in Angular: `npm run serve:prs:angular`, open `http://localhost:4200/bugs/4004`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
