### PR TITLE
fix(#3738): correct Examples tab URL hash and add example deep links

### DIFF
--- a/docs/src/components/ExamplePreview.tsx
+++ b/docs/src/components/ExamplePreview.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect, useRef } from "react";
 import { GoabTooltip } from "@abgov/react-components";
 import { CodeSnippet } from "./CodeSnippet";
 import type { ExampleCode } from "../lib/example-code";
+import { getActiveTabHash } from "../lib/tab-hash";
 import DOMPurify from "dompurify";
 
 // Allow GoA web component custom elements through DOMPurify.
@@ -114,7 +115,9 @@ export function ExamplePreview({
   // Handle copy link
   const handleCopyLink = async () => {
     try {
-      const url = `${window.location.origin}${window.location.pathname}#${anchorId}`;
+      const tabHash = getActiveTabHash(previewRef.current);
+      const hash = tabHash ? `${tabHash}#${anchorId}` : anchorId;
+      const url = `${window.location.origin}${window.location.pathname}#${hash}`;
       await navigator.clipboard.writeText(url);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);

--- a/docs/src/components/TableOfContents.tsx
+++ b/docs/src/components/TableOfContents.tsx
@@ -8,6 +8,7 @@
 
 import css from "./toc.module.css";
 import { useEffect, useState, useRef } from "react";
+import { getActiveTabHash } from "../lib/tab-hash";
 
 export type TOCItem = {
   title: string;
@@ -23,6 +24,7 @@ export function TableOfContents({ cssQuery }: TOCProps) {
   const [items, setItems] = useState<TOCItem[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
   const containerRef = useRef<HTMLElement>(null);
+  const initialHashHandled = useRef(false);
 
   useEffect(() => {
     // Check if element is visible (not hidden by display:none or in hidden tab)
@@ -62,13 +64,64 @@ export function TableOfContents({ cssQuery }: TOCProps) {
     function updateHeadings() {
       const headings = queryHeadings();
       setItems(headings);
-      if (headings.length > 0) {
+      if (headings.length > 0 && initialHashHandled.current) {
         setActiveId(headings[0].id);
       }
     }
 
+    // On first load, honor a direct link to one of this TOC's own anchors.
+    // Tabs.svelte's built-in anchor scroll only handles a single hash segment,
+    // so it can't be relied on once multiple tabs contribute their own hash.
+    // The owning tab may still be hidden (goa-tabs activates it asynchronously),
+    // so retry briefly rather than giving up on the first check.
+    const hashSegments = window.location.hash.slice(1).split("#").filter(Boolean);
+    let hashRetryTimer: ReturnType<typeof setTimeout> | null = null;
+    const resettleTimers: ReturnType<typeof setTimeout>[] = [];
+
+    function tryResolveInitialHash(attempt = 0) {
+      if (hashSegments.length === 0) {
+        initialHashHandled.current = true;
+        updateHeadings();
+        return;
+      }
+
+      const candidate = Array.from(
+        document.querySelectorAll<HTMLElement>(cssQuery),
+      ).find((el) => {
+        const id = el.getAttribute("id");
+        return id && hashSegments.includes(id);
+      });
+
+      if (candidate && isVisible(candidate)) {
+        initialHashHandled.current = true;
+        updateHeadings();
+        setActiveId(candidate.id);
+        candidate.scrollIntoView({ behavior: "smooth" });
+
+        // Other examples on the page can still be hydrating (live component
+        // previews, syntax highlighting) and shift layout after this point,
+        // silently invalidating a scroll already in flight. Re-assert the
+        // position a couple more times while things settle.
+        [400, 900].forEach((delay) => {
+          resettleTimers.push(
+            setTimeout(() => candidate.scrollIntoView({ block: "start" }), delay),
+          );
+        });
+        return;
+      }
+
+      if (candidate && attempt < 20) {
+        hashRetryTimer = setTimeout(() => tryResolveInitialHash(attempt + 1), 100);
+        return;
+      }
+
+      // No matching anchor (or it never became visible) - fall back to default.
+      initialHashHandled.current = true;
+      updateHeadings();
+    }
+
     // Initial query with small delay for DOM to be ready
-    const timer = setTimeout(updateHeadings, 100);
+    const timer = setTimeout(tryResolveInitialHash, 100);
 
     // Listen for goa-tabs change events - re-query when tab becomes visible
     // goa-tabs dispatches "_change" with { tab: number } when switching tabs
@@ -113,6 +166,8 @@ export function TableOfContents({ cssQuery }: TOCProps) {
 
     return () => {
       clearTimeout(timer);
+      if (hashRetryTimer) clearTimeout(hashRetryTimer);
+      resettleTimers.forEach(clearTimeout);
       document.removeEventListener("_change", handleTabChange);
       document.removeEventListener("scroll", handleScroll);
     };
@@ -124,6 +179,14 @@ export function TableOfContents({ cssQuery }: TOCProps) {
     if (el) {
       el.scrollIntoView({ behavior: "smooth" });
       setActiveId(id);
+
+      const tabHash = getActiveTabHash(e.currentTarget);
+      const newHash = tabHash ? `${tabHash}#${id}` : id;
+      history.replaceState(
+        {},
+        "",
+        `${window.location.pathname}${window.location.search}#${newHash}`,
+      );
     }
   }
 

--- a/docs/src/components/TableOfContents.tsx
+++ b/docs/src/components/TableOfContents.tsx
@@ -7,7 +7,7 @@
  */
 
 import css from "./toc.module.css";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { getActiveTabHash } from "../lib/tab-hash";
 
 export type TOCItem = {
@@ -20,60 +20,62 @@ type TOCProps = {
   cssQuery: string;
 };
 
+// Check if element is visible (not hidden by display:none or in hidden tab)
+function isVisible(el: HTMLElement): boolean {
+  return el.offsetParent !== null || el.offsetWidth > 0 || el.offsetHeight > 0;
+}
+
+// Query headings matching cssQuery - only visible ones
+function queryHeadings(cssQuery: string): TOCItem[] {
+  const headings = document.querySelectorAll<HTMLHeadingElement>(cssQuery);
+  const result: TOCItem[] = [];
+
+  headings.forEach((el) => {
+    const id = el.getAttribute("id");
+    const title = el.textContent?.trim();
+
+    // For goa-text elements, read the "as" attribute for the heading level
+    const tagName =
+      el.tagName === "GOA-TEXT"
+        ? (el.getAttribute("as") || "h2").toUpperCase()
+        : el.tagName;
+
+    // Only include visible headings
+    if (id && title && isVisible(el)) {
+      result.push({
+        id,
+        title,
+        tagName,
+      });
+    }
+  });
+
+  return result;
+}
+
 export function TableOfContents({ cssQuery }: TOCProps) {
   const [items, setItems] = useState<TOCItem[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
   const containerRef = useRef<HTMLElement>(null);
   const initialHashHandled = useRef(false);
 
+  // Re-query headings and default to the first one as active. Before the
+  // initial hash has been resolved, skip the default so it can't steal
+  // activation from the anchor that resolution is still trying to reach.
+  const refreshHeadings = useCallback(() => {
+    const headings = queryHeadings(cssQuery);
+    setItems(headings);
+    if (headings.length > 0 && initialHashHandled.current) {
+      setActiveId(headings[0].id);
+    }
+  }, [cssQuery]);
+
+  // On first load, honor a direct link to one of this TOC's own anchors.
+  // Tabs.svelte's built-in anchor scroll only handles a single hash segment,
+  // so it can't be relied on once multiple tabs contribute their own hash.
+  // The owning tab may still be hidden (goa-tabs activates it asynchronously),
+  // so retry briefly rather than giving up on the first check.
   useEffect(() => {
-    // Check if element is visible (not hidden by display:none or in hidden tab)
-    function isVisible(el: HTMLElement): boolean {
-      return el.offsetParent !== null || el.offsetWidth > 0 || el.offsetHeight > 0;
-    }
-
-    // Query headings - only visible ones
-    function queryHeadings(): TOCItem[] {
-      const headings = document.querySelectorAll<HTMLHeadingElement>(cssQuery);
-      const result: TOCItem[] = [];
-
-      headings.forEach((el) => {
-        const id = el.getAttribute("id");
-        const title = el.textContent?.trim();
-
-        // For goa-text elements, read the "as" attribute for the heading level
-        const tagName =
-          el.tagName === "GOA-TEXT"
-            ? (el.getAttribute("as") || "h2").toUpperCase()
-            : el.tagName;
-
-        // Only include visible headings
-        if (id && title && isVisible(el)) {
-          result.push({
-            id,
-            title,
-            tagName,
-          });
-        }
-      });
-
-      return result;
-    }
-
-    // Update items and set first as active
-    function updateHeadings() {
-      const headings = queryHeadings();
-      setItems(headings);
-      if (headings.length > 0 && initialHashHandled.current) {
-        setActiveId(headings[0].id);
-      }
-    }
-
-    // On first load, honor a direct link to one of this TOC's own anchors.
-    // Tabs.svelte's built-in anchor scroll only handles a single hash segment,
-    // so it can't be relied on once multiple tabs contribute their own hash.
-    // The owning tab may still be hidden (goa-tabs activates it asynchronously),
-    // so retry briefly rather than giving up on the first check.
     const hashSegments = window.location.hash.slice(1).split("#").filter(Boolean);
     let hashRetryTimer: ReturnType<typeof setTimeout> | null = null;
     const resettleTimers: ReturnType<typeof setTimeout>[] = [];
@@ -81,7 +83,7 @@ export function TableOfContents({ cssQuery }: TOCProps) {
     function tryResolveInitialHash(attempt = 0) {
       if (hashSegments.length === 0) {
         initialHashHandled.current = true;
-        updateHeadings();
+        refreshHeadings();
         return;
       }
 
@@ -94,7 +96,7 @@ export function TableOfContents({ cssQuery }: TOCProps) {
 
       if (candidate && isVisible(candidate)) {
         initialHashHandled.current = true;
-        updateHeadings();
+        refreshHeadings();
         setActiveId(candidate.id);
         candidate.scrollIntoView({ behavior: "smooth" });
 
@@ -117,22 +119,33 @@ export function TableOfContents({ cssQuery }: TOCProps) {
 
       // No matching anchor (or it never became visible) - fall back to default.
       initialHashHandled.current = true;
-      updateHeadings();
+      refreshHeadings();
     }
 
     // Initial query with small delay for DOM to be ready
     const timer = setTimeout(tryResolveInitialHash, 100);
 
-    // Listen for goa-tabs change events - re-query when tab becomes visible
-    // goa-tabs dispatches "_change" with { tab: number } when switching tabs
+    return () => {
+      clearTimeout(timer);
+      if (hashRetryTimer) clearTimeout(hashRetryTimer);
+      resettleTimers.forEach(clearTimeout);
+    };
+  }, [cssQuery, refreshHeadings]);
+
+  // goa-tabs dispatches "_change" with { tab: number } when switching tabs -
+  // re-query so the TOC reflects whichever tab just became visible.
+  useEffect(() => {
     function handleTabChange() {
       // Small delay to ensure tab content is visible after the event
-      setTimeout(updateHeadings, 50);
+      setTimeout(refreshHeadings, 50);
     }
 
     document.addEventListener("_change", handleTabChange);
+    return () => document.removeEventListener("_change", handleTabChange);
+  }, [refreshHeadings]);
 
-    // Update active heading on scroll - only check visible headings
+  // Highlight whichever visible heading is nearest the top of the viewport.
+  useEffect(() => {
     function handleScroll() {
       const headings = document.querySelectorAll<HTMLHeadingElement>(cssQuery);
       const visibleHeadings = Array.from(headings).filter(isVisible);
@@ -163,14 +176,7 @@ export function TableOfContents({ cssQuery }: TOCProps) {
     }
 
     document.addEventListener("scroll", handleScroll);
-
-    return () => {
-      clearTimeout(timer);
-      if (hashRetryTimer) clearTimeout(hashRetryTimer);
-      resettleTimers.forEach(clearTimeout);
-      document.removeEventListener("_change", handleTabChange);
-      document.removeEventListener("scroll", handleScroll);
-    };
+    return () => document.removeEventListener("scroll", handleScroll);
   }, [cssQuery]);
 
   function handleClick(e: React.MouseEvent<HTMLAnchorElement>, id: string) {

--- a/docs/src/lib/tab-hash.ts
+++ b/docs/src/lib/tab-hash.ts
@@ -1,0 +1,13 @@
+/**
+ * Reads the URL hash of the active tab in the nearest ancestor goa-tabs.
+ * Scoped to `fromElement` because a page can nest multiple goa-tabs
+ * (e.g. framework code tabs inside each example within the documentation tabs).
+ */
+export function getActiveTabHash(fromElement: Element | null): string | null {
+  const tabsEl = fromElement?.closest('goa-tabs');
+  const activeTab = tabsEl?.shadowRoot?.querySelector<HTMLAnchorElement>(
+    '[role="tab"][aria-selected="true"]',
+  );
+  const href = activeTab?.getAttribute('href') || '';
+  return href.split('#')[1] || null;
+}

--- a/docs/src/pages/components/[slug].astro
+++ b/docs/src/pages/components/[slug].astro
@@ -147,9 +147,8 @@ const v1DocsUrl = `https://v1.design.alberta.ca/components/${slug}`;
     </goa-tab>
 
     <!-- Examples Tab -->
-    <!-- TODO: URL shows "tab-1" instead of "examples" because heading slot overrides heading attribute for URL generation -->
     {!hideTabs.includes('examples') && (
-    <goa-tab heading="Examples">
+    <goa-tab heading="Examples" slug="examples">
       <span slot="heading">Examples <goa-badge version="2" type="default" emphasis="subtle" icon="false" content={String(componentExamples.length)}></goa-badge></span>
       <TabContentWrapper tocQuery=".example-preview .example-title">
         {componentExamples.length > 0 ? (

--- a/libs/react-components/specs/tabs.browser.spec.tsx
+++ b/libs/react-components/specs/tabs.browser.spec.tsx
@@ -460,6 +460,11 @@ describe("Tabs Browser Tests", () => {
     });
 
     it("should navigate to correct hash when clicking tab with slug", async () => {
+      // Start from a clean hash: a previous test's leftover hash is no
+      // longer silently wiped by clicking a tab (see fix for #3738), so it
+      // would otherwise still be sitting in the URL when this test starts.
+      window.history.pushState({}, "", "/test");
+
       const Component = () => {
         return (
           <GoabTabs testId="test-tabs">
@@ -568,6 +573,11 @@ describe("Tabs Browser Tests", () => {
     });
 
     it("should navigate correctly when clicking tab with component heading and slug", async () => {
+      // Start from a clean hash: a previous test's leftover hash is no
+      // longer silently wiped by clicking a tab (see fix for #3738), so it
+      // would otherwise still be sitting in the URL when this test starts.
+      window.history.pushState({}, "", "/test");
+
       const Component = () => {
         return (
           <GoabTabs testId="test-tabs">

--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -227,7 +227,14 @@
           e.stopPropagation();
         });
       } else {
-        link.addEventListener("click", () => setCurrentTab(index + 1));
+        link.addEventListener("click", (e) => {
+          // Prevent the browser's own hash navigation from firing after this
+          // handler: it would set location.hash to only this tab's own slug,
+          // discarding any other hash segments setCurrentTab just merged in
+          // (a nested tabs' hash, or a content anchor like #example-x).
+          e.preventDefault();
+          setCurrentTab(index + 1);
+        });
       }
 
       link.appendChild(headingEl);
@@ -355,6 +362,7 @@
     }
 
     let currentLocation = "";
+    const ownHashes = new Set<string>();
 
     // send message to each tab to set visibility within
     [..._tabsEl.querySelectorAll<HTMLElement>("[role=tab]")].map((el, index) => {
@@ -362,6 +370,12 @@
 
       el.setAttribute("aria-selected", fromBoolean(isCurrent));
       el.setAttribute("tabindex", isCurrent ? "0" : "-1");
+
+      // Track every hash this tabs instance could produce, so its own
+      // previous hash can be told apart from hashes contributed elsewhere
+      // (a nested tabs' hash, or a content anchor).
+      const ownHash = (el as HTMLLinkElement).getAttribute("href")?.split("#")[1];
+      if (ownHash) ownHashes.add(ownHash);
 
       if (isCurrent) {
         currentLocation = (el as HTMLLinkElement).href;
@@ -388,9 +402,12 @@
     // update the browser's url with the new hash (skip when navigation is "none")
     if (currentLocation && navigation !== "none") {
       const url = new URL(currentLocation);
-      // to make sure we preserve multiple #, for example /#tab-1#example
+      // Preserve any hash segments that don't belong to this tabs instance
+      // (e.g. /#examples#example-x when a nested tabs or a content anchor
+      // contributed the other segment), replacing only this instance's own
+      // previous hash.
       const allHashes = window.location.href.split("#").slice(1);
-      const otherHashes = allHashes.filter((hash) => !hash.startsWith("tab-")); // #example
+      const otherHashes = allHashes.filter((hash) => !ownHashes.has(hash));
       const uniqHashes = [...new Set([url.hash.substring(1), ...otherHashes])];
       const newHash = uniqHashes.filter(Boolean).join("#");
 

--- a/libs/web-components/src/components/tabs/tabs.spec.ts
+++ b/libs/web-components/src/components/tabs/tabs.spec.ts
@@ -274,4 +274,53 @@ describe("Tabs", () => {
       expect(tab1Link.getAttribute("aria-selected")).toBe("true");
     });
   });
+
+  it("should replace its own previous hash instead of accumulating it when navigating by keyboard", async () => {
+    // A mouse click on the next tab also triggers the browser's native anchor
+    // navigation, which happens to overwrite any accumulated hash anyway.
+    // Keyboard navigation calls setCurrentTab() directly with no such
+    // navigation, so it's the interaction that actually exposes this bug.
+    const SlugTabs = await import("./TabsWrapperWithSlug.test.svelte");
+    const { container } = render(SlugTabs.default);
+
+    await waitFor(() => {
+      expect(container.querySelector("a#tab-1")).toBeTruthy();
+    });
+
+    const tab1Link = container.querySelector("a#tab-1") as HTMLElement;
+
+    await fireEvent.click(tab1Link);
+    await waitFor(() => expect(window.location.hash).toBe("#review-pending"));
+
+    tab1Link.focus();
+    await fireEvent.keyDown(tab1Link, { key: "ArrowRight" });
+
+    await waitFor(() => {
+      // Neither slug starts with "tab-", so the old filter would have kept
+      // "review-pending" around as if it were an unrelated content anchor.
+      expect(window.location.hash).toBe("#complete");
+    });
+  });
+
+  it("should preserve an unrelated hash segment when switching tabs", async () => {
+    window.history.pushState({}, "", "/test#complete#some-content-anchor");
+
+    const SlugTabs = await import("./TabsWrapperWithSlug.test.svelte");
+    const { container } = render(SlugTabs.default);
+
+    await waitFor(() => {
+      const tab2Link = container.querySelector("a#tab-2") as HTMLElement;
+      expect(tab2Link?.getAttribute("aria-selected")).toBe("true");
+    });
+
+    const tab1Link = container.querySelector("a#tab-1") as HTMLElement;
+    await fireEvent.click(tab1Link);
+
+    await waitFor(() => {
+      // The browser's own anchor navigation must not be left to fire here:
+      // it would replace the whole hash with just "#review-pending" and
+      // silently drop "some-content-anchor".
+      expect(window.location.hash).toBe("#review-pending#some-content-anchor");
+    });
+  });
 });


### PR DESCRIPTION
# Before (the change)

On a component page, clicking the Examples tab produced a generic `#tab-1` hash instead of a proper slug, and selecting an example didn't update the URL at all, so there was no way to share a link directly to a specific example.

# After (the change)

- Examples tab now uses `slug="examples"` so the URL hash correctly reads `#examples`.
- Clicking an entry in the tab's table of contents (or the example's "copy link" button) now updates the URL to include both the tab hash and the example anchor, e.g. `#examples#example-confirm-a-destructive-action`.
- Loading that URL directly reopens the Examples tab and scrolls to the correct example, including a retry/resettle fix for pages where other examples are still hydrating and would otherwise shift the layout out from under the scroll.

Closes #3738

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Run `npx nx run web-components:build` then `npm run docs:dev`
2. Open any component page, e.g. `/components/button`
3. Click the Examples tab — the URL hash should become `#examples`
4. Click an example in the right-side table of contents — the URL should update to `#examples#example-<slug>`
5. Reload that exact URL — it should reopen the Examples tab and scroll to that example