### PR TITLE
fix(#3275): sync DatePicker input-type value on programmatic set/clear

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3275/bug3275.component.html
+++ b/apps/prs/angular/src/routes/bugs/3275/bug3275.component.html
@@ -1,7 +1,8 @@
 <div>
   <p>
     Select a value with the DatePicker and it should show in "Current value" below.
-    Changing the Month to "--select a month--" will clear the value.
+    Changing the Month to "—Select a month—" will clear the value. The buttons below
+    set/clear the value programmatically, and should update the month/day/year fields.
   </p>
   <goab-form-item label="Date picker (input)" mb="xl">
     <goab-date-picker
@@ -13,16 +14,13 @@
   </goab-form-item>
 
   <goab-button-group mb="l">
+    <goab-button size="compact" (onClick)="setValue('2024-03-15')">
+      Set March 15
+    </goab-button>
     <goab-button size="compact" type="secondary" (onClick)="setValue('')">
       Clear programmatically
     </goab-button>
   </goab-button-group>
-  <div>
-    <p>
-      <b>Note:</b> The button clears the value in the form but does not change the
-      DatePicker when <code>type=input</code>. Its just for testing.
-    </p>
-  </div>
 
   <div>
     Current value: <strong>{{ inputValue || '"" (empty)' }}</strong>

--- a/apps/prs/angular/src/routes/bugs/3275/bug3275.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3275/bug3275.component.ts
@@ -15,7 +15,7 @@ import {
   imports: [GoabButton, GoabButtonGroup, GoabDatePicker, GoabFormItem],
 })
 export class Bug3275Component {
-  inputValue = "";
+  inputValue = "2024-03-15";
 
   handleChange(detail: GoabDatePickerOnChangeDetail) {
     this.inputValue = detail.valueStr ?? "";

--- a/apps/prs/react/src/routes/bugs/bug3275.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3275.tsx
@@ -7,13 +7,14 @@ import {
 import React, { useState } from "react";
 
 export function Bug3275Route() {
-  const [inputValue, setInputValue] = useState<string>("");
+  const [inputValue, setInputValue] = useState<string>("2024-03-15");
 
   return (
     <div>
       <p>
         Select a value with the DatePicker and it should show in "Current value" below.
-        Changing the Month to "--select a month--" will clear the value.
+        Changing the Month to "—Select a month—" will clear the value. The buttons below
+        set/clear the value programmatically, and should update the month/day/year fields.
       </p>
 
       <GoabFormItem label="Date picker (input)" mb="xl">
@@ -26,16 +27,13 @@ export function Bug3275Route() {
       </GoabFormItem>
 
       <GoabButtonGroup alignment="start" mb="l">
+        <GoabButton size="compact" onClick={() => setInputValue("2024-03-15")}>
+          Set March 15
+        </GoabButton>
         <GoabButton size="compact" type="secondary" onClick={() => setInputValue("")}>
           Clear programmatically
         </GoabButton>
       </GoabButtonGroup>
-      <div>
-        <p>
-          <b>Note:</b> The button clears the value in the form but does not change the
-          DatePicker when <code>type=input</code>. Its just for testing.
-        </p>
-      </div>
 
       <div>
         Current value: <strong>{inputValue || '"" (empty)'}</strong>

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -151,15 +151,13 @@
   }
 
   function setDate(value: string) {
-    if (type === "calendar") {
-      if (value) {
-        _date = new CalendarDate(value);
-        if (!_date.isValid) {
-          _date = new CalendarDate(0);
-        }
-      } else {
+    if (value) {
+      _date = new CalendarDate(value);
+      if (!_date.isValid()) {
         _date = new CalendarDate(0);
       }
+    } else {
+      _date = new CalendarDate(0);
     }
   }
 

--- a/libs/web-components/src/components/date-picker/date-picker.spec.ts
+++ b/libs/web-components/src/components/date-picker/date-picker.spec.ts
@@ -151,3 +151,71 @@ describe("day and year inputs", () => {
     expect(value).toBe("2025-06-15");
   });
 });
+
+describe("programmatic value changes for input type (#3275)", () => {
+  it("populates month, day, and year from the initial value", async () => {
+    const { container } = render(DatePicker, {
+      type: "input",
+      value: "2024-03-15",
+    });
+
+    const monthInput = container.querySelector("[testid='input-month']");
+    const dayInput = container.querySelector("[testid='input-day']");
+    const yearInput = container.querySelector("[testid='input-year']");
+
+    expect(monthInput?.getAttribute("value")).toBe("3");
+    expect(dayInput?.getAttribute("value")).toBe("15");
+    expect(yearInput?.getAttribute("value")).toBe("2024");
+  });
+
+  it("updates the fields when value is changed programmatically", async () => {
+    const { container, rerender } = render(DatePicker, {
+      type: "input",
+      value: "2024-03-15",
+    });
+
+    await rerender({ type: "input", value: "2025-11-02" });
+
+    const monthInput = container.querySelector("[testid='input-month']");
+    const dayInput = container.querySelector("[testid='input-day']");
+    const yearInput = container.querySelector("[testid='input-year']");
+
+    expect(monthInput?.getAttribute("value")).toBe("11");
+    expect(dayInput?.getAttribute("value")).toBe("2");
+    expect(yearInput?.getAttribute("value")).toBe("2025");
+  });
+
+  it("clears the fields when value is set to an empty string", async () => {
+    const { container, rerender } = render(DatePicker, {
+      type: "input",
+      value: "2024-03-15",
+    });
+
+    await rerender({ type: "input", value: "" });
+
+    const monthInput = container.querySelector("[testid='input-month']");
+    const dayInput = container.querySelector("[testid='input-day']");
+    const yearInput = container.querySelector("[testid='input-year']");
+
+    expect(monthInput?.getAttribute("value")).toBe("0");
+    expect(dayInput?.getAttribute("value")).toBe("");
+    expect(yearInput?.getAttribute("value")).toBe("");
+  });
+});
+
+describe("invalid date handling (#3275)", () => {
+  it("resets to blank when given a nonexistent calendar date", async () => {
+    const { container } = render(DatePicker, {
+      type: "input",
+      value: "2025-02-31",
+    });
+
+    const monthInput = container.querySelector("[testid='input-month']");
+    const dayInput = container.querySelector("[testid='input-day']");
+    const yearInput = container.querySelector("[testid='input-year']");
+
+    expect(monthInput?.getAttribute("value")).toBe("0");
+    expect(dayInput?.getAttribute("value")).toBe("");
+    expect(yearInput?.getAttribute("value")).toBe("");
+  });
+});


### PR DESCRIPTION
## Before (the change)

`GoabDatePicker` with `type="input"` ignored the `value` prop entirely:

- The initial value was never shown on load.
- Setting `value` programmatically after mount did not update the month/day/year fields.
- Clearing `value` (e.g. `value=""`) did not clear the fields.

Root cause: `setDate()` in `DatePicker.svelte` only recomputed the internal `_date` state when `type === "calendar"`. The `type === "input"` branch was dropped during an earlier refactor (`fix(#2664): move away from Date value within the calendar/datepicker`) that unified both types onto a shared `CalendarDate` state, but the sync function was never updated to match.

**Note for the tester:** while fixing this, I found a second, related bug in the same function and fixed it too: `!_date.isValid` referenced the `isValid` method without calling it (`!_date.isValid()`), so it was always falsy and the "reset to blank on invalid date" branch never ran. A value like `2025-02-31` (a day that doesn't exist) would previously be accepted as-is instead of resetting to blank. Both fixes are in the same `setDate()` function, see the diff.

## After (the change)

`type="input"` now stays in sync with the `value` prop in all three cases: initial load, programmatic set, and programmatic clear. Invalid dates (e.g. `2025-02-31`) now correctly reset the fields to blank instead of being accepted.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the setup steps
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Open the "3275 - Can't unset month" playground page (Bugs menu) in both the React and Angular playgrounds.
2. Confirm the DatePicker shows "March / 15 / 2024" on initial load.
3. Click "Clear programmatically" and confirm all three fields (month/day/year) reset to blank and "Current value" shows empty.
4. Click "Set March 15" and confirm the fields populate again and "Current value" shows `2024-03-15`.
5. Manually change the Month dropdown to "—Select a month—" and confirm the value clears.

Fixes #3275