### PR TITLE
feat(#1351): Dropdown item slot for rich HTML content

### DIFF
--- a/apps/prs/angular/src/routes/features/feat1351/feat1351.component.html
+++ b/apps/prs/angular/src/routes/features/feat1351/feat1351.component.html
@@ -1,0 +1,104 @@
+<div>
+  <goab-text tag="h1" mt="m">Feat #1351: Dropdown item slot</goab-text>
+
+  <goab-block>
+    <goab-link trailingIcon="open">
+      <a href="https://github.com/GovAlta/ui-components/issues/1351" target="_blank" rel="noopener">
+        View on GitHub
+      </a>
+    </goab-link>
+
+    <goab-details heading="Issue Description">
+      <goab-text tag="p">
+        The ability to have a slot for Dropdown Items that can be filled with anything (HTML). This needs to be
+        supported for the filterable property (Combobox), where any/all text included in the slot is filterable.
+        Multiple line support, icon and badge to indicate status. The label property is shown in the input once an
+        item is selected.
+      </goab-text>
+    </goab-details>
+  </goab-block>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <goab-text tag="h2">Test Cases</goab-text>
+
+  <goab-text tag="h3">Test 1: Base dropdown with rich item content</goab-text>
+  <goab-text tag="p">
+    Each item renders multi-line content with a name, role, location and a status badge. Selecting an item shows its
+    label in the input.
+  </goab-text>
+  <goab-dropdown name="basic" [value]="basicValue" width="360px" (onChange)="onBasicChange($event)">
+    @for (person of people; track person.value) {
+      <goab-dropdown-item [value]="person.value" [label]="person.name">
+        <div style="display: flex; flex-direction: column; gap: 0.25rem">
+          <strong>{{ person.name }}</strong>
+          <span>{{ person.role }} &middot; {{ person.location }}</span>
+          <goab-badge [type]="person.status" [content]="person.statusText"></goab-badge>
+        </div>
+      </goab-dropdown-item>
+    }
+  </goab-dropdown>
+  <goab-text tag="p">Selected value: {{ basicValue || "(none)" }}</goab-text>
+
+  <goab-text tag="h3">Test 2: Filterable (combobox) with rich item content</goab-text>
+  <goab-text tag="p">
+    All text within the slot is filterable: try typing a name (Sarah), a role (Supervisor) or a location (Red Deer).
+    Text rendered inside a nested component's own shadow DOM (like the badge content) is not part of the slot text;
+    use the filter property to add extra search terms.
+  </goab-text>
+  <goab-dropdown
+    name="filterable"
+    [value]="filterValue"
+    [filterable]="true"
+    width="360px"
+    (onChange)="onFilterChange($event)"
+  >
+    @for (person of people; track person.value) {
+      <goab-dropdown-item [value]="person.value" [label]="person.name">
+        <div style="display: flex; flex-direction: column; gap: 0.25rem">
+          <strong>{{ person.name }}</strong>
+          <span>{{ person.role }} &middot; {{ person.location }}</span>
+          <goab-badge [type]="person.status" [content]="person.statusText"></goab-badge>
+        </div>
+      </goab-dropdown-item>
+    }
+  </goab-dropdown>
+  <goab-text tag="p">Selected value: {{ filterValue || "(none)" }}</goab-text>
+
+  <goab-text tag="h3">Test 3: Mixed rich and label-only items, filter override</goab-text>
+  <goab-text tag="p">
+    Plain label items work alongside rich items. The first item overrides the search text of its slot content with the
+    filter property ("preferred"): typing "preferred" matches it, and so does typing "Sarah", because the label is
+    always searchable. Typing "Edmonton" does not match, because the filter property replaced the slot text.
+  </goab-text>
+  <goab-dropdown name="mixed" [value]="mixedValue" [filterable]="true" width="360px" (onChange)="onMixedChange($event)">
+    <goab-dropdown-item value="sarah" label="Sarah Johnson" filter="preferred">
+      <div style="display: flex; flex-direction: column; gap: 0.25rem">
+        <strong>{{ people[0].name }}</strong>
+        <span>{{ people[0].role }} &middot; {{ people[0].location }}</span>
+        <goab-badge [type]="people[0].status" [content]="people[0].statusText"></goab-badge>
+      </div>
+    </goab-dropdown-item>
+    <goab-dropdown-item value="plain-1" label="Plain item one"></goab-dropdown-item>
+    <goab-dropdown-item value="plain-2" label="Plain item two"></goab-dropdown-item>
+  </goab-dropdown>
+  <goab-text tag="p">Selected value: {{ mixedValue || "(none)" }}</goab-text>
+
+  <goab-text tag="h3">Test 4: Native select with rich items</goab-text>
+  <goab-text tag="p">
+    A native select cannot contain HTML, so slotted content is ignored and each option falls back to its label. The
+    rich content must not leak into the page around the select.
+  </goab-text>
+  <goab-dropdown name="native" [value]="nativeValue" [native]="true" width="360px" (onChange)="onNativeChange($event)">
+    @for (person of people; track person.value) {
+      <goab-dropdown-item [value]="person.value" [label]="person.name">
+        <div style="display: flex; flex-direction: column; gap: 0.25rem">
+          <strong>{{ person.name }}</strong>
+          <span>{{ person.role }} &middot; {{ person.location }}</span>
+          <goab-badge [type]="person.status" [content]="person.statusText"></goab-badge>
+        </div>
+      </goab-dropdown-item>
+    }
+  </goab-dropdown>
+  <goab-text tag="p">Selected value: {{ nativeValue || "(none)" }}</goab-text>
+</div>

--- a/apps/prs/angular/src/routes/features/feat1351/feat1351.component.ts
+++ b/apps/prs/angular/src/routes/features/feat1351/feat1351.component.ts
@@ -1,0 +1,86 @@
+import { Component } from "@angular/core";
+import {
+  GoabBadge,
+  GoabBlock,
+  GoabDetails,
+  GoabDivider,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabDropdownOnChangeDetail,
+  GoabLink,
+  GoabText,
+} from "@abgov/angular-components";
+
+type Person = {
+  value: string;
+  name: string;
+  role: string;
+  location: string;
+  status: "information" | "success" | "emergency";
+  statusText: string;
+};
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat1351",
+  templateUrl: "./feat1351.component.html",
+  imports: [
+    GoabBadge,
+    GoabBlock,
+    GoabDetails,
+    GoabDivider,
+    GoabDropdown,
+    GoabDropdownItem,
+    GoabLink,
+    GoabText,
+  ],
+})
+export class Feat1351Component {
+  people: Person[] = [
+    {
+      value: "sarah",
+      name: "Sarah Johnson",
+      role: "Case worker",
+      location: "Edmonton",
+      status: "success",
+      statusText: "Available",
+    },
+    {
+      value: "michael",
+      name: "Michael Chen",
+      role: "Supervisor",
+      location: "Calgary",
+      status: "information",
+      statusText: "In a meeting",
+    },
+    {
+      value: "amara",
+      name: "Amara Okafor",
+      role: "Case worker",
+      location: "Red Deer",
+      status: "emergency",
+      statusText: "On leave",
+    },
+  ];
+
+  basicValue?: string;
+  filterValue?: string;
+  mixedValue?: string;
+  nativeValue?: string;
+
+  onBasicChange(detail: GoabDropdownOnChangeDetail) {
+    this.basicValue = detail.value as string;
+  }
+
+  onFilterChange(detail: GoabDropdownOnChangeDetail) {
+    this.filterValue = detail.value as string;
+  }
+
+  onMixedChange(detail: GoabDropdownOnChangeDetail) {
+    this.mixedValue = detail.value as string;
+  }
+
+  onNativeChange(detail: GoabDropdownOnChangeDetail) {
+    this.nativeValue = detail.value as string;
+  }
+}

--- a/apps/prs/angular/src/routes/features/feat1351/feat1351.route.json
+++ b/apps/prs/angular/src/routes/features/feat1351/feat1351.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Dropdown item slot",
+  "path": "features/1351",
+  "id": "1351",
+  "type": "feature"
+}

--- a/apps/prs/react/src/app/routes/features/feat1351.route.ts
+++ b/apps/prs/react/src/app/routes/features/feat1351.route.ts
@@ -1,0 +1,9 @@
+import { Feat1351Route } from "../../../routes/features/feat1351";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "feature",
+  id: "1351",
+  path: "features/1351",
+  title: "Dropdown item slot",
+  component: Feat1351Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/features/feat1351.tsx
+++ b/apps/prs/react/src/routes/features/feat1351.tsx
@@ -1,0 +1,198 @@
+import { useState } from "react";
+import {
+  GoabBlock,
+  GoabText,
+  GoabDivider,
+  GoabDetails,
+  GoabLink,
+  GoabBadge,
+  GoabDropdown,
+  GoabDropdownItem,
+} from "@abgov/react-components";
+
+type Person = {
+  value: string;
+  name: string;
+  role: string;
+  location: string;
+  status: "information" | "success" | "emergency";
+  statusText: string;
+};
+
+const people: Person[] = [
+  {
+    value: "sarah",
+    name: "Sarah Johnson",
+    role: "Case worker",
+    location: "Edmonton",
+    status: "success",
+    statusText: "Available",
+  },
+  {
+    value: "michael",
+    name: "Michael Chen",
+    role: "Supervisor",
+    location: "Calgary",
+    status: "information",
+    statusText: "In a meeting",
+  },
+  {
+    value: "amara",
+    name: "Amara Okafor",
+    role: "Case worker",
+    location: "Red Deer",
+    status: "emergency",
+    statusText: "On leave",
+  },
+];
+
+function PersonItem({ person }: { person: Person }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+      <strong>{person.name}</strong>
+      <span>
+        {person.role} &middot; {person.location}
+      </span>
+      <GoabBadge type={person.status} content={person.statusText} />
+    </div>
+  );
+}
+
+export function Feat1351Route() {
+  const [basicValue, setBasicValue] = useState<string | undefined>();
+  const [filterValue, setFilterValue] = useState<string | undefined>();
+  const [mixedValue, setMixedValue] = useState<string | undefined>();
+  const [nativeValue, setNativeValue] = useState<string | undefined>();
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Feat #1351: Dropdown item slot
+      </GoabText>
+
+      <GoabBlock>
+        <GoabLink trailingIcon="open">
+          <a
+            href="https://github.com/GovAlta/ui-components/issues/1351"
+            target="_blank"
+            rel="noopener"
+          >
+            View on GitHub
+          </a>
+        </GoabLink>
+
+        <GoabDetails heading="Issue Description">
+          <GoabText tag="p">
+            The ability to have a slot for Dropdown Items that can be filled
+            with anything (HTML). This needs to be supported for the filterable
+            property (Combobox), where any/all text included in the slot is
+            filterable. Multiple line support, icon and badge to indicate
+            status. The label property is shown in the input once an item is
+            selected.
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      <GoabText tag="h3">Test 1: Base dropdown with rich item content</GoabText>
+      <GoabText tag="p">
+        Each item renders multi-line content with a name, role, location and a
+        status badge. Selecting an item shows its label in the input.
+      </GoabText>
+      <GoabDropdown
+        name="basic"
+        value={basicValue}
+        width="360px"
+        onChange={(detail) => setBasicValue(detail.value)}
+      >
+        {people.map((person) => (
+          <GoabDropdownItem
+            key={person.value}
+            value={person.value}
+            label={person.name}
+          >
+            <PersonItem person={person} />
+          </GoabDropdownItem>
+        ))}
+      </GoabDropdown>
+      <GoabText tag="p">Selected value: {basicValue || "(none)"}</GoabText>
+
+      <GoabText tag="h3">Test 2: Filterable (combobox) with rich item content</GoabText>
+      <GoabText tag="p">
+        All text within the slot is filterable: try typing a name (Sarah), a
+        role (Supervisor) or a location (Red Deer). Text rendered inside a
+        nested component's own shadow DOM (like the badge content) is not part
+        of the slot text; use the filter property to add extra search terms.
+      </GoabText>
+      <GoabDropdown
+        name="filterable"
+        value={filterValue}
+        filterable={true}
+        width="360px"
+        onChange={(detail) => setFilterValue(detail.value)}
+      >
+        {people.map((person) => (
+          <GoabDropdownItem
+            key={person.value}
+            value={person.value}
+            label={person.name}
+          >
+            <PersonItem person={person} />
+          </GoabDropdownItem>
+        ))}
+      </GoabDropdown>
+      <GoabText tag="p">Selected value: {filterValue || "(none)"}</GoabText>
+
+      <GoabText tag="h3">Test 3: Mixed rich and label-only items, filter override</GoabText>
+      <GoabText tag="p">
+        Plain label items work alongside rich items. The first item overrides
+        the search text of its slot content with the filter property
+        ("preferred"): typing "preferred" matches it, and so does typing
+        "Sarah", because the label is always searchable. Typing "Edmonton"
+        does not match, because the filter property replaced the slot text.
+      </GoabText>
+      <GoabDropdown
+        name="mixed"
+        value={mixedValue}
+        filterable={true}
+        width="360px"
+        onChange={(detail) => setMixedValue(detail.value)}
+      >
+        <GoabDropdownItem value="sarah" label="Sarah Johnson" filter="preferred">
+          <PersonItem person={people[0]} />
+        </GoabDropdownItem>
+        <GoabDropdownItem value="plain-1" label="Plain item one" />
+        <GoabDropdownItem value="plain-2" label="Plain item two" />
+      </GoabDropdown>
+      <GoabText tag="p">Selected value: {mixedValue || "(none)"}</GoabText>
+
+      <GoabText tag="h3">Test 4: Native select with rich items</GoabText>
+      <GoabText tag="p">
+        A native select cannot contain HTML, so slotted content is ignored and
+        each option falls back to its label. The rich content must not leak
+        into the page around the select.
+      </GoabText>
+      <GoabDropdown
+        name="native"
+        value={nativeValue}
+        native={true}
+        width="360px"
+        onChange={(detail) => setNativeValue(detail.value)}
+      >
+        {people.map((person) => (
+          <GoabDropdownItem
+            key={person.value}
+            value={person.value}
+            label={person.name}
+          >
+            <PersonItem person={person} />
+          </GoabDropdownItem>
+        ))}
+      </GoabDropdown>
+      <GoabText tag="p">Selected value: {nativeValue || "(none)"}</GoabText>
+    </div>
+  );
+}

--- a/docs/generated/component-apis/dropdown-item.json
+++ b/docs/generated/component-apis/dropdown-item.json
@@ -9,7 +9,7 @@
           "type": "string",
           "required": false,
           "default": null,
-          "description": "Text used to filter and match this item in typeahead search."
+          "description": "Additional text used to match this item in typeahead search, alongside the label. Defaults to the children's text."
         },
         {
           "name": "label",
@@ -50,7 +50,7 @@
           "type": "string",
           "required": false,
           "default": null,
-          "description": "Text used to filter and match this item in typeahead search."
+          "description": "Additional text used to match this item in typeahead search, alongside the label. Defaults to the projected content's text."
         },
         {
           "name": "label",
@@ -91,7 +91,7 @@
           "type": "string",
           "required": false,
           "default": "",
-          "description": "Text used to filter and match this item in typeahead search."
+          "description": "Additional text used to match this item in typeahead search, alongside the label. Defaults to the slotted content's text."
         },
         {
           "name": "label",

--- a/docs/generated/component-apis/dropdown-item.json
+++ b/docs/generated/component-apis/dropdown-item.json
@@ -9,7 +9,7 @@
           "type": "string",
           "required": false,
           "default": null,
-          "description": "Additional text used to match this item in typeahead search, alongside the label. Defaults to the children's text."
+          "description": "Rich item content. On selection, `label` is shown and `filter` defaults to the content's text."
         },
         {
           "name": "label",
@@ -50,7 +50,7 @@
           "type": "string",
           "required": false,
           "default": null,
-          "description": "Additional text used to match this item in typeahead search, alongside the label. Defaults to the projected content's text."
+          "description": "Rich item content. On selection, `label` is shown and `filter` defaults to the content's text."
         },
         {
           "name": "label",

--- a/docs/src/content/guidance/dropdown-filter-rich-item-content.mdx
+++ b/docs/src/content/guidance/dropdown-filter-rich-item-content.mdx
@@ -1,0 +1,18 @@
+---
+id: dropdown-filter-rich-item-content
+type: tip
+description: A filterable dropdown searches an item's label and the text of its content, but not text rendered inside a nested component such as a Badge. Use the filter property to add those terms to the search.
+topic: interaction
+tags:
+  - dropdown
+  - filterable
+  - content
+appliesTo:
+  components:
+    - dropdown
+    - dropdown-item
+relatedProps:
+  - filterable
+  - filter
+status: published
+---

--- a/docs/src/content/guidance/dropdown-native-ignores-item-content.mdx
+++ b/docs/src/content/guidance/dropdown-native-ignores-item-content.mdx
@@ -1,0 +1,18 @@
+---
+id: dropdown-native-ignores-item-content
+type: warning
+description: The native dropdown renders a native select element, which cannot contain HTML. Items with rich content fall back to their label, so set a label on every item that you also give content to.
+topic: types
+tags:
+  - dropdown
+  - native
+  - content
+appliesTo:
+  components:
+    - dropdown
+    - dropdown-item
+relatedProps:
+  - native
+  - label
+status: published
+---

--- a/docs/src/content/guidance/dropdown-no-interactive-item-content.mdx
+++ b/docs/src/content/guidance/dropdown-no-interactive-item-content.mdx
@@ -1,0 +1,16 @@
+---
+id: dropdown-no-interactive-item-content
+type: warning
+description: Don't put buttons, links, inputs, or other interactive elements in an item's content. Each item is a listbox option, so nested controls are not in the tab order and cannot be reached by keyboard, and clicking one selects the item instead of activating the control. Use text, icons, and badges instead.
+topic: accessibility
+tags:
+  - dropdown
+  - accessibility
+  - keyboard
+  - content
+appliesTo:
+  components:
+    - dropdown
+    - dropdown-item
+status: published
+---

--- a/docs/src/data/configurations/dropdown.ts
+++ b/docs/src/data/configurations/dropdown.ts
@@ -451,11 +451,10 @@ export const dropdownConfigurations: ComponentConfigurations = {
     {
       id: "rich-item-content",
       name: "Rich item content",
-      description:
-        "Dropdown items containing formatted content instead of a plain label",
+      description: "Dropdown items containing formatted content instead of a plain label",
       code: {
         react: `<GoabFormItem label="Assign to" mb="l">
-  <GoabDropdown name="assignee">
+  <GoabDropdown name="assignee" width="250px">
     <GoabDropdownItem value="sarah" label="Sarah Johnson">
       <GoabBlock direction="column" gap="3xs">
         <strong>Sarah Johnson</strong>
@@ -485,7 +484,7 @@ export const dropdownConfigurations: ComponentConfigurations = {
 }`,
             template: `<form [formGroup]="form">
   <goab-form-item label="Assign to" mb="l">
-    <goab-dropdown name="assignee" formControlName="assignee">
+    <goab-dropdown name="assignee" formControlName="assignee" width="250px">
       <goab-dropdown-item value="sarah" label="Sarah Johnson">
         <goab-block direction="column" gap="3xs">
           <strong>Sarah Johnson</strong>
@@ -519,6 +518,7 @@ export const dropdownConfigurations: ComponentConfigurations = {
       name="assignee"
       [(ngModel)]="assignee"
       (onChange)="dropdownOnChange($event)"
+      width="250px"
     >
       <goab-dropdown-item value="sarah" label="Sarah Johnson">
         <goab-block direction="column" gap="3xs">
@@ -540,7 +540,7 @@ export const dropdownConfigurations: ComponentConfigurations = {
           },
         ],
         webComponents: `<goa-form-item version="2" label="Assign to" mb="l">
-  <goa-dropdown version="2" name="assignee">
+  <goa-dropdown version="2" name="assignee" width="250px">
     <goa-dropdown-item value="sarah" label="Sarah Johnson">
       <goa-block version="2" direction="column" gap="3xs">
         <strong>Sarah Johnson</strong>

--- a/docs/src/data/configurations/dropdown.ts
+++ b/docs/src/data/configurations/dropdown.ts
@@ -455,6 +455,7 @@ export const dropdownConfigurations: ComponentConfigurations = {
       code: {
         react: `<GoabFormItem label="Assign to" mb="l">
   <GoabDropdown name="assignee" width="250px">
+
     <GoabDropdownItem value="sarah" label="Sarah Johnson">
       <GoabBlock direction="column" gap="3xs">
         <strong>Sarah Johnson</strong>

--- a/docs/src/data/configurations/dropdown.ts
+++ b/docs/src/data/configurations/dropdown.ts
@@ -449,6 +449,267 @@ export const dropdownConfigurations: ComponentConfigurations = {
       },
     },
     {
+      id: "rich-item-content",
+      name: "Rich item content",
+      description:
+        "Dropdown items containing formatted content instead of a plain label",
+      code: {
+        react: `<GoabFormItem label="Assign to" mb="l">
+  <GoabDropdown name="assignee">
+    <GoabDropdownItem value="sarah" label="Sarah Johnson">
+      <GoabBlock direction="column" gap="3xs">
+        <strong>Sarah Johnson</strong>
+        <span>Case worker &middot; Edmonton</span>
+        <GoabBadge type="success" content="Available" />
+      </GoabBlock>
+    </GoabDropdownItem>
+    <GoabDropdownItem value="michael" label="Michael Chen">
+      <GoabBlock direction="column" gap="3xs">
+        <strong>Michael Chen</strong>
+        <span>Supervisor &middot; Calgary</span>
+        <GoabBadge type="information" content="In a meeting" />
+      </GoabBlock>
+    </GoabDropdownItem>
+  </GoabDropdown>
+</GoabFormItem>`,
+        angular: [
+          {
+            title: "Reactive forms (FormControl)",
+            ts: `export class SomeOtherComponent {
+  form!: FormGroup;
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      assignee: [""],
+    });
+  }
+}`,
+            template: `<form [formGroup]="form">
+  <goab-form-item label="Assign to" mb="l">
+    <goab-dropdown name="assignee" formControlName="assignee">
+      <goab-dropdown-item value="sarah" label="Sarah Johnson">
+        <goab-block direction="column" gap="3xs">
+          <strong>Sarah Johnson</strong>
+          <span>Case worker &middot; Edmonton</span>
+          <goab-badge type="success" content="Available"></goab-badge>
+        </goab-block>
+      </goab-dropdown-item>
+      <goab-dropdown-item value="michael" label="Michael Chen">
+        <goab-block direction="column" gap="3xs">
+          <strong>Michael Chen</strong>
+          <span>Supervisor &middot; Calgary</span>
+          <goab-badge type="information" content="In a meeting"></goab-badge>
+        </goab-block>
+      </goab-dropdown-item>
+    </goab-dropdown>
+  </goab-form-item>
+</form>`,
+          },
+          {
+            title: "Template driven (ngModel)",
+            ts: `export class SomeOtherComponent {
+  assignee = "";
+
+  dropdownOnChange(event: GoabDropdownOnChangeDetail) {
+    this.assignee = event.value as string;
+  }
+}`,
+            template: `<form>
+  <goab-form-item label="Assign to" mb="l">
+    <goab-dropdown
+      name="assignee"
+      [(ngModel)]="assignee"
+      (onChange)="dropdownOnChange($event)"
+    >
+      <goab-dropdown-item value="sarah" label="Sarah Johnson">
+        <goab-block direction="column" gap="3xs">
+          <strong>Sarah Johnson</strong>
+          <span>Case worker &middot; Edmonton</span>
+          <goab-badge type="success" content="Available"></goab-badge>
+        </goab-block>
+      </goab-dropdown-item>
+      <goab-dropdown-item value="michael" label="Michael Chen">
+        <goab-block direction="column" gap="3xs">
+          <strong>Michael Chen</strong>
+          <span>Supervisor &middot; Calgary</span>
+          <goab-badge type="information" content="In a meeting"></goab-badge>
+        </goab-block>
+      </goab-dropdown-item>
+    </goab-dropdown>
+  </goab-form-item>
+</form>`,
+          },
+        ],
+        webComponents: `<goa-form-item version="2" label="Assign to" mb="l">
+  <goa-dropdown version="2" name="assignee">
+    <goa-dropdown-item value="sarah" label="Sarah Johnson">
+      <goa-block version="2" direction="column" gap="3xs">
+        <strong>Sarah Johnson</strong>
+        <span>Case worker &middot; Edmonton</span>
+        <goa-badge version="2" type="success" content="Available"></goa-badge>
+      </goa-block>
+    </goa-dropdown-item>
+    <goa-dropdown-item value="michael" label="Michael Chen">
+      <goa-block version="2" direction="column" gap="3xs">
+        <strong>Michael Chen</strong>
+        <span>Supervisor &middot; Calgary</span>
+        <goa-badge version="2" type="information" content="In a meeting"></goa-badge>
+      </goa-block>
+    </goa-dropdown-item>
+  </goa-dropdown>
+</goa-form-item>`,
+      },
+    },
+    {
+      id: "filterable-rich-item-content",
+      name: "Filterable rich item content",
+      description:
+        "Rich item content that is searchable, using filter to add terms the text does not contain",
+      code: {
+        react: `<GoabFormItem label="Assign to" mb="l">
+  <GoabDropdown name="assignee" filterable leadingIcon="search">
+    <GoabDropdownItem
+      value="sarah"
+      label="Sarah Johnson"
+      filter="Sarah Johnson Case worker Edmonton Available"
+    >
+      <GoabBlock direction="column" gap="3xs">
+        <strong>Sarah Johnson</strong>
+        <span>Case worker &middot; Edmonton</span>
+        <GoabBadge type="success" content="Available" />
+      </GoabBlock>
+    </GoabDropdownItem>
+    <GoabDropdownItem
+      value="michael"
+      label="Michael Chen"
+      filter="Michael Chen Supervisor Calgary In a meeting"
+    >
+      <GoabBlock direction="column" gap="3xs">
+        <strong>Michael Chen</strong>
+        <span>Supervisor &middot; Calgary</span>
+        <GoabBadge type="information" content="In a meeting" />
+      </GoabBlock>
+    </GoabDropdownItem>
+  </GoabDropdown>
+</GoabFormItem>`,
+        angular: [
+          {
+            title: "Reactive forms (FormControl)",
+            ts: `export class SomeOtherComponent {
+  form!: FormGroup;
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      assignee: [""],
+    });
+  }
+}`,
+            template: `<form [formGroup]="form">
+  <goab-form-item label="Assign to" mb="l">
+    <goab-dropdown
+      name="assignee"
+      [filterable]="true"
+      leadingIcon="search"
+      formControlName="assignee"
+    >
+      <goab-dropdown-item
+        value="sarah"
+        label="Sarah Johnson"
+        filter="Sarah Johnson Case worker Edmonton Available"
+      >
+        <goab-block direction="column" gap="3xs">
+          <strong>Sarah Johnson</strong>
+          <span>Case worker &middot; Edmonton</span>
+          <goab-badge type="success" content="Available"></goab-badge>
+        </goab-block>
+      </goab-dropdown-item>
+      <goab-dropdown-item
+        value="michael"
+        label="Michael Chen"
+        filter="Michael Chen Supervisor Calgary In a meeting"
+      >
+        <goab-block direction="column" gap="3xs">
+          <strong>Michael Chen</strong>
+          <span>Supervisor &middot; Calgary</span>
+          <goab-badge type="information" content="In a meeting"></goab-badge>
+        </goab-block>
+      </goab-dropdown-item>
+    </goab-dropdown>
+  </goab-form-item>
+</form>`,
+          },
+          {
+            title: "Template driven (ngModel)",
+            ts: `export class SomeOtherComponent {
+  assignee = "";
+
+  dropdownOnChange(event: GoabDropdownOnChangeDetail) {
+    this.assignee = event.value as string;
+  }
+}`,
+            template: `<form>
+  <goab-form-item label="Assign to" mb="l">
+    <goab-dropdown
+      name="assignee"
+      [filterable]="true"
+      leadingIcon="search"
+      [(ngModel)]="assignee"
+      (onChange)="dropdownOnChange($event)"
+    >
+      <goab-dropdown-item
+        value="sarah"
+        label="Sarah Johnson"
+        filter="Sarah Johnson Case worker Edmonton Available"
+      >
+        <goab-block direction="column" gap="3xs">
+          <strong>Sarah Johnson</strong>
+          <span>Case worker &middot; Edmonton</span>
+          <goab-badge type="success" content="Available"></goab-badge>
+        </goab-block>
+      </goab-dropdown-item>
+      <goab-dropdown-item
+        value="michael"
+        label="Michael Chen"
+        filter="Michael Chen Supervisor Calgary In a meeting"
+      >
+        <goab-block direction="column" gap="3xs">
+          <strong>Michael Chen</strong>
+          <span>Supervisor &middot; Calgary</span>
+          <goab-badge type="information" content="In a meeting"></goab-badge>
+        </goab-block>
+      </goab-dropdown-item>
+    </goab-dropdown>
+  </goab-form-item>
+</form>`,
+          },
+        ],
+        webComponents: `<goa-form-item version="2" label="Assign to" mb="l">
+  <goa-dropdown version="2" name="assignee" filterable leadingicon="search">
+    <goa-dropdown-item
+      value="sarah"
+      label="Sarah Johnson"
+      filter="Sarah Johnson Case worker Edmonton Available"
+    >
+      <goa-block version="2" direction="column" gap="3xs">
+        <strong>Sarah Johnson</strong>
+        <span>Case worker &middot; Edmonton</span>
+        <goa-badge version="2" type="success" content="Available"></goa-badge>
+      </goa-block>
+    </goa-dropdown-item>
+    <goa-dropdown-item
+      value="michael"
+      label="Michael Chen"
+      filter="Michael Chen Supervisor Calgary In a meeting"
+    >
+      <goa-block version="2" direction="column" gap="3xs">
+        <strong>Michael Chen</strong>
+        <span>Supervisor &middot; Calgary</span>
+        <goa-badge version="2" type="information" content="In a meeting"></goa-badge>
+      </goa-block>
+    </goa-dropdown-item>
+  </goa-dropdown>
+</goa-form-item>`,
+      },
+    },
+    {
       id: "native",
       name: "Native",
       description: "Native HTML select element compared with custom dropdown",

--- a/libs/angular-components/src/lib/components/dropdown-item/dropdown-item.spec.ts
+++ b/libs/angular-components/src/lib/components/dropdown-item/dropdown-item.spec.ts
@@ -1,12 +1,33 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Component } from "@angular/core";
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { GoabDropdownItem } from "./dropdown-item";
+
+@Component({
+  standalone: true,
+  imports: [GoabDropdownItem],
+  template: `
+    <goab-dropdown-item value="red" label="Red">
+      <div data-testid="rich-red">
+        <strong>Red</strong>
+        <span>Warm color</span>
+      </div>
+    </goab-dropdown-item>
+  `,
+})
+class TestHostComponent {}
 
 let component: GoabDropdownItem;
 let fixture: ComponentFixture<GoabDropdownItem>;
 
 beforeEach(() => {
   TestBed.configureTestingModule({
-    imports: [GoabDropdownItem],
+    imports: [GoabDropdownItem, TestHostComponent],
   });
   fixture = TestBed.createComponent(GoabDropdownItem);
   component = fixture.componentInstance;
@@ -15,3 +36,16 @@ beforeEach(() => {
 it("should render", () => {
   expect(component).toBeTruthy();
 });
+
+it("should project content into the dropdown item", fakeAsync(() => {
+  const hostFixture = TestBed.createComponent(TestHostComponent);
+  hostFixture.detectChanges();
+  tick();
+  hostFixture.detectChanges();
+
+  const content = hostFixture.debugElement.query(
+    By.css("goa-dropdown-item [data-testid=rich-red]"),
+  );
+  expect(content.nativeElement.textContent).toContain("Red");
+  expect(content.nativeElement.textContent).toContain("Warm color");
+}));

--- a/libs/angular-components/src/lib/components/dropdown-item/dropdown-item.ts
+++ b/libs/angular-components/src/lib/components/dropdown-item/dropdown-item.ts
@@ -20,6 +20,7 @@ import { GoabDropdownItemMountType } from "@abgov/ui-components-common";
       [attr.name]="name"
       [attr.mount]="mountType"
     >
+      <ng-content />
     </goa-dropdown-item>
   }`,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -30,7 +31,7 @@ export class GoabDropdownItem implements OnInit {
 
   /** The value submitted when this item is selected. */
   @Input() value?: string;
-  /** Text used to filter and match this item in typeahead search. */
+  /** Additional text used to match this item in typeahead search, alongside the label. Defaults to the projected content's text. */
   @Input() filter?: string;
   /** Display label for the dropdown item. */
   @Input() label?: string;

--- a/libs/angular-components/src/lib/components/dropdown-item/dropdown-item.ts
+++ b/libs/angular-components/src/lib/components/dropdown-item/dropdown-item.ts
@@ -31,7 +31,7 @@ export class GoabDropdownItem implements OnInit {
 
   /** The value submitted when this item is selected. */
   @Input() value?: string;
-  /** Additional text used to match this item in typeahead search, alongside the label. Defaults to the projected content's text. */
+  /** Rich item content. On selection, `label` is shown and `filter` defaults to the content's text. */
   @Input() filter?: string;
   /** Display label for the dropdown item. */
   @Input() label?: string;

--- a/libs/react-components/specs/dropdown.browser.spec.tsx
+++ b/libs/react-components/specs/dropdown.browser.spec.tsx
@@ -4,6 +4,28 @@ import { GoabDropdown, GoabDropdownItem } from "../src";
 import { expect, describe, it, vi } from "vitest";
 import { page, userEvent } from "@vitest/browser/context";
 
+// Slotted content's DOM parent stays in the light DOM even once assigned, so
+// closest("li") can't cross the shadow boundary into the menu. Item content
+// crosses two shadow boundaries (the item's own default slot, then the
+// dropdown's named option-{value} slot), so walk assignedSlot repeatedly,
+// hopping to each slot's shadow host, until the named option slot is found.
+function findAssignedSlot(el: Element | null): HTMLSlotElement | null {
+  let current: Element | null = el;
+  while (current) {
+    const slot = (current as HTMLElement).assignedSlot;
+    if (!slot) {
+      current = current.parentElement;
+      continue;
+    }
+    if (slot.getAttribute("name")?.startsWith("option-")) {
+      return slot;
+    }
+    const root = slot.getRootNode();
+    current = root instanceof ShadowRoot ? (root.host as Element) : null;
+  }
+  return null;
+}
+
 describe("Dropdown", () => {
   const noop = () => {
     // noop
@@ -87,6 +109,80 @@ describe("Dropdown", () => {
         expect(detail.name).toEqual("favcolor");
         expect(detail.value).toEqual("red");
         expect(detail.event).toBeInstanceOf(Event);
+      });
+    });
+
+    describe("item slots", () => {
+      it("renders rich item content inside the menu and selects it", async () => {
+        const handleChange = vi.fn();
+
+        const Component = () => {
+          return (
+            <GoabDropdown name="rich" testId="dropdown" onChange={handleChange}>
+              <GoabDropdownItem value="red" label="Red">
+                <div data-testid="rich-red">
+                  <strong>Red</strong>
+                  <span>Warm color</span>
+                </div>
+              </GoabDropdownItem>
+              <GoabDropdownItem value="blue" label="Blue" />
+            </GoabDropdown>
+          );
+        };
+
+        const result = render(<Component />);
+        const dropdown = result.getByTestId("dropdown");
+        await dropdown.click();
+
+        const richContent = result.getByTestId("rich-red");
+        await vi.waitFor(() => {
+          const slot = findAssignedSlot(richContent.element());
+          expect(slot).not.toBeNull();
+          expect(slot?.getAttribute("name")).toBe("option-red");
+          expect(slot?.closest("li")).not.toBeNull();
+          expect(richContent.element().textContent).toContain("Warm color");
+        });
+
+        const menuItem = result.getByTestId("dropdown-item-red");
+        await menuItem.click();
+
+        await vi.waitFor(() => {
+          expect(handleChange).toHaveBeenCalledTimes(1);
+          const detail = handleChange.mock.calls[0][0];
+          expect(detail.value).toEqual("red");
+          const inputField = result.getByRole("combobox").element() as HTMLInputElement;
+          expect(inputField.value).toBe("Red");
+        });
+      });
+
+      it("renders rich item content when nested inside another element (e.g. an Angular-style wrapper)", async () => {
+        // Reproduces the framework-wrapper case where the actual dropdown item
+        // custom element is not a direct child of the dropdown, but is nested
+        // one level deeper (as Angular's goab-dropdown-item does). Slot
+        // assignment must walk up to the correct direct-child ancestor.
+        const Component = () => {
+          return (
+            <GoabDropdown name="nested" testId="dropdown" onChange={noop}>
+              <div>
+                <GoabDropdownItem value="red" label="Red">
+                  <div data-testid="rich-red">Rich Red</div>
+                </GoabDropdownItem>
+              </div>
+            </GoabDropdown>
+          );
+        };
+
+        const result = render(<Component />);
+        const dropdown = result.getByTestId("dropdown");
+        await dropdown.click();
+
+        const richContent = result.getByTestId("rich-red");
+        await vi.waitFor(() => {
+          const slot = findAssignedSlot(richContent.element());
+          expect(slot).not.toBeNull();
+          expect(slot?.getAttribute("name")).toBe("option-red");
+          expect(slot?.closest("li")).not.toBeNull();
+        });
       });
     });
 

--- a/libs/react-components/src/lib/dropdown/dropdown-item.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown-item.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { ReactNode, useEffect } from "react";
 import { GoabDropdownItemMountType } from "@abgov/ui-components-common";
 
 interface WCProps {
@@ -25,12 +25,14 @@ export interface GoabDropdownItemProps {
   value: string;
   /** Display label for the dropdown item. */
   label?: string;
-  /** Text used to filter and match this item in typeahead search. */
+  /** Additional text used to match this item in typeahead search, alongside the label. Defaults to the children's text. */
   filter?: string;
   /** Sets a data-testid attribute for automated testing. */
   testId?: string;
   /** Controls how the item is registered with the parent dropdown. */
   mountType?: GoabDropdownItemMountType;
+  /** Rich content rendered for this item in the dropdown menu. When set, `label` is shown in the dropdown input on selection and `filter` defaults to the content's text. */
+  children?: ReactNode;
   /** @deprecated */
   name?: string;
 }
@@ -51,6 +53,7 @@ export function GoabDropdownItem({
   filter,
   name,
   mountType = "append",
+  children,
 }: GoabDropdownItemProps) {
   return (
     <goa-dropdown-item
@@ -59,6 +62,8 @@ export function GoabDropdownItem({
       filter={filter}
       name={name}
       mount={mountType}
-    />
+    >
+      {children}
+    </goa-dropdown-item>
   );
 }

--- a/libs/react-components/src/lib/dropdown/dropdown-item.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown-item.tsx
@@ -25,7 +25,7 @@ export interface GoabDropdownItemProps {
   value: string;
   /** Display label for the dropdown item. */
   label?: string;
-  /** Additional text used to match this item in typeahead search, alongside the label. Defaults to the children's text. */
+  /** Rich item content. On selection, `label` is shown and `filter` defaults to the content's text. */
   filter?: string;
   /** Sets a data-testid attribute for automated testing. */
   testId?: string;

--- a/libs/react-components/src/lib/dropdown/dropdown.spec.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown.spec.tsx
@@ -158,4 +158,22 @@ describe("GoabDropdown", () => {
     const el = baseElement.querySelector("goa-dropdown");
     expect(el?.getAttribute("data-grid")).toBe("cell");
   });
+
+  it("should render children inside the dropdown item", () => {
+    const { baseElement } = render(
+      <GoabDropdown name="favColor" onChange={noop}>
+        <GoabDropdownItem value="red" label="Red">
+          <div data-testid="rich-red">
+            <strong>Red</strong>
+            <span>Warm color</span>
+          </div>
+        </GoabDropdownItem>
+      </GoabDropdown>,
+    );
+
+    const item = baseElement.querySelector("goa-dropdown-item");
+    const content = item?.querySelector("[data-testid=rich-red]");
+    expect(content?.textContent).toContain("Red");
+    expect(content?.textContent).toContain("Warm color");
+  });
 });

--- a/libs/web-components/src/components/dropdown/Dropdown.spec.ts
+++ b/libs/web-components/src/components/dropdown/Dropdown.spec.ts
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
 import GoADropdown from "./Dropdown.svelte";
 import GoADropdownWrapper from "./DropdownWrapper.test.svelte";
+import GoADropdownSlotWrapper from "./DropdownSlotWrapper.test.svelte";
 import { describe, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import type { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
@@ -413,6 +414,47 @@ describe("GoADropdown", () => {
             expect(liElements.length).toBe(1);
 
             if (expectedOption === "null") {
+              expect(liElements[0].getAttribute("data-testid")).toBe(
+                "dropdown-item-not-found",
+              );
+            } else {
+              expect(liElements[0].getAttribute("data-value")).toBe(
+                expectedOption,
+              );
+            }
+          });
+        },
+      );
+
+      it.each`
+        query        | expectedOption | because
+        ${"alber"}   | ${"Alberta"}   | ${"an item without a label is matched by its value"}
+        ${"wild"}    | ${"ca-on"}     | ${"the filter property is matched"}
+        ${"ontar"}   | ${"ca-on"}     | ${"the label is matched alongside the filter property"}
+        ${"ca-"}     | ${null}        | ${"the value is not matched once a label is set"}
+        ${"zzz"}     | ${null}        | ${"unrelated text matches nothing"}
+      `(
+        `search for $query matches $expectedOption: $because`,
+        async ({ query, expectedOption }) => {
+          const result = render(GoADropdownSlotWrapper, {
+            name,
+            filterable: "true",
+            items: [
+              { value: "Alberta" },
+              { value: "ca-on", label: "Ontario", filter: "wild rose" },
+            ],
+          });
+
+          const input = result.getByTestId("input") as HTMLInputElement;
+          await fireEvent.focus(input);
+          await fireEvent.keyUp(input, { key: query[0] });
+          await fireEvent.input(input, { target: { value: query } });
+
+          await waitFor(() => {
+            const liElements = result.container.querySelectorAll("li");
+            expect(liElements.length).toBe(1);
+
+            if (expectedOption === null) {
               expect(liElements[0].getAttribute("data-testid")).toBe(
                 "dropdown-item-not-found",
               );
@@ -1310,6 +1352,146 @@ describe("GoADropdown", () => {
         const dropdown = result.container.querySelector(".dropdown");
         expect(dropdown?.getAttribute("style")).toContain("--width: 300px");
         expect(dropdown?.getAttribute("style")).not.toContain("--width: 500px");
+      });
+    });
+  });
+
+  describe("item slots", () => {
+    it("should render a named slot in the menu for items with slotted content", async () => {
+      const result = render(GoADropdownSlotWrapper, {
+        name,
+        items: [
+          { value: "apple", label: "Apple", text: "Apple", meta: "In stock" },
+          { value: "plain", label: "Plain" },
+        ],
+      });
+
+      await waitFor(() => {
+        expect(result.container.querySelectorAll("li").length).toBe(2);
+      });
+
+      const richOption = result.getByTestId("dropdown-item-apple");
+      const plainOption = result.getByTestId("dropdown-item-plain");
+      expect(
+        richOption.querySelector("slot[name='option-apple']"),
+      ).not.toBeNull();
+      expect(richOption).toHaveTextContent("");
+      expect(plainOption.querySelector("slot")).toBeNull();
+      expect(plainOption).toHaveTextContent("Plain");
+    });
+
+    it("should filter items by the text of their slotted content", async () => {
+      const result = render(GoADropdownSlotWrapper, {
+        name,
+        filterable: "true",
+        items: [
+          { value: "apple", label: "Apple", text: "Apple", meta: "Fruit" },
+          { value: "banana", label: "Banana", text: "Banana", meta: "Fruit" },
+        ],
+      });
+
+      const input = result.getByTestId("input") as HTMLInputElement;
+      await fireEvent.focus(input);
+      await fireEvent.keyUp(input, { key: "b" });
+      await fireEvent.input(input, { target: { value: "ban" } });
+
+      await waitFor(() => {
+        const liElements = result.container.querySelectorAll("li");
+        expect(liElements.length).toBe(1);
+        expect(liElements[0].getAttribute("data-value")).toBe("banana");
+      });
+    });
+
+    it("should keep text in adjacent slotted elements word-separated when filtering", async () => {
+      const result = render(GoADropdownSlotWrapper, {
+        name,
+        filterable: "true",
+        items: [
+          { value: "apple", label: "Apple", text: "Apple", meta: "Orchard" },
+          { value: "banana", label: "Banana", text: "Banana", meta: "Tropics" },
+        ],
+      });
+
+      const input = result.getByTestId("input") as HTMLInputElement;
+      await fireEvent.focus(input);
+      await fireEvent.keyUp(input, { key: "t" });
+      await fireEvent.input(input, { target: { value: "trop" } });
+
+      await waitFor(() => {
+        const liElements = result.container.querySelectorAll("li");
+        expect(liElements.length).toBe(1);
+        expect(liElements[0].getAttribute("data-value")).toBe("banana");
+      });
+    });
+
+    it("should filter by the filter property over the slotted content text", async () => {
+      const result = render(GoADropdownSlotWrapper, {
+        name,
+        filterable: "true",
+        items: [
+          { value: "apple", label: "Apple", filter: "alpha", text: "Orchard" },
+        ],
+      });
+
+      const input = result.getByTestId("input") as HTMLInputElement;
+      await fireEvent.focus(input);
+      await fireEvent.keyUp(input, { key: "o" });
+      await fireEvent.input(input, { target: { value: "orch" } });
+
+      const notFoundOption = result.getByTestId("dropdown-item-not-found");
+      await waitFor(() => {
+        expect(notFoundOption).toHaveTextContent("No matches found");
+      });
+
+      await fireEvent.keyUp(input, { key: "a" });
+      await fireEvent.input(input, { target: { value: "alp" } });
+
+      await waitFor(() => {
+        const liElements = result.container.querySelectorAll("li");
+        expect(liElements.length).toBe(1);
+        expect(liElements[0].getAttribute("data-value")).toBe("apple");
+      });
+    });
+
+    it("should filter by the label of an item that sets the filter property", async () => {
+      const result = render(GoADropdownSlotWrapper, {
+        name,
+        filterable: "true",
+        items: [
+          { value: "apple", label: "Apple", filter: "alpha", text: "Orchard" },
+        ],
+      });
+
+      const input = result.getByTestId("input") as HTMLInputElement;
+      await fireEvent.focus(input);
+      await fireEvent.keyUp(input, { key: "a" });
+      await fireEvent.input(input, { target: { value: "app" } });
+
+      await waitFor(() => {
+        const liElements = result.container.querySelectorAll("li");
+        expect(liElements.length).toBe(1);
+        expect(liElements[0].getAttribute("data-value")).toBe("apple");
+      });
+    });
+
+    it("should show the label in the input when a slotted item is selected", async () => {
+      const result = render(GoADropdownSlotWrapper, {
+        name,
+        items: [
+          { value: "apple", label: "Apple", text: "Apple", meta: "In stock" },
+        ],
+      });
+
+      await waitFor(() => {
+        expect(result.container.querySelectorAll("li").length).toBe(1);
+      });
+
+      const input = result.getByTestId("input") as HTMLInputElement;
+      const option = result.getByTestId("dropdown-item-apple");
+      await fireEvent.click(option);
+
+      await waitFor(() => {
+        expect(input.value).toBe("Apple");
       });
     });
   });

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -306,6 +306,10 @@
     // send message back to child that contains a reference to this component
     relay(detail.el, "dropdown:bind", { el: _rootEl });
 
+    if (detail.hasSlotContent) {
+      assignOptionSlot(detail);
+    }
+
     // ensure bind only runs once for all children
     if (_bindTimeoutId) {
       clearTimeout(_bindTimeoutId);
@@ -320,6 +324,27 @@
         }
       }
     }, 1);
+  }
+
+  /**
+   * Assign the slot after mount. For wrapped items, apply the slot attribute
+   * to the wrapper element directly inside the dropdown.
+   * @param detail
+   */
+  function assignOptionSlot(detail: DropdownItemMountedRelayDetail) {
+    const dropdownRoot = _rootEl.getRootNode();
+    const itemRoot = detail.el.getRootNode();
+    if (!(dropdownRoot instanceof ShadowRoot) || !(itemRoot instanceof ShadowRoot)) {
+      return;
+    }
+
+    const dropdownHost = dropdownRoot.host;
+    let slotTarget: Element | null = itemRoot.host as Element;
+    while (slotTarget && slotTarget.parentElement !== dropdownHost) {
+      slotTarget = slotTarget.parentElement;
+    }
+
+    slotTarget?.setAttribute("slot", `option-${detail.value}`);
   }
 
   /**
@@ -353,7 +378,12 @@
     // set width to longest item
     const optionsWidth = Math.max(
       ...options.map((option: Option) => {
-        const label = `${option.label}` || `${option.value}` || "";
+        // slotted items fall back to their filter text, which carries the slot's text content
+        const label =
+          option.label ||
+          (option.hasSlotContent ? option.filter : "") ||
+          option.value ||
+          "";
         return label.length;
       }),
     );
@@ -471,19 +501,27 @@
     }
   }
 
+  // Match against the filter text and the text the user sees, which is the
+  // label, or the value when no label is set. Both are searched so that adding
+  // a filter supplies extra search terms rather than replacing the visible text.
   function isFilterMatch(option: Option, filter: string, partialMatch = true) {
     // empty string matches all
     if (filter.length === 0) return true;
 
-    let value = option.filter || option.label || option.value;
-    value = value.toLowerCase();
+    const targets = [option.filter, option.label || option.value].filter(
+      (target) => target !== "",
+    );
     filter = filter.toLowerCase().trim();
 
-    if (!partialMatch) {
-      return value === filter;
-    }
+    return targets.some((target) => {
+      const value = target.toLowerCase();
 
-    return value.startsWith(filter) || value.includes(" " + filter);
+      if (!partialMatch) {
+        return value === filter;
+      }
+
+      return value.startsWith(filter) || value.includes(" " + filter);
+    });
   }
 
   // update the value show to the user in the <input> element
@@ -940,7 +978,11 @@
               _inputEl?.focus();
             }}
           >
-            {option.label || option.value}
+            {#if option.hasSlotContent}
+              <svelte:element this={"slot"} name={`option-${option.value}`} />
+            {:else}
+              {option.label || option.value}
+            {/if}
           </li>
         {:else}
           {#if _filterable}

--- a/libs/web-components/src/components/dropdown/DropdownItem.svelte
+++ b/libs/web-components/src/components/dropdown/DropdownItem.svelte
@@ -11,6 +11,7 @@
     filter: string;
     value: string;
     label: string;
+    hasSlotContent: boolean;
     mountType: DropdownItemMountType;
   }
   export type DropdownItemDestroyRelayDetail = {
@@ -23,6 +24,7 @@
     label: string;
     value: string;
     filter: string;
+    hasSlotContent: boolean;
     mountType: DropdownItemMountType;
   };
 </script>
@@ -33,7 +35,7 @@
 
   // Props
 
-  /** Text used to filter and match this item in typeahead search. */
+  /** Additional text used to match this item in typeahead search, alongside the label. Defaults to the slotted content's text. */
   export let filter: string = "";
   /** Display label for the dropdown item. */
   export let label: string = "";
@@ -48,13 +50,57 @@
   onMount(() => {
     addMessageListener();
 
+    const slotText = getSlotText();
+    const hasSlotContent = slotText !== "" || hasSlottedElements();
+
     relay<DropdownItemMountedRelayDetail>(
       _rootEl,
       DropdownItemMountedMsg,
-      { el: _rootEl, filter, value, label, mountType: mount },
+      {
+        el: _rootEl,
+        filter: filter || (hasSlotContent ? slotText : ""),
+        value,
+        label,
+        hasSlotContent,
+        mountType: mount,
+      },
       { bubbles: true, timeout: 10 },
       );
   });
+
+  // Use the slotted content's text as the default filter value. Separate text
+  // nodes with spaces so words in adjacent elements do not run together.
+  function getSlotText(): string {
+    const parts: string[] = [];
+    const collectText = (node: Node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const text = (node.textContent ?? "").trim();
+        if (text !== "") {
+          parts.push(text);
+        }
+        return;
+      }
+      node.childNodes.forEach(collectText);
+    };
+    getSlottedNodes().forEach(collectText);
+    return parts.join(" ").replace(/\s+/g, " ");
+  }
+
+  function hasSlottedElements(): boolean {
+    return getSlottedNodes().some(
+      (node) => node.nodeType === Node.ELEMENT_NODE,
+    );
+  }
+
+  function getSlottedNodes(): Node[] {
+    const slotEl = _rootEl.querySelector("slot");
+    if (slotEl) {
+      return slotEl.assignedNodes({ flatten: true });
+    }
+    // for unit tests only: without a shadow DOM slotted content is rendered
+    // directly within the root element
+    return Array.from(_rootEl.childNodes);
+  }
 
   function addMessageListener() {
     receive(_rootEl, (action, data) => {
@@ -76,4 +122,6 @@
   });
 </script>
 
-<span bind:this={_rootEl} />
+<span bind:this={_rootEl}>
+  <slot />
+</span>

--- a/libs/web-components/src/components/dropdown/DropdownSlotWrapper.test.svelte
+++ b/libs/web-components/src/components/dropdown/DropdownSlotWrapper.test.svelte
@@ -1,0 +1,40 @@
+<svelte:options customElement="test-dropdown-slot-wrapper" />
+
+<!-- Script -->
+<script lang="ts">
+  import GoADropdown from "./Dropdown.svelte";
+  import GoADropdownItem from "./DropdownItem.svelte";
+
+  type Item = {
+    value: string;
+    label?: string;
+    filter?: string;
+    text?: string;
+    meta?: string;
+  };
+
+  export let name: string = "";
+  export let value: string = "";
+  export let filterable: string = "false";
+  export let items: Item[] = [];
+
+  function onChange(e: Event) {
+    value = (e as CustomEvent).detail.value;
+  }
+</script>
+
+<!-- HTML -->
+<GoADropdown {name} {value} {filterable} on:_change={onChange}>
+  {#each items as item (item.value)}
+    <GoADropdownItem
+      value={item.value}
+      label={item.label ?? ""}
+      filter={item.filter ?? ""}
+    >
+      {#if item.text || item.meta}
+        <!-- prettier-ignore: elements are kept adjacent (no whitespace) to match framework-rendered markup -->
+        <div data-testid={`rich-content-${item.value}`}><strong>{item.text}</strong>{#if item.meta}<span>{item.meta}</span>{/if}</div>
+      {/if}
+    </GoADropdownItem>
+  {/each}
+</GoADropdown>


### PR DESCRIPTION
## Summary
- Adds a slot to goa-dropdown-item so items can contain arbitrary HTML (multi line text, icons, badges) that renders inside the dropdown menu. Implemented with dynamic named slots: each rich item is assigned to an option-{value} slot rendered inside its menu li, so consumer markup (and framework bindings) stay in the light DOM.
- Works with the filterable property (combobox). All text in the slotted content is filterable by default, built from individual text nodes so words in adjacent elements stay separated. The filter property replaces the slot text when provided.
- The label property is shown in the dropdown input when a slotted item is selected. Label only items keep the existing text rendering path.
- React wrapper (GoabDropdownItem) now accepts children; Angular wrapper projects content via ng-content.
- Slot assignment happens on the parent side after the mount relay is received. An element assigned to a slot name that does not exist yet has no slot in its event path, so its relayed messages would never reach the dropdown.
- Slot assignment walks up from the goa-dropdown-item to the ancestor that is a direct child of goa-dropdown before setting the slot attribute. Framework wrappers like Angular's goab-dropdown-item nest the custom element one level deeper, and slot assignment only honors direct children of the shadow host. Verified in the Angular playground.

## Filter matching change
Raised in review. `isFilterMatch` used to take the first non-empty of `filter`, `label`, `value`, so supplying `filter` stopped the label from being searched at all. It now matches against the filter text **and** the visible text (the label, or the value when no label is set).

| Item | Before | After |
| --- | --- | --- |
| `value` only | matches value | matches value (unchanged) |
| `value` + `label` | matches label | matches label (unchanged) |
| `value` + `label` + `filter` | filter only | filter and label |

This is additive rather than breaking. `value` stays searchable because `label` is optional and the value is the visible text when no label is set (items like `<GoabDropdownItem value="Airdrie" />`, including the existing filterable example on the docs page). The one behavior change: an item using `filter` to deliberately narrow matching will now also match its label.

## Documentation
- Two examples on the Dropdown base component page (acceptance criteria item 3): "Rich item content" and "Filterable rich item content", each covering React, Angular (reactive forms and ngModel) and web components.
- Guidance: native ignores slotted content and falls back to the label.
- Guidance: a filterable dropdown searches the label and the content text, but not text inside a nested component's shadow DOM (a Badge for example); `filter` adds those terms.
- Guidance: don't put interactive elements in item content. Each item is a `role="option"` inside a `role="listbox"`, the menu preventDefaults `mousedown`, and the li click handler selects the item and returns focus to the input, so a nested button or link is unreachable by keyboard and its own click never fires. The issue originally asked for "icon + tooltip to indicate status", which is not achievable accessibly since `goa-tooltip` renders with `tabindex="0"`; that line of the acceptance criteria has been updated to "icon or badge", and the examples use a Badge for status.

## Known limitations
- Text rendered inside a nested component's own shadow DOM (for example GoabBadge content) is not part of the slot text and is not filterable. The filter property is the escape hatch for adding extra search terms.
- Native mode (native="true") ignores slotted content and falls back to the label, since a native select cannot contain HTML.
- Slot content is read once when the item mounts, matching existing item behavior.
- The `children` prop does not appear in the generated API table. `extract-api` only collects named slots, and a pure slot carrier prop is filed under a `default` slot that never renders, so `DropdownItem`'s bare `<slot />` falls into that gap. This is repo wide (Button, Badge, Callout and Text all report `slots: []`), so it is not addressed here. Tracked in #4136.

## Pre-existing issue surfaced by the docs example
The menu auto-width comes from `getLongestChildWidth`, which measures `option.label || (option.hasSlotContent ? option.filter : "") || option.value` in `ch`. A slotted item effectively always has a label (it is what shows in the input on selection), so `option.label ||` short-circuits and the slot text branch never runs. The menu is sized to the label and wider content clips: measured li clientWidth 185px against scrollWidth 201px, with `ul` set to `overflow-x: auto`, so it clips rather than wrapping. That also conflicts with the existing "don't truncate labels" guidance.

Not fixed here. There is no good text length proxy for multi line content: the label is too narrow, the joined slot text is too wide (longest line 22 characters, joined text 36), and `filter` is worse. A real fix means measuring rendered width after slot distribution, which wants its own issue and browser tests. Setting `width` on the dropdown works around it today (verified). Tracked in #4135.

## Test plan
- [x] 63 web component unit tests pass, including 6 new filter matching cases covering value only items, the filter property, the label alongside the filter property, and slot text replaced by an explicit filter
- [x] React wrapper tests pass, including a children passthrough test
- [x] 277 Angular tests pass, including an ng-content projection test
- [x] 42 React browser tests pass across Chromium and Firefox, including 2 that verify real shadow DOM slot distribution: rich content renders inside the menu li and selection works, plus a regression test for items nested inside a wrapper element (the Angular case)
- [x] The two new filter matching cases that assert the new behavior fail against the previous implementation, and the cases covering existing behavior pass against both, confirming the change is additive
- [x] Both new documentation examples verified rendering in the docs site: rich content renders in the open menu with name, role, location and status badge
- [x] Verified in both playgrounds (React features/1351 and Angular features/1351): rich items render in the open menu; selection fires the change event and shows the label in the input; typing slot only text (for example "calg", "super") filters correctly; keyboard navigation and aria-activedescendant work on rich items; native mode (Test 4) shows plain labels in the select and leaks no rich content into the page

## Steps needed to test
1. npm run build, then npm run serve:prs:react (or npm run serve:prs:angular)
2. Open Features > 1351 Dropdown item slot in the side menu
3. Test 1: open the base dropdown, confirm multi line items with badges render, select one and confirm the label appears in the input
4. Test 2: type a name, role, or location in the combobox and confirm filtering matches slot text
5. Test 3: confirm plain items work alongside rich items, and that the filter property replaces the slot text while the label stays searchable ("preferred" matches, "Sarah" matches, "Edmonton" does not)
6. Test 4: confirm the native select shows plain labels for rich items, selection works, and no rich content leaks into the page
7. Docs: npm run dev in docs/, open Components > Dropdown and check the "Rich item content" and "Filterable rich item content" configurations

Fixes #1351

Once this passes code review, notify @twjeffery so the Figma assets can be prepared for release (acceptance criteria item 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
