### PR TITLE
fix(#3860): App Header menu aligns right when squeezed against the screen edge

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3860/bug3860.component.html
+++ b/apps/prs/angular/src/routes/bugs/3860/bug3860.component.html
@@ -1,0 +1,235 @@
+<div>
+  <goab-text tag="h1" mt="m" mb="m">
+    Bug #3860: App Header Menu aligned to the left instead of the right
+  </goab-text>
+
+  <goab-block gap="m" direction="column">
+    <goab-link trailingIcon="open">
+      <a
+        href="https://github.com/GovAlta/ui-components/issues/3860"
+        target="_blank"
+        rel="noopener"
+      >
+        View on GitHub
+      </a>
+    </goab-link>
+
+    <goab-details heading="Issue description">
+      <goab-text tag="p" mb="s">
+        When the App Header collapses to mobile size, overflowing navigation is collected
+        into a "More" menu (an AppHeaderMenu). Its popover anchors to the LEFT of the
+        button, so when the button sits near the right edge of the screen the menu is
+        squeezed into the remaining right-hand space and appears too narrow.
+      </goab-text>
+      <goab-text tag="p" mb="none">
+        Acceptance criteria: (1) the popover created by AppHeaderMenu can align to the
+        RIGHT of the button so it uses its full width; (2) right alignment only happens
+        when there isn't room to align left.
+      </goab-text>
+    </goab-details>
+  </goab-block>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <goab-text tag="h2" mb="s">The fix</goab-text>
+  <goab-text tag="p" mb="m">
+    The Popover's automatic right-align compared the space on the trigger's right against
+    the popover's already-squeezed width, so a menu clipped by the screen edge never
+    flipped. It now compares against the width the popover would take with room (its max
+    width), so it right-aligns whenever a left-aligned menu would otherwise be squeezed.
+  </goab-text>
+
+  <goab-text tag="h2" mb="s">How to reproduce</goab-text>
+  <goab-text tag="p" mb="xs">
+    Narrow the browser (around 700px, or use responsive/device mode) until several nav
+    items collapse into a <b>More</b> button near the right edge. Open it and watch where
+    the dropdown anchors.
+  </goab-text>
+  <ul style="margin-top: 0">
+    <li>
+      <goab-text tag="span">
+        <b>Fixed (expected):</b> the menu right-aligns to the button and stays fully on
+        screen.
+      </goab-text>
+    </li>
+    <li>
+      <goab-text tag="span">
+        <b>Bug:</b> the menu left-aligns and is squeezed or clipped at the right edge.
+      </goab-text>
+    </li>
+  </ul>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <goab-text tag="h3" mb="s"
+    >Scenario: V2 App Header with overflowing navigation</goab-text
+  >
+  <goab-text tag="p" mb="m">
+    Seven navigation items plus an "Account" menu. At desktop width they sit inline; as
+    the window narrows they overflow into the "More" menu on the right.
+  </goab-text>
+
+  <goab-app-header heading="Service Portal" url="/">
+    <a slot="navigation" href="#">Dashboard</a>
+    <a slot="navigation" href="#">Applications</a>
+    <a slot="navigation" href="#">Reports</a>
+    <a slot="navigation" href="#">Notifications</a>
+    <a slot="navigation" href="#">Billing</a>
+    <a slot="navigation" href="#">Support</a>
+    <goab-app-header-menu slotName="navigation" heading="Account">
+      <a href="#">Profile</a>
+      <a href="#">Organization settings</a>
+      <a href="#">Sign out</a>
+    </goab-app-header-menu>
+  </goab-app-header>
+
+  <goab-divider mt="l" mb="l"></goab-divider>
+
+  <goab-text tag="h3" mb="s"
+    >Scenario: other Popover consumers, with room and against the edge</goab-text
+  >
+  <goab-text tag="p" mb="m">
+    The change lives in the shared Popover, which MenuButton, DatePicker, and Dropdown
+    also use. Each row starts with room on the right, so you can see the normal alignment
+    first. Drag the dashed spacer's corner (or narrow the window) to push a component
+    toward the screen edge and open it again to see its popover flip. Shrink the spacer to
+    get the normal alignment back.
+  </goab-text>
+
+  <goab-text tag="h4" mb="xs">MenuButton</goab-text>
+  <goab-text tag="p" mb="xs">
+    With room: the menu opens at the button's left edge. Against the edge: it opens
+    leftward (right-aligned to the button) at its full width.
+  </goab-text>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem">
+    <div
+      style="
+        resize: horizontal;
+        overflow: auto;
+        width: 320px;
+        min-width: 48px;
+        max-width: 75vw;
+        flex-shrink: 0;
+        border: 1px dashed #999;
+        border-radius: 4px;
+        padding: 0.5rem;
+        color: #666;
+        white-space: nowrap;
+        font-size: 0.875rem;
+      "
+    >
+      spacer: drag my corner to push →
+    </div>
+    <div style="flex-shrink: 0">
+      <goab-menu-button text="More">
+        <goab-menu-action
+          text="Organization settings and preferences"
+          action="a1"
+        ></goab-menu-action>
+        <goab-menu-action text="Notification preferences" action="a2"></goab-menu-action>
+        <goab-menu-action text="Sign out" action="a3"></goab-menu-action>
+      </goab-menu-button>
+    </div>
+  </div>
+
+  <goab-text tag="h4" mb="xs">DatePicker</goab-text>
+  <goab-text tag="p" mb="xs">
+    With room: the calendar opens at the input's left edge. Against the edge: it opens
+    leftward at its full width.
+  </goab-text>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem">
+    <div
+      style="
+        resize: horizontal;
+        overflow: auto;
+        width: 320px;
+        min-width: 48px;
+        max-width: 75vw;
+        flex-shrink: 0;
+        border: 1px dashed #999;
+        border-radius: 4px;
+        padding: 0.5rem;
+        color: #666;
+        white-space: nowrap;
+        font-size: 0.875rem;
+      "
+    >
+      spacer: drag my corner to push →
+    </div>
+    <div style="flex-shrink: 0">
+      <goab-date-picker name="edge-date"></goab-date-picker>
+    </div>
+  </div>
+
+  <goab-text tag="h4" mb="xs">Dropdown</goab-text>
+  <goab-text tag="p" mb="xs">
+    Either way: the option list matches the input's width and stays anchored to it (a
+    fixed-width list is never squeezed).
+  </goab-text>
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem">
+    <div
+      style="
+        resize: horizontal;
+        overflow: auto;
+        width: 320px;
+        min-width: 48px;
+        max-width: 75vw;
+        flex-shrink: 0;
+        border: 1px dashed #999;
+        border-radius: 4px;
+        padding: 0.5rem;
+        color: #666;
+        white-space: nowrap;
+        font-size: 0.875rem;
+      "
+    >
+      spacer: drag my corner to push →
+    </div>
+    <div style="flex-shrink: 0">
+      <goab-dropdown name="edge-color" width="200px">
+        <goab-dropdown-item label="Red" value="red"></goab-dropdown-item>
+        <goab-dropdown-item label="Blue" value="blue"></goab-dropdown-item>
+        <goab-dropdown-item label="Green" value="green"></goab-dropdown-item>
+      </goab-dropdown>
+    </div>
+  </div>
+
+  <goab-text tag="h4" mb="xs">Popover</goab-text>
+  <goab-text tag="p" mb="xs">
+    With room: the popover stays left-aligned. Against the edge: it opens leftward at its
+    full width.
+  </goab-text>
+  <div style="display: flex; align-items: center; gap: 0.75rem">
+    <div
+      style="
+        resize: horizontal;
+        overflow: auto;
+        width: 320px;
+        min-width: 48px;
+        max-width: 75vw;
+        flex-shrink: 0;
+        border: 1px dashed #999;
+        border-radius: 4px;
+        padding: 0.5rem;
+        color: #666;
+        white-space: nowrap;
+        font-size: 0.875rem;
+      "
+    >
+      spacer: drag my corner to push →
+    </div>
+    <div style="flex-shrink: 0">
+      <goab-popover [target]="popoverTarget">
+        <p style="width: 260px; margin: 0">
+          This popover keeps its full width by opening toward the available space.
+        </p>
+      </goab-popover>
+    </div>
+  </div>
+  <ng-template #popoverTarget>
+    <goab-button type="secondary">Open popover</goab-button>
+  </ng-template>
+
+  <!-- Room for the dropdown to open into view -->
+  <div style="height: 24rem"></div>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3860/bug3860.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3860/bug3860.component.ts
@@ -1,0 +1,40 @@
+import { Component } from "@angular/core";
+import {
+  GoabAppHeader,
+  GoabAppHeaderMenu,
+  GoabBlock,
+  GoabButton,
+  GoabDatePicker,
+  GoabDetails,
+  GoabDivider,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabLink,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabPopover,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3860",
+  templateUrl: "./bug3860.component.html",
+  imports: [
+    GoabAppHeader,
+    GoabAppHeaderMenu,
+    GoabBlock,
+    GoabButton,
+    GoabDatePicker,
+    GoabDetails,
+    GoabDivider,
+    GoabDropdown,
+    GoabDropdownItem,
+    GoabLink,
+    GoabMenuAction,
+    GoabMenuButton,
+    GoabPopover,
+    GoabText,
+  ],
+})
+export class Bug3860Component {}

--- a/apps/prs/angular/src/routes/bugs/3860/bug3860.route.json
+++ b/apps/prs/angular/src/routes/bugs/3860/bug3860.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3860",
+  "path": "bugs/3860",
+  "title": "App Header Menu right alignment"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3860.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3860.route.ts
@@ -1,0 +1,10 @@
+import { Bug3860Route } from "../../../routes/bugs/bug3860";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3860",
+  path: "bugs/3860",
+  title: "App Header Menu aligned left instead of right",
+  component: Bug3860Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3860.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3860.tsx
@@ -1,0 +1,126 @@
+import {
+  GoabAppHeader,
+  GoabAppHeaderMenu,
+  GoabBlock,
+  GoabDetails,
+  GoabDivider,
+  GoabLink,
+  GoabText,
+} from "@abgov/react-components";
+
+const ISSUE_NUMBER = "3860";
+const ISSUE_TITLE = "App Header Menu aligned to the left instead of the right";
+
+export function Bug3860Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m" mb="m">
+        Bug #{ISSUE_NUMBER}: {ISSUE_TITLE}
+      </GoabText>
+
+      <GoabBlock gap="m" direction="column">
+        <GoabLink trailingIcon="open">
+          <a
+            href={`https://github.com/GovAlta/ui-components/issues/${ISSUE_NUMBER}`}
+            target="_blank"
+            rel="noopener"
+          >
+            View on GitHub
+          </a>
+        </GoabLink>
+
+        <GoabDetails heading="Issue description">
+          <GoabText tag="p" mb="s">
+            When the App Header collapses to mobile size, overflowing navigation is
+            collected into a "More" menu (an AppHeaderMenu). Its popover anchors to the
+            LEFT of the button, so when the button sits near the right edge of the
+            screen the menu is squeezed into the remaining right-hand space and appears
+            too narrow.
+          </GoabText>
+          <GoabText tag="p" mb="none">
+            Acceptance criteria: (1) the popover created by AppHeaderMenu can align to
+            the RIGHT of the button so it uses its full width; (2) right alignment only
+            happens when there isn't room to align left.
+          </GoabText>
+        </GoabDetails>
+      </GoabBlock>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2" mb="s">
+        The fix
+      </GoabText>
+      <GoabText tag="p" mb="m">
+        The Popover's automatic right-align compared the space on the trigger's right
+        against the popover's already-squeezed width, so a menu clipped by the screen
+        edge never flipped. It now compares against the width the popover would take
+        with room (its max width), so it right-aligns whenever a left-aligned menu
+        would otherwise be squeezed.
+      </GoabText>
+
+      <GoabText tag="h2" mb="s">
+        How to reproduce
+      </GoabText>
+      <GoabText tag="p" mb="xs">
+        Narrow the browser (around 700px, or use responsive/device mode) until several
+        nav items collapse into a <b>More</b> button near the right edge. Open it and
+        watch where the dropdown anchors.
+      </GoabText>
+      <ul style={{ marginTop: 0 }}>
+        <li>
+          <GoabText tag="span">
+            <b>Fixed (expected):</b> the menu right-aligns to the button and stays fully
+            on screen.
+          </GoabText>
+        </li>
+        <li>
+          <GoabText tag="span">
+            <b>Bug:</b> the menu left-aligns and is squeezed or clipped at the right
+            edge.
+          </GoabText>
+        </li>
+      </ul>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h3" mb="s">
+        Scenario: V2 App Header with overflowing navigation
+      </GoabText>
+      <GoabText tag="p" mb="m">
+        Seven navigation items plus an "Account" menu. At desktop width they sit inline;
+        as the window narrows they overflow into the "More" menu on the right.
+      </GoabText>
+
+      <GoabAppHeader heading="Service Portal" url="/">
+        <a slot="navigation" href="#">
+          Dashboard
+        </a>
+        <a slot="navigation" href="#">
+          Applications
+        </a>
+        <a slot="navigation" href="#">
+          Reports
+        </a>
+        <a slot="navigation" href="#">
+          Notifications
+        </a>
+        <a slot="navigation" href="#">
+          Billing
+        </a>
+        <a slot="navigation" href="#">
+          Support
+        </a>
+        <GoabAppHeaderMenu slotName="navigation" heading="Account">
+          <a href="#">Profile</a>
+          <a href="#">Organization settings</a>
+          <a href="#">Sign out</a>
+        </GoabAppHeaderMenu>
+      </GoabAppHeader>
+
+      {/* Room for the dropdown to open into view */}
+      <div style={{ height: "24rem" }} />
+    </div>
+  );
+}
+
+export default Bug3860Route;

--- a/apps/prs/react/src/routes/bugs/bug3860.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3860.tsx
@@ -19,6 +19,9 @@ import type { ReactNode } from "react";
 const ISSUE_NUMBER = "3860";
 const ISSUE_TITLE = "App Header Menu aligned to the left instead of the right";
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
 // A draggable spacer sits before the component. Small spacer = room on the
 // right (normal alignment). Drag its corner wider (or narrow the window) to
 // push the component toward the screen edge and see its popover flip.
@@ -208,7 +211,7 @@ export function Bug3860Route() {
         it (a fixed-width list is never squeezed).
       </GoabText>
       <PushRow>
-        <GoabDropdown name="edge-color" width="200px" onChange={() => {}}>
+        <GoabDropdown name="edge-color" width="200px" onChange={noop}>
           <GoabDropdownItem label="Red" value="red" />
           <GoabDropdownItem label="Blue" value="blue" />
           <GoabDropdownItem label="Green" value="green" />

--- a/apps/prs/react/src/routes/bugs/bug3860.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3860.tsx
@@ -2,14 +2,58 @@ import {
   GoabAppHeader,
   GoabAppHeaderMenu,
   GoabBlock,
+  GoabButton,
+  GoabDatePicker,
   GoabDetails,
   GoabDivider,
+  GoabDropdown,
+  GoabDropdownItem,
   GoabLink,
+  GoabMenuAction,
+  GoabMenuButton,
+  GoabPopover,
   GoabText,
 } from "@abgov/react-components";
+import type { ReactNode } from "react";
 
 const ISSUE_NUMBER = "3860";
 const ISSUE_TITLE = "App Header Menu aligned to the left instead of the right";
+
+// A draggable spacer sits before the component. Small spacer = room on the
+// right (normal alignment). Drag its corner wider (or narrow the window) to
+// push the component toward the screen edge and see its popover flip.
+function PushRow({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "0.75rem",
+        marginBottom: "1.5rem",
+      }}
+    >
+      <div
+        style={{
+          resize: "horizontal",
+          overflow: "auto",
+          width: "320px",
+          minWidth: "48px",
+          maxWidth: "75vw",
+          flexShrink: 0,
+          border: "1px dashed #999",
+          borderRadius: "4px",
+          padding: "0.5rem",
+          color: "#666",
+          whiteSpace: "nowrap",
+          fontSize: "0.875rem",
+        }}
+      >
+        spacer: drag my corner to push →
+      </div>
+      <div style={{ flexShrink: 0 }}>{children}</div>
+    </div>
+  );
+}
 
 export function Bug3860Route() {
   return (
@@ -116,6 +160,75 @@ export function Bug3860Route() {
           <a href="#">Sign out</a>
         </GoabAppHeaderMenu>
       </GoabAppHeader>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h3" mb="s">
+        Scenario: other Popover consumers, with room and against the edge
+      </GoabText>
+      <GoabText tag="p" mb="m">
+        The change lives in the shared Popover, which MenuButton, DatePicker, and
+        Dropdown also use. Each row starts with room on the right, so you can see the
+        normal alignment first. Drag the dashed spacer's corner (or narrow the
+        window) to push a component toward the screen edge and open it again to see
+        its popover flip. Shrink the spacer to get the normal alignment back.
+      </GoabText>
+
+      <GoabText tag="h4" mb="xs">
+        MenuButton
+      </GoabText>
+      <GoabText tag="p" mb="xs">
+        With room: the menu opens at the button's left edge. Against the edge: it
+        opens leftward (right-aligned to the button) at its full width.
+      </GoabText>
+      <PushRow>
+        <GoabMenuButton text="More">
+          <GoabMenuAction text="Organization settings and preferences" action="a1" />
+          <GoabMenuAction text="Notification preferences" action="a2" />
+          <GoabMenuAction text="Sign out" action="a3" />
+        </GoabMenuButton>
+      </PushRow>
+
+      <GoabText tag="h4" mb="xs">
+        DatePicker
+      </GoabText>
+      <GoabText tag="p" mb="xs">
+        With room: the calendar opens at the input's left edge. Against the edge: it
+        opens leftward at its full width.
+      </GoabText>
+      <PushRow>
+        <GoabDatePicker name="edge-date" />
+      </PushRow>
+
+      <GoabText tag="h4" mb="xs">
+        Dropdown
+      </GoabText>
+      <GoabText tag="p" mb="xs">
+        Either way: the option list matches the input's width and stays anchored to
+        it (a fixed-width list is never squeezed).
+      </GoabText>
+      <PushRow>
+        <GoabDropdown name="edge-color" width="200px" onChange={() => {}}>
+          <GoabDropdownItem label="Red" value="red" />
+          <GoabDropdownItem label="Blue" value="blue" />
+          <GoabDropdownItem label="Green" value="green" />
+        </GoabDropdown>
+      </PushRow>
+
+      <GoabText tag="h4" mb="xs">
+        Popover
+      </GoabText>
+      <GoabText tag="p" mb="xs">
+        With room: the popover stays left-aligned. Against the edge: it opens
+        leftward at its full width.
+      </GoabText>
+      <PushRow>
+        <GoabPopover target={<GoabButton type="secondary">Open popover</GoabButton>}>
+          <p style={{ width: "260px", margin: 0 }}>
+            This popover keeps its full width by opening toward the available space.
+          </p>
+        </GoabPopover>
+      </PushRow>
 
       {/* Room for the dropdown to open into view */}
       <div style={{ height: "24rem" }} />

--- a/libs/react-components/specs/app-header-menu.browser.spec.tsx
+++ b/libs/react-components/specs/app-header-menu.browser.spec.tsx
@@ -70,4 +70,42 @@ describe("AppHeaderMenu", () => {
     });
     expect(result.getByTestId("menu-item-1").element().checkVisibility()).toBeTruthy();
   });
+
+  it("aligns the menu to the right of the trigger when it would be squeezed against the screen edge - issue 3860", async () => {
+    // Pin the menu near the right edge. Left-aligned, its popover would be clipped
+    // by the screen and forced narrow. It should instead open leftward, aligning
+    // its right edge to the trigger so it keeps its full width.
+    const Component = () => (
+      <div style={{ position: "absolute", top: 0, left: "1112px" }}>
+        <GoabAppHeaderMenu heading="Account" testId="account-menu">
+          <a href="#" data-testid="acct-item-1">
+            Organization settings and preferences
+          </a>
+          <a href="#" data-testid="acct-item-2">
+            Notification preferences
+          </a>
+          <a href="#" data-testid="acct-item-3">
+            Sign out
+          </a>
+        </GoabAppHeaderMenu>
+      </div>
+    );
+
+    const result = render(<Component />);
+    await result.getByText("Account").click();
+
+    const popoverContent = result.getByTestId("popover-content");
+    await vi.waitFor(() => {
+      expect(popoverContent.element().checkVisibility()).toBeTruthy();
+    });
+
+    const popoverTarget = result.getByTestId("popover-target");
+    await vi.waitFor(() => {
+      const content = popoverContent.element().getBoundingClientRect();
+      const target = popoverTarget.element().getBoundingClientRect();
+      // Right-aligned: the menu's right edge meets the trigger's right edge, so it
+      // opens leftward into the available space instead of clipping at the screen edge.
+      expect(Math.abs(content.right - target.right)).toBeLessThan(5);
+    });
+  });
 });

--- a/libs/react-components/specs/datepicker.browser.spec.tsx
+++ b/libs/react-components/specs/datepicker.browser.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from "vitest-browser-react";
 import { GoabDatePicker } from "../src";
-import { expect, describe, it, vi } from "vitest";
-import { userEvent } from "@vitest/browser/context";
+import { expect, describe, it, vi, beforeAll } from "vitest";
+import { page, userEvent } from "@vitest/browser/context";
 import { format } from "date-fns";
 
 function getTodayDate(): Date {
@@ -502,6 +502,67 @@ describe("Date Picker input type", () => {
       expect(monthInput).toBeDisabled();
       expect(datePickerDay).toBeDisabled();
       expect(datePickerYear).toBeDisabled();
+    });
+  });
+});
+
+describe("DatePicker calendar popover position", () => {
+  beforeAll(async () => {
+    await page.viewport(1280, 800);
+  });
+
+  it("opens the calendar left-aligned when there is room on the right", async () => {
+    const Component = () => (
+      <div style={{ position: "absolute", top: 0, left: "100px" }}>
+        <GoabDatePicker testId="date-picker" value="2026-03-01" />
+      </div>
+    );
+
+    const result = render(<Component />);
+    const input = result.getByTestId("calendar-input");
+    // The calendar contains month/year dropdowns with their own nested popovers,
+    // so take the first (outermost) popover parts: the calendar's own.
+    const popoverContent = result.getByTestId("popover-content").first();
+    const popoverTarget = result.getByTestId("popover-target").first();
+
+    await input.click();
+
+    await vi.waitFor(() => {
+      expect(popoverContent).toBeVisible();
+      const content = popoverContent.element().getBoundingClientRect();
+      const target = popoverTarget.element().getBoundingClientRect();
+      // Left-aligned: the calendar opens at the input's left edge
+      expect(Math.abs(content.left - target.left)).toBeLessThanOrEqual(2);
+    });
+  });
+
+  it("opens the calendar right-aligned at full width when squeezed against the screen edge - issue 3860", async () => {
+    // Pin the date picker near the right edge (fully on screen). Left-aligned, the
+    // calendar would be clipped by the screen and forced narrow. It should open
+    // leftward instead, aligning its right edge to its trigger to keep full width.
+    const Component = () => (
+      <div style={{ position: "absolute", top: 0, left: "1000px" }}>
+        <GoabDatePicker testId="date-picker" value="2026-03-01" />
+      </div>
+    );
+
+    const result = render(<Component />);
+    const input = result.getByTestId("calendar-input");
+    // The calendar contains month/year dropdowns with their own nested popovers,
+    // so take the first (outermost) popover parts: the calendar's own.
+    const popoverContent = result.getByTestId("popover-content").first();
+    const popoverTarget = result.getByTestId("popover-target").first();
+
+    await input.click();
+
+    await vi.waitFor(() => {
+      expect(popoverContent).toBeVisible();
+      const content = popoverContent.element().getBoundingClientRect();
+      const target = popoverTarget.element().getBoundingClientRect();
+      // Right-aligned: the calendar's right edge meets its trigger's right edge and
+      // the calendar stays fully on screen at its natural width.
+      expect(Math.abs(content.right - target.right)).toBeLessThanOrEqual(5);
+      expect(content.right).toBeLessThanOrEqual(window.innerWidth);
     });
   });
 });

--- a/libs/react-components/specs/datepicker.browser.spec.tsx
+++ b/libs/react-components/specs/datepicker.browser.spec.tsx
@@ -525,6 +525,11 @@ describe("DatePicker calendar popover position", () => {
     const popoverContent = result.getByTestId("popover-content").first();
     const popoverTarget = result.getByTestId("popover-target").first();
 
+    // Wait for the popover to be mounted before clicking: on a slow run a click
+    // that lands before the popover's wiring is live does nothing.
+    await vi.waitFor(() => {
+      expect(popoverTarget).toBeVisible();
+    });
     await input.click();
 
     await vi.waitFor(() => {
@@ -553,6 +558,11 @@ describe("DatePicker calendar popover position", () => {
     const popoverContent = result.getByTestId("popover-content").first();
     const popoverTarget = result.getByTestId("popover-target").first();
 
+    // Wait for the popover to be mounted before clicking: on a slow run a click
+    // that lands before the popover's wiring is live does nothing.
+    await vi.waitFor(() => {
+      expect(popoverTarget).toBeVisible();
+    });
     await input.click();
 
     await vi.waitFor(() => {

--- a/libs/react-components/specs/dropdown.browser.spec.tsx
+++ b/libs/react-components/specs/dropdown.browser.spec.tsx
@@ -580,6 +580,40 @@ describe("Dropdown", () => {
           expect(Math.abs(dropdownOptionRect.width - dropdownRect.width)).toBeLessThanOrEqual(1);
         });
       });
+
+      it("keeps the option list anchored to the input near the right edge of the screen", async () => {
+        await page.viewport(1280, 800);
+        const Component = () => (
+          <div style={{ position: "absolute", top: 0, left: "1050px" }}>
+            <GoabDropdown
+              name="edge"
+              testId="edge-dropdown"
+              width="200px"
+              onChange={noop}
+            >
+              <GoabDropdownItem label="Red" value="red" />
+              <GoabDropdownItem label="Blue" value="blue" />
+            </GoabDropdown>
+          </div>
+        );
+
+        const result = render(<Component />);
+        const dropdown = result.getByTestId("edge-dropdown");
+        const popoverContent = result.getByTestId("popover-content");
+        const popoverTarget = result.getByTestId("popover-target");
+
+        await dropdown.click();
+
+        await vi.waitFor(() => {
+          expect(popoverContent).toBeVisible();
+          const content = popoverContent.element().getBoundingClientRect();
+          const target = popoverTarget.element().getBoundingClientRect();
+          // A fixed-width option list matches its input's width, so it can never be
+          // squeezed by the screen edge: it stays anchored to the input's left edge.
+          expect(Math.abs(content.left - target.left)).toBeLessThanOrEqual(2);
+          expect(Math.abs(content.width - target.width)).toBeLessThanOrEqual(2);
+        });
+      });
     })
   })
 

--- a/libs/react-components/specs/menu-button.browser.spec.tsx
+++ b/libs/react-components/specs/menu-button.browser.spec.tsx
@@ -1,5 +1,6 @@
 import { render } from "vitest-browser-react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeAll } from "vitest";
+import { page } from "@vitest/browser/context";
 import { GoabMenuAction, GoabMenuButton } from "../src";
 
 describe("MenuButton", () => {
@@ -268,6 +269,69 @@ describe("GoabMenuButton", () => {
     await vi.waitFor(() => {
       expect(result.getByTestId("action-1")).toBeVisible();
       expect(result.getByTestId("action-2")).not.toBeVisible();
+    });
+  });
+});
+
+describe("MenuButton popover position", () => {
+  beforeAll(async () => {
+    await page.viewport(1280, 800);
+  });
+
+  it("opens the menu left-aligned under its button when there is room on the right", async () => {
+    const Component = () => (
+      <div style={{ position: "absolute", top: 0, left: "100px" }}>
+        <GoabMenuButton text="Show actions" testId="menu-button-position">
+          <GoabMenuAction text="Organization settings and preferences" action="a1" />
+          <GoabMenuAction text="Notification preferences" action="a2" />
+          <GoabMenuAction text="Sign out" action="a3" />
+        </GoabMenuButton>
+      </div>
+    );
+
+    const result = render(<Component />);
+    const menuButton = result.getByTestId("menu-button-position");
+    const popoverContent = result.getByTestId("popover-content");
+    const popoverTarget = result.getByTestId("popover-target");
+
+    await menuButton.click();
+
+    await vi.waitFor(() => {
+      expect(popoverContent).toBeVisible();
+      const content = popoverContent.element().getBoundingClientRect();
+      const target = popoverTarget.element().getBoundingClientRect();
+      // Left-aligned: the menu opens at the button's left edge and stays on screen
+      expect(Math.abs(content.left - target.left)).toBeLessThanOrEqual(2);
+      expect(content.right).toBeLessThanOrEqual(window.innerWidth);
+    });
+  });
+
+  it("opens the menu right-aligned when it would be squeezed against the screen edge", async () => {
+    const Component = () => (
+      <div style={{ position: "absolute", top: 0, left: "1080px" }}>
+        <GoabMenuButton text="More" testId="menu-button-edge">
+          <GoabMenuAction text="Organization settings and preferences" action="a1" />
+          <GoabMenuAction text="Notification preferences" action="a2" />
+          <GoabMenuAction text="Sign out" action="a3" />
+        </GoabMenuButton>
+      </div>
+    );
+
+    const result = render(<Component />);
+    const menuButton = result.getByTestId("menu-button-edge");
+    const popoverContent = result.getByTestId("popover-content");
+    const popoverTarget = result.getByTestId("popover-target");
+
+    await menuButton.click();
+
+    await vi.waitFor(() => {
+      expect(popoverContent).toBeVisible();
+      const content = popoverContent.element().getBoundingClientRect();
+      const target = popoverTarget.element().getBoundingClientRect();
+      // Right-aligned: the menu's right edge meets the button's right edge and the
+      // menu keeps its full width on screen.
+      expect(Math.abs(content.right - target.right)).toBeLessThanOrEqual(2);
+      expect(content.right).toBeLessThanOrEqual(window.innerWidth);
     });
   });
 });

--- a/libs/react-components/specs/popover.browser.spec.tsx
+++ b/libs/react-components/specs/popover.browser.spec.tsx
@@ -309,6 +309,46 @@ describe("Popover", () => {
     });
   });
 
+  it("should keep the popover left-aligned when there is enough space on the right", async () => {
+    const Component = () => {
+      return (
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "flex-start",
+            padding: "0.5rem",
+          }}
+        >
+          <GoabPopover
+            testId="popover-left-default"
+            target={<GoabButton testId={"target-left-default"}>Open popover</GoabButton>}
+          >
+            <div style={{ width: "300px" }}>
+              This popover has room on the right and should stay left aligned.
+            </div>
+          </GoabPopover>
+        </div>
+      );
+    };
+
+    const result = render(<Component />);
+    const target = result.getByTestId("target-left-default");
+    const popover = result.getByTestId("popover-left-default");
+    const popoverContent = popover.getByTestId("popover-content");
+
+    await target.click();
+
+    await vi.waitFor(() => {
+      expect(popoverContent).toBeVisible();
+      const targetRect = target.element().getBoundingClientRect();
+      const contentRect = popoverContent.element().getBoundingClientRect();
+
+      // The left edges of the popover content and target should be aligned (within a small tolerance)
+      expect(Math.abs(contentRect.left - targetRect.left)).toBeLessThanOrEqual(2);
+    });
+  });
+
   describe("Popover within a modal", () => {
     it("should open the popover within a modal even with long content", async () => {
       const Component = () => {

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -407,15 +407,32 @@
       return;
     }
 
+    // A fit-content popover shrinks to the space on the trigger's right when the
+    // trigger sits near the screen edge, so its measured width understates the
+    // width it actually wants — comparing that squeezed width against itself never
+    // flips. Compare against the width it would take with room (its max width).
+    const intendedWidth = getIntendedWidth(popoverRect.width);
+
     const spaceRight = window.innerWidth - targetRect.left;
-    if (
-      spaceRight < popoverRect.width &&
-      targetRect.right > popoverRect.width
-    ) {
+    if (spaceRight < intendedWidth && targetRect.right > intendedWidth) {
       _alignment = "right";
     } else {
       _alignment = "left";
     }
+  }
+
+  // The width the popover would occupy if it had room. A fixed-width popover keeps
+  // its width; a fit-content one can grow up to its configured max width. Reads the
+  // computed max-width rather than resizing the live popover, which must not be
+  // mutated while it is open in the top layer.
+  function getIntendedWidth(measuredWidth: number): number {
+    if ((!!width && !_fitContent) || !_popoverEl) {
+      return measuredWidth;
+    }
+    const maxWidthPx = parseFloat(getComputedStyle(_popoverEl).maxWidth);
+    return Number.isNaN(maxWidthPx)
+      ? measuredWidth
+      : Math.max(measuredWidth, maxWidthPx);
   }
 </script>
 


### PR DESCRIPTION
## Summary

When the app header narrows and its navigation overflows into a "More" menu near the right edge, the menu was opening to the right of its button, into the sliver of space before the screen edge. That squeezed it narrower than it should be, so a long item like "Organization settings" wrapped to two lines.

The Popover already had logic to open a menu leftward when there isn't room on the right, but it was comparing against the menu's already-squeezed width, so it almost never kicked in. It now compares against the width the menu actually wants, so a menu near the right edge opens leftward at its full width.

## What changed

- Popover: the right-align check now uses the width the menu would take with room (its max width) instead of the width it got squeezed into. One function, no new props or events.
- No React or Angular wrapper changes. This lives entirely in the Popover web component's positioning, so nothing changes in how the wrappers are used.

## One note

It compares against the menu's max width rather than measuring its exact content, because measuring means resizing the live popover, which isn't safe while it's open. The effect is that a menu very close to the right edge can open leftward even when its content would have just fit, which reads fine that close to an edge.

## Test plan

- Added a browser test that opens a menu near the right edge and checks it aligns to the right of its button (opens leftward). Fails on the old behavior, passes on the new.
- Full browser, unit, and Angular suites pass with no regressions.
- Playground: `bugs/3860` has a header that overflows into a "More" menu. Narrow to around 700px so "More" sits near the right edge, then open it.

## Screenshots

### Before

<img width="933" height="1019" alt="image" src="https://github.com/user-attachments/assets/827e2364-679d-4bf0-b625-9ea8035bdddd" />

### After

<img width="1137" height="1019" alt="image" src="https://github.com/user-attachments/assets/08a41f88-01df-4ab8-a8dd-d5ada6e27d58" />
<img width="873" height="1019" alt="image" src="https://github.com/user-attachments/assets/d196e3e5-9b4b-4c84-a375-5af90d03587a" />
<img width="629" height="1019" alt="image" src="https://github.com/user-attachments/assets/f3e13f0b-4038-4c42-928e-2df54b9725e9" />
