### PR TITLE
Demo: Minimal CSS-only fix for Input Date Picker width

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3815/bug3815.component.html
+++ b/apps/prs/angular/src/routes/bugs/3815/bug3815.component.html
@@ -1,0 +1,67 @@
+<h1>3815 - Date picker size prop</h1>
+<p>
+  GoabDatePicker now exposes a <code>size</code> prop ("default" | "compact") that
+  applies to both the calendar and input variants.
+</p>
+<p>
+  Known follow-up: when <code>type="input"</code> is used in a narrow container, the
+  three fields still overflow instead of staying on one line (see the last example).
+  The responsive fix is not part of this change.
+</p>
+
+<h2>Calendar variant sizes</h2>
+<goab-form-item label="Default size" mb="l">
+  <goab-date-picker name="calDefault" [value]="date" (onChange)="onDateChange($event)">
+  </goab-date-picker>
+</goab-form-item>
+<goab-form-item label="Compact size" labelSize="compact" mb="l">
+  <goab-date-picker
+    name="calCompact"
+    size="compact"
+    [value]="date"
+    (onChange)="onDateChange($event)"
+  >
+  </goab-date-picker>
+</goab-form-item>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<h2>Input variant sizes</h2>
+<goab-form-item label="Default size" mb="l">
+  <goab-date-picker
+    name="inputDefault"
+    type="input"
+    [value]="date"
+    (onChange)="onDateChange($event)"
+  >
+  </goab-date-picker>
+</goab-form-item>
+<goab-form-item label="Compact size" labelSize="compact" mb="l">
+  <goab-date-picker
+    name="inputCompact"
+    type="input"
+    size="compact"
+    [value]="date"
+    (onChange)="onDateChange($event)"
+  >
+  </goab-date-picker>
+</goab-form-item>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<h2>Input variant in a narrow container (known issue)</h2>
+<p>
+  Currently the three fields overflow the container. The responsive fix (keeping them
+  on one line) is a follow-up to this change.
+</p>
+<div style="width: 20rem; outline: 1px dashed var(--goa-color-greyscale-400)">
+  <goab-form-item label="Date of birth">
+    <goab-date-picker
+      name="inputNarrow"
+      type="input"
+      [value]="date"
+      (onChange)="onDateChange($event)"
+    >
+    </goab-date-picker>
+  </goab-form-item>
+</div>

--- a/apps/prs/angular/src/routes/bugs/3815/bug3815.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3815/bug3815.component.ts
@@ -1,0 +1,21 @@
+import { Component } from "@angular/core";
+import {
+  GoabDatePicker,
+  GoabDivider,
+  GoabFormItem,
+} from "@abgov/angular-components";
+import { GoabDatePickerOnChangeDetail } from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3815",
+  templateUrl: "./bug3815.component.html",
+  imports: [GoabDatePicker, GoabDivider, GoabFormItem],
+})
+export class Bug3815Component {
+  date?: string;
+
+  onDateChange(detail: GoabDatePickerOnChangeDetail) {
+    this.date = detail.valueStr || undefined;
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3815/bug3815.route.json
+++ b/apps/prs/angular/src/routes/bugs/3815/bug3815.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3815",
+  "path": "bugs/3815",
+  "title": "Date picker size prop"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3815.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3815.route.ts
@@ -1,0 +1,10 @@
+import { Bug3815Route } from "../../../routes/bugs/bug3815";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3815",
+  path: "bugs/3815",
+  title: "Date picker size prop",
+  component: Bug3815Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3815.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3815.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import {
+  GoabDatePicker,
+  GoabDivider,
+  GoabFormItem,
+  GoabText,
+} from "@abgov/react-components";
+import type { GoabDatePickerOnChangeDetail } from "@abgov/ui-components-common";
+
+export function Bug3815Route() {
+  const [date, setDate] = useState<string | undefined>();
+
+  const handleChange = (detail: GoabDatePickerOnChangeDetail) => {
+    setDate(detail.valueStr || undefined);
+  };
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m" mb="m">
+        Bug #3815: Date picker size prop
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        GoabDatePicker now exposes a <code>size</code> prop ("default" | "compact")
+        that applies to both the calendar and input variants.
+      </GoabText>
+      <GoabText tag="p" mb="l">
+        Known follow-up: when <code>type="input"</code> is used in a narrow
+        container, the three fields still overflow instead of staying on one line
+        (see the last example). The responsive fix is not part of this change.
+      </GoabText>
+
+      <GoabText tag="h2" mb="s">
+        Calendar variant sizes
+      </GoabText>
+      <GoabFormItem label="Default size" mb="l">
+        <GoabDatePicker name="calDefault" value={date} onChange={handleChange} />
+      </GoabFormItem>
+      <GoabFormItem label="Compact size" labelSize="compact" mb="l">
+        <GoabDatePicker
+          name="calCompact"
+          size="compact"
+          value={date}
+          onChange={handleChange}
+        />
+      </GoabFormItem>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2" mb="s">
+        Input variant sizes
+      </GoabText>
+      <GoabFormItem label="Default size" mb="l">
+        <GoabDatePicker
+          name="inputDefault"
+          type="input"
+          value={date}
+          onChange={handleChange}
+        />
+      </GoabFormItem>
+      <GoabFormItem label="Compact size" labelSize="compact" mb="l">
+        <GoabDatePicker
+          name="inputCompact"
+          type="input"
+          size="compact"
+          value={date}
+          onChange={handleChange}
+        />
+      </GoabFormItem>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2" mb="s">
+        Input variant in a narrow container (known issue)
+      </GoabText>
+      <GoabText tag="p" mb="m">
+        Currently the three fields overflow the container. The responsive fix
+        (keeping them on one line) is a follow-up to this change.
+      </GoabText>
+      <div style={{ width: "20rem", outline: "1px dashed var(--goa-color-greyscale-400)" }}>
+        <GoabFormItem label="Date of birth">
+          <GoabDatePicker
+            name="inputNarrow"
+            type="input"
+            value={date}
+            onChange={handleChange}
+          />
+        </GoabFormItem>
+      </div>
+    </div>
+  );
+}
+
+export default Bug3815Route;

--- a/docs/generated/component-apis/date-picker.json
+++ b/docs/generated/component-apis/date-picker.json
@@ -76,6 +76,13 @@
           "description": "Name of the date field."
         },
         {
+          "name": "size",
+          "type": "GoabDatePickerSize",
+          "required": false,
+          "default": "default",
+          "description": "Sets the size of the date picker. 'compact' reduces height for dense layouts."
+        },
+        {
           "name": "testId",
           "type": "string",
           "required": false,
@@ -215,6 +222,13 @@
           "required": false,
           "default": null,
           "description": "Sets the name of the date field."
+        },
+        {
+          "name": "size",
+          "type": "GoabDatePickerSize",
+          "required": false,
+          "default": "default",
+          "description": "Sets the size of the date picker. 'compact' reduces height for dense layouts."
         },
         {
           "name": "testId",

--- a/docs/src/data/configurations/date-picker.ts
+++ b/docs/src/data/configurations/date-picker.ts
@@ -208,34 +208,31 @@ export const datePickerConfigurations: ComponentConfigurations = {
 </goa-form-item>`,
       },
     },
-    // TODO: Re-enable when GoabDatePicker exposes a `size` prop. The web
-    // component (goa-date-picker) does not currently support sizes; the
-    // snippet below is kept for reference only.
-    // {
-    //   id: "sizes",
-    //   name: "Sizes",
-    //   description: "Default and compact size variants",
-    //   code: {
-    //     react: `<GoabFormItem label="Default size" mb="l">
-    //   <GoabDatePicker name="sizeDefault" onChange={handleDateChange} />
-    // </GoabFormItem>
-    // <GoabFormItem label="Compact size" labelSize="compact" mb="l">
-    //   <GoabDatePicker name="sizeCompact" size="compact" onChange={handleDateChange} />
-    // </GoabFormItem>`,
-    //     angular: `<goab-form-item label="Default size" mb="l">
-    //   <goab-date-picker name="sizeDefault" (onChange)="handleDateChange($event)"></goab-date-picker>
-    // </goab-form-item>
-    // <goab-form-item label="Compact size" labelSize="compact" mb="l">
-    //   <goab-date-picker name="sizeCompact" size="compact" (onChange)="handleDateChange($event)"></goab-date-picker>
-    // </goab-form-item>`,
-    //     webComponents: `<goa-form-item version="2" label="Default size" mb="l">
-    //   <goa-date-picker version="2" name="sizeDefault"></goa-date-picker>
-    // </goa-form-item>
-    // <goa-form-item version="2" label="Compact size" labelsize="compact" mb="l">
-    //   <goa-date-picker version="2" name="sizeCompact" size="compact"></goa-date-picker>
-    // </goa-form-item>`,
-    //   },
-    // },
+    {
+      id: "sizes",
+      name: "Sizes",
+      description: "Default and compact size variants",
+      code: {
+        react: `<GoabFormItem label="Default size" mb="l">
+  <GoabDatePicker name="sizeDefault" onChange={handleDateChange} />
+</GoabFormItem>
+<GoabFormItem label="Compact size" labelSize="compact" mb="l">
+  <GoabDatePicker name="sizeCompact" size="compact" onChange={handleDateChange} />
+</GoabFormItem>`,
+        angular: `<goab-form-item label="Default size" mb="l">
+  <goab-date-picker name="sizeDefault" (onChange)="handleDateChange($event)"></goab-date-picker>
+</goab-form-item>
+<goab-form-item label="Compact size" labelSize="compact" mb="l">
+  <goab-date-picker name="sizeCompact" size="compact" (onChange)="handleDateChange($event)"></goab-date-picker>
+</goab-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Default size" mb="l">
+  <goa-date-picker version="2" name="sizeDefault"></goa-date-picker>
+</goa-form-item>
+<goa-form-item version="2" label="Compact size" labelsize="compact" mb="l">
+  <goa-date-picker version="2" name="sizeCompact" size="compact"></goa-date-picker>
+</goa-form-item>`,
+      },
+    },
     {
       id: "input-type",
       name: "Input type",

--- a/libs/angular-components/src/lib/components/date-picker/date-picker.spec.ts
+++ b/libs/angular-components/src/lib/components/date-picker/date-picker.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { GoabDatePicker } from "./date-picker";
 import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
-import { CalendarDate, Spacing } from "@abgov/ui-components-common";
+import { CalendarDate, GoabDatePickerSize, Spacing } from "@abgov/ui-components-common";
 import { ReactiveFormsModule } from "@angular/forms";
 import { addMonths } from "date-fns";
 import { By } from "@angular/platform-browser";
@@ -17,6 +17,7 @@ import { fireEvent } from "@testing-library/dom";
       [min]="min"
       [max]="max"
       type="input"
+      [size]="size"
       [error]="error"
       [mt]="mt"
       [mb]="mb"
@@ -33,6 +34,7 @@ class TestDatePickerComponent {
   value?: Date | string;
   min?: Date | string;
   max?: Date | string;
+  size?: GoabDatePickerSize;
   error?: boolean;
   mt?: Spacing;
   mb?: Spacing;
@@ -70,6 +72,7 @@ describe("GoABDatePicker", () => {
     component.min = addMonths(value, -1);
     component.max = addMonths(value, 1);
     component.value = value;
+    component.size = "compact";
     component.error = true;
     component.mt = "l";
     component.mb = "m";
@@ -100,6 +103,7 @@ describe("GoABDatePicker", () => {
     expect(el?.getAttribute("ml")).toBe(component.ml);
     expect(el?.getAttribute("mr")).toBe(component.mr);
     expect(el?.getAttribute("type")).toBe("input");
+    expect(el?.getAttribute("size")).toBe("compact");
   });
 
   it("should handle event", fakeAsync(() => {

--- a/libs/angular-components/src/lib/components/date-picker/date-picker.ts
+++ b/libs/angular-components/src/lib/components/date-picker/date-picker.ts
@@ -4,6 +4,7 @@ import {
   GoabDatePickerOnBlurDetail,
   GoabDatePickerOnChangeDetail,
   GoabDatePickerOnFocusDetail,
+  GoabDatePickerSize,
   Once,
 } from "@abgov/ui-components-common";
 import {
@@ -17,7 +18,7 @@ import {
   HostListener,
   OnInit,
   ChangeDetectorRef,
-    inject,
+  inject,
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 import { GoabControlValueAccessor } from "../base.component";
@@ -39,6 +40,7 @@ import { GoabControlValueAccessor } from "../base.component";
       [attr.type]="type"
       [attr.testid]="testId"
       [attr.width]="width"
+      [attr.size]="size"
       [attr.mt]="mt"
       [attr.mb]="mb"
       [attr.ml]="ml"
@@ -81,6 +83,8 @@ export class GoabDatePicker extends GoabControlValueAccessor implements OnInit {
   @Input() relative?: boolean;
   /** Sets the width of the date picker input. */
   @Input() width?: string;
+  /** Sets the size of the date picker. 'compact' reduces height for dense layouts. @default "default" */
+  @Input() size?: GoabDatePickerSize;
 
   /** Emits when the selected date changes. Emits the date picker change detail including name and value. */
   @Output() onChange = new EventEmitter<GoabDatePickerOnChangeDetail>();
@@ -126,7 +130,10 @@ export class GoabDatePicker extends GoabControlValueAccessor implements OnInit {
   }
 
   _onFocus(e: Event) {
-    const detail = { ...(e as CustomEvent<GoabDatePickerOnFocusDetail>).detail, event: e };
+    const detail = {
+      ...(e as CustomEvent<GoabDatePickerOnFocusDetail>).detail,
+      event: e,
+    };
     this.onFocus.emit(detail);
   }
 
@@ -135,7 +142,6 @@ export class GoabDatePicker extends GoabControlValueAccessor implements OnInit {
     this.markAsTouched();
     this.onBlur.emit(detail);
   }
-
 
   ngOnInit(): void {
     // For Angular 20, we need to delay rendering the web component

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -227,6 +227,8 @@ export type GoabDatePickerOnBlurDetail = GoabDatePickerOnFocusDetail;
 
 export type GoabDatePickerInputType = "calendar" | "input";
 
+export type GoabDatePickerSize = "default" | "compact";
+
 export type GoabChipVariant = "filter";
 
 export type GoabChipTheme = "outline" | "filled";

--- a/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.spec.tsx
@@ -113,4 +113,18 @@ describe("DatePicker", () => {
     const el = baseElement.querySelector("goa-date-picker");
     expect(el?.getAttribute("data-grid")).toBe("cell");
   });
+
+  it("should pass the size attribute when set", () => {
+    const { baseElement } = render(
+      <DatePicker name="foo" size="compact" onChange={noop} />,
+    );
+    const el = baseElement.querySelector("goa-date-picker");
+    expect(el?.getAttribute("size")).toBe("compact");
+  });
+
+  it("should not set a size attribute by default", () => {
+    const { baseElement } = render(<DatePicker name="foo" onChange={noop} />);
+    const el = baseElement.querySelector("goa-date-picker");
+    expect(el?.getAttribute("size")).toBeNull();
+  });
 });

--- a/libs/react-components/src/lib/date-picker/date-picker.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.tsx
@@ -5,6 +5,7 @@ import {
   GoabDatePickerOnBlurDetail,
   GoabDatePickerOnChangeDetail,
   GoabDatePickerOnFocusDetail,
+  GoabDatePickerSize,
   Margins,
   DataAttributes,
 } from "@abgov/ui-components-common";
@@ -21,6 +22,7 @@ interface WCProps extends Margins {
   disabled?: string;
   testid?: string;
   width?: string;
+  size?: string;
   version?: string;
 }
 
@@ -57,6 +59,8 @@ export interface GoabDatePickerProps extends Margins, DataAttributes {
   disabled?: boolean;
   /** Sets the width of the date picker input. */
   width?: string;
+  /** Sets the size of the date picker. 'compact' reduces height for dense layouts. @default "default" */
+  size?: GoabDatePickerSize;
   /** Callback fired when the selected date changes. */
   onChange?: (detail: GoabDatePickerOnChangeDetail) => void;
   /** Callback fired when focus enters any of the date picker's internal fields. */

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -11,7 +11,12 @@
   import { onMount, tick } from "svelte";
   import type { Spacing } from "../../common/styling";
   import { toBoolean } from "../../common/utils";
-  import { receive, dispatch, relay, watchFocusWithin } from "../../common/utils";
+  import {
+    receive,
+    dispatch,
+    relay,
+    watchFocusWithin,
+  } from "../../common/utils";
   import { isValidDimension } from "../../common/validators";
   import {
     FieldsetSetValueMsg,
@@ -361,8 +366,8 @@
   {/if}
 {:else if type === "input"}
   <goa-form-item error={_error && error} bind:this={_rootEl} {version}>
-    <goa-block direction="row">
-      <goa-form-item helptext="Month" {version}>
+    <div class="date-input-row">
+      <goa-form-item helptext="Month" {version} class="month-field">
         <goa-dropdown
           name="month"
           testid="input-month"
@@ -390,7 +395,11 @@
           <goa-dropdown-item value="12" label="December" />
         </goa-dropdown>
       </goa-form-item>
-      <goa-form-item helptext={size === "compact" ? "Day" : "Day (DD)"} {version}>
+      <goa-form-item
+        helptext={size === "compact" ? "Day" : "Day (DD)"}
+        {version}
+        class="day-field"
+      >
         <goa-input
           name="day"
           type="number"
@@ -409,7 +418,11 @@
           {version}
         />
       </goa-form-item>
-      <goa-form-item helptext={size === "compact" ? "Year" : "Year (YYYY)"} {version}>
+      <goa-form-item
+        helptext={size === "compact" ? "Year" : "Year (YYYY)"}
+        {version}
+        class="year-field"
+      >
         <goa-input
           name="year"
           type="number"
@@ -428,7 +441,7 @@
           {version}
         />
       </goa-form-item>
-    </goa-block>
+    </div>
   </goa-form-item>
 {/if}
 
@@ -438,5 +451,23 @@
     --goa-text-input-color-bg-readonly: var(--goa-text-input-color-bg);
     --goa-text-input-border-readonly: var(--goa-text-input-border);
     --goa-text-input-cursor-readonly: var(--goa-date-input-cursor);
+  }
+
+  .date-input-row {
+    display: flex;
+    flex-direction: row;
+    gap: var(--goa-space-m);
+    width: max-content;
+    max-width: 100%;
+  }
+
+  .month-field {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .day-field,
+  .year-field {
+    flex: 0 0 auto;
   }
 </style>

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -390,7 +390,7 @@
           <goa-dropdown-item value="12" label="December" />
         </goa-dropdown>
       </goa-form-item>
-      <goa-form-item helptext="Day (DD)" {version}>
+      <goa-form-item helptext={size === "compact" ? "Day" : "Day (DD)"} {version}>
         <goa-input
           name="day"
           type="number"
@@ -409,7 +409,7 @@
           {version}
         />
       </goa-form-item>
-      <goa-form-item helptext="Year (YYYY)" {version}>
+      <goa-form-item helptext={size === "compact" ? "Year" : "Year (YYYY)"} {version}>
         <goa-input
           name="year"
           type="number"

--- a/libs/web-components/src/components/date-picker/date-picker.spec.ts
+++ b/libs/web-components/src/components/date-picker/date-picker.spec.ts
@@ -279,4 +279,16 @@ describe("invalid date handling (#3275)", () => {
     expect(dayInput?.getAttribute("value")).toBe("");
     expect(yearInput?.getAttribute("value")).toBe("");
   });
+
+  it("shortens the Day and Year helptext for the compact size only", async () => {
+    const regular = render(DatePicker, { type: "input" });
+    const regularItems = regular.container.querySelectorAll("goa-form-item");
+    expect(regularItems[2]?.getAttribute("helptext")).toBe("Day (DD)");
+    expect(regularItems[3]?.getAttribute("helptext")).toBe("Year (YYYY)");
+
+    const compact = render(DatePicker, { type: "input", size: "compact" });
+    const compactItems = compact.container.querySelectorAll("goa-form-item");
+    expect(compactItems[2]?.getAttribute("helptext")).toBe("Day");
+    expect(compactItems[3]?.getAttribute("helptext")).toBe("Year");
+  });
 });

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -978,6 +978,7 @@
     background-color: var(--goa-dropdown-color-bg);
     cursor: pointer;
     width: 100%;
+    max-width: 100%;
   }
 
   .dropdown-input-group:hover {
@@ -1033,6 +1034,7 @@
     padding: var(--goa-dropdown-padding);
     background-color: transparent;
     width: 100%;
+    min-width: 0;
     flex: 1 1 auto;
     z-index: 1;
     text-overflow: ellipsis;

--- a/libs/web-components/src/components/popover/Popover.svelte
+++ b/libs/web-components/src/components/popover/Popover.svelte
@@ -424,6 +424,7 @@
   data-testid={testid}
   style={styles(
     "display: inline-block",
+    "max-width: 100%",
     height === "full" && "height: 100%;",
     calculateMargin(mt, mr, mb, ml),
     style("--offset-top", voffset),
@@ -499,6 +500,7 @@
     cursor: pointer;
     display: block;
     height: 100%;
+    max-width: 100%;
     outline: none;
     border: none;
     padding: 0;


### PR DESCRIPTION
This PR demonstrates a small, CSS-only fix for the Input Date Picker in a narrow width.