### PR TITLE
chore(skills): update using-goa-design-system

### DIFF
--- a/skills/using-goa-design-system/README.md
+++ b/skills/using-goa-design-system/README.md
@@ -6,19 +6,18 @@ The skill that turns "I'm building X for users" into the right Government of Alb
 
 For anyone building with the design system: tell your AI what you're making in plain terms ("a renewal form for citizens", "a case queue for workers") and it works out the right GoA product type, the matching page and section templates, and the exact components with their props and gotchas, before it writes any code.
 
-Under the hood: it is the composition layer to the MCP's knowledge layer. The MCP answers "what is this component"; this skill answers "I'm building this, how should I approach it," following the design system's service-first method so an AI tool uses our conventions by default.
+Under the hood: it is the composition layer to the MCP's knowledge layer. The MCP answers "what is this component"; this skill answers "I'm building this, how should I approach it," walking the design system's structure top-down so an AI tool uses our conventions by default.
 
 ## What it does
 
 When you describe what you're building in user-facing terms, the skill walks the design system's structure top-down instead of jumping to a component:
 
-1. Names the service type: what the user is trying to accomplish, in service language ("getting permission", "requesting information", "getting financial support"). This uses Kate Tarling's Common Service Types vocabulary.
-2. Maps that to a product type: workspace (worker-facing) or public-form (citizen-facing), saying the translation out loud, and naming a gap if it does not fit cleanly.
-3. Pulls the matching templates by size (interaction, section, page, task, product) from the MCP.
-4. Pulls each component's real props, token references, and embedded guidance (the do's and don'ts) from the MCP, before any code is written.
-5. Hands back the plan and the known gotchas first, names what it assumed, and flags decisions a person should make.
+1. Works out the product type: workspace (worker-facing) or public-form (citizen-facing), from which side of the service the intent describes, naming a gap if it does not fit cleanly.
+2. Pulls the matching templates by size (interaction, section, page, task, product) from the MCP.
+3. Pulls each component's real props, token references, and embedded guidance (the do's and don'ts) from the MCP, before any code is written.
+4. Hands back the plan and the known gotchas first, names what it assumed, and flags decisions a person should make.
 
-A guided descent: service, to product type, to template, to component, to tokens, with the MCP supplying the facts at each step.
+A guided descent: product type, to template, to component, to tokens, with the MCP supplying the facts at each step.
 
 ## How it works
 
@@ -26,7 +25,6 @@ The MCP is the knowledge layer (facts, through its `search` and `get` tools). Th
 
 The structure it walks:
 
-- Service type: what the user is trying to accomplish (vocabulary layer)
 - Product type: workspace (worker) or public-form (citizen)
 - Example by size: interaction, section, page, task, product
 - Components: the atomic UI building blocks
@@ -35,7 +33,7 @@ The structure it walks:
 
 ## What makes it distinctive
 
-- Service-first, not component-first. It establishes product type and template before reaching for a component, so the result follows the system's conventions instead of being correct-looking code that ignores them.
+- Structure-first, not component-first. It establishes product type and template before reaching for a component, so the result follows the system's conventions instead of being correct-looking code that ignores them.
 - Derives, does not interrogate. It infers worker-vs-citizen from the product type instead of asking.
 - Advisory and transparent. It names its defaults ("I'll scaffold in React, the same works in Angular") and escalates real decisions to people.
 - Same content, different lens. A designer gets design language; a developer gets technical language. It reframes, it does not withhold.
@@ -58,5 +56,4 @@ Then describe what you are building in plain terms, and the skill loads on its o
 
 ## Good to know
 
-- The service-type layer is vocabulary, not data yet. The skill leads with the Kate Tarling service types as a navigation lens; they are not a queryable layer in the MCP. As the service-mapping work formalizes them, the skill will get more opinionated about the building blocks each type expects.
 - The bundled `taxonomy.md` is a cache. It is a fast lookup of sizes, product types, and current templates, and it can drift from the docs site. The docs site and the MCP are the source of truth. Keep `taxonomy.md` in sync when product types or templates change.

--- a/skills/using-goa-design-system/SKILL.md
+++ b/skills/using-goa-design-system/SKILL.md
@@ -26,16 +26,13 @@ When NOT to use:
 
 | Layer | What it is | Examples |
 |---|---|---|
-| Service type | What the user is trying to accomplish (Kate Tarling Common Service Types) | "Getting permission" (permit), "Requesting/sharing information" (case lookup), "Getting financial support" (benefit claim) |
 | Product type | The kind of digital product the service is realized as (its own content collection) | `workspace` (worker), `public-form` (citizen) |
 | Example by size | Scale of artifact | `interaction` → `section` → `page` → `task` → `product` |
 | Components | Atomic UI building blocks | `goa-button`, `goa-form-item`, `goa-table` |
 | Guidance atoms | Do/don't/tip/warning/info linked to component + topic | "use goa-block for spacing, not goa-container" |
 | Tokens | Sizing, color, spacing values | `--goa-space-m`, `--goa-color-text-default` |
 
-Service type is the vocabulary layer (Kate Tarling), not a schema layer yet. The skill leads with it when recognizable, then narrates the mapping to product type. See `taxonomy.md` for the full framework.
-
-Public services typically have two sides: one to **provide and manage** (worker), and one to **receive** (citizen). When the intent names one side, name it. When the intent could apply to either, name both. The product type follows from which side the developer is building for.
+Public services typically have two sides: a **citizen-facing** side (applying, renewing, checking) and a **worker-facing** side (processing, reviewing, managing). When the intent names one side, name it. When the intent could apply to either, name both. The product type follows from which side the developer is building for.
 
 `task` is the unit for a complete user job — between a single page and a full product. When an intent is task-shaped (a complete job the user is trying to do), look for it in the tasks collection before composing from pages and components alone.
 
@@ -43,13 +40,12 @@ For full enumeration of sizes, product types, and aliases, see `taxonomy.md`.
 
 ## Navigation pattern
 
-1. Read the intent. Recognize the **service type**: what is the user trying to accomplish in service terms? If recognizable, name it using Kate Tarling's Common Service Types vocabulary (see `taxonomy.md`): "Getting permission," "Requesting/sharing information," "Getting financial support," etc.
-2. Map the service type to a product type. Narrate the translation explicitly: "this is a [service type], most often expressed as a [productType] in the GoA system today." If the service doesn't map cleanly to today's product types (workspace, public-form), name the gap rather than forcing a fit.
-3. `goa-design-system:get` the product type from the productTypes collection to surface its summary, demo URL, and listed components.
-4. `goa-design-system:search` filtered by `size` and `productType` for sections, non-canonical pages, or filtered queries (step 3 already lists the canonical pages).
-5. For each template, `goa-design-system:get` the entry to surface its components, source URLs, preview, and embedded guidance. For each component, `goa-design-system:get` to confirm props, types, and token references before generating code.
-6. If a task entry matches the intent, surface it. If no task captures it, name the gap and offer the closest pages so the developer can compose the job themselves.
-7. Surface result and gotchas to the developer before generating code. Apply the Decision calibration principles below: name what was defaulted (transparency) and frame through the developer's lens.
+1. Read the intent. Determine which side of the service it's for — citizen-facing or worker-facing — and map to a product type: worker tools → `workspace`, citizen-facing form flows → `public-form` (see the routing table in `taxonomy.md`). If the intent doesn't map cleanly to today's product types, name the gap rather than forcing a fit.
+2. `goa-design-system:get` the product type from the productTypes collection to surface its summary, demo URL, and listed components.
+3. `goa-design-system:search` filtered by `size` and `productType` for sections, non-canonical pages, or filtered queries (step 2 already lists the canonical pages).
+4. For each template, `goa-design-system:get` the entry to surface its components, source URLs, preview, and embedded guidance. For each component, `goa-design-system:get` to confirm props, types, and token references before generating code.
+5. If a task entry matches the intent, surface it. If no task captures it, name the gap and offer the closest pages so the developer can compose the job themselves.
+6. Surface result and gotchas to the developer before generating code. Apply the Decision calibration principles below: name what was defaulted (transparency) and frame through the developer's lens.
 
 ## When to use which MCP tool
 
@@ -72,7 +68,6 @@ For consequential choices that warrant team coordination (state-management archi
 
 ## Common mistakes
 
-- **Skipping the service type.** Service language ("intake service", "permit application service") deserves explicit acknowledgment, not silent translation to product type. Name the service type, then narrate the mapping to product type.
 - **Skipping the product type layer.** Going straight to components produces correct-looking code that ignores the system's layered conventions.
 - **Asking for user type.** Don't. Derive from product type.
 - **Inventing tokens.** Always reference the actual token; never hardcode a value. If a value doesn't fit, use a component-level override; tokens themselves are referenced, not modified by teams.

--- a/skills/using-goa-design-system/taxonomy.md
+++ b/skills/using-goa-design-system/taxonomy.md
@@ -7,7 +7,7 @@ A fast lookup for this skill. Treat the docs site as the source of truth; this f
 - Sizes
 - Product types
 - User type
-- Service types (vocabulary layer)
+- Intent → product type
 - Aliases (slugs)
 - Pages within each product (today)
 - What this file is NOT
@@ -49,33 +49,17 @@ Other product types (e.g. `error-pages`) may exist as example overviews without 
 
 This derivation replaces the previous `userType` field on examples.
 
-## Service types (vocabulary layer)
+## Intent → product type
 
-A service type names what a citizen or worker is trying to accomplish in service terms. The Kate Tarling "Common Service Types" framework names nine:
+A fast routing table from common intent shapes to the product type they usually land in. When neither fits, name the gap rather than forcing one.
 
-1. Registering, providing, or reporting information
-2. Requesting, sharing, or checking information
-3. Paying for something
-4. Getting financial support or claiming something
-5. Getting permission to do something
-6. Scheduling something
-7. Buying or ordering something
-8. Becoming something
-9. Protecting something
-
-**They are not modelled in the design system schema yet, but the skill leads with this framing.** When intent is recognizable in service-type terms, name it explicitly using this vocabulary as the first navigation step, then map to a `productType` as the next explicit step. When the framework is formalized in the schema (likely via a separate service-mapping data source), the skill will become more opinionated about expected building blocks per type.
-
-Map intent to productType:
-
-| Intent shape | Service type (informal) | Likely productType |
-|---|---|---|
-| "case management", "intake", "review and decide", "queue" | Requesting / sharing information; sometimes Getting permission | `workspace` |
-| "apply for X", "register for Y" | Getting permission, Becoming something | `public-form` |
-| "renew", "report status" | Registering / providing information | `public-form` |
-| "claim", "request support" | Getting financial support | `public-form` |
-| "schedule X", "book a Y" | Scheduling something | `public-form` (booking) or `workspace` (queue) |
-
-Don't promote service types into a structured field; use them as intent vocabulary until the framework is formally adopted in the schema.
+| Intent shape | Likely productType |
+|---|---|
+| "case management", "intake", "review and decide", "queue" | `workspace` |
+| "apply for X", "register for Y" | `public-form` |
+| "renew", "report status" | `public-form` |
+| "claim", "request support" | `public-form` |
+| "schedule X", "book a Y" | `public-form` (booking) or `workspace` (queue) |
 
 ## Aliases (slugs)
 


### PR DESCRIPTION
## Summary

The using-goa-design-system skill was leading its navigation with a vocabulary layer that isn't modelled anywhere in the system. There's no collection for it, no docs page, and the MCP can't return one, so the skill was asserting a layer of the design system that isn't there.

This scopes the skill to the layers the system actually models. It now enters at product type, from which side of the service the intent describes (citizen-facing or worker-facing), and everything it names maps to a real collection the MCP can answer for.

## What changed

- SKILL.md: navigation starts at product type. The extra opening layer is replaced with one step that reads the intent for which side it serves.
- taxonomy.md: reduced to a plain intent to product type routing table. Sizes, product types, user type derivation, aliases, and page lists are untouched, they all match the schema.
- README.md: same story for humans. The descent starts at product type.

If the system ever wants a richer entry layer, it can come back as modelled data. Until then the skill only teaches what it can back.
