### PR TITLE
feat: add component-search skill for AI-friendly markdown endpoints

### DIFF
--- a/docs/src/content/get-started/ai-tools-and-resources/skills.mdx
+++ b/docs/src/content/get-started/ai-tools-and-resources/skills.mdx
@@ -34,6 +34,13 @@ import { withBase } from "@/lib/base-url";
 <CodeSnippet language="bash" showCopy client:visible code={`npx skills add GovAlta/ui-components --skill content-design`} />
 <p><goa-link mt="s" trailingicon="open"><a href="https://github.com/GovAlta/ui-components/tree/dev/skills/content-design" target="_blank" rel="noopener noreferrer">View on GitHub</a></goa-link></p>
 
+<goa-text size="heading-s" mt="xl">component-search</goa-text>
+<goa-text size="body-m">This skill looks up component APIs, props, events, and usage or accessibility guidance from the Design System's AI-friendly Markdown endpoints (<code>llms.txt</code> and <code>/components/{"{slug}"}.md</code>).</goa-text>
+<goa-text size="body-m">It loads when you ask about a specific component's API or guidance, or want to find components for a purpose — for example "what components handle warnings?" or "show me React props for Button".</goa-text>
+<goa-text size="body-m"><strong>How to add it:</strong></goa-text>
+<CodeSnippet language="bash" showCopy client:visible code={`npx skills add GovAlta/ui-components --skill component-search`} />
+<p><goa-link mt="s" trailingicon="open"><a href="https://github.com/GovAlta/ui-components/tree/dev/skills/component-search" target="_blank" rel="noopener noreferrer">View on GitHub</a></goa-link></p>
+
 <goa-text as="h2" id="how-they-work" size="heading-m" mt="2xl">How they work</goa-text>
 <goa-text size="body-m">Each skill is a folder with a SKILL.md file plus any supporting notes. Your AI reads the short description at startup and loads the full instructions only when your request matches, so they add capability without crowding the context.</goa-text>
 <goa-text size="body-m">Because they follow the open Agent Skills standard, the same files work in Claude Code, Cursor, GitHub Copilot, and other tools that read the format.</goa-text>

--- a/docs/src/lib/component-markdown.ts
+++ b/docs/src/lib/component-markdown.ts
@@ -1,0 +1,270 @@
+/**
+ * Builds clean Markdown for a component page.
+ * Used by the /components/[slug].md endpoint so AI agents get structured
+ * text instead of rendered HTML with custom elements.
+ */
+import type { CollectionEntry } from "astro:content";
+import type {
+  ComponentApi,
+  PropDefinition,
+  EventDefinition,
+  SlotDefinition,
+  FrameworkApiData,
+} from "./content-queries";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ComponentMarkdownInput {
+  slug: string;
+  component: CollectionEntry<"components">;
+  api: ComponentApi | null;
+  usageGuidance: Record<string, CollectionEntry<"guidance">[]>;
+  accessibilityGuidance: Record<string, CollectionEntry<"guidance">[]>;
+  componentExamples: CollectionEntry<"examples">[];
+  relatedComponents: CollectionEntry<"components">[];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatCategory(category: string): string {
+  return category
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/** Escape pipe characters so they don't break Markdown table column alignment. */
+function cell(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
+/** Truncate a type string to a readable length for table cells, then escape. */
+function formatType(type: string, maxLen = 80): string {
+  if (!type) return "";
+  const truncated = type.length > maxLen ? type.slice(0, maxLen - 1) + "…" : type;
+  return cell(truncated);
+}
+
+function propsTable(props: PropDefinition[]): string {
+  if (props.length === 0) return "_No props._\n";
+
+  const rows = props.map((p) => {
+    const name = `\`${cell(p.name)}\``;
+    const type = formatType(p.type);
+    const def = p.default !== null && p.default !== "" ? `\`${cell(p.default)}\`` : "(none)";
+    const req = p.required ? "Yes" : "No";
+    const desc = [cell(p.description ?? ""), p.deprecated ? "*(deprecated)*" : ""]
+      .filter(Boolean)
+      .join(" ") || "(none)";
+    return `| ${name} | ${type} | ${def} | ${req} | ${desc} |`;
+  });
+
+  return [
+    "| Prop | Type | Default | Required | Description |",
+    "|------|------|---------|----------|-------------|",
+    ...rows,
+  ].join("\n");
+}
+
+function eventsSection(events: EventDefinition[]): string {
+  if (events.length === 0) return "";
+
+  const rows = events.map(
+    (e) => `| \`${cell(e.name)}\` | ${cell(e.type) || "(none)"} | ${cell(e.description ?? "") || "(none)"} |`,
+  );
+
+  return [
+    "### Events",
+    "",
+    "| Event | Type | Description |",
+    "|-------|------|-------------|",
+    ...rows,
+  ].join("\n");
+}
+
+function slotsSection(slots: SlotDefinition[]): string {
+  if (slots.length === 0) return "";
+
+  const rows = slots.map((s) => {
+    const name = s.name || "(default)";
+    const req = s.required ? "Yes" : "No";
+    return `| \`${cell(name)}\` | ${req} | ${cell(s.description ?? "") || "(none)"} |`;
+  });
+
+  return [
+    "### Slots",
+    "",
+    "| Slot | Required | Description |",
+    "|------|----------|-------------|",
+    ...rows,
+  ].join("\n");
+}
+
+function frameworkSection(
+  heading: string,
+  tag: string | null,
+  data: FrameworkApiData,
+  propLabel = "Props",
+): string {
+  const parts: string[] = [`## ${heading}`, ""];
+
+  if (tag) {
+    parts.push(`Tag: \`${tag}\``, "");
+  }
+
+  parts.push(`### ${propLabel}`, "", propsTable(data.props), "");
+
+  const ev = eventsSection(data.events);
+  if (ev) parts.push(ev, "");
+
+  const sl = slotsSection(data.slots);
+  if (sl) parts.push(sl, "");
+
+  return parts.join("\n");
+}
+
+const GUIDANCE_PREFIX: Record<string, string> = {
+  do: "[Do]",
+  dont: "[Don't]",
+  tip: "[Tip]",
+  warning: "[Warning]",
+  info: "[Note]",
+};
+
+function guidanceSection(
+  heading: string,
+  grouped: Record<string, CollectionEntry<"guidance">[]>,
+): string {
+  if (Object.keys(grouped).length === 0) return "";
+
+  const lines: string[] = [`## ${heading}`, ""];
+
+  for (const [topic, items] of Object.entries(grouped)) {
+    const topicLabel = topic
+      .split("-")
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(" ");
+
+    lines.push(`### ${topicLabel}`, "");
+
+    for (const item of items) {
+      const prefix = GUIDANCE_PREFIX[item.data.type] ?? "[Note]";
+      lines.push(`- **${prefix}** ${item.data.description}`);
+    }
+
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+// ─── Main builder ─────────────────────────────────────────────────────────────
+
+export function buildComponentMarkdown(input: ComponentMarkdownInput): string {
+  const { slug, component, api, usageGuidance, accessibilityGuidance, componentExamples, relatedComponents } = input;
+  const { data } = component;
+
+  const parts: string[] = [
+    `# ${data.name}`,
+    "",
+  ];
+
+  if (data.description) {
+    parts.push(data.description, "");
+  }
+
+  parts.push(
+    `**Status:** ${data.status} | **Category:** ${formatCategory(data.category)} | **Docs:** https://design.alberta.ca/components/${slug}`,
+    "",
+    "---",
+    "",
+  );
+
+  if (!api) {
+    parts.push("_API data not available for this component._", "");
+  } else {
+    const wcTag = `goa-${slug}`;
+
+    parts.push(
+      frameworkSection("React", null, api.frameworks.react),
+      "---",
+      "",
+      frameworkSection("Angular", null, api.frameworks.angular),
+      "---",
+      "",
+      frameworkSection("Web Components", wcTag, {
+        ...api.frameworks.webComponents,
+        props: api.frameworks.webComponents.props.filter((p) => p.name !== "version"),
+      }, "Attributes"),
+    );
+
+    if (api.subComponents && api.subComponents.length > 0) {
+      parts.push("---", "");
+      for (const sub of api.subComponents) {
+        parts.push(`## ${sub.name}`, "");
+        if (sub.description) parts.push(sub.description, "");
+        parts.push(`Tag: \`${sub.webComponentTag}\``, "");
+        parts.push(
+          frameworkSection("React (subcomponent)", null, sub.frameworks.react),
+          frameworkSection("Angular (subcomponent)", null, sub.frameworks.angular),
+          frameworkSection("Web Components (subcomponent)", sub.webComponentTag, {
+            ...sub.frameworks.webComponents,
+            props: sub.frameworks.webComponents.props.filter((p) => p.name !== "version"),
+          }, "Attributes"),
+        );
+      }
+    }
+
+    if (api.staticMethods && api.staticMethods.length > 0) {
+      parts.push("---", "", "## Static methods", "");
+      for (const method of api.staticMethods) {
+        parts.push(`### \`${method.signature}\``, "");
+        if (method.description) parts.push(method.description, "");
+        parts.push(`**Returns:** ${method.returnType}`, "");
+        if (method.params.length > 0) {
+          const paramRows = method.params.map(
+              (p) => `| \`${cell(p.name)}\` | ${cell(p.type)} | ${p.required ? "Yes" : "No"} | ${cell(p.description ?? "")} |`,
+          );
+          parts.push(
+            "| Parameter | Type | Required | Description |",
+            "|-----------|------|----------|-------------|",
+            ...paramRows,
+            "",
+          );
+        }
+      }
+    }
+  }
+
+  const usageBlock = guidanceSection("Usage guidance", usageGuidance);
+  if (usageBlock) {
+    parts.push("---", "", usageBlock);
+  }
+
+  const a11yBlock = guidanceSection("Accessibility guidance", accessibilityGuidance);
+  if (a11yBlock) {
+    parts.push("---", "", a11yBlock);
+  }
+
+  if (componentExamples.length > 0) {
+    parts.push("---", "", "## Examples", "");
+    for (const example of componentExamples) {
+      const exSlug = example.data.slug || example.id;
+      const desc = example.data.description ? `: ${example.data.description}` : "";
+      parts.push(`- [${example.data.title}](/examples/${exSlug})${desc}`);
+    }
+    parts.push("");
+  }
+
+  if (relatedComponents.length > 0) {
+    parts.push("---", "", "## Related components", "");
+    for (const related of relatedComponents) {
+      const relSlug = related.data.slug || related.id;
+      const desc = related.data.description ? `: ${related.data.description}` : "";
+      parts.push(`- [${related.data.name}](/components/${relSlug})${desc}`);
+    }
+    parts.push("");
+  }
+
+  return parts.join("\n");
+}

--- a/docs/src/pages/components/[slug].md.ts
+++ b/docs/src/pages/components/[slug].md.ts
@@ -19,6 +19,14 @@ import {
 } from "@/lib/content-queries";
 import { buildComponentMarkdown } from "@/lib/component-markdown";
 
+type Props = {
+  component: CollectionEntry<"components">;
+};
+
+type Params = {
+  slug: string;
+};
+
 export async function getStaticPaths() {
   const components = await getCollection("components");
   return components
@@ -29,17 +37,16 @@ export async function getStaticPaths() {
     }));
 }
 
-export const GET: APIRoute = async ({ params, props }) => {
+export const GET: APIRoute<Props, Params> = async ({ params, props }) => {
   const { slug } = params;
-  const { component } = props as { component: CollectionEntry<"components"> };
+  const { component } = props;
 
-  const [api, allGuidance, componentExamples, relatedComponents] =
-    await Promise.all([
-      getComponentApi(slug),
-      getGuidanceForComponent(slug),
-      getExamplesForComponent(slug),
-      getRelatedComponents(component.data.relatedComponents ?? []),
-    ]);
+  const [api, allGuidance, componentExamples, relatedComponents] = await Promise.all([
+    getComponentApi(slug),
+    getGuidanceForComponent(slug),
+    getExamplesForComponent(slug),
+    getRelatedComponents(component.data.relatedComponents ?? []),
+  ]);
 
   const { usage: usageGuidance, accessibility: accessibilityGuidance } =
     categorizeGuidance(allGuidance);

--- a/docs/src/pages/components/[slug].md.ts
+++ b/docs/src/pages/components/[slug].md.ts
@@ -1,0 +1,60 @@
+/**
+ * /components/[slug].md — AI-friendly Markdown for a single component
+ *
+ * Parallel to /components/[slug] (the HTML page). Returns clean Markdown
+ * that aggregates everything an AI agent needs: the full API for React,
+ * Angular, and Web Components, usage guidance, accessibility guidance,
+ * and related examples — without any custom elements or JavaScript.
+ *
+ * Linked from /llms.txt so agents can discover it without crawling HTML.
+ */
+import type { APIRoute } from "astro";
+import { getCollection, type CollectionEntry } from "astro:content";
+import {
+  getComponentApi,
+  getGuidanceForComponent,
+  getExamplesForComponent,
+  getRelatedComponents,
+  categorizeGuidance,
+} from "@/lib/content-queries";
+import { buildComponentMarkdown } from "@/lib/component-markdown";
+
+export async function getStaticPaths() {
+  const components = await getCollection("components");
+  return components
+    .filter((c) => !c.data.hidden && !c.data.subcomponent)
+    .map((component) => ({
+      params: { slug: component.data.slug || component.id },
+      props: { component },
+    }));
+}
+
+export const GET: APIRoute = async ({ params, props }) => {
+  const { slug } = params;
+  const { component } = props as { component: CollectionEntry<"components"> };
+
+  const [api, allGuidance, componentExamples, relatedComponents] =
+    await Promise.all([
+      getComponentApi(slug),
+      getGuidanceForComponent(slug),
+      getExamplesForComponent(slug),
+      getRelatedComponents(component.data.relatedComponents ?? []),
+    ]);
+
+  const { usage: usageGuidance, accessibility: accessibilityGuidance } =
+    categorizeGuidance(allGuidance);
+
+  const markdown = buildComponentMarkdown({
+    slug,
+    component,
+    api,
+    usageGuidance,
+    accessibilityGuidance,
+    componentExamples,
+    relatedComponents,
+  });
+
+  return new Response(markdown, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+};

--- a/docs/src/pages/llms.txt.ts
+++ b/docs/src/pages/llms.txt.ts
@@ -1,0 +1,70 @@
+/**
+ * /llms.txt — AI agent discovery index
+ *
+ * Follows the llms.txt convention (https://llmstxt.org).
+ * Lists every significant page in the site so agents can build
+ * a navigation map without crawling rendered HTML.
+ *
+ * Component entries point to /components/{slug}.md (clean Markdown)
+ * rather than the HTML page, so agents get structured text directly.
+ */
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+
+export const GET: APIRoute = async () => {
+  const [components, examples] = await Promise.all([
+    getCollection("components"),
+    getCollection("examples"),
+  ]);
+
+  const visibleComponents = components
+    .filter((c) => !c.data.hidden && !c.data.subcomponent)
+    .sort((a, b) => a.data.name.localeCompare(b.data.name));
+
+  // Only top-level examples (those in subdirectories have id like "button-with-icon",
+  // while nested product pages have ids like "workspace/dashboard").
+  const visibleExamples = examples
+    .filter((e) => !e.data.hidden && e.data.status === "published" && !e.id.includes("/"))
+    .sort((a, b) => a.data.title.localeCompare(b.data.title));
+
+  const lines: string[] = [
+    "# Government of Alberta Design System",
+    "",
+    "> Documentation for the GoA Design System — components, patterns,",
+    "> examples, and guidance for building Alberta government digital services.",
+    "> Full site: https://design.alberta.ca",
+    "",
+    "## Components",
+    "",
+    "> Each /components/{slug}.md page contains the full API for React,",
+    "> Angular, and Web Components (props, events, slots), usage guidance,",
+    "> accessibility guidance, and links to related examples.",
+    "",
+  ];
+
+  for (const component of visibleComponents) {
+    const slug = component.data.slug || component.id;
+    const desc = component.data.description ? `: ${component.data.description}` : "";
+    lines.push(`- [${component.data.name}](/components/${slug}.md)${desc}`);
+  }
+
+  lines.push("");
+  lines.push("## Examples");
+  lines.push("");
+  lines.push(
+    "> Usage patterns and page compositions built with GoA Design System components.",
+  );
+  lines.push("");
+
+  for (const example of visibleExamples) {
+    const slug = example.data.slug || example.id;
+    const desc = example.data.description ? `: ${example.data.description}` : "";
+    lines.push(`- [${example.data.title}](/examples/${slug})${desc}`);
+  }
+
+  lines.push("");
+
+  return new Response(lines.join("\n"), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/docs/src/scripts/component-markdown.test.ts
+++ b/docs/src/scripts/component-markdown.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Tests for buildComponentMarkdown()
+ *
+ * The function has no Astro runtime dependencies (CollectionEntry is a type-
+ * only import, erased by tsx), so it runs in plain Node without an Astro server.
+ *
+ * Run with: npm test (from docs/)
+ * Or directly: npx tsx --test 'src/scripts/component-markdown.test.ts'
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildComponentMarkdown } from "../lib/component-markdown.js";
+import type { ComponentMarkdownInput } from "../lib/component-markdown.js";
+import type { ComponentApi } from "../lib/content-queries.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** Minimal CollectionEntry<"components"> shape the function actually reads. */
+function componentEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "button",
+    data: {
+      name: "Button",
+      description: "Carry out an important action or navigate to another page.",
+      status: "stable",
+      category: "inputs-and-actions",
+      relatedComponents: [],
+      ...overrides,
+    },
+  } as ComponentMarkdownInput["component"];
+}
+
+/** Minimal ComponentApi using the real button.json shape (subset). */
+const buttonApi: ComponentApi = {
+  componentSlug: "button",
+  extractedFrom: "libs/web-components/src/components/button/Button.svelte",
+  frameworks: {
+    react: {
+      props: [
+        {
+          name: "type",
+          type: "GoabButtonType",
+          required: false,
+          default: "primary",
+          description:
+            'Sets the visual style of the button. Use "primary" for main actions.',
+        },
+        {
+          name: "disabled",
+          type: "boolean",
+          required: false,
+          default: null,
+          description: "When true, prevents user interaction.",
+        },
+      ],
+      events: [
+        {
+          name: "onClick",
+          type: "() => void",
+          description: "Callback fired when the button is clicked.",
+          frameworks: ["react"],
+        },
+      ],
+      slots: [],
+    },
+    angular: {
+      props: [
+        {
+          name: "type",
+          type: "GoabButtonType",
+          required: false,
+          default: "primary",
+          description: "Sets the visual style of the button.",
+        },
+      ],
+      events: [
+        {
+          name: "onClick",
+          type: "() => void",
+          description: "Emits when the button is clicked.",
+          frameworks: ["angular"],
+        },
+      ],
+      slots: [],
+    },
+    webComponents: {
+      props: [
+        {
+          name: "type",
+          type: '"primary" | "secondary" | "tertiary" | "start" | "text"',
+          typeLabel: "GoabButtonType",
+          values: ["primary", "secondary", "tertiary", "start", "text"],
+          required: false,
+          default: "primary",
+          description: "Sets the visual style of the button.",
+        },
+        {
+          name: "version",
+          type: '"1" | "2"',
+          required: false,
+          default: "1",
+          description: "Design system version for styling.",
+        },
+      ],
+      events: [
+        {
+          name: "_click",
+          type: "CustomEvent",
+          description: "",
+          frameworks: ["webComponents"],
+        },
+      ],
+      slots: [],
+    },
+  },
+};
+
+function baseInput(overrides: Partial<ComponentMarkdownInput> = {}): ComponentMarkdownInput {
+  return {
+    slug: "button",
+    component: componentEntry(),
+    api: buttonApi,
+    usageGuidance: {},
+    accessibilityGuidance: {},
+    componentExamples: [],
+    relatedComponents: [],
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test("output starts with the component name as an H1", () => {
+  const out = buildComponentMarkdown(baseInput());
+  assert.match(out, /^# Button/);
+});
+
+test("output includes the component description", () => {
+  const out = buildComponentMarkdown(baseInput());
+  assert.match(out, /Carry out an important action or navigate to another page\./);
+});
+
+test("output includes a status/category/docs metadata line", () => {
+  const out = buildComponentMarkdown(baseInput());
+  assert.match(out, /\*\*Status:\*\* stable/);
+  assert.match(out, /\*\*Category:\*\* Inputs And Actions/);
+  assert.match(out, /https:\/\/design\.alberta\.ca\/components\/button/);
+});
+
+test("output has H2 sections for all three frameworks", () => {
+  const out = buildComponentMarkdown(baseInput());
+  assert.match(out, /^## React$/m);
+  assert.match(out, /^## Angular$/m);
+  assert.match(out, /^## Web Components$/m);
+});
+
+test("web components section includes the goa- tag", () => {
+  const out = buildComponentMarkdown(baseInput());
+  assert.match(out, /Tag: `goa-button`/);
+});
+
+test("props tables contain prop names and types", () => {
+  const out = buildComponentMarkdown(baseInput());
+  assert.match(out, /\| `type` \|/);
+  assert.match(out, /GoabButtonType/);
+  assert.match(out, /\| `disabled` \|/);
+});
+
+test("props table shows the default value when present", () => {
+  const out = buildComponentMarkdown(baseInput());
+  assert.match(out, /`primary`/);
+});
+
+test("props table shows (none) when default is null", () => {
+  const out = buildComponentMarkdown(baseInput());
+  // disabled has default: null — should render as (none)
+  assert.match(out, /\| `disabled` \| boolean \| \(none\) \|/);
+});
+
+test("events section appears under each framework", () => {
+  const out = buildComponentMarkdown(baseInput());
+  const reactIdx = out.indexOf("## React");
+  const angularIdx = out.indexOf("## Angular");
+  const wcIdx = out.indexOf("## Web Components");
+
+  const reactSection = out.slice(reactIdx, angularIdx);
+  const wcSection = out.slice(wcIdx);
+
+  assert.match(reactSection, /### Events/);
+  assert.match(reactSection, /`onClick`/);
+  assert.match(wcSection, /`_click`/);
+  // _click has empty description — should render (none) not an empty cell
+  assert.match(wcSection, /`_click`.*\(none\)/);
+});
+
+test("usage guidance section appears when guidance is provided", () => {
+  const out = buildComponentMarkdown(
+    baseInput({
+      usageGuidance: {
+        types: [
+          {
+            id: "g1",
+            data: {
+              id: "g1",
+              type: "do",
+              description: "Use a button for important actions.",
+              topic: "types",
+              status: "published",
+            },
+          } as ComponentMarkdownInput["usageGuidance"][string][number],
+        ],
+      },
+    }),
+  );
+  assert.match(out, /## Usage guidance/);
+  assert.match(out, /\[Do\]\*\* Use a button for important actions\./)
+});
+
+test("accessibility guidance section appears when guidance is provided", () => {
+  const out = buildComponentMarkdown(
+    baseInput({
+      accessibilityGuidance: {
+        keyboard: [
+          {
+            id: "a1",
+            data: {
+              id: "a1",
+              type: "dont",
+              description: "Don't trap keyboard focus.",
+              topic: "keyboard",
+              status: "published",
+            },
+          } as ComponentMarkdownInput["accessibilityGuidance"][string][number],
+        ],
+      },
+    }),
+  );
+  assert.match(out, /## Accessibility guidance/);
+  assert.match(out, /\[Don't\]\*\* Don't trap keyboard focus\./)
+});
+
+test("examples section lists examples with links", () => {
+  const out = buildComponentMarkdown(
+    baseInput({
+      componentExamples: [
+        {
+          id: "button-with-icon",
+          data: {
+            id: "button-with-icon",
+            title: "Button with Icon",
+            size: "interaction",
+            components: ["button"],
+            status: "published",
+          },
+        } as ComponentMarkdownInput["componentExamples"][number],
+      ],
+    }),
+  );
+  assert.match(out, /## Examples/);
+  assert.match(out, /\[Button with Icon\]\(\/examples\/button-with-icon\)/);
+});
+
+test("related components section lists with links", () => {
+  const out = buildComponentMarkdown(
+    baseInput({
+      relatedComponents: [
+        {
+          id: "button-group",
+          data: {
+            name: "Button Group",
+            description: "Groups related buttons.",
+            status: "stable",
+            category: "inputs-and-actions",
+          },
+        } as ComponentMarkdownInput["relatedComponents"][number],
+      ],
+    }),
+  );
+  assert.match(out, /## Related components/);
+  assert.match(out, /\[Button Group\]\(\/components\/button-group\)/);
+  assert.match(out, /Groups related buttons\./);
+});
+
+test("no raw HTML or goa-* elements appear in the output", () => {
+  const out = buildComponentMarkdown(baseInput());
+  assert.doesNotMatch(out, /<[a-z]/i, "found raw HTML or web component tags in output");
+});
+
+test("gracefully handles null api", () => {
+  const out = buildComponentMarkdown(baseInput({ api: null }));
+  assert.match(out, /# Button/);
+  assert.match(out, /API data not available/);
+  assert.doesNotMatch(out, /## React/);
+});
+
+test("pipe characters in union types are escaped so table columns don't break", () => {
+  const apiWithUnion: ComponentApi = {
+    ...buttonApi,
+    frameworks: {
+      ...buttonApi.frameworks,
+      webComponents: {
+        ...buttonApi.frameworks.webComponents,
+        props: [
+          {
+            name: "type",
+            type: '"primary" | "secondary" | "tertiary"',
+            required: false,
+            default: "primary",
+            description: "Sets the visual style.",
+          },
+        ],
+      },
+    },
+  };
+  const out = buildComponentMarkdown(baseInput({ api: apiWithUnion }));
+  // Each row must have exactly 5 pipe-delimited columns (name|type|default|required|desc)
+  // An unescaped union like "primary" | "secondary" would create extra columns.
+  const wcSection = out.slice(out.indexOf("## Web Components"));
+  const tableRows = wcSection
+    .split("\n")
+    .filter((l) => l.startsWith("| `type`"));
+  assert.equal(tableRows.length, 1, "should find exactly one type row");
+  const columns = tableRows[0].split(/(?<!\\)\|/).filter((c) => c.trim() !== "");
+  assert.equal(columns.length, 5, "type row should have exactly 5 columns (name, type, default, required, desc)");
+  assert.match(tableRows[0], /\\|/, "pipe in union type should be escaped with backslash");
+});
+
+test("version attribute is filtered out of the Web Components table", () => {
+  const out = buildComponentMarkdown(baseInput());
+  const wcSection = out.slice(out.indexOf("## Web Components"));
+  const angularIdx = out.indexOf("## Angular");
+  const wcOnlySection = wcSection.slice(0, wcSection.indexOf("---") || wcSection.length);
+  assert.doesNotMatch(wcOnlySection, /\| `version` \|/, "version attr should not appear in WC Attributes table");
+});
+
+test("guidance prefixes are ASCII-safe (no emoji)", () => {
+  const out = buildComponentMarkdown(
+    baseInput({
+      usageGuidance: {
+        types: [
+          {
+            id: "g1",
+            data: { id: "g1", type: "do", description: "Use buttons for actions.", topic: "types", status: "published" },
+          } as ComponentMarkdownInput["usageGuidance"][string][number],
+          {
+            id: "g2",
+            data: { id: "g2", type: "dont", description: "Don't overuse.", topic: "types", status: "published" },
+          } as ComponentMarkdownInput["usageGuidance"][string][number],
+          {
+            id: "g3",
+            data: { id: "g3", type: "tip", description: "Use descriptive labels.", topic: "types", status: "published" },
+          } as ComponentMarkdownInput["usageGuidance"][string][number],
+        ],
+      },
+    }),
+  );
+  // Must contain ASCII bracket prefixes
+  assert.match(out, /\[Do\]/);
+  assert.match(out, /\[Don't\]/);
+  assert.match(out, /\[Tip\]/);
+  // Must not contain any character above U+007F
+  assert.doesNotMatch(out, /[^\x00-\x7F]/, "output must be pure ASCII");
+});
+
+
+test("deprecated props are flagged in the table", () => {
+  const apiWithDeprecated: ComponentApi = {
+    ...buttonApi,
+    frameworks: {
+      ...buttonApi.frameworks,
+      react: {
+        ...buttonApi.frameworks.react,
+        props: [
+          ...buttonApi.frameworks.react.props,
+          {
+            name: "oldProp",
+            type: "string",
+            required: false,
+            default: null,
+            description: "An old prop.",
+            deprecated: true,
+          },
+        ],
+      },
+    },
+  };
+  const out = buildComponentMarkdown(baseInput({ api: apiWithDeprecated }));
+  assert.match(out, /\*\(deprecated\)\*/);
+});

--- a/skills/README.md
+++ b/skills/README.md
@@ -10,6 +10,7 @@ A skill is plain-Markdown guidance your AI loads on its own when the work matche
 |---|---|
 | [`using-goa-design-system`](./using-goa-design-system/) | Turns "I'm building X for users" into the right product type, templates, and components. The navigator. |
 | [`content-design`](./content-design/) | Designs user-facing words for their reader, a citizen or a worker. The writer. |
+| [`component-search`](./component-search/) | Searches AI-friendly markdown endpoints for component APIs, props, events, and guidance. The lookup tool. |
 
 Each skill folder has a `SKILL.md` (the instructions your AI reads) and a `README.md` (what it is, for humans).
 
@@ -20,6 +21,7 @@ Add a skill, pointed at this repo:
 ```
 npx skills add GovAlta/ui-components --skill using-goa-design-system
 npx skills add GovAlta/ui-components --skill content-design
+npx skills add GovAlta/ui-components --skill component-search
 ```
 
 It loads on its own when your work matches. Pair it with the GoA design system MCP for the live component facts.

--- a/skills/component-search/README.md
+++ b/skills/component-search/README.md
@@ -1,0 +1,129 @@
+# Component Search
+
+Search and retrieve information from the Government of Alberta Design System's AI-friendly markdown endpoints.
+
+## What it does
+
+This skill enables AI agents to discover and query the design system's component documentation through its AI-friendly endpoints:
+
+- **`/llms.txt`** - Complete index of all 60+ components and 70+ examples
+- **`/components/[slug].md`** - Full API documentation, usage guidance, and accessibility guidance for each component in clean markdown format
+
+Unlike scraping HTML pages, these endpoints return structured, machine-readable content specifically designed for AI consumption.
+
+## Use Cases
+
+| Query Type | Example | What it Returns |
+|------------|---------|----------------|
+| Component discovery | "What components do you have for forms?" | List of form-related components with descriptions |
+| API lookup | "Show me React props for Button" | Extracted props table with types, defaults, descriptions |
+| Cross-component search | "Which components have a `disabled` prop?" | List of all components with that prop across all frameworks |
+| Guidance search | "What are the accessibility requirements for Input?" | Accessibility guidance section with do/don't/tip/warning notes |
+| Example search | "Show me examples for tables" | List of table-related examples with descriptions |
+| Comparison | "Compare Button and Icon button" | Side-by-side comparison of APIs and guidance |
+
+## How it works
+
+1. **Index**: Fetches `llms.txt` once per session to build a searchable index of all components and examples
+2. **Resolve**: Maps component names to slugs using the index
+3. **Fetch**: Retrieves individual component markdown files (`/components/{slug}.md`)
+4. **Parse**: Extracts relevant sections (APIs, props, guidance) from the markdown
+5. **Present**: Returns clean, formatted information optimized for readability
+
+## Installation
+
+```bash
+npx skills add GovAlta/ui-components --skill component-search
+```
+
+## Base URL
+
+Production: `https://design.alberta.ca/`
+
+Local development: `http://localhost:4203/`
+
+## Design System Version
+
+This skill is compatible with the design system's AI-friendly endpoints introduced in:
+- `d2b9b8afb2` - feat: add /llms.txt AI agent discovery index
+- `e87edf906b` - feat: add /components/[slug].md AI-friendly Markdown endpoint
+
+## Related Skills
+
+| Skill | Purpose | Relationship |
+|-------|---------|--------------|
+| [using-goa-design-system](../using-goa-design-system/) | High-level product type and template navigation | Use for architectural questions; this skill for component details |
+| [content-design](../content-design/) | Writing user-facing content | Complementary - handles content; this handles technical docs |
+
+## File Structure
+
+```
+skills/component-search/
+├── SKILL.md    # AI instructions (loaded automatically)
+└── README.md   # This file (human documentation)
+```
+
+## Implementation Details
+
+### Supported Frameworks
+
+- **React** - Props, events
+- **Angular** - Props, events
+- **Web Components** - Attributes, events, slots
+
+### Documentation Sections
+
+Each component markdown includes:
+- Basic info (status, category, docs link)
+- Framework-specific APIs
+- Usage guidance (with ✅ Do / ❌ Don't / 💡 Tip / ⚠️ Warning / ℹ️ Note)
+- Accessibility guidance (same format)
+- Related examples
+- Related components
+
+### Caching
+
+- `llms.txt` index: Cached for session
+- Component markdown: Cached after first fetch
+- Rate limited to ~10 requests/second
+
+### Error Handling
+
+- Missing llms.txt: "Cannot access design system index"
+- Missing component: "Component '[name]' not found"
+- Site unavailable: "Design system documentation is currently unavailable"
+
+## Examples
+
+### Simple Query
+**Input:** "Tell me about the Button component"
+
+**Output:** Full Button documentation including description, status, category, React/Angular/Web Components APIs, usage guidance, accessibility guidance, examples, and related components.
+
+### API-Specific Query
+**Input:** "What are the Web Components attributes for Modal?"
+
+**Output:** Extracted Web Components section showing the tag (`goa-modal`), all attributes in a table format, events, and slots.
+
+### Guidance Query
+**Input:** "What should I avoid when using Checkbox?"
+
+**Output:** All "❌ Don't:" entries from the Checkbox usage and accessibility guidance sections.
+
+### Search Query
+**Input:** "Find components for date selection"
+
+**Output:** List of matching components (Date picker, possibly others) with their descriptions and links.
+
+## Contributing
+
+To update this skill:
+1. Edit `SKILL.md` with new capabilities or corrected behavior
+2. Update this `README.md` with any user-facing changes
+3. Test by loading the skill and trying various queries
+
+The skill automatically adapts to changes in the design system's markdown endpoints, as it parses the content dynamically rather than relying on hardcoded patterns.
+
+## License
+
+Same as the ui-components repository.

--- a/skills/component-search/README.md
+++ b/skills/component-search/README.md
@@ -6,7 +6,7 @@ Search and retrieve information from the Government of Alberta Design System's A
 
 This skill enables AI agents to discover and query the design system's component documentation through its AI-friendly endpoints:
 
-- **`/llms.txt`** - Complete index of all 60+ components and 70+ examples
+- **`/llms.txt`** - Complete index of all components and examples
 - **`/components/[slug].md`** - Full API documentation, usage guidance, and accessibility guidance for each component in clean markdown format
 
 Unlike scraping HTML pages, these endpoints return structured, machine-readable content specifically designed for AI consumption.
@@ -76,7 +76,7 @@ skills/component-search/
 Each component markdown includes:
 - Basic info (status, category, docs link)
 - Framework-specific APIs
-- Usage guidance (with ✅ Do / ❌ Don't / 💡 Tip / ⚠️ Warning / ℹ️ Note)
+- Usage guidance (with [Do] / [Don't] / [Tip] / [Warning] / [Note])
 - Accessibility guidance (same format)
 - Related examples
 - Related components
@@ -108,7 +108,7 @@ Each component markdown includes:
 ### Guidance Query
 **Input:** "What should I avoid when using Checkbox?"
 
-**Output:** All "❌ Don't:" entries from the Checkbox usage and accessibility guidance sections.
+**Output:** All "[Don't]" entries from the Checkbox usage and accessibility guidance sections.
 
 ### Search Query
 **Input:** "Find components for date selection"

--- a/skills/component-search/SKILL.md
+++ b/skills/component-search/SKILL.md
@@ -1,0 +1,436 @@
+---
+name: component-search
+description: Search and retrieve information from the Government of Alberta Design System's AI-friendly markdown endpoints (llms.txt and /components/[slug].md). Use when the user asks about design system components, APIs, props, events, usage guidance, or accessibility guidance.
+---
+
+# Design System Component Search
+
+## Overview
+
+This skill enables AI agents to search and retrieve structured documentation from the Government of Alberta Design System using its AI-friendly markdown endpoints. The design system provides:
+
+- **llms.txt** - A complete index of all components and examples
+- **/components/[slug].md** - AI-friendly markdown for each component containing full API documentation, usage guidance, and accessibility guidance
+
+These endpoints return clean, structured markdown without custom elements or JavaScript, making them ideal for AI consumption.
+
+**Base URL**: `https://design.alberta.ca/`
+
+## When to Use
+
+Apply this skill when the user's request relates to:
+- Government of Alberta Design System components
+- Questions about component APIs (React, Angular, Web Components)
+- Props, events, slots, or attributes
+- Usage guidance or accessibility requirements
+- Finding components for specific purposes
+- Examples and patterns
+
+When NOT to use:
+- General web development questions unrelated to the GoA Design System
+- Questions about frameworks not covered by the design system
+- Non-documentation requests
+
+## Discovery & Indexing
+
+### Step 1: Fetch the Master Index
+
+```
+GET https://design.alberta.ca/llms.txt
+```
+
+This file contains the complete inventory organized into two sections:
+
+**Components Section** (starts with `## Components`):
+```
+- [Component Name](/components/{slug}.md): Brief description of purpose
+```
+
+**Examples Section** (starts with `## Examples`):
+```
+- [Example Name](/examples/{slug}): Brief description
+```
+
+### Step 2: Parse and Cache
+
+Parse llms.txt to extract:
+- Component names, slugs, descriptions
+- Example names, slugs, descriptions
+- Build an in-memory index for quick lookup
+
+Cache the parsed index for the session to avoid repeated fetching.
+
+## Component Markdown Structure
+
+Each component markdown file (`/components/{slug}.md`) follows this structure:
+
+```markdown
+# Component Name
+
+Description of the component.
+
+**Status:** stable | **Category:** Category Name | **Docs:** https://design.alberta.ca/components/{slug}
+
+---
+
+## React
+Tag: (none for React)
+
+### Props
+| Prop | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `propName` | type | default | Yes/No | Description |
+
+### Events
+| Event | Type | Description |
+|-------|------|-------------|
+
+---
+
+## Angular
+
+### Props
+| Prop | Type | Default | Required | Description |
+
+### Events
+| Event | Type | Description |
+
+---
+
+## Web Components
+Tag: `goa-{slug}`
+
+### Attributes
+| Prop | Type | Default | Required | Description |
+
+### Events
+| Event | Type | Description |
+
+### Slots
+| Slot | Required | Description |
+
+---
+
+## Usage guidance
+
+### [Topic Name]
+- ✅ Do: Recommended practice
+- ❌ Don't: Anti-pattern to avoid
+- 💡 Tip: Helpful suggestion
+- ⚠️ Warning: Important caution
+- ℹ️ Note: Informational note
+
+---
+
+## Accessibility guidance
+
+### [Topic Name]
+- ✅ Do: ...
+- ❌ Don't: ...
+
+---
+
+## Examples
+- [Example Name](/examples/{slug}): Description
+
+---
+
+## Related components
+- [Component Name](/components/{slug}): Description
+```
+
+## Search Capabilities
+
+### 1. Component Discovery
+
+**Query patterns:**
+- "Find components for [purpose]"
+- "List all [category] components"
+- "What components handle [function]?"
+- "Show me input components"
+- "What table components do you have?"
+
+**Action:**
+1. Search the cached llms.txt index for matching component names and descriptions
+2. Return matching components with:
+   - Component name
+   - Slug
+   - Brief description
+   - Category (if available)
+3. Offer to fetch full details for specific matches
+
+### 2. Detailed Component Lookup
+
+**Query patterns:**
+- "Tell me about [Component Name]"
+- "Show me the [Component Name] API"
+- "What are the props for [Component Name]?"
+- "Show me React props for Button"
+- "What events does Modal have?"
+- "What are the accessibility requirements for Input?"
+
+**Action:**
+1. Resolve component name to slug using the llms.txt index
+2. Fetch `https://design.alberta.ca/components/{slug}.md`
+3. Parse the markdown to extract the requested information:
+   - For API questions: Extract the relevant framework section (React/Angular/Web Components)
+   - For props/attributes: Extract and format the Props/Attributes table
+   - For events: Extract and format the Events table
+   - For guidance: Extract Usage or Accessibility guidance sections
+4. Return the information in a clean, readable format
+
+### 3. Cross-Component Search
+
+**Query patterns:**
+- "Which components have a [prop name] prop?"
+- "Find all components with [specific guidance]"
+- "Show me components with a `disabled` attribute"
+- "Which components mention [term] in their accessibility guidance?"
+
+**Action:**
+1. First, search the cached llms.txt descriptions for likely matches — avoid fetching full markdown unless the query cannot be resolved from descriptions alone
+2. For likely matches only (not all 70+ components):
+   - Fetch the component markdown (use cached versions if available)
+   - Search the relevant section (props table, guidance, etc.) for the query term
+3. Return matching components with context about where the match was found
+
+> **Note:** Fetching all 70+ component markdown files in one agent turn is expensive and likely to exceed tool-call limits. Rely on llms.txt descriptions as a first-pass filter and only fetch full pages for strong matches.
+
+### 4. Example Search
+
+**Query patterns:**
+- "Show me examples for [use case]"
+- "Find examples using [component]"
+- "List all form examples"
+- "What examples demonstrate tables?"
+
+**Action:**
+1. Parse the Examples section of llms.txt
+2. Match example names and descriptions against the query
+3. Return matching examples with:
+   - Example name
+   - Slug
+   - Description
+   - URL
+
+### 5. Comparison Queries
+
+**Query patterns:**
+- "Compare [Component A] and [Component B]"
+- "What's the difference between Button and Icon button?"
+- "Show me React vs Angular API for [Component]"
+
+**Action:**
+1. Fetch markdown for all mentioned components
+2. Extract the relevant sections (APIs, props, guidance)
+3. Present side-by-side comparison in markdown tables
+
+## Implementation Guidelines
+
+### Caching Strategy
+
+- **llms.txt**: Fetch once per session, cache the parsed index
+- **Component markdown**: Cache after first fetch, reuse for subsequent queries in the same session
+- **Cache invalidation**: Refetch only if the user explicitly requests fresh data
+
+### Error Handling
+
+- If `llms.txt` is unavailable: "Cannot access design system index. The documentation may be temporarily unavailable."
+- If a component markdown file returns 404: "Component '[name]' not found in the design system."
+- If the site is down: "Design system documentation is currently unavailable at https://design.alberta.ca/"
+- If parsing fails: "Unable to parse the component documentation. The format may have changed."
+
+### Rate Limiting
+
+- Maximum 10 requests per second to avoid overwhelming the server
+- Batch requests where possible (e.g., fetch multiple components in parallel)
+- Use cached data for repeated queries
+
+## Output Formatting
+
+### Structured Data (Props, Events, Attributes)
+
+Use markdown tables for tabular data:
+
+```markdown
+### Button Props (React)
+
+| Prop | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `type` | "primary" \| "secondary" \| "tertiary" | `primary` | No | Visual style of the button |
+| `disabled` | boolean | `false` | No | When true, prevents user interaction |
+```
+
+### Guidance
+
+Preserve the emoji prefixes and formatting:
+
+```markdown
+### Usage Guidance
+
+**Content**
+- ✅ **Do:** Use one word to explain the function (Save, Submit, Search)
+- ❌ **Don't:** Use all uppercase or all lowercase for button labels
+- 💡 **Tip:** Use descriptive verbs (Submit application, Save draft)
+```
+
+### Component Lists
+
+Use bullet lists with links:
+
+```markdown
+### Matching Components
+
+- **[Button](/components/button.md)**: Carry out an important action or navigate to another page
+- **[Icon button](/components/icon-button.md)**: A compact button with an icon and no text
+- **[Dropdown](/components/dropdown.md)**: Present a list of options to the user to select from
+```
+
+### Always Include
+
+- Links back to the full documentation: `https://design.alberta.ca/components/{slug}`
+- The component's status (stable, experimental, deprecated)
+- The component's category for context
+
+## Example Interactions
+
+### Example 1: Component Discovery
+
+**User:** "What components do you have for forms?"
+
+**Agent:**
+1. Fetch and parse llms.txt
+2. Search for components with descriptions containing "form", "input", "field", "submit"
+3. Return:
+
+```markdown
+I found these form-related components in the GoA Design System:
+
+**Input Components:**
+- **[Input](/components/input.md)**: A single-line field where users can input and edit text
+- **[Text area](/components/text-area.md)**: A multi-line field where users can input and edit text
+- **[Checkbox](/components/checkbox.md)**: Let the user select one or more options
+- **[Radio group](/components/radio-group.md)**: Allow users to select one option from a set
+- **[Dropdown](/components/dropdown.md)**: Present a list of options to the user to select from
+- **[Date picker](/components/date-picker.md)**: Lets users select a date through a calendar
+
+**Form Structure:**
+- **[Form item](/components/form-item.md)**: Wraps an input control with a text label, requirement label, helper text, and error text
+- **[Button](/components/button.md)**: Carry out an important action (e.g., Submit)
+
+Would you like me to show the API for any of these components?
+```
+
+### Example 2: Detailed API Lookup
+
+**User:** "Show me the React props for Button"
+
+**Agent:**
+1. Find Button slug from llms.txt (button)
+2. Fetch `/components/button.md`
+3. Extract the React section and Props table
+4. Return:
+
+```markdown
+## Button - React API
+
+**Status:** stable | **Category:** Inputs And Actions
+
+Full docs: https://design.alberta.ca/components/button
+
+### Props
+
+| Prop | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `type` | GoabButtonType | `primary` | No | Sets the visual style of the button. Use "primary" for main actions, "secondary" for alternative actions, "tertiary" for low-emphasis actions, "start" for prominent call-to-action buttons, and "text" for text-only buttons. |
+| `size` | GoabButtonSize | `normal` | No | Controls the size of the button. Use "compact" for inline actions or space-constrained layouts. |
+| `disabled` | boolean | `false` | No | When true, prevents user interaction and applies disabled styling. |
+| `leadingIcon` | GoabIconType | — | No | Icon displayed before the button text. |
+| `trailingIcon` | GoabIconType | — | No | Icon displayed after the button text. |
+
+### Events
+
+| Event | Type | Description |
+|-------|------|-------------|
+| `onClick` | () => void | Callback fired when the button is clicked. |
+
+*See [Button component docs](https://design.alberta.ca/components/button) for complete usage guidance.*
+```
+
+### Example 3: Cross-Component Search
+
+**User:** "Which components have a `disabled` prop?"
+
+**Agent:**
+1. Iterate through all components from llms.txt
+2. For each, fetch markdown and search for "disabled" in props/attributes tables
+3. Return:
+
+```markdown
+These components have a `disabled` prop/attribute:
+
+| Component | Framework | Type | Default | Description |
+|-----------|-----------|------|---------|-------------|
+| [Button](/components/button.md) | React | boolean | `false` | When true, prevents user interaction |
+| [Button](/components/button.md) | Angular | boolean | `false` | Sets the disabled state |
+| [Button](/components/button.md) | Web Components | boolean | `false` | When true, prevents user interaction |
+| [Input](/components/input.md) | React | boolean | `false` | When true, prevents user input |
+| [Input](/components/input.md) | Angular | boolean | `false` | When true, prevents user input |
+| [Checkbox](/components/checkbox.md) | React | boolean | `false` | When true, prevents user interaction |
+| [Dropdown](/components/dropdown.md) | React | boolean | `false` | When true, prevents user interaction |
+
+Would you like to see the full API for any of these components?
+```
+
+### Example 4: Guidance Search
+
+**User:** "What are the accessibility requirements for buttons?"
+
+**Agent:**
+1. Find Button slug (button)
+2. Fetch `/components/button.md`
+3. Extract Accessibility guidance section
+4. Return:
+
+```markdown
+## Button - Accessibility Guidance
+
+### Screen Readers
+- ❌ **Don't:** Don't read the icon class or description for icon buttons with labels. Screen readers should read the button label only.
+- ✅ **Do:** Icon-only buttons must include a descriptive label for screen readers.
+
+### Focus
+- ❌ **Don't:** Don't focus on just the icon within a button. Focus the button as a whole.
+
+*See [Button accessibility docs](https://design.alberta.ca/components/button#accessibility) for more details.*
+```
+
+## Performance Considerations
+
+1. **First query**: Fetch llms.txt and build the index (one request)
+2. **Subsequent queries**: Use cached index, only fetch new component markdown as needed
+3. **Batch operations**: When searching across all components, consider:
+   - First try searching the cached llms.txt descriptions
+   - Only fetch full markdown for likely matches
+   - Parallelize fetches where possible
+
+## Integration with Other Skills
+
+This skill complements other GoA Design System skills:
+- **using-goa-design-system**: For high-level product type and template navigation
+- **content-design**: For writing user-facing content
+
+When a user asks a specific component question, this skill provides the detailed technical information. When they ask about building a feature, defer to using-goa-design-system for the architectural guidance.
+
+## Common Mistakes to Avoid
+
+- **Don't fetch llms.txt repeatedly**: Cache it for the session
+- **Don't assume slug == name**: Use the slug from llms.txt, not a URL-ified version of the name
+- **Don't invent information**: Only return what's in the markdown files
+- **Don't ignore the guidance sections**: Usage and accessibility guidance are as important as the API
+- **Do present the markdown as-is**: The `.md` files are already clean and structured — render or present them directly rather than reparsing and reformatting, which risks losing information
+- **Do handle 404s gracefully**: Components may be renamed or removed
+
+## Version
+
+This skill is designed for the GoA Design System's AI-friendly markdown endpoints as documented in commit `d2b9b8afb2` (feat: add /llms.txt AI agent discovery index) and `e87edf906b` (feat: add /components/[slug].md AI-friendly Markdown endpoint).

--- a/skills/component-search/SKILL.md
+++ b/skills/component-search/SKILL.md
@@ -74,7 +74,6 @@ Description of the component.
 ---
 
 ## React
-Tag: (none for React)
 
 ### Props
 | Prop | Type | Default | Required | Description |
@@ -114,19 +113,19 @@ Tag: `goa-{slug}`
 ## Usage guidance
 
 ### [Topic Name]
-- ✅ Do: Recommended practice
-- ❌ Don't: Anti-pattern to avoid
-- 💡 Tip: Helpful suggestion
-- ⚠️ Warning: Important caution
-- ℹ️ Note: Informational note
+- **[Do]** Recommended practice
+- **[Don't]** Anti-pattern to avoid
+- **[Tip]** Helpful suggestion
+- **[Warning]** Important caution
+- **[Note]** Informational note
 
 ---
 
 ## Accessibility guidance
 
 ### [Topic Name]
-- ✅ Do: ...
-- ❌ Don't: ...
+- **[Do]** ...
+- **[Don't]** ...
 
 ---
 
@@ -189,12 +188,12 @@ Tag: `goa-{slug}`
 
 **Action:**
 1. First, search the cached llms.txt descriptions for likely matches — avoid fetching full markdown unless the query cannot be resolved from descriptions alone
-2. For likely matches only (not all 70+ components):
+2. For likely matches only (not all components):
    - Fetch the component markdown (use cached versions if available)
    - Search the relevant section (props table, guidance, etc.) for the query term
 3. Return matching components with context about where the match was found
 
-> **Note:** Fetching all 70+ component markdown files in one agent turn is expensive and likely to exceed tool-call limits. Rely on llms.txt descriptions as a first-pass filter and only fetch full pages for strong matches.
+> **Note:** Fetching all component markdown files in one agent turn is expensive and likely to exceed tool-call limits. Rely on llms.txt descriptions as a first-pass filter and only fetch full pages for strong matches.
 
 ### 4. Example Search
 
@@ -263,15 +262,15 @@ Use markdown tables for tabular data:
 
 ### Guidance
 
-Preserve the emoji prefixes and formatting:
+Preserve the bracket prefixes and formatting:
 
 ```markdown
 ### Usage Guidance
 
 **Content**
-- ✅ **Do:** Use one word to explain the function (Save, Submit, Search)
-- ❌ **Don't:** Use all uppercase or all lowercase for button labels
-- 💡 **Tip:** Use descriptive verbs (Submit application, Save draft)
+- **[Do]** Use one word to explain the function (Save, Submit, Search)
+- **[Don't]** Use all uppercase or all lowercase for button labels
+- **[Tip]** Use descriptive verbs (Submit application, Save draft)
 ```
 
 ### Component Lists
@@ -396,11 +395,11 @@ Would you like to see the full API for any of these components?
 ## Button - Accessibility Guidance
 
 ### Screen Readers
-- ❌ **Don't:** Don't read the icon class or description for icon buttons with labels. Screen readers should read the button label only.
-- ✅ **Do:** Icon-only buttons must include a descriptive label for screen readers.
+- **[Don't]** Don't read the icon class or description for icon buttons with labels. Screen readers should read the button label only.
+- **[Do]** Icon-only buttons must include a descriptive label for screen readers.
 
 ### Focus
-- ❌ **Don't:** Don't focus on just the icon within a button. Focus the button as a whole.
+- **[Don't]** Don't focus on just the icon within a button. Focus the button as a whole.
 
 *See [Button accessibility docs](https://design.alberta.ca/components/button#accessibility) for more details.*
 ```

--- a/skills/component-search/SKILL.md
+++ b/skills/component-search/SKILL.md
@@ -36,7 +36,7 @@ When NOT to use:
 ### Step 1: Fetch the Master Index
 
 ```
-GET https://design.alberta.ca/llms.txt
+GET {Base URL}llms.txt
 ```
 
 This file contains the complete inventory organized into two sections:
@@ -155,8 +155,7 @@ Tag: `goa-{slug}`
    - Component name
    - Slug
    - Brief description
-   - Category (if available)
-3. Offer to fetch full details for specific matches
+3. Offer to fetch full details for specific matches (category is only available on the component's markdown page, not in the llms.txt index)
 
 ### 2. Detailed Component Lookup
 
@@ -170,7 +169,7 @@ Tag: `goa-{slug}`
 
 **Action:**
 1. Resolve component name to slug using the llms.txt index
-2. Fetch `https://design.alberta.ca/components/{slug}.md`
+2. Fetch `{Base URL}components/{slug}.md`
 3. Parse the markdown to extract the requested information:
    - For API questions: Extract the relevant framework section (React/Angular/Web Components)
    - For props/attributes: Extract and format the Props/Attributes table
@@ -236,7 +235,7 @@ Tag: `goa-{slug}`
 
 - If `llms.txt` is unavailable: "Cannot access design system index. The documentation may be temporarily unavailable."
 - If a component markdown file returns 404: "Component '[name]' not found in the design system."
-- If the site is down: "Design system documentation is currently unavailable at https://design.alberta.ca/"
+- If the site is down: "Design system documentation is currently unavailable at {Base URL}"
 - If parsing fails: "Unable to parse the component documentation. The format may have changed."
 
 ### Rate Limiting
@@ -287,7 +286,7 @@ Use bullet lists with links:
 
 ### Always Include
 
-- Links back to the full documentation: `https://design.alberta.ca/components/{slug}`
+- Links back to the full documentation: `{Base URL}components/{slug}`
 - The component's status (stable, experimental, deprecated)
 - The component's category for context
 


### PR DESCRIPTION
Add new skill that enables AI agents to search and retrieve structured documentation from the design system's AI-friendly markdown endpoints:
- /llms.txt for component and example discovery
- /components/[slug].md for full API, usage, and accessibility guidance

#### The skill supports
- Component discovery by purpose or category
- Detailed API lookups (React, Angular, Web Components)
- Cross-component searches (e.g., find all components with a prop)
- Guidance searches (usage and accessibility)
- Example searches
- Component comparisons

#### Example links
- llms.txt: https://govalta.github.io/ui-components/pr-preview/pr-4150/llms.txt
- Example component MD page: https://govalta.github.io/ui-components/pr-preview/pr-4150/components/button.md 

#### How to test locally
1. Run docs locally (docs app) on a port (ex: 4203).
2. In the [component-search skill file](https://github.com/GovAlta/ui-components/pull/4150/changes#diff-03344aaa52feb5e194ec074700628c0dbde532620be5116e02cd6601bda5c3fa), temporarily set Base URL to http://localhost:4203 (instead of prod).
3. Ask the agent to use the skill for...
    - component discovery (/llms.txt)
    - component details (/components/button.md)
    - cross-component search flow

### Demos

I asked, "What components are available for choosing between multiple options on a form?"

<img width="1215" height="434" alt="image" src="https://github.com/user-attachments/assets/7f58c841-b69f-495e-93f3-d28087f78b6e" />

---

I asked, "What components could I use for displaying a warning on a page?"

<img width="1229" height="608" alt="image" src="https://github.com/user-attachments/assets/708b1636-75a0-41ee-ba4c-1b3f787c3d21" />
