### PR TITLE
fix(#3838): Updated border-radius on segmented tabs

### DIFF
--- a/libs/web-components/src/components/tabs/Tabs.svelte
+++ b/libs/web-components/src/components/tabs/Tabs.svelte
@@ -839,7 +839,7 @@
     background: var(--goa-color-greyscale-white, #ffffff);
     border: var(--goa-border-width-s) solid
       var(--goa-color-greyscale-150, #dcdcdc);
-    border-radius: var(--goa-border-radius-xl);
+    border-radius: var(--goa-border-radius-m);
     pointer-events: none;
     z-index: 0;
     box-sizing: border-box;
@@ -856,7 +856,7 @@
     background: transparent;
     /* Override base border-bottom and border-left (mobile) */
     border: var(--goa-border-width-s) solid transparent;
-    border-radius: var(--goa-border-radius-xl);
+    border-radius: var(--goa-border-radius-m);
     min-height: 30px;
     padding: 0 var(--goa-space-s, 12px);
     /* Typography */


### PR DESCRIPTION
# Before (the change)

The individual segmented tabs had a border radius of `--goa-border-radius-xl`, while the outer container for them had a border radius of `--goa-border-radius-m`

# After (the change)

Both the individual segmented tabs and the outer container should now both be using `--goa-border-radius-m`

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the docs PR for the Tab component to verify
