### PR TITLE
fix(#3846): Added a default color for Menu Action text

### DIFF
--- a/libs/web-components/src/components/menu-button/MenuAction.svelte
+++ b/libs/web-components/src/components/menu-button/MenuAction.svelte
@@ -106,6 +106,7 @@
   }
 
   .text {
+    color: var(--goa-color-text-default);
     padding-bottom: var(--font-valign-fix);
     width: 100%;
   }


### PR DESCRIPTION
# Before (the change)

Safari was using it's own default colour on Menu Action labels because no `color` property was ever set.

# After (the change)

An explicit `color` property as been set to `--goa-color-text-default`, which should be used by Safari.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Use the docs PR for the Menu Button component to confirm text colour is accurate for Menu Action in Safari
