### PR TITLE
fix(#3827): Updated pagination dropdown size

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3827/bug3827.component.html
+++ b/apps/prs/angular/src/routes/bugs/3827/bug3827.component.html
@@ -1,0 +1,35 @@
+<h3>Pagination with 5 pages</h3>
+<goab-pagination
+  [pageNumber]="basicPage"
+  [itemCount]="50"
+  [perPageCount]="10"
+  (onChange)="handleBasicPageChange($event)"
+>
+</goab-pagination>
+
+<h3>Pagination with 15 pages</h3>
+<goab-pagination
+  [pageNumber]="basicPage"
+  [itemCount]="150"
+  [perPageCount]="10"
+  (onChange)="handleBasicPageChange($event)"
+>
+</goab-pagination>
+
+<h3>Pagination with 105 pages</h3>
+<goab-pagination
+  [pageNumber]="basicPage"
+  [itemCount]="1050"
+  [perPageCount]="10"
+  (onChange)="handleBasicPageChange($event)"
+>
+</goab-pagination>
+
+<h3>Pagination with 1005 pages</h3>
+<goab-pagination
+  [pageNumber]="basicPage"
+  [itemCount]="10050"
+  [perPageCount]="10"
+  (onChange)="handleBasicPageChange($event)"
+>
+</goab-pagination>

--- a/apps/prs/angular/src/routes/bugs/3827/bug3827.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3827/bug3827.component.ts
@@ -1,0 +1,16 @@
+import { Component } from "@angular/core";
+import { GoabPagination, GoabPaginationOnChangeDetail } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3827",
+  templateUrl: "./bug3827.component.html",
+  imports: [GoabPagination],
+})
+export class Bug3827Component {
+  basicPage = 1;
+
+  handleBasicPageChange(event: GoabPaginationOnChangeDetail): void {
+    this.basicPage = event.page;
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/3827/bug3827.route.json
+++ b/apps/prs/angular/src/routes/bugs/3827/bug3827.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3827",
+  "path": "bugs/3827",
+  "title": "Page selection dropdown length"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3827.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3827.route.ts
@@ -1,0 +1,10 @@
+import { Bug3827Route } from "../../../routes/bugs/bug3827";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3827",
+  path: "bugs/3827",
+  title: "Page selection dropdown length",
+  component: Bug3827Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3827.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3827.tsx
@@ -1,0 +1,47 @@
+import { GoabPagination } from "@abgov/react-components";
+import { GoabPaginationOnChangeDetail } from "@abgov/ui-components-common";
+import { useState } from "react";
+
+export function Bug3827Route() {
+  const [page, setPage] = useState(1);
+
+  function handleBasicPageChange(event: GoabPaginationOnChangeDetail): void {
+    setPage(event.page);
+  }
+
+  return (
+    <>
+      <h3>Pagination with 5 pages</h3>
+      <GoabPagination
+        pageNumber={page}
+        itemCount={50}
+        perPageCount={10}
+        onChange={(e) => handleBasicPageChange(e)}
+      />
+
+      <h3>Pagination with 15 pages</h3>
+      <GoabPagination
+        pageNumber={page}
+        itemCount={150}
+        perPageCount={10}
+        onChange={(e) => handleBasicPageChange(e)}
+      />
+
+      <h3>Pagination with 105 pages</h3>
+      <GoabPagination
+        pageNumber={page}
+        itemCount={1050}
+        perPageCount={10}
+        onChange={(e) => handleBasicPageChange(e)}
+      />
+
+      <h3>Pagination with 1005 pages</h3>
+      <GoabPagination
+        pageNumber={page}
+        itemCount={10050}
+        perPageCount={10}
+        onChange={(e) => handleBasicPageChange(e)}
+      />
+    </>
+  );
+}

--- a/libs/web-components/src/components/dropdown/Dropdown.spec.ts
+++ b/libs/web-components/src/components/dropdown/Dropdown.spec.ts
@@ -1240,6 +1240,18 @@ describe("GoADropdown", () => {
       });
     });
 
+    it("should calculate width from numeric options", async () => {
+      const result = render(GoADropdownWrapper, {
+        name: "test",
+        items: [1, 20, 100],
+      });
+
+      await waitFor(() => {
+        const dropdown = result.container.querySelector(".dropdown");
+        expect(dropdown?.getAttribute("style")).toContain("--width: 10ch");
+      });
+    });
+
     describe("Popover width behavior", () => {
       it("should set popover max width to min(_width, 100%) for non-percentage widths", async () => {
         const result = render(GoADropdownWrapper, {

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -388,7 +388,8 @@
           (option.hasSlotContent ? option.filter : "") ||
           option.value ||
           "";
-        return label.length;
+        // label is not guarenteed to be a string
+        return String(label).length;
       }),
     );
 

--- a/libs/web-components/src/components/dropdown/DropdownWrapper.test.svelte
+++ b/libs/web-components/src/components/dropdown/DropdownWrapper.test.svelte
@@ -18,7 +18,7 @@
   export let width: string = "";
   export let maxwidth: string = "";
   export let native: string = "false";
-  export let items: string[];
+  export let items: Array<string | number>;
   export let filterable: string = "false";
   export let autocomplete: string = 'on';
   export let testid: string = "";


### PR DESCRIPTION
# Before (the change)

Pagination page dropdown size was using `7ch` width no matter how many pages were present.

# After (the change)

The pagination page dropdown size should now accurately size itself based on the number of pages in the dropdown.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use PRs `/bugs/3827` for both Angular and React
