### PR TITLE
chore(#4158): add AGENTS.md pointing other AI tools at existing standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+This repo keeps its development standards and workflows in a set of Markdown
+files. Claude Code loads them automatically; other tools do not. If you are any
+agent other than Claude Code, read the files below before making changes. They
+are the source of truth, so this file points to them rather than repeating them
+(a copy here would drift out of date).
+
+## Read first
+
+1. `CLAUDE.md` (repo root) — architecture, the wrapper pattern, development
+   standards, props conventions, and the pre-PR checklist.
+2. Every file in `.claude/rules/` — the detailed standards that back up
+   `CLAUDE.md`:
+   - `component-authoring.md` — Svelte component structure, props, events, naming.
+   - `styling.md` — design tokens, V2 fallbacks, responsive patterns, CSS.
+   - `framework-wrappers.md` — React and Angular wrapper templates.
+   - `testing.md` — test tiers and enforced test patterns.
+   - `common-utilities.md` — shared utilities to use instead of reinventing.
+
+## Task workflows: `.claude/skills/`
+
+Each skill is a step-by-step workflow for a specific contributor task. When your
+task matches one, read that skill's `SKILL.md` (in its own directory under
+`.claude/skills/`) and follow it.
+
+- `fix-bug` — pick up a small, triaged style or refinement bug from the backlog.
+- `write-wrapper` — write or update a React or Angular wrapper for a web component.
+- `create-component` — create a new design system component across all frameworks.
+- `create-playground-page` — add the React and Angular PR playground test pages.
+- `writing-specs` — locator conventions for writing component tests and specs.
+- `open-pr` — rebase, fill the PR template, and open as a draft.
+- `write-issue` — file a new GitHub issue with the right template, labels, and type.
+- `write-design-system-content` — write or revise longer-form website content.
+- `ds-evolution-reference` — source of truth for design system evolution terms and FAQs.
+
+## Design system usage skills: `skills/`
+
+These help you build with the design system rather than change the repo itself.
+Some rely on the `goa-design-system` MCP tools.
+
+- `using-goa-design-system` — go from a user-facing intent to the right
+  components, guidance, and tokens.
+- `content-design` — design user-facing service copy for its reader (citizen or
+  worker).
+
+## The rule of thumb
+
+`CLAUDE.md` and `.claude/rules/` tell you the standards. `.claude/skills/` and
+`skills/` tell you the procedures. Read the relevant ones before you write code,
+and keep every changed line justified by the task you were given.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ task matches one, read that skill's `SKILL.md` (in its own directory under
 ## Design system usage skills: `skills/`
 
 These help you build with the design system rather than change the repo itself.
-Some rely on the `goa-design-system` MCP tools.
+These rely on the `goa-design-system` MCP tools. If your tool does not have
+those tools configured, skip this section.
 
 - `using-goa-design-system` — go from a user-facing intent to the right
   components, guidance, and tokens.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,54 +1,23 @@
 # AGENTS.md
 
-Guidance for AI coding agents working in this repository.
-
-This repo keeps its development standards and workflows in a set of Markdown
-files. Claude Code loads them automatically; other tools do not. If you are any
-agent other than Claude Code, read the files below before making changes. They
-are the source of truth, so this file points to them rather than repeating them
-(a copy here would drift out of date).
+Standards and workflows for AI coding agents working in this repo. Read the
+relevant files below before making changes; they are the source of truth.
 
 ## Read first
 
-1. `CLAUDE.md` (repo root) — architecture, the wrapper pattern, development
+1. `CLAUDE.md` (repo root): architecture, the wrapper pattern, development
    standards, props conventions, and the pre-PR checklist.
-2. Every file in `.claude/rules/` — the detailed standards that back up
-   `CLAUDE.md`:
-   - `component-authoring.md` — Svelte component structure, props, events, naming.
-   - `styling.md` — design tokens, V2 fallbacks, responsive patterns, CSS.
-   - `framework-wrappers.md` — React and Angular wrapper templates.
-   - `testing.md` — test tiers and enforced test patterns.
-   - `common-utilities.md` — shared utilities to use instead of reinventing.
+2. Every file in `.claude/rules/`: the detailed standards behind `CLAUDE.md`.
 
 ## Task workflows: `.claude/skills/`
 
-Each skill is a step-by-step workflow for a specific contributor task. When your
-task matches one, read that skill's `SKILL.md` (in its own directory under
-`.claude/skills/`) and follow it.
-
-- `fix-bug` — pick up a small, triaged style or refinement bug from the backlog.
-- `write-wrapper` — write or update a React or Angular wrapper for a web component.
-- `create-component` — create a new design system component across all frameworks.
-- `create-playground-page` — add the React and Angular PR playground test pages.
-- `writing-specs` — locator conventions for writing component tests and specs.
-- `open-pr` — rebase, fill the PR template, and open as a draft.
-- `write-issue` — file a new GitHub issue with the right template, labels, and type.
-- `write-design-system-content` — write or revise longer-form website content.
-- `ds-evolution-reference` — source of truth for design system evolution terms and FAQs.
+Each subdirectory holds one step-by-step workflow for a specific task. List the
+directory and read the `description` at the top of each `SKILL.md` (it says, in
+"use when..." form, when the skill applies); follow any that match your task.
 
 ## Design system usage skills: `skills/`
 
-These help you build with the design system rather than change the repo itself.
-These rely on the `goa-design-system` MCP tools. If your tool does not have
-those tools configured, skip this section.
-
-- `using-goa-design-system` — go from a user-facing intent to the right
-  components, guidance, and tokens.
-- `content-design` — design user-facing service copy for its reader (citizen or
-  worker).
-
-## The rule of thumb
-
-`CLAUDE.md` and `.claude/rules/` tell you the standards. `.claude/skills/` and
-`skills/` tell you the procedures. Read the relevant ones before you write code,
-and keep every changed line justified by the task you were given.
+Each subdirectory helps you build with the design system rather than change the
+repo. Select the same way, by reading each `SKILL.md`'s `description`. These rely
+on the `goa-design-system` MCP tools; skip this section if your tool does not
+have them configured.


### PR DESCRIPTION
## Summary

Adds a root-level `AGENTS.md` so AI coding tools other than Claude Code can discover the standards and workflows this repo already keeps in `CLAUDE.md`, `.claude/rules/`, and `.claude/skills/`. Claude Code auto-loads those; other tools do not.

`AGENTS.md` points to the existing files rather than restating them, so there is nothing to keep in sync and no risk of drift. `CLAUDE.md` and `.claude/rules/` are left unchanged.

## What it does

- Tells non-Claude agents to read `CLAUDE.md` and every file in `.claude/rules/` first.
- References all task workflows in `.claude/skills/` and the design system usage skills in `skills/`.
- Duplicates no content from any of those files.

## Steps needed to test

1. Open `AGENTS.md` at the repo root.
2. Confirm every file and skill it references exists at the stated path.
3. Confirm no standards content is copied inline (it should only describe and link).

## Notes

Came out of reviewing #4148. The AC in #4158 named `CLAUDE.md` and `.claude/rules/` only; this draft also references `.claude/skills/` and `skills/`, since `bug-fix-workflow` moved into `.claude/skills/fix-bug` and leaving skills out would send other tools to the standards but not the procedures.

Fixes #4158