### PR TITLE
fix(#3887): Updated Angular badge to use iconType the same as React

### DIFF
--- a/libs/angular-components/src/lib/components/badge/badge.spec.ts
+++ b/libs/angular-components/src/lib/components/badge/badge.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { GoabBadge } from "./badge";
 import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
-import { GoabBadgeType, Spacing } from "@abgov/ui-components-common";
+import { GoabBadgeType, GoabIconType, Spacing } from "@abgov/ui-components-common";
 import { By } from "@angular/platform-browser";
 
 @Component({
@@ -11,6 +11,7 @@ import { By } from "@angular/platform-browser";
     <goab-badge
       [type]="type"
       [icon]="icon"
+      [iconType]="iconType"
       [content]="content"
       [ariaLabel]="ariaLabel"
       [testId]="testId"
@@ -26,6 +27,7 @@ class TestBadgeComponent {
   content?: string;
   testId?: string;
   icon?: boolean;
+  iconType?: GoabIconType;
   ariaLabel?: string;
   mt?: Spacing;
   mb?: Spacing;
@@ -36,11 +38,18 @@ class TestBadgeComponent {
 @Component({
   standalone: true,
   imports: [GoabBadge],
-  template: ` <goab-badge [type]="type" [content]="content"></goab-badge> `,
+  template: `
+    <goab-badge
+      [type]="type"
+      [content]="content"
+      [iconType]="iconType"
+    ></goab-badge>
+  `,
 })
 class TestBadgeNoIconComponent {
   type?: GoabBadgeType;
   content?: string;
+  iconType?: GoabIconType;
 }
 
 describe("GoABBadge", () => {
@@ -102,6 +111,36 @@ describe("GoABBadge", () => {
     component.type = "information";
     component.content = "Information";
     component.icon = false;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    const badgeElement = fixture.debugElement.query(By.css("goa-badge")).nativeElement;
+    expect(badgeElement.getAttribute("icon")).toBe("false");
+  }));
+
+  it("should render an icon when only iconType is supplied", fakeAsync(() => {
+    const noIconFixture = TestBed.createComponent(TestBadgeNoIconComponent);
+    const noIconComponent = noIconFixture.componentInstance;
+    noIconComponent.type = "information";
+    noIconComponent.content = "Information";
+    noIconComponent.iconType = "information-circle";
+    noIconFixture.detectChanges();
+    tick();
+    noIconFixture.detectChanges();
+    const badgeElement = noIconFixture.debugElement.query(
+      By.css("goa-badge"),
+    ).nativeElement;
+    expect(badgeElement.getAttribute("icon")).toBe("true");
+    expect(badgeElement.getAttribute("icontype")).toBe("information-circle");
+  }));
+
+  it("should not render an icon when icon is false and iconType is supplied", fakeAsync(() => {
+    fixture = TestBed.createComponent(TestBadgeComponent);
+    component = fixture.componentInstance;
+    component.type = "information";
+    component.content = "Information";
+    component.icon = false;
+    component.iconType = "information-circle";
     fixture.detectChanges();
     tick();
     fixture.detectChanges();

--- a/libs/angular-components/src/lib/components/badge/badge.ts
+++ b/libs/angular-components/src/lib/components/badge/badge.ts
@@ -26,7 +26,7 @@ import { GoabBaseComponent } from "../base.component";
         [attr.size]="size"
         [attr.emphasis]="emphasis"
         [attr.type]="type"
-        [attr.icon]="icon ? 'true' : 'false'"
+        [attr.icon]="showIcon ? 'true' : 'false'"
         [attr.icontype]="iconType"
         [attr.arialabel]="ariaLabel"
         [attr.content]="content"
@@ -57,7 +57,6 @@ export class GoabBadge extends GoabBaseComponent implements OnInit {
   @Input() type?: GoabBadgeType;
   /** Sets the text label of the badge. */
   @Input() content?: string;
-  // Ensure boolean input; attribute only set when true so default behaviour is false
   /** @deprecated Use icontype instead. Includes an icon in the badge. */
   @Input({ transform: booleanAttribute }) icon?: boolean;
   /** Sets the icon type to display in the badge. */
@@ -71,6 +70,10 @@ export class GoabBadge extends GoabBaseComponent implements OnInit {
 
   isReady = false;
   version = "2";
+
+  get showIcon(): boolean {
+    return this.icon ?? !!this.iconType;
+  }
 
   ngOnInit(): void {
     // For Angular 20, we need to delay rendering the web component


### PR DESCRIPTION
# Before (the change)

When using `iconType` in Angular, you also had to supply `[icon]="true"`. Whereas for React, you just had to supply `iconType`

# After (the change)

Now when using the Badge component in Angular, you only need to supply `iconType` in order to get a custom icon showing. Just like in React.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the badge docs PR to see the change. The Angular PR page already had `iconType` being used without `icon`. It should work now.
