### PR TITLE
fix(#3841): Modified focus ring for WorkSideMenu to not overlap items

### DIFF
--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuGroup.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuGroup.svelte
@@ -32,7 +32,12 @@
   }
 
   function handleMouseEnter() {
-    dispatch(_rootEl, "_hoverItem", { el: _rootEl, label: heading }, { bubbles: true });
+    dispatch(
+      _rootEl,
+      "_hoverItem",
+      { el: _rootEl, label: heading },
+      { bubbles: true },
+    );
   }
 </script>
 
@@ -45,7 +50,11 @@
   >
     <summary aria-expanded={open}>
       {#if icon}
-        <goa-icon type={icon} size="small" theme={open ? "filled" : "outline"} />
+        <goa-icon
+          type={icon}
+          size="small"
+          theme={open ? "filled" : "outline"}
+        />
       {/if}
       <span class="label">{heading}</span>
       <goa-icon class="marker-icon" type="chevron-forward" size="small" />
@@ -111,7 +120,7 @@
 
   summary:focus-visible {
     outline: var(--goa-border-width-l) solid var(--goa-color-interactive-focus);
-    outline-offset: 2px;
+    outline-offset: calc(0px - var(--goa-border-width-l));
   }
   summary goa-icon {
     margin-top: var(--goa-space-3xs);
@@ -171,9 +180,9 @@
     details[open] summary {
       background: transparent;
       color: var(
-      --goa-work-side-menu-item-text-color,
-      var(--goa-color-greyscale-600)
-    );
+        --goa-work-side-menu-item-text-color,
+        var(--goa-color-greyscale-600)
+      );
     }
   }
 

--- a/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte
+++ b/libs/web-components/src/components/work-side-menu/WorkSideMenuItem.svelte
@@ -443,7 +443,7 @@
 
   .menu-item:focus-visible {
     outline: var(--goa-border-width-l) solid var(--goa-color-interactive-focus);
-    outline-offset: 2px;
+    outline-offset: calc(0px - var(--goa-border-width-l));
   }
 
   goa-icon {


### PR DESCRIPTION
# Before (the change)

Look at image from before the change to see the Overlap on WorkSideMenu items that had keyboard focus.

# After (the change)

These are the same images taken after this change:
<img width="279" height="450" alt="image" src="https://github.com/user-attachments/assets/294979ca-0f50-4287-b6fc-245732303644" />
<img width="271" height="449" alt="image" src="https://github.com/user-attachments/assets/ec544e99-ff0a-4164-94d8-53f189d9d2d9" />
<img width="273" height="727" alt="image" src="https://github.com/user-attachments/assets/8f18f8fe-f126-4604-b0cd-15beb69f5e6f" />

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

This can be tested on the Docs website, that's where the images were taken from.