### PR TITLE
fix(#3826): Modified Pagination button placement for desktop and mobile

### DIFF
--- a/apps/prs/angular/src/routes/docs/pagination/pagination.component.html
+++ b/apps/prs/angular/src/routes/docs/pagination/pagination.component.html
@@ -5,7 +5,8 @@
   [pageNumber]="basicPage"
   [itemCount]="100"
   [perPageCount]="10"
-  (onChange)="handleBasicPageChange($event)">
+  (onChange)="handleBasicPageChange($event)"
+>
 </goab-pagination>
 
 <h3>Simple</h3>
@@ -14,7 +15,35 @@
   [itemCount]="50"
   [perPageCount]="10"
   variant="links-only"
-  (onChange)="handleSimplePageChange($event)">
+  (onChange)="handleSimplePageChange($event)"
+>
+</goab-pagination>
+
+<h3>Simple Table</h3>
+<goab-table width="100%" mb="xl">
+  <thead>
+    <tr>
+      <th>First name</th>
+      <th>Last name</th>
+      <th>Age</th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (user of pageUsers; track user.id) {
+      <tr>
+        <td>{{ user.firstName }}</td>
+        <td>{{ user.lastName }}</td>
+        <td>{{ user.age }}</td>
+      </tr>
+    }
+  </tbody>
+</goab-table>
+<goab-pagination
+  [pageNumber]="simplePage"
+  [itemCount]="50"
+  [perPageCount]="10"
+  (onChange)="handlePageChange($event)"
+>
 </goab-pagination>
 
 <h2>Examples</h2>
@@ -46,7 +75,8 @@
       size="compact"
       (onChange)="handlePerPageCountChangeEvent($event)"
       [value]="perPage.toString()"
-      width="9ch">
+      width="9ch"
+    >
       <goab-dropdown-item value="10" label="10"></goab-dropdown-item>
       <goab-dropdown-item value="20" label="20"></goab-dropdown-item>
       <goab-dropdown-item value="30" label="30"></goab-dropdown-item>
@@ -60,6 +90,7 @@
     [itemCount]="users.length"
     [perPageCount]="perPage"
     [pageNumber]="page"
-    (onChange)="handlePageChange($event)">
+    (onChange)="handlePageChange($event)"
+  >
   </goab-pagination>
 </goab-block>

--- a/apps/prs/angular/src/routes/docs/pagination/pagination.component.ts
+++ b/apps/prs/angular/src/routes/docs/pagination/pagination.component.ts
@@ -20,8 +20,50 @@ interface User {
 }
 
 function generateUsers(): User[] {
-  const firstNames = ["Emma", "Liam", "Olivia", "Noah", "Ava", "James", "Sophia", "William", "Isabella", "Oliver", "Mia", "Benjamin", "Charlotte", "Elijah", "Amelia", "Lucas", "Harper", "Mason", "Evelyn", "Logan"];
-  const lastNames = ["Smith", "Johnson", "Williams", "Brown", "Jones", "Garcia", "Miller", "Davis", "Rodriguez", "Martinez", "Wilson", "Anderson", "Taylor", "Thomas", "Moore", "Jackson", "Martin", "Lee", "Thompson", "White"];
+  const firstNames = [
+    "Emma",
+    "Liam",
+    "Olivia",
+    "Noah",
+    "Ava",
+    "James",
+    "Sophia",
+    "William",
+    "Isabella",
+    "Oliver",
+    "Mia",
+    "Benjamin",
+    "Charlotte",
+    "Elijah",
+    "Amelia",
+    "Lucas",
+    "Harper",
+    "Mason",
+    "Evelyn",
+    "Logan",
+  ];
+  const lastNames = [
+    "Smith",
+    "Johnson",
+    "Williams",
+    "Brown",
+    "Jones",
+    "Garcia",
+    "Miller",
+    "Davis",
+    "Rodriguez",
+    "Martinez",
+    "Wilson",
+    "Anderson",
+    "Taylor",
+    "Thomas",
+    "Moore",
+    "Jackson",
+    "Martin",
+    "Lee",
+    "Thompson",
+    "White",
+  ];
   const users: User[] = [];
   for (let i = 1; i <= 100; i++) {
     users.push({

--- a/apps/prs/react/src/routes/docs/pagination/pagination.tsx
+++ b/apps/prs/react/src/routes/docs/pagination/pagination.tsx
@@ -20,8 +20,50 @@ interface User {
 }
 
 function generateUsers(): User[] {
-  const firstNames = ["Emma", "Liam", "Olivia", "Noah", "Ava", "James", "Sophia", "William", "Isabella", "Oliver", "Mia", "Benjamin", "Charlotte", "Elijah", "Amelia", "Lucas", "Harper", "Mason", "Evelyn", "Logan"];
-  const lastNames = ["Smith", "Johnson", "Williams", "Brown", "Jones", "Garcia", "Miller", "Davis", "Rodriguez", "Martinez", "Wilson", "Anderson", "Taylor", "Thomas", "Moore", "Jackson", "Martin", "Lee", "Thompson", "White"];
+  const firstNames = [
+    "Emma",
+    "Liam",
+    "Olivia",
+    "Noah",
+    "Ava",
+    "James",
+    "Sophia",
+    "William",
+    "Isabella",
+    "Oliver",
+    "Mia",
+    "Benjamin",
+    "Charlotte",
+    "Elijah",
+    "Amelia",
+    "Lucas",
+    "Harper",
+    "Mason",
+    "Evelyn",
+    "Logan",
+  ];
+  const lastNames = [
+    "Smith",
+    "Johnson",
+    "Williams",
+    "Brown",
+    "Jones",
+    "Garcia",
+    "Miller",
+    "Davis",
+    "Rodriguez",
+    "Martinez",
+    "Wilson",
+    "Anderson",
+    "Taylor",
+    "Thomas",
+    "Moore",
+    "Jackson",
+    "Martin",
+    "Lee",
+    "Thompson",
+    "White",
+  ];
   const users: User[] = [];
   for (let i = 1; i <= 100; i++) {
     users.push({
@@ -70,6 +112,32 @@ export function DocsPaginationRoute() {
         perPageCount={10}
         variant="links-only"
         onChange={(detail: GoabPaginationOnChangeDetail) => setSimplePage(detail.page)}
+      />
+
+      <h3>Simple Table</h3>
+      <GoabTable width="100%" mb="xl">
+        <thead>
+          <tr>
+            <th>First name</th>
+            <th>Last name</th>
+            <th>Age</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pageUsers.map((u) => (
+            <tr key={u.id}>
+              <td>{u.firstName}</td>
+              <td>{u.lastName}</td>
+              <td>{u.age}</td>
+            </tr>
+          ))}
+        </tbody>
+      </GoabTable>
+      <GoabPagination
+        pageNumber={simplePage}
+        itemCount={50}
+        perPageCount={10}
+        onChange={(detail: GoabPaginationOnChangeDetail) => setPage(detail.page)}
       />
 
       <h2>Examples</h2>

--- a/libs/web-components/src/components/pagination/Pagination.svelte
+++ b/libs/web-components/src/components/pagination/Pagination.svelte
@@ -1,7 +1,7 @@
 <svelte:options customElement="goa-pagination" />
 
 <script lang="ts">
-  import type { Spacing } from "../../common/styling";
+  import { calculateMargin, type Spacing } from "../../common/styling";
   import { onMount, tick } from "svelte";
   import { typeValidator, validateRequired } from "../../common/utils";
 
@@ -103,7 +103,7 @@
   }
 </script>
 
-<goa-block id="root" {ml} {mr} {mb} {mt}>
+<div id="root" style={calculateMargin(mt, mr, mb, ml)}>
   <div class="controls" data-testid={testid}>
     {#if variant === "all"}
       <goa-block data-testid="page-selector" alignment="center" gap="s">
@@ -137,7 +137,7 @@
         <span>of {itemcount <= 0 ? "1" : _pageCount}</span>
       </goa-block>
     {/if}
-    <goa-block alignment="center" gap="l" data-testid="page-links">
+    <div class="page-links" data-testid="page-links">
       <!-- svelte-ignore a11y-no-static-element-interactions -->
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <goa-button
@@ -146,7 +146,9 @@
         type="tertiary"
         size={version === "2" ? "compact" : "normal"}
         leadingicon="arrow-back"
-        disabled={itemcount <= 0 || pagenumber <= 1 ? "true" : "false"}>Previous</goa-button>
+        disabled={itemcount <= 0 || pagenumber <= 1 ? "true" : "false"}
+        >Previous</goa-button
+      >
       <!-- svelte-ignore a11y-no-static-element-interactions -->
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <goa-button
@@ -155,12 +157,18 @@
         type="tertiary"
         size={version === "2" ? "compact" : "normal"}
         trailingicon="arrow-forward"
-        disabled={itemcount <= 0 || pagenumber >= _pageCount ? "true" : "false"}>Next</goa-button>
-    </goa-block>
+        disabled={itemcount <= 0 || pagenumber >= _pageCount ? "true" : "false"}
+        >Next</goa-button
+      >
+    </div>
   </div>
-</goa-block>
+</div>
 
 <style>
+  :host {
+    display: block;
+  }
+
   span {
     white-space: nowrap;
     font: var(--goa-pagination-text-size);
@@ -175,10 +183,22 @@
     width: 100%;
   }
 
+  .page-links {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--goa-space-l);
+    width: 100%;
+  }
+
   @media (--not-mobile) {
     .controls {
       flex-direction: row;
       justify-content: space-between;
+    }
+
+    .page-links {
+      width: auto;
     }
   }
 </style>


### PR DESCRIPTION
# Before (the change)

Pagination component placement before
Desktop (Both buttons left aligned):
<img width="1794" height="364" alt="image" src="https://github.com/user-attachments/assets/79bd62c0-a3c2-461b-bd16-87c4d9045733" />

Mobile (Both buttons left aligned):
<img width="331" height="452" alt="image" src="https://github.com/user-attachments/assets/761e0596-4b55-4c1c-b966-14f4180af142" />

# After (the change)

Pagination button placement has changed.
Desktop (placed on the far right of the parent container):
<img width="1575" height="602" alt="image" src="https://github.com/user-attachments/assets/025ce1a7-7633-4019-93d4-fed8dcbae1ee" />

Mobile (Previous on left side, Next on right side):
<img width="220" height="321" alt="image" src="https://github.com/user-attachments/assets/d38cde7a-27fa-4960-879b-eef6a59c91eb" />

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the Pagination docs PR and the table examples to see the new layout being used.
