### PR TITLE
feat(#1514): Updated content property for FilterChip to support HTML …

### DIFF
--- a/apps/prs/angular/src/routes/features/feat1514/feat1514.component.html
+++ b/apps/prs/angular/src/routes/features/feat1514/feat1514.component.html
@@ -1,0 +1,33 @@
+<goab-text tag="h1" mt="m">Feature #1514: FilterChip rich content</goab-text>
+
+<goab-text tag="h3">1. Text content</goab-text>
+<goab-filter-chip content="Text only" />
+
+<goab-text tag="h3">2. Bold text</goab-text>
+<goab-filter-chip [content]="boldContent" />
+
+<goab-text tag="h3">3. Strikethrough text</goab-text>
+<goab-filter-chip [content]="strikethroughContent" />
+
+<goab-text tag="h3">4. Underline text</goab-text>
+<goab-filter-chip [content]="underlineContent" />
+
+<goab-text tag="h3">5. Text and badge</goab-text>
+<goab-filter-chip [content]="badgeContent" />
+
+<ng-template #boldContent>
+  <strong>Bold text</strong>
+</ng-template>
+
+<ng-template #strikethroughContent>
+  <s>Strikethrough text</s>
+</ng-template>
+
+<ng-template #underlineContent>
+  <u>Underline text</u>
+</ng-template>
+
+<ng-template #badgeContent>
+  Application status
+  <goab-badge type="success" content="Active"></goab-badge>
+</ng-template>

--- a/apps/prs/angular/src/routes/features/feat1514/feat1514.component.ts
+++ b/apps/prs/angular/src/routes/features/feat1514/feat1514.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabBadge, GoabFilterChip, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat1514",
+  templateUrl: "./feat1514.component.html",
+  imports: [GoabBadge, GoabFilterChip, GoabText],
+})
+export class Feat1514Component {}

--- a/apps/prs/angular/src/routes/features/feat1514/feat1514.route.json
+++ b/apps/prs/angular/src/routes/features/feat1514/feat1514.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "FilterChip Rich Content",
+  "path": "features/1514",
+  "id": "1514",
+  "type": "feature"
+}

--- a/apps/prs/react/src/app/routes/features/feat1514.route.ts
+++ b/apps/prs/react/src/app/routes/features/feat1514.route.ts
@@ -1,0 +1,10 @@
+import { Feat1514Route } from "../../../routes/features/feat1514";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "feature",
+  id: "1514",
+  path: "features/1514",
+  title: "FilterChip Rich Content",
+  component: Feat1514Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/features/feat1514.tsx
+++ b/apps/prs/react/src/routes/features/feat1514.tsx
@@ -1,0 +1,37 @@
+import { GoabBadge, GoabFilterChip, GoabText } from "@abgov/react-components";
+
+export function Feat1514Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Feature #1514: FilterChip rich content
+      </GoabText>
+
+      <GoabText tag="h3">1. Text content</GoabText>
+      <GoabFilterChip content="Text only" />
+
+      <GoabText tag="h3">2. Bold text</GoabText>
+      <GoabFilterChip content={<strong>Bold text</strong>} />
+
+      <GoabText tag="h3">3. Strikethrough text</GoabText>
+      <GoabFilterChip content={<s>Strikethrough text</s>} />
+
+      <GoabText tag="h3">4. Underline text</GoabText>
+      <GoabFilterChip content={<u>Underline text</u>} />
+
+      <div>
+        <GoabText tag="h3">5. Text and badge</GoabText>
+        <GoabFilterChip
+          content={
+            <>
+              Application status
+              <GoabBadge type="success" content="Active" />
+            </>
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+export default Feat1514Route;

--- a/docs/generated/component-apis/filter-chip.json
+++ b/docs/generated/component-apis/filter-chip.json
@@ -5,11 +5,11 @@
     "react": {
       "props": [
         {
-          "name": "content",
+          "name": "ariaLabel",
           "type": "string",
-          "required": true,
+          "required": false,
           "default": null,
-          "description": "Text label of the chip."
+          "description": "Accessible content used to label the filter chip controls."
         },
         {
           "name": "error",
@@ -85,16 +85,34 @@
           ]
         }
       ],
-      "slots": []
+      "slots": [
+        {
+          "name": "content",
+          "type": "ReactNode",
+          "description": "Content displayed in the chip. Accepts a string or ReactNode for custom content.",
+          "required": true
+        }
+      ]
     },
     "angular": {
       "props": [
         {
-          "name": "content",
+          "name": "ariaLabel",
           "type": "string",
           "required": false,
+          "default": null,
+          "description": "Accessible content used to label the filter chip controls."
+        },
+        {
+          "name": "content",
+          "type": "string | TemplateRef<unknown>",
+          "values": [
+            "string",
+            "TemplateRef<unknown>"
+          ],
+          "required": false,
           "default": "",
-          "description": "Text label of the chip."
+          "description": "Content displayed in the chip. Accepts a string or template for custom content."
         },
         {
           "name": "deletable",
@@ -180,7 +198,14 @@
           ]
         }
       ],
-      "slots": []
+      "slots": [
+        {
+          "name": "content",
+          "type": "TemplateRef",
+          "description": "Content displayed in the chip. Accepts a string or ngTemplate for custom content.",
+          "required": true
+        }
+      ]
     },
     "webComponents": {
       "props": [
@@ -189,14 +214,14 @@
           "type": "string",
           "required": false,
           "default": "",
-          "description": "Accessible label for the filter chip. Defaults to content with 'removable' suffix."
+          "description": "Accessible content used to label the filter chip controls."
         },
         {
           "name": "content",
           "type": "string",
           "required": true,
-          "default": null,
-          "description": "Text label of the chip."
+          "default": "",
+          "description": "Content displayed in the chip. Use the content slot for custom HTML."
         },
         {
           "name": "error",
@@ -281,7 +306,13 @@
           ]
         }
       ],
-      "slots": []
+      "slots": [
+        {
+          "name": "content",
+          "description": "Content displayed in the chip. Accepts a string or ReactNode for custom content.",
+          "required": true
+        }
+      ]
     }
   }
 }

--- a/libs/angular-components/src/lib/components/filter-chip/filter-chip.spec.ts
+++ b/libs/angular-components/src/lib/components/filter-chip/filter-chip.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { Component, CUSTOM_ELEMENTS_SCHEMA, TemplateRef } from "@angular/core";
 import { GoabChipTheme, Spacing } from "@abgov/ui-components-common";
 import { By } from "@angular/platform-browser";
 import { fireEvent } from "@testing-library/dom";
@@ -12,7 +12,8 @@ import { GoabFilterChip } from "./filter-chip";
     <goab-filter-chip
       [error]="error"
       [iconTheme]="iconTheme"
-      [content]="content"
+      [content]="contentSlot ? contentTemplate : content"
+      [ariaLabel]="ariaLabel"
       [testId]="testId"
       [mt]="mt"
       [mb]="mb"
@@ -20,12 +21,17 @@ import { GoabFilterChip } from "./filter-chip";
       [mr]="mr"
       (onClick)="onClick()"
     >
+      <ng-template #contentTemplate>
+        <strong>some filter chip template</strong>
+      </ng-template>
     </goab-filter-chip>
   `,
 })
 class TestFilterChipComponent {
   error?: boolean;
-  content?: string;
+  content?: string | TemplateRef<unknown>;
+  contentSlot?: boolean;
+  ariaLabel?: string;
   iconTheme?: GoabChipTheme;
   testId?: string;
   mt?: Spacing;
@@ -52,6 +58,7 @@ describe("GoabFilterChip", () => {
 
     component.error = true;
     component.content = "some chip";
+    component.ariaLabel = "Accessible filter";
     component.testId = "chip-test";
     component.iconTheme = "filled";
     component.mt = "s";
@@ -69,12 +76,27 @@ describe("GoabFilterChip", () => {
     ).nativeElement;
     expect(chipElement.getAttribute("error")).toBe(`${component.error}`);
     expect(chipElement.getAttribute("content")).toBe(component.content);
+    expect(chipElement.getAttribute("arialabel")).toBe(component.ariaLabel);
     expect(chipElement.getAttribute("icontheme")).toBe(`${component.iconTheme}`);
     expect(chipElement.getAttribute("testid")).toBe(component.testId);
     expect(chipElement.getAttribute("mt")).toBe(component.mt);
     expect(chipElement.getAttribute("mr")).toBe(component.mr);
     expect(chipElement.getAttribute("mb")).toBe(component.mb);
     expect(chipElement.getAttribute("ml")).toBe(component.ml);
+  });
+
+  it("should render template content in the content slot for version 2", () => {
+    component.contentSlot = true;
+    fixture.detectChanges();
+
+    const chipElement = fixture.debugElement.query(
+      By.css("goa-filter-chip"),
+    ).nativeElement;
+    const content = chipElement.querySelector("[slot='content']");
+    expect(chipElement.getAttribute("content")).toBeNull();
+    expect(content.querySelector("strong").textContent).toContain(
+      "some filter chip template",
+    );
   });
 
   it("should allow to handle delete event", fakeAsync(() => {

--- a/libs/angular-components/src/lib/components/filter-chip/filter-chip.ts
+++ b/libs/angular-components/src/lib/components/filter-chip/filter-chip.ts
@@ -9,19 +9,23 @@ import {
   OnInit,
   ChangeDetectorRef,
   inject,
+  TemplateRef,
 } from "@angular/core";
+import { NgTemplateOutlet } from "@angular/common";
 
 import { GoabBaseComponent } from "../base.component";
 
 @Component({
   standalone: true,
   selector: "goab-filter-chip",
+  imports: [NgTemplateOutlet],
   template: `@if (isReady) {
     <goa-filter-chip
       [attr.version]="version"
       [attr.error]="error"
       [attr.icontheme]="iconTheme"
-      [attr.content]="content"
+      [attr.content]="getContentAsString()"
+      [attr.arialabel]="ariaLabel"
       [attr.secondarytext]="secondaryText"
       [attr.leadingicon]="leadingIcon"
       [attr.testid]="testId"
@@ -31,6 +35,11 @@ import { GoabBaseComponent } from "../base.component";
       [attr.mr]="mr"
       (_click)="_onClick()"
     >
+      @if (getContentAsTemplate()) {
+        <div slot="content">
+          <ng-container [ngTemplateOutlet]="getContentAsTemplate()"></ng-container>
+        </div>
+      }
       <ng-content />
     </goa-filter-chip>
   }`,
@@ -44,8 +53,10 @@ export class GoabFilterChip extends GoabBaseComponent implements OnInit {
   @Input({ transform: booleanAttribute }) error?: boolean;
   /** Marks the chip as deletable. */
   @Input({ transform: booleanAttribute }) deletable?: boolean;
-  /** Text label of the chip. */
-  @Input() content?: string = "";
+  /** Content displayed in the chip. Accepts a string or template for custom content. */
+  @Input() content?: string | TemplateRef<unknown> = "";
+  /** Accessible content used to label the filter chip controls. */
+  @Input() ariaLabel?: string;
   /** Sets the icon theme style for the filter chip. */
   @Input() iconTheme?: GoabChipTheme;
   /** Secondary text displayed in a smaller size before the main content. */
@@ -58,6 +69,14 @@ export class GoabFilterChip extends GoabBaseComponent implements OnInit {
 
   isReady = false;
   version = "2";
+
+  getContentAsString(): string | undefined {
+    return typeof this.content === "string" ? this.content : undefined;
+  }
+
+  getContentAsTemplate(): TemplateRef<unknown> | null {
+    return this.content instanceof TemplateRef ? this.content : null;
+  }
 
   ngOnInit(): void {
     // For Angular 20, we need to delay rendering the web component

--- a/libs/react-components/src/lib/filter-chip/filter-chip.spec.tsx
+++ b/libs/react-components/src/lib/filter-chip/filter-chip.spec.tsx
@@ -11,12 +11,24 @@ describe("GoabFilterChip", () => {
     expect(el?.getAttribute("error")).toBeNull();
   });
 
+  it("should render ReactNode content in the content slot for version 2", () => {
+    const { container } = render(
+      <GoabFilterChip content={<strong>some filter chip</strong>} />,
+    );
+
+    const el = container.querySelector("goa-filter-chip");
+    const content = el?.querySelector("[slot=content]");
+    expect(el?.getAttribute("content")).toBeNull();
+    expect(content?.querySelector("strong")?.textContent).toBe("some filter chip");
+  });
+
   it("should bind all properties correctly", async () => {
     const { container } = render(
       <GoabFilterChip
         content="some filter chip"
         secondaryText="secondary text"
         leadingIcon="accessibility"
+        ariaLabel="Accessible filter"
         mt="s"
         mr="m"
         mb="l"
@@ -38,6 +50,7 @@ describe("GoabFilterChip", () => {
     expect(el?.getAttribute("icontheme")).toBe("filled");
     expect(el?.getAttribute("secondarytext")).toBe("secondary text");
     expect(el?.getAttribute("leadingicon")).toBe("accessibility");
+    expect(el?.getAttribute("arialabel")).toBe("Accessible filter");
     expect(el?.getAttribute("testid")).toBe("test-chip");
   });
 

--- a/libs/react-components/src/lib/filter-chip/filter-chip.tsx
+++ b/libs/react-components/src/lib/filter-chip/filter-chip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 import {
   DataAttributes,
   GoabFilterChipTheme,
@@ -10,7 +10,8 @@ import { transformProps, lowercase } from "../common/extract-props";
 interface WCProps extends Margins {
   icontheme: GoabFilterChipTheme;
   error?: string;
-  content: string;
+  content?: string;
+  arialabel?: string;
   secondarytext?: string;
   leadingicon?: GoabIconType;
   testid?: string;
@@ -30,8 +31,10 @@ declare module "react" {
 }
 
 export interface GoabFilterChipProps extends Margins, DataAttributes {
-  /** @required Text label of the chip. */
-  content: string;
+  /** @required Content displayed in the chip. Accepts a string or ReactNode for custom content. */
+  content: ReactNode;
+  /** Accessible content used to label the filter chip controls. */
+  ariaLabel?: string;
   /** Theme style of the leading icon. @default "outline" */
   iconTheme?: GoabFilterChipTheme;
   /** Shows an error state. */
@@ -48,6 +51,7 @@ export interface GoabFilterChipProps extends Margins, DataAttributes {
 
 /** Allow the user to enter information, filter content, and make selections. */
 export const GoabFilterChip = ({
+  content,
   iconTheme = "outline",
   error,
   onClick,
@@ -72,10 +76,15 @@ export const GoabFilterChip = ({
   return (
     <goa-filter-chip
       ref={el}
+      content={typeof content === "string" ? content : undefined}
       error={error ? "true" : undefined}
       version="2"
       {..._props}
-    />
+    >
+      {typeof content !== "string" && content != null && (
+        <div slot="content">{content}</div>
+      )}
+    </goa-filter-chip>
   );
 };
 

--- a/libs/web-components/src/components/filter-chip/FilterChip.spec.ts
+++ b/libs/web-components/src/components/filter-chip/FilterChip.spec.ts
@@ -12,6 +12,88 @@ describe("FilterChip", () => {
     expect(container.querySelector(".error")).toBeNull();
   });
 
+  it("should render HTML content in the content slot for version 2", async () => {
+    const chip = document.createElement("goa-filter-chip");
+    chip.setAttribute("version", "2");
+    chip.innerHTML = '<span slot="content"><strong>Some Badge</strong></span>';
+    document.body.appendChild(chip);
+    await Promise.resolve();
+
+    const contentSlot = chip.shadowRoot?.querySelector<HTMLSlotElement>(
+      'slot[name="content"]',
+    );
+    const content = contentSlot?.assignedElements()[0];
+
+    expect(content?.querySelector("strong")).toHaveTextContent("Some Badge");
+    chip.remove();
+  });
+
+  it("should use string content in the accessible label", async () => {
+    const result = render(GoAFilterChip, {
+      content: "Some Badge",
+      testid: "chip",
+    });
+    const chip = await result.findByTestId("chip");
+
+    expect(chip).toHaveAttribute("aria-label", "Some Badge, removable");
+  });
+
+  it("should retain an explicit accessible label for version 1", async () => {
+    const result = render(GoAFilterChip, {
+      ariaLabel: "Custom filter label",
+      content: "Some Badge",
+      testid: "chip",
+    });
+    const chip = await result.findByTestId("chip");
+
+    expect(chip).toHaveAttribute("aria-label", "Custom filter label");
+  });
+
+  it("should use slotted text to label the remove button for version 2", async () => {
+    const chip = document.createElement("goa-filter-chip");
+    chip.setAttribute("version", "2");
+    chip.innerHTML =
+      '<span slot="content"><strong>Some</strong> filter chip</span>';
+    document.body.appendChild(chip);
+    await Promise.resolve();
+
+    const contentSlot = chip.shadowRoot?.querySelector<HTMLSlotElement>(
+      'slot[name="content"]',
+    );
+    contentSlot?.dispatchEvent(new Event("slotchange", { bubbles: true }));
+    await Promise.resolve();
+
+    expect(chip.shadowRoot?.querySelector(".chip")).not.toHaveAttribute(
+      "aria-label",
+    );
+    expect(chip.shadowRoot?.querySelector("goa-icon-button")).toHaveAttribute(
+      "arialabel",
+      "Remove filter: Some filter chip",
+    );
+    chip.remove();
+  });
+
+  it("should allow an accessible label to override slotted text", async () => {
+    const chip = document.createElement("goa-filter-chip");
+    chip.setAttribute("version", "2");
+    chip.setAttribute("arialabel", "Custom filter");
+    chip.innerHTML = '<span slot="content">Some filter chip</span>';
+    document.body.appendChild(chip);
+    await Promise.resolve();
+
+    const contentSlot = chip.shadowRoot?.querySelector<HTMLSlotElement>(
+      'slot[name="content"]',
+    );
+    contentSlot?.dispatchEvent(new Event("slotchange", { bubbles: true }));
+    await Promise.resolve();
+
+    expect(chip.shadowRoot?.querySelector("goa-icon-button")).toHaveAttribute(
+      "arialabel",
+      "Remove filter: Custom filter",
+    );
+    chip.remove();
+  });
+
   it("should show the chip in the error state", async () => {
     const { container } = render(GoAFilterChip, {
       content: "Some Badge",

--- a/libs/web-components/src/components/filter-chip/FilterChip.svelte
+++ b/libs/web-components/src/components/filter-chip/FilterChip.svelte
@@ -19,15 +19,15 @@
   // Props
   /** Shows an error state. */
   export let error: string = "false";
-  /** @required Text label of the chip. */
-  export let content: string;
+  /** @required Content displayed in the chip. Use the content slot for custom HTML. */
+  export let content: string = "";
   /** Secondary text displayed in a smaller size before the main content. */
   export let secondarytext: string = "";
   /** Icon displayed at the start of the chip. */
   export let leadingicon: GoAIconType | null = null;
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
-  /** Accessible label for the filter chip. Defaults to content with 'removable' suffix. */
+  /** Accessible content used to label the filter chip controls. */
   export let ariaLabel: string = "";
   /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
@@ -39,14 +39,21 @@
   let _hovering: boolean = false;
   let _focused: boolean = false;
   let _error: boolean;
+  let _slottedContent: string = "";
 
   // Reactive declarations
   $: _error = toBoolean(error);
+  $: accessibleContent = ariaLabel || content || _slottedContent;
   $: chipAriaLabel = ariaLabel || `${content}, removable`;
+  $: removeFilterAriaLabel = accessibleContent
+    ? `Remove filter: ${accessibleContent}`
+    : "Remove filter";
 
   // Event handlers
   function onDelete(e: Event) {
-    el.dispatchEvent(new CustomEvent("_click", { composed: true, bubbles: true }));
+    el.dispatchEvent(
+      new CustomEvent("_click", { composed: true, bubbles: true }),
+    );
     e.stopPropagation();
   }
 
@@ -55,6 +62,16 @@
       onDelete(e);
       e.preventDefault();
     }
+  }
+
+  function handleContentSlotChange(e: Event) {
+    const slot = e.target as HTMLSlotElement;
+    _slottedContent = slot
+      .assignedNodes({ flatten: true })
+      .map((node) => node.textContent || "")
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
   }
 </script>
 
@@ -66,7 +83,6 @@
     class="v2 chip"
     class:error={_error}
     role="presentation"
-    aria-label={chipAriaLabel}
     style={calculateMargin(mt, mr, mb, ml)}
   >
     <div class="label-container">
@@ -85,15 +101,19 @@
           {secondarytext}
         </div>
       {/if}
-      <div class="text">
-        {content}
+      <div class="text" on:slotchange={handleContentSlotChange}>
+        {#if $$slots.content}
+          <slot name="content" />
+        {:else}
+          {content}
+        {/if}
       </div>
     </div>
     <goa-icon-button
       size="3"
       icon="close"
       on:_click={onDelete}
-      arialabel="Remove filter"
+      arialabel={removeFilterAriaLabel}
       variant={_error ? "destructive" : "dark"}
       testid="delete-button"
     >
@@ -137,7 +157,10 @@
   .chip {
     display: inline-flex;
     align-items: center;
-    background-color: var(--goa-filter-chip-bg-color, var(--goa-color-greyscale-white));
+    background-color: var(
+      --goa-filter-chip-bg-color,
+      var(--goa-color-greyscale-white)
+    );
     border-radius: var(--goa-filter-chip-border-radius, 1rem);
     border: var(
       --goa-filter-chip-border,
@@ -180,7 +203,10 @@
       --goa-filter-chip-border-color-error,
       var(--goa-color-emergency-default)
     );
-    color: var(--goa-filter-chip-text-color-error, var(--goa-color-emergency-default));
+    color: var(
+      --goa-filter-chip-text-color-error,
+      var(--goa-color-emergency-default)
+    );
   }
 
   .chip:not(.v2).error:hover {
@@ -201,7 +227,10 @@
   }
 
   .text {
-    line-height: var(--goa-filter-chip-line-height, var(--goa-line-height-2)); /* 24px */
+    line-height: var(
+      --goa-filter-chip-line-height,
+      var(--goa-line-height-2)
+    ); /* 24px */
     padding-top: 0;
     display: flex;
     align-items: center;


### PR DESCRIPTION
# Before (the change)

The `content` property in our `GoabFilterChip` component only accepted "string" content

# After (the change)

The `content` property in our `GoabFilterChip` component now accepts both "string" content and "ReactNode" for React and TemplateRef for Angular.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the Feature 1514 PR Playground pages for both Angular and React
