### PR TITLE
feat(#2374): Updated content property for Badge to support HTML content

### DIFF
--- a/apps/prs/angular/src/routes/features/feat2374/feat2374.component.html
+++ b/apps/prs/angular/src/routes/features/feat2374/feat2374.component.html
@@ -1,0 +1,33 @@
+<goab-text tag="h1" mt="m">Feature #2374: Badge rich content</goab-text>
+
+<goab-text tag="h3">1. Text content</goab-text>
+<goab-badge type="information" content="Text only"></goab-badge>
+
+<goab-text tag="h3">2. Bold text</goab-text>
+<goab-badge type="information" [content]="boldContent"></goab-badge>
+
+<goab-text tag="h3">3. Strikethrough text</goab-text>
+<goab-badge type="information" [content]="strikethroughContent"></goab-badge>
+
+<goab-text tag="h3">4. Underline text</goab-text>
+<goab-badge type="information" [content]="underlineContent"></goab-badge>
+
+<goab-text tag="h3">5. Text and badge</goab-text>
+<goab-badge type="information" [content]="badgeContent"></goab-badge>
+
+<ng-template #boldContent>
+  <strong>Bold text</strong>
+</ng-template>
+
+<ng-template #strikethroughContent>
+  <s>Strikethrough text</s>
+</ng-template>
+
+<ng-template #underlineContent>
+  <u>Underline text</u>
+</ng-template>
+
+<ng-template #badgeContent>
+  Application status
+  <goab-badge type="success" content="Active"></goab-badge>
+</ng-template>

--- a/apps/prs/angular/src/routes/features/feat2374/feat2374.component.ts
+++ b/apps/prs/angular/src/routes/features/feat2374/feat2374.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabBadge, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat2374",
+  templateUrl: "./feat2374.component.html",
+  imports: [GoabBadge, GoabText],
+})
+export class Feat2374Component {}

--- a/apps/prs/angular/src/routes/features/feat2374/feat2374.route.json
+++ b/apps/prs/angular/src/routes/features/feat2374/feat2374.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Badge Rich Content",
+  "path": "features/2374",
+  "id": "2374",
+  "type": "feature"
+}

--- a/apps/prs/react/src/app/routes/features/feat2374.route.ts
+++ b/apps/prs/react/src/app/routes/features/feat2374.route.ts
@@ -1,0 +1,10 @@
+import { Feat2374Route } from "../../../routes/features/feat2374";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "feature",
+  id: "2374",
+  path: "features/2374",
+  title: "Badge Rich Content",
+  component: Feat2374Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/features/feat2374.tsx
+++ b/apps/prs/react/src/routes/features/feat2374.tsx
@@ -1,0 +1,36 @@
+import { GoabBadge, GoabText } from "@abgov/react-components";
+
+export function Feat2374Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Feature #2374: Badge rich content
+      </GoabText>
+
+      <GoabText tag="h3">1. Text content</GoabText>
+      <GoabBadge type="information" content="Text only" />
+
+      <GoabText tag="h3">2. Bold text</GoabText>
+      <GoabBadge type="information" content={<strong>Bold text</strong>} />
+
+      <GoabText tag="h3">3. Strikethrough text</GoabText>
+      <GoabBadge type="information" content={<s>Strikethrough text</s>} />
+
+      <GoabText tag="h3">4. Underline text</GoabText>
+      <GoabBadge type="information" content={<u>Underline text</u>} />
+
+      <GoabText tag="h3">5. Text and badge</GoabText>
+      <GoabBadge
+        type="information"
+        content={
+          <>
+            Application status
+            <GoabBadge type="success" content="Active" />
+          </>
+        }
+      />
+    </div>
+  );
+}
+
+export default Feat2374Route;

--- a/docs/generated/component-apis/badge.json
+++ b/docs/generated/component-apis/badge.json
@@ -12,13 +12,6 @@
           "description": "Accessible label for screen readers."
         },
         {
-          "name": "content",
-          "type": "string",
-          "required": false,
-          "default": null,
-          "description": "Text label of the badge."
-        },
-        {
           "name": "emphasis",
           "type": "GoabBadgeEmphasis",
           "required": false,
@@ -83,7 +76,14 @@
         }
       ],
       "events": [],
-      "slots": []
+      "slots": [
+        {
+          "name": "content",
+          "type": "ReactNode",
+          "description": "Content displayed in the badge. Accepts a string or ReactNode for custom content.",
+          "required": false
+        }
+      ]
     },
     "angular": {
       "props": [
@@ -96,10 +96,14 @@
         },
         {
           "name": "content",
-          "type": "string",
+          "type": "string | TemplateRef<unknown>",
+          "values": [
+            "string",
+            "TemplateRef<unknown>"
+          ],
           "required": false,
           "default": null,
-          "description": "Sets the text label of the badge."
+          "description": "Sets the content displayed in the badge. Accepts a string or template for custom content."
         },
         {
           "name": "emphasis",
@@ -166,7 +170,14 @@
         }
       ],
       "events": [],
-      "slots": []
+      "slots": [
+        {
+          "name": "content",
+          "type": "TemplateRef",
+          "description": "Content displayed in the badge. Accepts a string or ngTemplate for custom content.",
+          "required": false
+        }
+      ]
     },
     "webComponents": {
       "props": [
@@ -182,7 +193,7 @@
           "type": "string",
           "required": false,
           "default": "",
-          "description": "Text label of the badge."
+          "description": "Content displayed in the badge. Use the content slot for custom HTML in version 2."
         },
         {
           "name": "emphasis",
@@ -328,7 +339,13 @@
         }
       ],
       "events": [],
-      "slots": []
+      "slots": [
+        {
+          "name": "content",
+          "description": "Content displayed in the badge. Accepts a string or ReactNode for custom content.",
+          "required": false
+        }
+      ]
     }
   }
 }

--- a/libs/angular-components/src/lib/components/badge/badge.spec.ts
+++ b/libs/angular-components/src/lib/components/badge/badge.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { GoabBadge } from "./badge";
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { Component, CUSTOM_ELEMENTS_SCHEMA, TemplateRef } from "@angular/core";
 import { GoabBadgeType, GoabIconType, Spacing } from "@abgov/ui-components-common";
 import { By } from "@angular/platform-browser";
 
@@ -12,19 +12,22 @@ import { By } from "@angular/platform-browser";
       [type]="type"
       [icon]="icon"
       [iconType]="iconType"
-      [content]="content"
+      [content]="contentSlot ? contentTemplate : content"
       [ariaLabel]="ariaLabel"
       [testId]="testId"
       [mt]="mt"
       [mb]="mb"
       [ml]="ml"
       [mr]="mr"
-    ></goab-badge>
+    >
+      <ng-template #contentTemplate><strong>Rich content</strong></ng-template>
+    </goab-badge>
   `,
 })
 class TestBadgeComponent {
   type?: GoabBadgeType;
-  content?: string;
+  content?: string | TemplateRef<unknown>;
+  contentSlot?: boolean;
   testId?: string;
   icon?: boolean;
   iconType?: GoabIconType;
@@ -89,6 +92,21 @@ describe("GoABBadge", () => {
     expect(badgeElement.getAttribute("mb")).toBe(component.mb);
     expect(badgeElement.getAttribute("ml")).toBe(component.ml);
     expect(badgeElement.getAttribute("mr")).toBe(component.mr);
+  }));
+
+  it("should render template content in the content slot for version 2", fakeAsync(() => {
+    fixture = TestBed.createComponent(TestBadgeComponent);
+    component = fixture.componentInstance;
+    component.type = "information";
+    component.contentSlot = true;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const badgeElement = fixture.debugElement.query(By.css("goa-badge")).nativeElement;
+    const content = badgeElement.querySelector("[slot='content']");
+    expect(badgeElement.getAttribute("content")).toBeNull();
+    expect(content.querySelector("strong").textContent).toContain("Rich content");
   }));
 
   it("should not set icon attribute by default (icon undefined)", fakeAsync(() => {

--- a/libs/angular-components/src/lib/components/badge/badge.ts
+++ b/libs/angular-components/src/lib/components/badge/badge.ts
@@ -12,13 +12,16 @@ import {
   OnInit,
   ChangeDetectorRef,
   inject,
+  TemplateRef,
 } from "@angular/core";
+import { NgTemplateOutlet } from "@angular/common";
 
 import { GoabBaseComponent } from "../base.component";
 
 @Component({
   standalone: true,
   selector: "goab-badge",
+  imports: [NgTemplateOutlet],
   template: `
     @if (isReady) {
       <goa-badge
@@ -29,13 +32,18 @@ import { GoabBaseComponent } from "../base.component";
         [attr.icon]="showIcon ? 'true' : 'false'"
         [attr.icontype]="iconType"
         [attr.arialabel]="ariaLabel"
-        [attr.content]="content"
+        [attr.content]="getContentAsString()"
         [attr.testid]="testId"
         [attr.mt]="mt"
         [attr.mb]="mb"
         [attr.ml]="ml"
         [attr.mr]="mr"
       >
+        @if (getContentAsTemplate()) {
+          <div slot="content">
+            <ng-container [ngTemplateOutlet]="getContentAsTemplate()"></ng-container>
+          </div>
+        }
       </goa-badge>
     }
   `,
@@ -55,8 +63,8 @@ export class GoabBadge extends GoabBaseComponent implements OnInit {
 
   /** Sets the context and colour of the badge. */
   @Input() type?: GoabBadgeType;
-  /** Sets the text label of the badge. */
-  @Input() content?: string;
+  /** Sets the content displayed in the badge. Accepts a string or template for custom content. */
+  @Input() content?: string | TemplateRef<unknown>;
   /** @deprecated Use icontype instead. Includes an icon in the badge. */
   @Input({ transform: booleanAttribute }) icon?: boolean;
   /** Sets the icon type to display in the badge. */
@@ -73,6 +81,14 @@ export class GoabBadge extends GoabBaseComponent implements OnInit {
 
   get showIcon(): boolean {
     return this.icon ?? !!this.iconType;
+  }
+
+  getContentAsString(): string | undefined {
+    return typeof this.content === "string" ? this.content : undefined;
+  }
+
+  getContentAsTemplate(): TemplateRef<unknown> | null {
+    return this.content instanceof TemplateRef ? this.content : null;
   }
 
   ngOnInit(): void {

--- a/libs/react-components/src/lib/badge/badge.spec.tsx
+++ b/libs/react-components/src/lib/badge/badge.spec.tsx
@@ -11,6 +11,17 @@ describe("GoabBadge", () => {
     expect(el?.getAttribute("icon")).toBe("false");
   });
 
+  it("should render ReactNode content in the content slot for version 2", () => {
+    const { container } = render(
+      <GoabBadge type="information" content={<strong>Rich content</strong>} />,
+    );
+
+    const el = container.querySelector("goa-badge");
+    const content = el?.querySelector("[slot=content]");
+    expect(el?.getAttribute("content")).toBeNull();
+    expect(content?.querySelector("strong")?.textContent).toBe("Rich content");
+  });
+
   it("should render the properties", () => {
     const { container } = render(
       <GoabBadge

--- a/libs/react-components/src/lib/badge/badge.tsx
+++ b/libs/react-components/src/lib/badge/badge.tsx
@@ -6,7 +6,7 @@ import {
   GoabIconType,
   Margins,
 } from "@abgov/ui-components-common";
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 import { transformProps, lowercase } from "../common/extract-props";
 
 interface WCProps extends Margins {
@@ -35,8 +35,8 @@ export interface GoabBadgeProps extends Margins, DataAttributes {
   type: GoabBadgeType;
   /** @deprecated Use iconType instead. When true, displays an icon in the badge. */
   icon?: boolean;
-  /** Text label of the badge. */
-  content?: string;
+  /** Content displayed in the badge. Accepts a string or ReactNode for custom content. */
+  content?: ReactNode;
   /** Sets a data-testid attribute for automated testing. */
   testId?: string;
   /** Accessible label for screen readers. */
@@ -69,6 +69,7 @@ function getIconValue(icon?: boolean, iconType?: GoabIconType): "true" | "false"
 
 /** Small labels which hold small amounts of information, system feedback, or states. */
 export function GoabBadge({
+  content,
   icon,
   iconType,
   size = "medium",
@@ -82,10 +83,15 @@ export function GoabBadge({
       // Handle icon display priority: explicit icon prop takes precedence over iconType
       icon={getIconValue(icon, iconType)}
       icontype={iconType}
+      content={typeof content === "string" ? content : undefined}
       {..._props}
       version="2"
       size={size}
       emphasis={emphasis}
-    />
+    >
+      {typeof content !== "string" && content != null && (
+        <div slot="content">{content}</div>
+      )}
+    </goa-badge>
   );
 }

--- a/libs/web-components/src/components/badge/Badge.spec.ts
+++ b/libs/web-components/src/components/badge/Badge.spec.ts
@@ -116,6 +116,29 @@ describe("GoABadgeComponent", () => {
   });
 
   describe("V2 Emphasis", () => {
+    it("should render HTML content in the content slot for version 2", async () => {
+      const badge = document.createElement("goa-badge");
+      badge.setAttribute("type", "information");
+      badge.setAttribute("version", "2");
+      badge.setAttribute("icon", "true");
+      badge.innerHTML =
+        '<span slot="content"><strong>Rich content</strong></span>';
+      document.body.appendChild(badge);
+      await Promise.resolve();
+
+      const root = badge.shadowRoot?.querySelector(".goa-badge");
+      const contentSlot = badge.shadowRoot?.querySelector<HTMLSlotElement>(
+        'slot[name="content"]',
+      );
+      const content = contentSlot?.assignedElements()[0];
+
+      expect(content?.querySelector("strong")).toHaveTextContent(
+        "Rich content",
+      );
+      expect(root).not.toHaveClass("icon-only");
+      badge.remove();
+    });
+
     it(`should apply strong emphasis class in v2`, async () => {
       const baseElement = render(GoABadge, {
         testid: "badge-test",

--- a/libs/web-components/src/components/badge/Badge.svelte
+++ b/libs/web-components/src/components/badge/Badge.svelte
@@ -89,7 +89,7 @@
   // Optional
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
-  /** Text label of the badge. */
+  /** Content displayed in the badge. Use the content slot for custom HTML in version 2. */
   export let content: string = "";
   /** @deprecated Use icontype instead. Includes an icon in the badge. */
   export let icon: string = "";
@@ -121,7 +121,9 @@
   // private
   // Show icon unless explicitly disabled, when either icon=true or icontype is provided
   $: showIcon = icon !== "false" && (toBoolean(icon) || !!icontype);
-  $: showIconOnly = showIcon && !content;
+  $: _hasSlottedContent = version === "2" && !!$$slots.content;
+  $: _hasContent = !!content || _hasSlottedContent;
+  $: showIconOnly = showIcon && !_hasContent;
 
   $: _defaultIconType = {
     success: "checkmark-circle",
@@ -166,7 +168,7 @@
     validateEmphasisLevel(emphasis);
     validateVersion(version);
 
-    if (!showIcon && !content) {
+    if (!showIcon && !_hasContent) {
       console.warn(
         "GoabBadge must have either the content or icon property set",
       );
@@ -200,9 +202,13 @@
   {:else}
     <div class="goa-badge-no-icon"></div>
   {/if}
-  {#if content}
+  {#if _hasContent}
     <div class="goa-badge-content">
-      {content}
+      {#if _hasSlottedContent}
+        <slot name="content" />
+      {:else}
+        {content}
+      {/if}
     </div>
   {/if}
 </div>


### PR DESCRIPTION
# Before (the change)

`content` property for `GoabBadge` only supported "string" values

# After (the change)

`content` property for `GoabBadge` now supports both "string" values and HTML content

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the PR pages for feature 2374