### PR TITLE
fix(#2378): Accordion and Details content read aloud

### DIFF
--- a/apps/prs/angular/src/routes/bugs/bug2378/bug2378.component.html
+++ b/apps/prs/angular/src/routes/bugs/bug2378/bug2378.component.html
@@ -1,0 +1,17 @@
+<main>
+  <goab-text tag="h1">Bug #2378: Expanded content is not read</goab-text>
+
+  <goab-text tag="h3">Details</goab-text>
+  <goab-details heading="Supporting details">
+    <goab-text tag="p">
+      This Details content should be announced when the component expands.
+    </goab-text>
+  </goab-details>
+
+  <goab-text tag="h3">Accordion</goab-text>
+  <goab-accordion heading="Supporting information">
+    <goab-text tag="p">
+      This Accordion content should be announced when the component expands.
+    </goab-text>
+  </goab-accordion>
+</main>

--- a/apps/prs/angular/src/routes/bugs/bug2378/bug2378.component.ts
+++ b/apps/prs/angular/src/routes/bugs/bug2378/bug2378.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabAccordion, GoabDetails, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug2378",
+  templateUrl: "./bug2378.component.html",
+  imports: [GoabAccordion, GoabDetails, GoabText],
+})
+export class Bug2378Component {}

--- a/apps/prs/angular/src/routes/bugs/bug2378/bug2378.route.json
+++ b/apps/prs/angular/src/routes/bugs/bug2378/bug2378.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "2378",
+  "path": "bugs/2378",
+  "title": "Expanded content announcement"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug2378.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug2378.route.ts
@@ -1,0 +1,10 @@
+import { Bug2378Route } from "../../../routes/bugs/bug2378";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "2378",
+  path: "bugs/2378",
+  title: "Expanded content announcement",
+  component: Bug2378Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug2378.tsx
+++ b/apps/prs/react/src/routes/bugs/bug2378.tsx
@@ -1,0 +1,23 @@
+import { GoabAccordion, GoabDetails, GoabText } from "@abgov/react-components";
+
+export function Bug2378Route() {
+  return (
+    <main>
+      <GoabText tag="h1">Bug #2378: Expanded content is not read</GoabText>
+
+      <GoabText tag="h3">Details</GoabText>
+      <GoabDetails heading="Supporting details">
+        <GoabText tag="p">
+          This Details content should be announced when the component expands.
+        </GoabText>
+      </GoabDetails>
+
+      <GoabText tag="h3">Accordion</GoabText>
+      <GoabAccordion heading="Supporting information">
+        <GoabText tag="p">
+          This Accordion content should be announced when the component expands.
+        </GoabText>
+      </GoabAccordion>
+    </main>
+  );
+}

--- a/libs/react-components/specs/accordion.browser.spec.tsx
+++ b/libs/react-components/specs/accordion.browser.spec.tsx
@@ -100,16 +100,23 @@ describe("Accordion", () => {
       expect(summary).toHaveAttribute("aria-expanded", "false");
     });
 
+    const content = summary.element().closest("details")?.querySelector(".content > div");
+
+    expect(content).not.toBeNull();
+    expect(content?.getAttribute("role")).toBeNull();
+
     await openButton.click();
 
     await vi.waitFor(() => {
       expect(summary).toHaveAttribute("aria-expanded", "true");
+      expect(content?.getAttribute("role")).toBe("alert");
     });
 
     await closeButton.click();
 
     await vi.waitFor(() => {
       expect(summary).toHaveAttribute("aria-expanded", "false");
+      expect(content?.getAttribute("role")).toBeNull();
     });
 
     await openButton.click();

--- a/libs/web-components/src/components/accordion/Accordion.spec.ts
+++ b/libs/web-components/src/components/accordion/Accordion.spec.ts
@@ -46,10 +46,30 @@ describe("Accordion", () => {
   });
 
   it("should not expand the container when open prop is not set", async () => {
-    const { container } = render(Accordion, { heading: "Title" });
+    const { container, queryByRole } = render(Accordion, { heading: "Title" });
     const details = container.querySelector("details");
     expect(details).toBeTruthy();
     expect(details?.getAttribute("open")).toBeNull();
+    expect(queryByRole("alert")).toBeNull();
+  });
+
+  it("announces the content when expanded", async () => {
+    vitest.useFakeTimers();
+
+    try {
+      const { getByRole, queryByRole } = render(Accordion, {
+        heading: "Title",
+        open: "true",
+      });
+
+      await vitest.advanceTimersByTimeAsync(99);
+      expect(queryByRole("alert")).toBeNull();
+
+      await vitest.advanceTimersByTimeAsync(1);
+      expect(getByRole("alert")).toBeInTheDocument();
+    } finally {
+      vitest.useRealTimers();
+    }
   });
 
   // Although this test passes, it doesn't fail with the `position: relative` fix is removed.

--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -9,7 +9,7 @@
 
 <!-- Script -->
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { calculateMargin } from "../../common/styling";
   import {
     typeValidator,
@@ -19,6 +19,8 @@
     ensureSlotExists,
     dispatch,
     parseCssTimeToMilliseconds,
+    performOnce,
+    watch,
   } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
   import { Once } from "@abgov/ui-components-common";
@@ -85,6 +87,8 @@
   let _slotEl: HTMLElement;
   let _headingSlotChildren: Element[] = [];
   let _accordionId: string = "";
+  let _shouldAnnounce: boolean = false;
+  let _announcementTimeoutId: ReturnType<typeof setTimeout>;
 
   // Store the animation object (so we can cancel it if needed)
   let _animation: Animation | null = null;
@@ -98,6 +102,7 @@
   // Reactive
 
   $: isOpen = toBoolean(open);
+  $: watch(updateAnnouncement, [isOpen]);
 
   // Functions
 
@@ -112,6 +117,8 @@
     _accordionId = `accordion-${generateRandomId()}`;
   });
 
+  onDestroy(() => clearTimeout(_announcementTimeoutId));
+
   function getHeadingChildren(): Element[] {
     if (_titleEl) {
       const slot = _titleEl.querySelector("slot") as HTMLSlotElement;
@@ -122,6 +129,16 @@
       }
     }
     return [];
+  }
+
+  function updateAnnouncement() {
+    _shouldAnnounce = false;
+    // Give Safari time to expose the expanded content before adding the alert role.
+    _announcementTimeoutId = performOnce(_announcementTimeoutId, () => {
+      if (isOpen) {
+        _shouldAnnounce = true;
+      }
+    }, 100);
   }
 
   function dispatchChangeEvent(accordionIsOpen: boolean) {
@@ -371,7 +388,9 @@
       aria-labelledby={`${_accordionId}-heading`}
       id={`${_accordionId}-content`}
     >
-      <slot />
+      <div role={_shouldAnnounce ? "alert" : undefined}>
+        <slot />
+      </div>
     </div>
   </details>
 </div>

--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -1,12 +1,14 @@
 <svelte:options customElement="goa-details" />
 
 <script lang="ts">
-  import { onMount, tick } from "svelte";
+  import { onDestroy, onMount, tick } from "svelte";
   import { calculateMargin } from "../../common/styling";
   import {
     toBoolean,
     validateRequired,
     generateRandomId,
+    performOnce,
+    watch,
   } from "../../common/utils";
   import type { Spacing } from "../../common/styling";
 
@@ -30,8 +32,11 @@
   let _isMouseOver: boolean = false;
   let _summaryEl: HTMLElement;
   let _detailsId: string = "";
+  let _shouldAnnounce: boolean = false;
+  let _announcementTimeoutId: ReturnType<typeof setTimeout>;
 
   $: _isOpen = toBoolean(open);
+  $: watch(updateAnnouncement, [_isOpen]);
 
   onMount(async () => {
     _detailsId = `details-${generateRandomId()}`;
@@ -47,6 +52,18 @@
       _isMouseOver = false;
     });
   });
+
+  onDestroy(() => clearTimeout(_announcementTimeoutId));
+
+  function updateAnnouncement() {
+    _shouldAnnounce = false;
+    // Give Safari time to expose the expanded content before adding the alert role.
+    _announcementTimeoutId = performOnce(_announcementTimeoutId, () => {
+      if (_isOpen) {
+        _shouldAnnounce = true;
+      }
+    }, 100);
+  }
 </script>
 
 <details
@@ -79,7 +96,9 @@
     aria-labelledby={`${_detailsId}-heading`}
     id={`${_detailsId}-content`}
   >
-    <slot />
+    <div role={_shouldAnnounce ? "alert" : undefined}>
+      <slot />
+    </div>
   </div>
 </details>
 

--- a/libs/web-components/src/components/details/details.spec.ts
+++ b/libs/web-components/src/components/details/details.spec.ts
@@ -32,3 +32,28 @@ it('should render - with max width', async () => {
   const details = container.querySelector("details");
   expect(details?.getAttribute("style")).toContain("max-width: 480px;");
 });
+
+it("announces the content when expanded", async () => {
+  vitest.useFakeTimers();
+
+  try {
+    const { getByRole, queryByRole } = render(Details, {
+      heading: "The title",
+      open: "true",
+    });
+
+    await vitest.advanceTimersByTimeAsync(99);
+    expect(queryByRole("alert")).toBeNull();
+
+    await vitest.advanceTimersByTimeAsync(1);
+    expect(getByRole("alert")).toBeInTheDocument();
+  } finally {
+    vitest.useRealTimers();
+  }
+});
+
+it("does not announce the content when collapsed", async () => {
+  const { queryByRole } = render(Details, { heading: "The title" });
+
+  expect(queryByRole("alert")).toBeNull();
+});


### PR DESCRIPTION
# Before (the change)

Content inside `GoabDetails` and `GoabAccordion` wasn't read out by a screen reader unless there was interactive content inside and the user tabbed to it.

# After (the change)

Content inside `GoabDetails` and `GoabAccordion` should now be read out as soon as the component is expanded.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the PR bug 2378
