### PR TITLE
fix(#4140): vertically align radio item label in V2

### DIFF
--- a/apps/prs/angular/src/routes/bugs/4140/bug4140.component.html
+++ b/apps/prs/angular/src/routes/bugs/4140/bug4140.component.html
@@ -1,0 +1,182 @@
+<goab-block direction="column" gap="l">
+  <goab-text tag="h1" size="heading-l" mb="m">Radio label vertical alignment</goab-text>
+
+  <goab-text size="body-m">
+    The radio label used to sit 3px too high, so it did not line up with the circle beside it.
+    It was most noticeable at the compact size. Check that the label text looks vertically
+    centred against the circle in every group below, and that it matches the checkbox list at
+    the bottom.
+  </goab-text>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">Default size</goab-text>
+  <goab-radio-group name="payment" [value]="payment">
+    <goab-radio-item value="deposit" label="Direct deposit"></goab-radio-item>
+    <goab-radio-item value="cheque" label="Cheque"></goab-radio-item>
+    <goab-radio-item value="card" label="Prepaid card"></goab-radio-item>
+  </goab-radio-group>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">Compact size</goab-text>
+  <goab-radio-group name="compactPayment" size="compact" [value]="compactPayment">
+    <goab-radio-item value="deposit" label="Direct deposit"></goab-radio-item>
+    <goab-radio-item value="cheque" label="Cheque"></goab-radio-item>
+    <goab-radio-item value="card" label="Prepaid card"></goab-radio-item>
+  </goab-radio-group>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">With descriptions</goab-text>
+  <goab-radio-group name="described" [value]="described">
+    <goab-radio-item
+      value="deposit"
+      label="Direct deposit"
+      description="Funds arrive in 2 to 3 business days"></goab-radio-item>
+    <goab-radio-item
+      value="cheque"
+      label="Cheque"
+      description="Mailed to your address on file"></goab-radio-item>
+  </goab-radio-group>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">With descriptions, compact</goab-text>
+  <goab-radio-group name="compactDescribed" size="compact" [value]="compactDescribed">
+    <goab-radio-item
+      value="deposit"
+      label="Direct deposit"
+      description="Funds arrive in 2 to 3 business days"></goab-radio-item>
+    <goab-radio-item
+      value="cheque"
+      label="Cheque"
+      description="Mailed to your address on file"></goab-radio-item>
+  </goab-radio-group>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">
+    Some items with descriptions, some without
+  </goab-text>
+  <goab-radio-group name="mixed" [value]="mixed">
+    <goab-radio-item
+      value="deposit"
+      label="Direct deposit"
+      description="Funds arrive in 2 to 3 business days"></goab-radio-item>
+    <goab-radio-item value="cheque" label="Cheque"></goab-radio-item>
+    <goab-radio-item
+      value="card"
+      label="Prepaid card"
+      description="A card is mailed to your address on file"></goab-radio-item>
+  </goab-radio-group>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">Labels that wrap</goab-text>
+  <goab-text size="body-s" mb="m">
+    The circle stays at the top when the label wraps. Items with wrapping labels are 3px taller
+    than they were, which is the height their content actually needs.
+  </goab-text>
+  <div style="max-width: 20rem">
+    <goab-radio-group name="wrapping" [value]="wrapping">
+      <goab-radio-item
+        value="deposit"
+        label="Direct deposit into the account you have on file"></goab-radio-item>
+      <goab-radio-item
+        value="cheque"
+        label="A cheque mailed to your current mailing address"></goab-radio-item>
+      <goab-radio-item value="card" label="Prepaid card"></goab-radio-item>
+    </goab-radio-group>
+  </div>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">
+    Labels that wrap, with descriptions
+  </goab-text>
+  <div style="max-width: 20rem">
+    <goab-radio-group name="wrappingDescribed" [value]="wrappingDescribed">
+      <goab-radio-item
+        value="deposit"
+        label="Direct deposit into the account on file"
+        description="Funds arrive in two to three business days after approval"></goab-radio-item>
+      <goab-radio-item
+        value="cheque"
+        label="A cheque mailed to your address"
+        description="Allow ten business days for delivery by mail"></goab-radio-item>
+    </goab-radio-group>
+  </div>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">
+    Labels that wrap, compact, with descriptions
+  </goab-text>
+  <div style="max-width: 20rem">
+    <goab-radio-group name="compactWrapping" size="compact" [value]="compactWrapping">
+      <goab-radio-item
+        value="deposit"
+        label="Direct deposit into the account on file"
+        description="Funds arrive in two to three business days"></goab-radio-item>
+      <goab-radio-item
+        value="cheque"
+        label="A cheque mailed to your address"
+        description="Allow ten business days for delivery"></goab-radio-item>
+    </goab-radio-group>
+  </div>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">Checkbox list, for comparison</goab-text>
+  <goab-text size="body-s" mb="m">
+    The radio labels should sit the same way against their circle as these labels do against
+    their box.
+  </goab-text>
+
+  <goab-checkbox-list name="cbDefault">
+    <goab-checkbox name="cbDeposit" text="Direct deposit"></goab-checkbox>
+    <goab-checkbox name="cbCheque" text="Cheque"></goab-checkbox>
+    <goab-checkbox name="cbCard" text="Prepaid card"></goab-checkbox>
+  </goab-checkbox-list>
+
+  <goab-text tag="h3" size="heading-s" mt="l" mb="m">Compact</goab-text>
+  <goab-checkbox-list name="cbCompact" size="compact">
+    <goab-checkbox name="cbcDeposit" size="compact" text="Direct deposit"></goab-checkbox>
+    <goab-checkbox name="cbcCheque" size="compact" text="Cheque"></goab-checkbox>
+    <goab-checkbox name="cbcCard" size="compact" text="Prepaid card"></goab-checkbox>
+  </goab-checkbox-list>
+
+  <goab-text tag="h3" size="heading-s" mt="l" mb="m">With descriptions</goab-text>
+  <goab-checkbox-list name="cbDescribed">
+    <goab-checkbox
+      name="cbdDeposit"
+      text="Direct deposit"
+      description="Funds arrive in 2 to 3 business days"></goab-checkbox>
+    <goab-checkbox
+      name="cbdCheque"
+      text="Cheque"
+      description="Mailed to your address on file"></goab-checkbox>
+  </goab-checkbox-list>
+
+  <goab-text tag="h3" size="heading-s" mt="l" mb="m">Labels that wrap</goab-text>
+  <div style="max-width: 20rem">
+    <goab-checkbox-list name="cbWrapping">
+      <goab-checkbox
+        name="cbwDeposit"
+        text="Direct deposit into the account you have on file"></goab-checkbox>
+      <goab-checkbox
+        name="cbwCheque"
+        text="A cheque mailed to your current mailing address"></goab-checkbox>
+    </goab-checkbox-list>
+  </div>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">Disabled and error</goab-text>
+  <goab-radio-group name="disabledGroup" value="one" [disabled]="true">
+    <goab-radio-item
+      value="one"
+      label="Disabled"
+      description="With a description"></goab-radio-item>
+    <goab-radio-item value="two" label="Also disabled"></goab-radio-item>
+  </goab-radio-group>
+
+  <goab-radio-group name="errorGroup" value="one" [error]="true" mt="l" mb="2xl">
+    <goab-radio-item
+      value="one"
+      label="Error state"
+      description="With a description"></goab-radio-item>
+    <goab-radio-item value="two" label="Second item"></goab-radio-item>
+  </goab-radio-group>
+</goab-block>

--- a/apps/prs/angular/src/routes/bugs/4140/bug4140.component.ts
+++ b/apps/prs/angular/src/routes/bugs/4140/bug4140.component.ts
@@ -1,0 +1,35 @@
+import { Component } from "@angular/core";
+import {
+  GoabBlock,
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabDivider,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug-4140",
+  templateUrl: "./bug4140.component.html",
+  imports: [
+    GoabBlock,
+    GoabCheckbox,
+    GoabCheckboxList,
+    GoabDivider,
+    GoabRadioGroup,
+    GoabRadioItem,
+    GoabText,
+  ],
+})
+export class Bug4140Component {
+  payment = "cheque";
+  compactPayment = "cheque";
+  described = "deposit";
+  compactDescribed = "deposit";
+  mixed = "cheque";
+  wrapping = "deposit";
+  wrappingDescribed = "deposit";
+  compactWrapping = "deposit";
+}

--- a/apps/prs/angular/src/routes/bugs/4140/bug4140.route.json
+++ b/apps/prs/angular/src/routes/bugs/4140/bug4140.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "4140",
+  "path": "bugs/4140",
+  "title": "Radio label vertical alignment"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug4140.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug4140.route.ts
@@ -1,0 +1,10 @@
+import { Bug4140Route } from "../../../routes/bugs/bug4140";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "4140",
+  path: "bugs/4140",
+  title: "Radio label vertical alignment",
+  component: Bug4140Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug4140.tsx
+++ b/apps/prs/react/src/routes/bugs/bug4140.tsx
@@ -1,0 +1,282 @@
+import React, { useState } from "react";
+import {
+  GoabBlock,
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabDivider,
+  GoabOneColumnLayout,
+  GoabPageBlock,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabText,
+} from "@abgov/react-components";
+import { Link } from "react-router-dom";
+
+const narrow: React.CSSProperties = { maxWidth: "20rem" };
+
+export function Bug4140Route() {
+  const [payment, setPayment] = useState("cheque");
+  const [compactPayment, setCompactPayment] = useState("cheque");
+  const [described, setDescribed] = useState("deposit");
+  const [compactDescribed, setCompactDescribed] = useState("deposit");
+  const [mixed, setMixed] = useState("cheque");
+  const [wrapping, setWrapping] = useState("deposit");
+  const [wrappingDescribed, setWrappingDescribed] = useState("deposit");
+  const [compactWrapping, setCompactWrapping] = useState("deposit");
+
+  return (
+    <GoabPageBlock width="full">
+      <GoabOneColumnLayout>
+        <GoabBlock direction="column" gap="l">
+          <goa-link mt={"xl"} leadingicon={"arrow-back"}>
+            <Link to="/">Back</Link>
+          </goa-link>
+
+          <GoabText tag="h1" size="heading-l" mb={"m"}>
+            Radio label vertical alignment
+          </GoabText>
+
+          <GoabText size="body-m">
+            The radio label used to sit 3px too high, so it did not line up with the circle
+            beside it. It was most noticeable at the compact size. Check that the label text
+            looks vertically centred against the circle in every group below, and that it
+            matches the checkbox list at the bottom.
+          </GoabText>
+
+          <GoabDivider />
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Default size
+          </GoabText>
+          <GoabRadioGroup
+            name="payment"
+            value={payment}
+            onChange={(e) => setPayment(e.value)}
+          >
+            <GoabRadioItem value="deposit" label="Direct deposit" />
+            <GoabRadioItem value="cheque" label="Cheque" />
+            <GoabRadioItem value="card" label="Prepaid card" />
+          </GoabRadioGroup>
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Compact size
+          </GoabText>
+          <GoabRadioGroup
+            name="compactPayment"
+            size="compact"
+            value={compactPayment}
+            onChange={(e) => setCompactPayment(e.value)}
+          >
+            <GoabRadioItem value="deposit" label="Direct deposit" />
+            <GoabRadioItem value="cheque" label="Cheque" />
+            <GoabRadioItem value="card" label="Prepaid card" />
+          </GoabRadioGroup>
+
+          <GoabDivider />
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            With descriptions
+          </GoabText>
+          <GoabRadioGroup
+            name="described"
+            value={described}
+            onChange={(e) => setDescribed(e.value)}
+          >
+            <GoabRadioItem
+              value="deposit"
+              label="Direct deposit"
+              description="Funds arrive in 2 to 3 business days"
+            />
+            <GoabRadioItem
+              value="cheque"
+              label="Cheque"
+              description="Mailed to your address on file"
+            />
+          </GoabRadioGroup>
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            With descriptions, compact
+          </GoabText>
+          <GoabRadioGroup
+            name="compactDescribed"
+            size="compact"
+            value={compactDescribed}
+            onChange={(e) => setCompactDescribed(e.value)}
+          >
+            <GoabRadioItem
+              value="deposit"
+              label="Direct deposit"
+              description="Funds arrive in 2 to 3 business days"
+            />
+            <GoabRadioItem
+              value="cheque"
+              label="Cheque"
+              description="Mailed to your address on file"
+            />
+          </GoabRadioGroup>
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Some items with descriptions, some without
+          </GoabText>
+          <GoabRadioGroup name="mixed" value={mixed} onChange={(e) => setMixed(e.value)}>
+            <GoabRadioItem
+              value="deposit"
+              label="Direct deposit"
+              description="Funds arrive in 2 to 3 business days"
+            />
+            <GoabRadioItem value="cheque" label="Cheque" />
+            <GoabRadioItem
+              value="card"
+              label="Prepaid card"
+              description="A card is mailed to your address on file"
+            />
+          </GoabRadioGroup>
+
+          <GoabDivider />
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Labels that wrap
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            The circle stays at the top when the label wraps. Items with wrapping labels are
+            3px taller than they were, which is the height their content actually needs.
+          </GoabText>
+          <div style={narrow}>
+            <GoabRadioGroup
+              name="wrapping"
+              value={wrapping}
+              onChange={(e) => setWrapping(e.value)}
+            >
+              <GoabRadioItem
+                value="deposit"
+                label="Direct deposit into the account you have on file"
+              />
+              <GoabRadioItem
+                value="cheque"
+                label="A cheque mailed to your current mailing address"
+              />
+              <GoabRadioItem value="card" label="Prepaid card" />
+            </GoabRadioGroup>
+          </div>
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Labels that wrap, with descriptions
+          </GoabText>
+          <div style={narrow}>
+            <GoabRadioGroup
+              name="wrappingDescribed"
+              value={wrappingDescribed}
+              onChange={(e) => setWrappingDescribed(e.value)}
+            >
+              <GoabRadioItem
+                value="deposit"
+                label="Direct deposit into the account on file"
+                description="Funds arrive in two to three business days after approval"
+              />
+              <GoabRadioItem
+                value="cheque"
+                label="A cheque mailed to your address"
+                description="Allow ten business days for delivery by mail"
+              />
+            </GoabRadioGroup>
+          </div>
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Labels that wrap, compact, with descriptions
+          </GoabText>
+          <div style={narrow}>
+            <GoabRadioGroup
+              name="compactWrapping"
+              size="compact"
+              value={compactWrapping}
+              onChange={(e) => setCompactWrapping(e.value)}
+            >
+              <GoabRadioItem
+                value="deposit"
+                label="Direct deposit into the account on file"
+                description="Funds arrive in two to three business days"
+              />
+              <GoabRadioItem
+                value="cheque"
+                label="A cheque mailed to your address"
+                description="Allow ten business days for delivery"
+              />
+            </GoabRadioGroup>
+          </div>
+
+          <GoabDivider />
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Checkbox list, for comparison
+          </GoabText>
+          <GoabText size="body-s" mb="m">
+            The radio labels should sit the same way against their circle as these labels do
+            against their box.
+          </GoabText>
+
+          <GoabCheckboxList name="cbDefault">
+            <GoabCheckbox name="cbDeposit" text="Direct deposit" />
+            <GoabCheckbox name="cbCheque" text="Cheque" />
+            <GoabCheckbox name="cbCard" text="Prepaid card" />
+          </GoabCheckboxList>
+
+          <GoabText tag="h3" size="heading-s" mt="l" mb="m">
+            Compact
+          </GoabText>
+          <GoabCheckboxList name="cbCompact" size="compact">
+            <GoabCheckbox name="cbcDeposit" size="compact" text="Direct deposit" />
+            <GoabCheckbox name="cbcCheque" size="compact" text="Cheque" />
+            <GoabCheckbox name="cbcCard" size="compact" text="Prepaid card" />
+          </GoabCheckboxList>
+
+          <GoabText tag="h3" size="heading-s" mt="l" mb="m">
+            With descriptions
+          </GoabText>
+          <GoabCheckboxList name="cbDescribed">
+            <GoabCheckbox
+              name="cbdDeposit"
+              text="Direct deposit"
+              description="Funds arrive in 2 to 3 business days"
+            />
+            <GoabCheckbox
+              name="cbdCheque"
+              text="Cheque"
+              description="Mailed to your address on file"
+            />
+          </GoabCheckboxList>
+
+          <GoabText tag="h3" size="heading-s" mt="l" mb="m">
+            Labels that wrap
+          </GoabText>
+          <div style={narrow}>
+            <GoabCheckboxList name="cbWrapping">
+              <GoabCheckbox
+                name="cbwDeposit"
+                text="Direct deposit into the account you have on file"
+              />
+              <GoabCheckbox
+                name="cbwCheque"
+                text="A cheque mailed to your current mailing address"
+              />
+            </GoabCheckboxList>
+          </div>
+
+          <GoabDivider />
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Disabled and error
+          </GoabText>
+          <GoabRadioGroup name="disabledGroup" value="one" disabled>
+            <GoabRadioItem value="one" label="Disabled" description="With a description" />
+            <GoabRadioItem value="two" label="Also disabled" />
+          </GoabRadioGroup>
+
+          <GoabRadioGroup name="errorGroup" value="one" error mt="l" mb="2xl">
+            <GoabRadioItem value="one" label="Error state" description="With a description" />
+            <GoabRadioItem value="two" label="Second item" />
+          </GoabRadioGroup>
+        </GoabBlock>
+      </GoabOneColumnLayout>
+    </GoabPageBlock>
+  );
+}

--- a/apps/prs/react/src/routes/bugs/bug4140.tsx
+++ b/apps/prs/react/src/routes/bugs/bug4140.tsx
@@ -10,7 +10,6 @@ import {
   GoabRadioItem,
   GoabText,
 } from "@abgov/react-components";
-import { Link } from "react-router-dom";
 
 const narrow: React.CSSProperties = { maxWidth: "20rem" };
 
@@ -28,11 +27,7 @@ export function Bug4140Route() {
     <GoabPageBlock width="full">
       <GoabOneColumnLayout>
         <GoabBlock direction="column" gap="l">
-          <goa-link mt={"xl"} leadingicon={"arrow-back"}>
-            <Link to="/">Back</Link>
-          </goa-link>
-
-          <GoabText tag="h1" size="heading-l" mb={"m"}>
+          <GoabText tag="h1" size="heading-l" mt={"xl"} mb={"m"}>
             Radio label vertical alignment
           </GoabText>
 

--- a/libs/web-components/src/components/radio-item/RadioItem.svelte
+++ b/libs/web-components/src/components/radio-item/RadioItem.svelte
@@ -344,8 +344,15 @@
   .label {
     font: var(--goa-radio-label);
     color: var(--goa-radio-color-label, var(--goa-input-color-text-secondary));
-    margin-top: -3px; /* V1: Optical centering - move text up */
     padding-left: var(--goa-radio-gap-label, var(--goa-space-s));
+  }
+
+  /* V1 only: the V1 label line-height (28px) is taller than the 24px radio
+     circle, so the text needs an optical nudge upward. In V2 the label
+     line-height matches the circle height, so no nudge is needed (this is
+     what the V2 checkbox already does). */
+  .radio:not(.v2) .label {
+    margin-top: -3px;
   }
 
   /* V2 compact: Use smaller gap */


### PR DESCRIPTION
The radio label sits too high, so it does not line up with the circle beside it. It is most noticeable at the compact size.

In V2 the label was still getting an upward nudge that only V1 needs. V1's label line height is taller than the circle, so it needs the nudge to look centred. V2's line height matches the circle height, so it does not. The V2 checkbox already works this way, and now the V2 radio matches it.

V1 renders exactly as it did before.

Closes #4140

<img width="770" height="471" alt="image" src="https://github.com/user-attachments/assets/c385690d-d88e-44a6-aa3b-27078e6f4e30" />

## Labels that wrap

Items whose label wraps onto more than one line are 3px taller than they were. The label was being pulled up out of its own box, so those items were rendering 3px shorter than their content. A wrapping item now measures the same as a wrapping item in a checkbox list.

Single line items are unchanged, with or without descriptions, including the spacing between items in a radio group.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Open bugs/4140 in the React and Angular test apps. Check that the label text looks vertically centred against the circle at both sizes, and that it sits the same way as the labels in the checkbox list at the bottom of the page.

The page also covers descriptions, a mix of items with and without descriptions, labels that wrap, and the disabled and error states.
