### PR TITLE
chore: Adding a new example for GoabTabs

### DIFF
--- a/apps/prs/angular/src/routes/docs/tabs/tabs.component.html
+++ b/apps/prs/angular/src/routes/docs/tabs/tabs.component.html
@@ -27,6 +27,17 @@
   <goab-tab heading="Third">Third tab content.</goab-tab>
 </goab-tabs>
 
+<h3>Activate a tab with a button</h3>
+<goab-button (onClick)="activateDetailsTab()">Open details</goab-button>
+<goab-tabs>
+  <goab-tab heading="Summary" slug="button-example-summary">
+    Summary content goes here.
+  </goab-tab>
+  <goab-tab heading="Details" slug="button-example-details">
+    Detailed information goes here.
+  </goab-tab>
+</goab-tabs>
+
 <h3>With badge in heading</h3>
 <goab-tabs>
   <goab-tab heading="Messages">

--- a/apps/prs/angular/src/routes/docs/tabs/tabs.component.ts
+++ b/apps/prs/angular/src/routes/docs/tabs/tabs.component.ts
@@ -1,6 +1,7 @@
 import { Component } from "@angular/core";
 import {
   GoabBadge,
+  GoabButton,
   GoabTab,
   GoabTabs,
   GoabText,
@@ -10,6 +11,10 @@ import {
   standalone: true,
   selector: "abgov-docs-tabs",
   templateUrl: "./tabs.component.html",
-  imports: [GoabBadge, GoabTab, GoabTabs, GoabText],
+  imports: [GoabBadge, GoabButton, GoabTab, GoabTabs, GoabText],
 })
-export class DocsTabsComponent {}
+export class DocsTabsComponent {
+  activateDetailsTab(): void {
+    window.location.hash = "button-example-details";
+  }
+}

--- a/apps/prs/react/src/routes/docs/tabs/tabs.tsx
+++ b/apps/prs/react/src/routes/docs/tabs/tabs.tsx
@@ -1,11 +1,16 @@
 import {
   GoabBadge,
+  GoabButton,
   GoabTab,
   GoabTabs,
   GoabText,
 } from "@abgov/react-components";
 
 export function DocsTabsRoute() {
+  const activateDetailsTab = () => {
+    window.location.hash = "button-example-details";
+  };
+
   return (
     <div>
       <h2>Tabs</h2>
@@ -35,6 +40,17 @@ export function DocsTabsRoute() {
         <GoabTab heading="First">First tab content.</GoabTab>
         <GoabTab heading="Second">Second tab content (initially shown).</GoabTab>
         <GoabTab heading="Third">Third tab content.</GoabTab>
+      </GoabTabs>
+
+      <h3>Activate a tab with a button</h3>
+      <GoabButton onClick={activateDetailsTab}>Open details</GoabButton>
+      <GoabTabs>
+        <GoabTab heading="Summary" slug="button-example-summary">
+          Summary content goes here.
+        </GoabTab>
+        <GoabTab heading="Details" slug="button-example-details">
+          Detailed information goes here.
+        </GoabTab>
       </GoabTabs>
 
       <h3>With badge in heading</h3>

--- a/docs/public/search-index.json
+++ b/docs/public/search-index.json
@@ -766,6 +766,27 @@
   },
   {
     "type": "example",
+    "id": "activate-a-specific-tab-with-a-button",
+    "title": "Activate a specific tab with a button",
+    "description": "Activate a tab from a button by setting the URL hash—the part after `#`—to match the tab's `slug`.",
+    "status": "published",
+    "size": "interaction",
+    "tags": [
+      "tabs",
+      "navigation",
+      "button",
+      "url-hash"
+    ],
+    "components": [
+      "tabs",
+      "tab",
+      "button"
+    ],
+    "aliases": [],
+    "slug": "activate-a-specific-tab-with-a-button"
+  },
+  {
+    "type": "example",
     "id": "add-a-filter-chip",
     "title": "Add a filter chip",
     "description": "Allow users to apply filters using selectable chips, which visually represent active filters and can be removed to update results dynamically.",

--- a/docs/src/content/examples/activate-a-specific-tab-with-a-button/angular.html
+++ b/docs/src/content/examples/activate-a-specific-tab-with-a-button/angular.html
@@ -1,0 +1,9 @@
+<goab-button (onClick)="activateDetailsTab()">Open details</goab-button>
+<goab-tabs>
+  <goab-tab heading="Summary" slug="button-example-summary">
+    Summary content goes here.
+  </goab-tab>
+  <goab-tab heading="Details" slug="button-example-details">
+    Detailed information goes here.
+  </goab-tab>
+</goab-tabs>

--- a/docs/src/content/examples/activate-a-specific-tab-with-a-button/angular.ts
+++ b/docs/src/content/examples/activate-a-specific-tab-with-a-button/angular.ts
@@ -1,0 +1,11 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "app-activate-a-specific-tab-with-a-button",
+  templateUrl: "./angular.html",
+})
+export class ActivateASpecificTabWithAButtonComponent {
+  activateDetailsTab(): void {
+    window.location.hash = "button-example-details";
+  }
+}

--- a/docs/src/content/examples/activate-a-specific-tab-with-a-button/index.mdx
+++ b/docs/src/content/examples/activate-a-specific-tab-with-a-button/index.mdx
@@ -1,0 +1,32 @@
+---
+id: activate-a-specific-tab-with-a-button
+title: Activate a specific tab with a button
+size: interaction
+tags:
+  - tabs
+  - navigation
+  - button
+  - url-hash
+components:
+  - tabs
+  - tab
+  - button
+status: published
+---
+
+Activate a tab from a button by setting the URL hash—the part after `#`—to match the
+tab's `slug`.
+
+## When to use
+
+Use this pattern when:
+
+- An action needs to show related content in another tab on the same page
+- You want the active tab to have a link that users can bookmark or share
+
+## Considerations
+
+- Give each tab a unique and stable `slug`
+- Keep the default `navigation="hash"` setting
+- Use `initialTab` only to select a tab when the component first loads
+- Label the button so its destination is clear

--- a/docs/src/content/examples/activate-a-specific-tab-with-a-button/react.tsx
+++ b/docs/src/content/examples/activate-a-specific-tab-with-a-button/react.tsx
@@ -1,0 +1,21 @@
+import { GoabButton, GoabTab, GoabTabs } from "@abgov/react-components";
+
+export function ActivateASpecificTabWithAButton() {
+  const activateDetailsTab = () => {
+    window.location.hash = "button-example-details";
+  };
+
+  return (
+    <>
+      <GoabButton onClick={activateDetailsTab}>Open details</GoabButton>
+      <GoabTabs>
+        <GoabTab heading="Summary" slug="button-example-summary">
+          Summary content goes here.
+        </GoabTab>
+        <GoabTab heading="Details" slug="button-example-details">
+          Detailed information goes here.
+        </GoabTab>
+      </GoabTabs>
+    </>
+  );
+}

--- a/docs/src/content/examples/activate-a-specific-tab-with-a-button/web-components.html
+++ b/docs/src/content/examples/activate-a-specific-tab-with-a-button/web-components.html
@@ -1,0 +1,11 @@
+<goa-button version="2" onclick="window.location.hash = 'button-example-details'">
+  Open details
+</goa-button>
+<goa-tabs version="2">
+  <goa-tab heading="Summary" slug="button-example-summary">
+    Summary content goes here.
+  </goa-tab>
+  <goa-tab heading="Details" slug="button-example-details">
+    Detailed information goes here.
+  </goa-tab>
+</goa-tabs>

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       },
       "devDependencies": {
         "@abgov/design-tokens": "1.10.0",
-        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.9.0",
+        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.12.0",
         "@abgov/nx-release": "12.0.0",
         "@angular-devkit/build-angular": "21.2.16",
         "@angular-devkit/core": "21.2.6",
@@ -134,9 +134,9 @@
     },
     "node_modules/@abgov/design-tokens-v2": {
       "name": "@abgov/design-tokens",
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.9.0.tgz",
-      "integrity": "sha512-Z3+wHUhLHCKJDXUBR0KpGBod5k5Jk+ehRNUC9J2OJZ0jcK3jF2/Ggeqhhze7+haiS0FdC1cikqT9vCnKZItU8Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.12.0.tgz",
+      "integrity": "sha512-oDDb4iGfi5fmuh+hSL8icEmmA0iXrPNRqMMd1MmTLvliesDxLoXk35JcQOpbqRWOXJdJabQA9VtJuzMMpARN5w==",
       "dev": true
     },
     "node_modules/@abgov/nx-release": {
@@ -12891,9 +12891,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12911,9 +12908,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12931,9 +12925,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12951,9 +12942,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@abgov/design-tokens": "1.10.0",
-    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.9.0",
+    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.12.0",
     "@abgov/nx-release": "12.0.0",
     "@angular-devkit/build-angular": "21.2.16",
     "@angular-devkit/core": "21.2.6",


### PR DESCRIPTION
This just adds a new example for the GoabTabs component. The example is making a specific tab active via a button click (or really any action on the page). This was a requested example on the Support page.
