### PR TITLE
feat(#1741): Added ariaHidden property to Icon

### DIFF
--- a/apps/prs/angular/src/routes/features/feat1741/feat1741.component.html
+++ b/apps/prs/angular/src/routes/features/feat1741/feat1741.component.html
@@ -1,0 +1,23 @@
+<goab-text tag="h1" mt="m">Feature #1741: Icon aria-hidden label</goab-text>
+
+<goab-text tag="h2">Test Cases</goab-text>
+
+<goab-text tag="p">
+  Test both icons with a screen reader. The 1st one has ariaLabel set to "Applicaton saved
+  icon" and it shouldn't be read. The second one has ariaLabel set to "Important
+  information" and it should be read.
+</goab-text>
+
+<goab-text tag="h3">Test 1: Decorative icon is hidden</goab-text>
+
+<goab-block direction="row" alignment="center">
+  <goab-icon
+    type="checkmark-circle"
+    [ariaHidden]="true"
+    ariaLabel="Application saved icon"
+  />
+  <span>Application saved</span>
+</goab-block>
+
+<goab-text tag="h3">Test 2: Default icon remains accessible</goab-text>
+<goab-icon type="information-circle" ariaLabel="Important information" />

--- a/apps/prs/angular/src/routes/features/feat1741/feat1741.component.ts
+++ b/apps/prs/angular/src/routes/features/feat1741/feat1741.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabBlock, GoabIcon, GoabText } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat1741",
+  templateUrl: "./feat1741.component.html",
+  imports: [GoabBlock, GoabIcon, GoabText],
+})
+export class Feat1741Component {}

--- a/apps/prs/angular/src/routes/features/feat1741/feat1741.route.json
+++ b/apps/prs/angular/src/routes/features/feat1741/feat1741.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Icon aria-hidden",
+  "path": "features/1741",
+  "id": "1741",
+  "type": "feature"
+}

--- a/apps/prs/react/src/app/routes/features/feat1741.route.ts
+++ b/apps/prs/react/src/app/routes/features/feat1741.route.ts
@@ -1,0 +1,10 @@
+import { Feat1741Route } from "../../../routes/features/feat1741";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "feature",
+  id: "1741",
+  path: "features/1741",
+  title: "Icon aria-hidden",
+  component: Feat1741Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/features/feat1741.tsx
+++ b/apps/prs/react/src/routes/features/feat1741.tsx
@@ -1,0 +1,35 @@
+import { GoabBlock, GoabIcon, GoabText } from "@abgov/react-components";
+
+export function Feat1741Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Feature #1741: Icon aria-hidden label
+      </GoabText>
+
+      <GoabText tag="h2">Test Cases</GoabText>
+
+      <GoabText tag="p">
+        Test both icons with a screen reader. The 1st one has ariaLabel set to "Applicaton
+        saved icon" and it shouldn't be read. The second one has ariaLabel set to
+        "Important information" and it should be read.
+      </GoabText>
+
+      <GoabText tag="h3">Test 1: Decorative icon is hidden</GoabText>
+
+      <GoabBlock direction="row" alignment="center">
+        <GoabIcon
+          type="checkmark-circle"
+          ariaHidden={true}
+          ariaLabel="Application saved icon"
+        />
+        <span>Application saved</span>
+      </GoabBlock>
+
+      <GoabText tag="h3">Test 2: Default icon remains accessible</GoabText>
+      <GoabIcon type="information-circle" ariaLabel="Important information" />
+    </div>
+  );
+}
+
+export default Feat1741Route;

--- a/docs/generated/component-apis/icon.json
+++ b/docs/generated/component-apis/icon.json
@@ -5,6 +5,13 @@
     "react": {
       "props": [
         {
+          "name": "ariaHidden",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Sets whether the icon is hidden from assistive technologies."
+        },
+        {
           "name": "ariaLabel",
           "type": "string",
           "required": false,
@@ -116,6 +123,13 @@
     },
     "angular": {
       "props": [
+        {
+          "name": "ariaHidden",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Sets whether the icon is hidden from assistive technologies."
+        },
         {
           "name": "ariaLabel",
           "type": "string",
@@ -237,6 +251,13 @@
           "required": false,
           "default": "",
           "description": "Indicates whether the element controlled by this icon is expanded or collapsed."
+        },
+        {
+          "name": "ariahidden",
+          "type": "boolean",
+          "required": false,
+          "default": "false",
+          "description": "Sets whether the icon is hidden from assistive technologies."
         },
         {
           "name": "arialabel",

--- a/docs/src/content/guidance/accessible-icons-need-label.mdx
+++ b/docs/src/content/guidance/accessible-icons-need-label.mdx
@@ -38,3 +38,12 @@ Icon-only interactive elements must have an accessible label so screen reader us
 The label should describe:
 - What action happens (for buttons): "Delete", "Edit", "Close"
 - What the icon represents (for informational icons): "Warning", "Success"
+
+**For decorative icons:** Set `ariaHidden` to `true` when nearby text or the parent control already communicates the same meaning. This prevents screen readers from announcing duplicate information.
+
+```jsx
+<GoabIcon type="checkmark-circle" ariaHidden />
+<span>Application saved</span>
+```
+
+Do not use `ariaHidden` to replace a missing accessible label. If the icon provides information that is not available elsewhere, use `ariaLabel` instead.

--- a/libs/angular-components/src/lib/components/icon/icon.spec.ts
+++ b/libs/angular-components/src/lib/components/icon/icon.spec.ts
@@ -23,6 +23,7 @@ import { By } from "@angular/platform-browser";
       [opacity]="opacity"
       [title]="title"
       [ariaLabel]="ariaLabel"
+      [ariaHidden]="ariaHidden"
       [role]="role"
       [testId]="testId"
       [mt]="mt"
@@ -41,6 +42,7 @@ class TestIconComponent {
   opacity?: number;
   title?: string;
   ariaLabel?: string;
+  ariaHidden?: boolean;
   role?: string;
   testId?: string;
   mt?: Spacing;
@@ -69,6 +71,7 @@ describe("GoABIcon", () => {
     component.opacity = 0.5;
     component.title = "foo";
     component.ariaLabel = "bar";
+    component.ariaHidden = true;
     component.role = "presentation";
     component.testId = "foo";
     component.mt = "s";
@@ -91,6 +94,7 @@ describe("GoABIcon", () => {
     expect(el?.getAttribute("opacity")).toBe(`${component.opacity}`);
     expect(el?.getAttribute("title")).toBe(component.title);
     expect(el?.getAttribute("arialabel")).toBe(component.ariaLabel);
+    expect(el?.getAttribute("ariahidden")).toBe(`${component.ariaHidden}`);
     expect(el?.getAttribute("role")).toBe(component.role);
     expect(el?.getAttribute("testid")).toBe(component.testId);
     expect(el?.getAttribute("mt")).toBe(component.mt);

--- a/libs/angular-components/src/lib/components/icon/icon.ts
+++ b/libs/angular-components/src/lib/components/icon/icon.ts
@@ -31,6 +31,7 @@ import { GoabBaseComponent } from "../base.component";
         [attr.opacity]="opacity"
         [attr.title]="title"
         [attr.arialabel]="ariaLabel"
+        [attr.ariahidden]="ariaHidden ? 'true' : undefined"
         [attr.role]="role"
         [attr.mt]="mt"
         [attr.mb]="mb"
@@ -64,6 +65,8 @@ export class GoabIcon extends GoabBaseComponent implements OnInit {
   @Input() title?: string;
   /** Defines how the icon will be announced by screen readers. */
   @Input() ariaLabel?: string;
+  /** Sets whether the icon is hidden from assistive technologies. @default false */
+  @Input({ transform: booleanAttribute }) ariaHidden?: boolean;
   /** Sets the ARIA role for the icon. Use 'presentation' for decorative icons. */
   @Input() role?: string;
 

--- a/libs/react-components/src/lib/icon/icon.spec.tsx
+++ b/libs/react-components/src/lib/icon/icon.spec.tsx
@@ -8,6 +8,7 @@ describe("GoabIcon", () => {
     const el = container.querySelector("goa-icon");
     expect(el?.getAttribute("type")).toBe("information");
     expect(el?.getAttribute("inverted")).toBeNull();
+    expect(el?.getAttribute("ariahidden")).toBeNull();
   });
 
   it("should render with properties", () => {
@@ -21,6 +22,7 @@ describe("GoabIcon", () => {
         opacity={0.5}
         title="foo"
         ariaLabel="bar"
+        ariaHidden
         role="presentation"
         testId="foo"
         mt="s"
@@ -39,6 +41,7 @@ describe("GoabIcon", () => {
     expect(el?.getAttribute("opacity")).toBe("0.5");
     expect(el?.getAttribute("title")).toBe("foo");
     expect(el?.getAttribute("arialabel")).toBe("bar");
+    expect(el?.getAttribute("ariahidden")).toBe("true");
     expect(el?.getAttribute("role")).toBe("presentation");
     expect(el?.getAttribute("testid")).toBe("foo");
     expect(el?.getAttribute("mt")).toBe("s");

--- a/libs/react-components/src/lib/icon/icon.tsx
+++ b/libs/react-components/src/lib/icon/icon.tsx
@@ -39,6 +39,8 @@ export interface GoabIconProps extends Margins, DataAttributes {
   title?: string;
   /** Defines how the icon will be announced by screen readers. */
   ariaLabel?: string;
+  /** Sets whether the icon is hidden from assistive technologies. @default false */
+  ariaHidden?: boolean;
   /** Sets the ARIA role for the icon. Use 'presentation' for decorative icons. @default "img" */
   role?: string;
   /** Sets a data-testid attribute for automated testing. */
@@ -54,12 +56,13 @@ interface WCProps extends Margins {
   opacity?: number;
   title?: string;
   arialabel?: string;
+  ariahidden?: string;
   role?: string;
   testid?: string;
 }
 
 /** A simple and universal graphic symbol representing an action, object, or concept to help guide the user. */
-export function GoabIcon({ inverted, ...rest }: GoabIconProps): JSX.Element {
+export function GoabIcon({ inverted, ariaHidden, ...rest }: GoabIconProps): JSX.Element {
   const _props = transformProps<WCProps>(rest, lowercase);
 
   return (
@@ -67,6 +70,7 @@ export function GoabIcon({ inverted, ...rest }: GoabIconProps): JSX.Element {
       inverted={
         typeof inverted === "boolean" ? (inverted ? "true" : undefined) : inverted
       }
+      ariahidden={ariaHidden ? "true" : undefined}
       {..._props}
     />
   );

--- a/libs/web-components/src/components/icon/Icon.spec.ts
+++ b/libs/web-components/src/components/icon/Icon.spec.ts
@@ -21,6 +21,17 @@ describe("Icon", () => {
       expect(icon).toHaveStyle("margin-bottom:var(--goa-space-l)");
       expect(icon).toHaveStyle("margin-left:var(--goa-space-xl)");
       expect(icon.getAttribute("role")).toBe("img");
+      expect(icon.getAttribute("aria-hidden")).toBeNull();
+    });
+    it("should omit aria-hidden when ariahidden is false", async () => {
+      const baseElement = render(GoAIcon, {
+        testid: "icon-test",
+        type: "ellipse",
+        ariahidden: "false",
+      });
+      const icon = await baseElement.findByTestId("icon-test");
+
+      expect(icon.getAttribute("aria-hidden")).toBeNull();
     });
     it("should render the goa-icon with accessibility add-ons attribute accordingly", async () => {
       const baseElement = render(GoAIcon, {
@@ -30,12 +41,14 @@ describe("Icon", () => {
         arialabel: "Clear input",
         ariacontrols: "menuId",
         ariaexpanded: "true",
+        ariahidden: "true",
       });
       const icon = await baseElement.findByTestId("icon-test");
       expect(icon.getAttribute("role")).toBe("button");
       expect(icon.getAttribute("aria-label")).toBe("Clear input");
       expect(icon.getAttribute("aria-controls")).toBe("menuId");
       expect(icon.getAttribute("aria-expanded")).toBe("true");
+      expect(icon.getAttribute("aria-hidden")).toBe("true");
     });
     it(`should change icon's role to be 'img' and add aria-label so the screen reader can read, when aria-label is set`, async () => {
       const baseElement = render(GoAIcon, {

--- a/libs/web-components/src/components/icon/Icon.svelte
+++ b/libs/web-components/src/components/icon/Icon.svelte
@@ -1,9 +1,11 @@
-<svelte:options customElement={{
-  tag: "goa-icon",
-  props: {
-    type: { type: "String", reflect: true }
-  }
-}} />
+<svelte:options
+  customElement={{
+    tag: "goa-icon",
+    props: {
+      type: { type: "String", reflect: true },
+    },
+  }}
+/>
 
 <script lang="ts" context="module">
   export type IconSize =
@@ -591,6 +593,8 @@
   export let ariacontrols: string = "";
   /** Indicates whether the element controlled by this icon is expanded or collapsed. */
   export let ariaexpanded: string = "";
+  /** Sets whether the icon is hidden from assistive technologies. */
+  export let ariahidden: string = "false";
   /** Sets the ARIA role for the icon. Defaults to 'img'. Use 'presentation' for decorative icons. */
   export let role: string = "img";
 
@@ -600,10 +604,12 @@
 
   $: _isInverted = toBoolean(inverted);
   $: _ariaExpanded = toBoolean(ariaexpanded);
-  $: ({ iconType: _iconType, iconTheme: _iconTheme, name: _iconName } = parseProperties(
-    type,
-    theme
-  ));
+  $: _ariaHidden = toBoolean(ariahidden);
+  $: ({
+    iconType: _iconType,
+    iconTheme: _iconTheme,
+    name: _iconName,
+  } = parseProperties(type, theme));
   // Private
 
   const _iconOverrides: Record<
@@ -705,7 +711,7 @@
 
   function parseProperties(
     type: GoAIconType | GoAIconOverridesType | GoAIconTypeWithTheme,
-    fallbackTheme: IconTheme
+    fallbackTheme: IconTheme,
   ) {
     const [iconType, maybeTheme] = type.split(":");
     const iconTheme =
@@ -720,21 +726,22 @@
     return {
       iconType: iconType as GoAIconType | GoAIconOverridesType,
       iconTheme,
-      name
+      name,
     };
   }
 </script>
 
 <div
-  role={role}
+  {role}
   aria-label={arialabel}
   aria-controls={ariacontrols}
   aria-expanded={_ariaExpanded}
+  aria-hidden={_ariaHidden || undefined}
   class={`goa-icon goa-icon--${size}`}
   class:inverted={_isInverted}
   data-testid={testid}
   data-type={_iconType || type}
-  title={title}
+  {title}
   style={`
     ${calculateMargin(mt, mr, mb, ml)}
     ${style("--fill-color", fillcolor)};
@@ -744,9 +751,8 @@
   {#if _iconType}
     {#if _iconType in _iconOverrides}
       <div class="icon-override">
-        {@html
-          _iconOverrides[`${_iconType}-${_iconTheme}`] ||
-            _iconOverrides[_iconType]}
+        {@html _iconOverrides[`${_iconType}-${_iconTheme}`] ||
+          _iconOverrides[_iconType]}
       </div>
     {:else}
       <ion-icon name={_iconName} />


### PR DESCRIPTION
# Before (the change)

All icons were found by automated accessibility tools and screen readers, even though in a lot of cases they didn't need to be, as they were just adding visual flare to something that was already read.

# After (the change)

This commit adds the `ariaHidden` property to the Icon component. By using this, you hide the icon from screen readers and automated accessibility tools. This way you can hide icons that don't need to be seen by screen readers.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the PRs feat1741 for both Angular and React
