### PR TITLE
fix(#4198): use the placeholder colour for multiselect placeholder fallbacks

### DIFF
--- a/apps/prs/angular/src/routes/bugs/4198/bug4198.component.html
+++ b/apps/prs/angular/src/routes/bugs/4198/bug4198.component.html
@@ -1,0 +1,184 @@
+<goab-block direction="column" gap="l">
+  <goab-text tag="h1" size="heading-l" mb="m">Dropdown text colour hierarchy</goab-text>
+
+  <goab-text size="body-m">
+    The dropdown used to paint its placeholder in the darkest text colour and its menu options
+    in a lighter grey, so an empty field looked filled and the options looked like the least
+    important thing on screen. That weighting is now the other way round.
+  </goab-text>
+
+  <goab-text size="body-m">
+    Two things to look for. The placeholder should look lighter than the text around it, and it
+    should match the placeholder in the text input and text area. Open a menu and the options
+    should be the darkest text in the component, darker than the placeholder sitting above them.
+  </goab-text>
+
+  <goab-text size="body-s">
+    Use the theme toggle in the nav to check both light and dark mode. The fix carries into dark
+    mode on its own, because these tokens resolve through greyscale values that the dark theme
+    already overrides.
+  </goab-text>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">Empty fields, all four together</goab-text>
+  <goab-text size="body-m" mb="m">
+    Every placeholder here should look the same weight. Before the fix the two dropdowns were
+    noticeably darker than the text input and text area.
+  </goab-text>
+
+  <div style="max-width: 20rem">
+    <goab-block direction="column" gap="m">
+      <goab-form-item label="Dropdown">
+        <goab-dropdown
+          name="emptyCity"
+          [value]="emptyCity"
+          (onChange)="onEmptyCityChange($event)"
+        >
+          <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+          <goab-dropdown-item value="calgary" label="Calgary"></goab-dropdown-item>
+          <goab-dropdown-item value="red-deer" label="Red Deer"></goab-dropdown-item>
+          <goab-dropdown-item value="lethbridge" label="Lethbridge"></goab-dropdown-item>
+        </goab-dropdown>
+      </goab-form-item>
+
+      <goab-form-item label="Dropdown multiselect">
+        <goab-dropdown-multiselect
+          name="cities"
+          placeholder="—Select—"
+          [value]="cities"
+          (onChange)="onCitiesChange($event)"
+        >
+          <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+          <goab-dropdown-item value="calgary" label="Calgary"></goab-dropdown-item>
+          <goab-dropdown-item value="red-deer" label="Red Deer"></goab-dropdown-item>
+          <goab-dropdown-item value="lethbridge" label="Lethbridge"></goab-dropdown-item>
+        </goab-dropdown-multiselect>
+      </goab-form-item>
+
+      <goab-form-item label="Text input">
+        <goab-input name="note" placeholder="—Select—" [value]="note"></goab-input>
+      </goab-form-item>
+
+      <goab-form-item label="Text area">
+        <goab-textarea name="comments" placeholder="—Select—" [value]="comments"></goab-textarea>
+      </goab-form-item>
+    </goab-block>
+  </div>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">An empty field beside a filled one</goab-text>
+  <goab-text size="body-m" mb="m">
+    This is the point of the change. Scanning a long form, an empty field should be obviously
+    empty. Before the fix both of these rendered in the same near black.
+  </goab-text>
+
+  <div style="max-width: 20rem">
+    <goab-block direction="column" gap="m">
+      <goab-form-item label="Nothing chosen yet">
+        <goab-dropdown name="emptyCompare" value="">
+          <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+          <goab-dropdown-item value="calgary" label="Calgary"></goab-dropdown-item>
+        </goab-dropdown>
+      </goab-form-item>
+
+      <goab-form-item label="Something chosen">
+        <goab-dropdown
+          name="filledCity"
+          [value]="filledCity"
+          (onChange)="onFilledCityChange($event)"
+        >
+          <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+          <goab-dropdown-item value="calgary" label="Calgary"></goab-dropdown-item>
+        </goab-dropdown>
+      </goab-form-item>
+    </goab-block>
+  </div>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">Open the menu</goab-text>
+  <goab-text size="body-m" mb="m">
+    Open this one and compare the options against the placeholder still visible in the field. The
+    options should be the darker of the two. Hover and selected states are unchanged and still
+    carry their own background colour, so they should read exactly as they did before.
+  </goab-text>
+
+  <div style="max-width: 20rem">
+    <goab-form-item label="City">
+      <goab-dropdown name="openCity" [value]="openCity" (onChange)="onOpenCityChange($event)">
+        <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+        <goab-dropdown-item value="calgary" label="Calgary"></goab-dropdown-item>
+        <goab-dropdown-item value="red-deer" label="Red Deer"></goab-dropdown-item>
+        <goab-dropdown-item value="lethbridge" label="Lethbridge"></goab-dropdown-item>
+        <goab-dropdown-item value="medicine-hat" label="Medicine Hat"></goab-dropdown-item>
+        <goab-dropdown-item value="grande-prairie" label="Grande Prairie"></goab-dropdown-item>
+      </goab-dropdown>
+    </goab-form-item>
+  </div>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">
+    Multiselect options are deliberately unchanged
+  </goab-text>
+  <goab-text size="body-m" mb="m">
+    Only the placeholder changed on this one. Its options are checkbox elements, so their text
+    comes from the checkbox label colour, which is already near black. Matching the dropdown
+    exactly would mean repainting every checkbox in the system for a very small difference, so
+    the two are not identical on purpose. Open it and the option text should look the same as it
+    always has.
+  </goab-text>
+
+  <div style="max-width: 20rem">
+    <goab-form-item label="Cities">
+      <goab-dropdown-multiselect
+        name="citiesOpen"
+        placeholder="—Select—"
+        [value]="cities"
+        (onChange)="onCitiesChange($event)"
+      >
+        <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+        <goab-dropdown-item value="calgary" label="Calgary"></goab-dropdown-item>
+        <goab-dropdown-item value="red-deer" label="Red Deer"></goab-dropdown-item>
+        <goab-dropdown-item value="lethbridge" label="Lethbridge"></goab-dropdown-item>
+      </goab-dropdown-multiselect>
+    </goab-form-item>
+  </div>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mt="xl" mb="m">States that should not have moved</goab-text>
+  <goab-text size="body-m" mb="m">
+    Disabled and error text use their own tokens and were not touched. These are here to confirm
+    nothing drifted.
+  </goab-text>
+
+  <div style="max-width: 20rem">
+    <goab-block direction="column" gap="m" mb="2xl">
+      <goab-form-item label="Disabled">
+        <goab-dropdown name="disabledCity" value="" [disabled]="true">
+          <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+        </goab-dropdown>
+      </goab-form-item>
+
+      <goab-form-item label="Error">
+        <goab-dropdown name="errorCity" value="" [error]="true">
+          <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+        </goab-dropdown>
+      </goab-form-item>
+
+      <goab-form-item label="Multiselect, disabled">
+        <goab-dropdown-multiselect
+          name="disabledCities"
+          placeholder="—Select—"
+          [value]="[]"
+          [disabled]="true"
+        >
+          <goab-dropdown-item value="edmonton" label="Edmonton"></goab-dropdown-item>
+        </goab-dropdown-multiselect>
+      </goab-form-item>
+    </goab-block>
+  </div>
+</goab-block>

--- a/apps/prs/angular/src/routes/bugs/4198/bug4198.component.ts
+++ b/apps/prs/angular/src/routes/bugs/4198/bug4198.component.ts
@@ -1,0 +1,57 @@
+import { Component } from "@angular/core";
+import {
+  GoabBlock,
+  GoabDivider,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabDropdownMultiselect,
+  GoabFormItem,
+  GoabInput,
+  GoabText,
+  GoabTextArea,
+} from "@abgov/angular-components";
+import {
+  GoabDropdownOnChangeDetail,
+  GoabDropdownMultiselectOnChangeDetail,
+} from "@abgov/ui-components-common";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug-4198",
+  templateUrl: "./bug4198.component.html",
+  imports: [
+    GoabBlock,
+    GoabDivider,
+    GoabDropdown,
+    GoabDropdownItem,
+    GoabDropdownMultiselect,
+    GoabFormItem,
+    GoabInput,
+    GoabText,
+    GoabTextArea,
+  ],
+})
+export class Bug4198Component {
+  emptyCity = "";
+  filledCity = "calgary";
+  openCity = "";
+  cities: string[] = [];
+  note = "";
+  comments = "";
+
+  onEmptyCityChange(detail: GoabDropdownOnChangeDetail) {
+    this.emptyCity = detail.value ?? "";
+  }
+
+  onFilledCityChange(detail: GoabDropdownOnChangeDetail) {
+    this.filledCity = detail.value ?? "";
+  }
+
+  onOpenCityChange(detail: GoabDropdownOnChangeDetail) {
+    this.openCity = detail.value ?? "";
+  }
+
+  onCitiesChange(detail: GoabDropdownMultiselectOnChangeDetail) {
+    this.cities = detail.value;
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/4198/bug4198.route.json
+++ b/apps/prs/angular/src/routes/bugs/4198/bug4198.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "4198",
+  "path": "bugs/4198",
+  "title": "Dropdown text colour hierarchy"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug4198.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug4198.route.ts
@@ -1,0 +1,10 @@
+import { Bug4198Route } from "../../../routes/bugs/bug4198";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "4198",
+  path: "bugs/4198",
+  title: "Dropdown text colour hierarchy",
+  component: Bug4198Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug4198.tsx
+++ b/apps/prs/react/src/routes/bugs/bug4198.tsx
@@ -1,0 +1,250 @@
+import React, { useState } from "react";
+import {
+  GoabBlock,
+  GoabDivider,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabDropdownMultiselect,
+  GoabFormItem,
+  GoabInput,
+  GoabOneColumnLayout,
+  GoabPageBlock,
+  GoabText,
+  GoabTextarea,
+} from "@abgov/react-components";
+
+const narrow: React.CSSProperties = { maxWidth: "20rem" };
+
+export function Bug4198Route() {
+  const [emptyCity, setEmptyCity] = useState("");
+  const [filledCity, setFilledCity] = useState("calgary");
+  const [openCity, setOpenCity] = useState("");
+  const [cities, setCities] = useState<string[]>([]);
+  const [note, setNote] = useState("");
+  const [comments, setComments] = useState("");
+
+  return (
+    <GoabPageBlock width="full">
+      <GoabOneColumnLayout>
+        <GoabBlock direction="column" gap="l">
+          <GoabText tag="h1" size="heading-l" mt="xl" mb="m">
+            Dropdown text colour hierarchy
+          </GoabText>
+
+          <GoabText size="body-m">
+            The dropdown used to paint its placeholder in the darkest text colour and its menu
+            options in a lighter grey, so an empty field looked filled and the options looked
+            like the least important thing on screen. That weighting is now the other way
+            round.
+          </GoabText>
+
+          <GoabText size="body-m">
+            Two things to look for. The placeholder should look lighter than the text around
+            it, and it should match the placeholder in the text input and text area. Open a
+            menu and the options should be the darkest text in the component, darker than the
+            placeholder sitting above them.
+          </GoabText>
+
+          <GoabText size="body-s">
+            Use the theme toggle in the nav to check both light and dark mode. The fix carries
+            into dark mode on its own, because these tokens resolve through greyscale values
+            that the dark theme already overrides.
+          </GoabText>
+
+          <GoabDivider />
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Empty fields, all four together
+          </GoabText>
+          <GoabText size="body-m" mb="m">
+            Every placeholder here should look the same weight. Before the fix the two
+            dropdowns were noticeably darker than the text input and text area.
+          </GoabText>
+
+          <div style={narrow}>
+            <GoabBlock direction="column" gap="m">
+              <GoabFormItem label="Dropdown">
+                <GoabDropdown
+                  name="emptyCity"
+                  value={emptyCity}
+                  onChange={(detail) => setEmptyCity(detail.value ?? "")}
+                >
+                  <GoabDropdownItem value="edmonton" label="Edmonton" />
+                  <GoabDropdownItem value="calgary" label="Calgary" />
+                  <GoabDropdownItem value="red-deer" label="Red Deer" />
+                  <GoabDropdownItem value="lethbridge" label="Lethbridge" />
+                </GoabDropdown>
+              </GoabFormItem>
+
+              <GoabFormItem label="Dropdown multiselect">
+                <GoabDropdownMultiselect
+                  name="cities"
+                  placeholder="—Select—"
+                  value={cities}
+                  onChange={(detail) => setCities(detail.value)}
+                >
+                  <GoabDropdownItem value="edmonton" label="Edmonton" />
+                  <GoabDropdownItem value="calgary" label="Calgary" />
+                  <GoabDropdownItem value="red-deer" label="Red Deer" />
+                  <GoabDropdownItem value="lethbridge" label="Lethbridge" />
+                </GoabDropdownMultiselect>
+              </GoabFormItem>
+
+              <GoabFormItem label="Text input">
+                <GoabInput
+                  name="note"
+                  placeholder="—Select—"
+                  value={note}
+                  onChange={(detail) => setNote(detail.value)}
+                />
+              </GoabFormItem>
+
+              <GoabFormItem label="Text area">
+                <GoabTextarea
+                  name="comments"
+                  placeholder="—Select—"
+                  value={comments}
+                  onChange={(detail) => setComments(detail.value)}
+                />
+              </GoabFormItem>
+            </GoabBlock>
+          </div>
+
+          <GoabDivider />
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            An empty field beside a filled one
+          </GoabText>
+          <GoabText size="body-m" mb="m">
+            This is the point of the change. Scanning a long form, an empty field should be
+            obviously empty. Before the fix both of these rendered in the same near black.
+          </GoabText>
+
+          <div style={narrow}>
+            <GoabBlock direction="column" gap="m">
+              <GoabFormItem label="Nothing chosen yet">
+                <GoabDropdown
+                  name="emptyCompare"
+                  value=""
+                  onChange={() => undefined}
+                >
+                  <GoabDropdownItem value="edmonton" label="Edmonton" />
+                  <GoabDropdownItem value="calgary" label="Calgary" />
+                </GoabDropdown>
+              </GoabFormItem>
+
+              <GoabFormItem label="Something chosen">
+                <GoabDropdown
+                  name="filledCity"
+                  value={filledCity}
+                  onChange={(detail) => setFilledCity(detail.value ?? "")}
+                >
+                  <GoabDropdownItem value="edmonton" label="Edmonton" />
+                  <GoabDropdownItem value="calgary" label="Calgary" />
+                </GoabDropdown>
+              </GoabFormItem>
+            </GoabBlock>
+          </div>
+
+          <GoabDivider />
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Open the menu
+          </GoabText>
+          <GoabText size="body-m" mb="m">
+            Open this one and compare the options against the placeholder still visible in the
+            field. The options should be the darker of the two. Hover and selected states are
+            unchanged and still carry their own background colour, so they should read exactly
+            as they did before.
+          </GoabText>
+
+          <div style={narrow}>
+            <GoabFormItem label="City">
+              <GoabDropdown
+                name="openCity"
+                value={openCity}
+                onChange={(detail) => setOpenCity(detail.value ?? "")}
+              >
+                <GoabDropdownItem value="edmonton" label="Edmonton" />
+                <GoabDropdownItem value="calgary" label="Calgary" />
+                <GoabDropdownItem value="red-deer" label="Red Deer" />
+                <GoabDropdownItem value="lethbridge" label="Lethbridge" />
+                <GoabDropdownItem value="medicine-hat" label="Medicine Hat" />
+                <GoabDropdownItem value="grande-prairie" label="Grande Prairie" />
+              </GoabDropdown>
+            </GoabFormItem>
+          </div>
+
+          <GoabDivider />
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            Multiselect options are deliberately unchanged
+          </GoabText>
+          <GoabText size="body-m" mb="m">
+            Only the placeholder changed on this one. Its options are checkbox elements, so
+            their text comes from the checkbox label colour, which is already near black.
+            Matching the dropdown exactly would mean repainting every checkbox in the system
+            for a very small difference, so the two are not identical on purpose. Open it and
+            the option text should look the same as it always has.
+          </GoabText>
+
+          <div style={narrow}>
+            <GoabFormItem label="Cities">
+              <GoabDropdownMultiselect
+                name="citiesOpen"
+                placeholder="—Select—"
+                value={cities}
+                onChange={(detail) => setCities(detail.value)}
+              >
+                <GoabDropdownItem value="edmonton" label="Edmonton" />
+                <GoabDropdownItem value="calgary" label="Calgary" />
+                <GoabDropdownItem value="red-deer" label="Red Deer" />
+                <GoabDropdownItem value="lethbridge" label="Lethbridge" />
+              </GoabDropdownMultiselect>
+            </GoabFormItem>
+          </div>
+
+          <GoabDivider />
+
+          <GoabText tag="h2" size="heading-m" mt="xl" mb="m">
+            States that should not have moved
+          </GoabText>
+          <GoabText size="body-m" mb="m">
+            Disabled and error text use their own tokens and were not touched. These are here
+            to confirm nothing drifted.
+          </GoabText>
+
+          <div style={narrow}>
+            <GoabBlock direction="column" gap="m" mb="2xl">
+              <GoabFormItem label="Disabled">
+                <GoabDropdown name="disabledCity" value="" disabled onChange={() => undefined}>
+                  <GoabDropdownItem value="edmonton" label="Edmonton" />
+                </GoabDropdown>
+              </GoabFormItem>
+
+              <GoabFormItem label="Error">
+                <GoabDropdown name="errorCity" value="" error onChange={() => undefined}>
+                  <GoabDropdownItem value="edmonton" label="Edmonton" />
+                </GoabDropdown>
+              </GoabFormItem>
+
+              <GoabFormItem label="Multiselect, disabled">
+                <GoabDropdownMultiselect
+                  name="disabledCities"
+                  placeholder="—Select—"
+                  value={[]}
+                  disabled
+                  onChange={() => undefined}
+                >
+                  <GoabDropdownItem value="edmonton" label="Edmonton" />
+                </GoabDropdownMultiselect>
+              </GoabFormItem>
+            </GoabBlock>
+          </div>
+        </GoabBlock>
+      </GoabOneColumnLayout>
+    </GoabPageBlock>
+  );
+}
+
+export default Bug4198Route;

--- a/libs/web-components/src/components/dropdown-multiselect/DropdownMultiselect.svelte
+++ b/libs/web-components/src/components/dropdown-multiselect/DropdownMultiselect.svelte
@@ -784,7 +784,7 @@
   .value-display.placeholder {
     color: var(
       --goa-dropdown-multiselect-color-text-placeholder,
-      var(--goa-input-color-text-default)
+      var(--goa-input-color-text-placeholder)
     );
   }
 
@@ -808,7 +808,7 @@
   .filter-input::placeholder {
     color: var(
       --goa-dropdown-multiselect-color-text-placeholder,
-      var(--goa-input-color-text-default)
+      var(--goa-input-color-text-placeholder)
     );
   }
 


### PR DESCRIPTION
Companion to GovAlta/design-tokens#171, which carries the actual colour change for issue #4198. Best reviewed together with that one.

## What is here

**The placeholder fallbacks.** Two CSS fallback values in `DropdownMultiselect.svelte` move from `var(--goa-input-color-text-default)` to `var(--goa-input-color-text-placeholder)`, on `.value-display.placeholder` and `.filter-input::placeholder`. These are the fallbacks for `--goa-dropdown-multiselect-color-text-placeholder`. That token is defined, so the fallback never fires and this changes no rendering on its own. They are wrong on their own terms and this makes them honest.

**Playground pages** at `bugs/4198` in both the React and Angular playgrounds. Empty fields side by side across dropdown, multiselect, text input and text area, an empty field next to a filled one, an open menu, the multiselect whose options are deliberately unchanged, and the disabled and error states as a no drift check. Use the theme toggle in the nav for dark mode.

## One commit still to come

`@abgov/design-tokens-v2` is pinned at 2.12.0. Once #171 merges and publishes, this PR takes a one line bump to the published version, which is what actually makes the change visible to consuming teams.

Flagging it up front so it is not a surprise after review. **Until that commit lands the playground pages render the unfixed state, which is expected.** Nothing else about this PR changes.

## Notes

For anyone applying the Svelte change by hand, `var(--goa-input-color-text-default)` appears five times in that file. The other three belong to `--goa-dropdown-multiselect-color-text`, the regular text colour, where falling back to the default is correct.

Dark mode needs no work. The tokens resolve through greyscale values that the dark theme already overrides, so `dark-theme.css` came back byte identical from the tokens rebuild and is not in #171.
