### PR TITLE
fix(#4201): Updated base angular component to allow for setting disabled

### DIFF
--- a/apps/prs/angular/src/routes/bugs/fix4201/fix4201.component.html
+++ b/apps/prs/angular/src/routes/bugs/fix4201/fix4201.component.html
@@ -1,0 +1,65 @@
+<goab-block direction="column" gap="l">
+  <goab-text tag="h1" size="heading-l" mb="m">
+    Bug #4201: Disabled radio groups with Angular forms
+  </goab-text>
+
+  <goab-text tag="h2" size="heading-m" mb="m">
+    1. Template-driven form using [disabled] property
+  </goab-text>
+  <goab-text size="body-m">
+    The component input supplies the disabled state while ngModel supplies the value.
+  </goab-text>
+  <goab-radio-group
+    name="templateDrivenDisabled"
+    [(ngModel)]="templateDrivenValue"
+    [disabled]="true"
+  >
+    <goab-radio-item value="one" label="Option one"></goab-radio-item>
+    <goab-radio-item value="two" label="Option two"></goab-radio-item>
+  </goab-radio-group>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mb="m">
+    2. Reactive form disabled via FormControl
+  </goab-text>
+  <goab-text tag="p">
+    The FormControl is created with disabled: true. The component has no disabled input.
+  </goab-text>
+  <goab-radio-group name="formControlDisabled" [formControl]="formControlDisabled">
+    <goab-radio-item value="one" label="Option one"></goab-radio-item>
+    <goab-radio-item value="two" label="Option two"></goab-radio-item>
+  </goab-radio-group>
+  <goab-text size="body-s">
+    FormControl disabled: {{ formControlDisabled.disabled }}
+  </goab-text>
+
+  <goab-divider></goab-divider>
+
+  <goab-text tag="h2" size="heading-m" mb="m">
+    3. Reactive form disabled using [disabled] property
+  </goab-text>
+  <goab-text tag="p">
+    The FormControl remains enabled while the disabled state is supplied directly to the
+    component. This is the option that didn't work prior to this bug.
+  </goab-text>
+  <goab-text tag="p">
+    This is technically the incorrect way of doing it and shouldn't be used. It's been
+    fixed though because some people will inevitably do it this way.
+  </goab-text>
+  <goab-text tag="p">
+    It's incorrect because while it disables the component in the UI, it doesn't disable
+    it to Angular, so Angular will still present the value in any FormGroup values.
+  </goab-text>
+  <goab-radio-group
+    name="componentDisabled"
+    [formControl]="componentDisabled"
+    [disabled]="true"
+  >
+    <goab-radio-item value="one" label="Option one"></goab-radio-item>
+    <goab-radio-item value="two" label="Option two"></goab-radio-item>
+  </goab-radio-group>
+  <goab-text size="body-s">
+    FormControl disabled: {{ componentDisabled.disabled }} (expected: false)
+  </goab-text>
+</goab-block>

--- a/apps/prs/angular/src/routes/bugs/fix4201/fix4201.component.ts
+++ b/apps/prs/angular/src/routes/bugs/fix4201/fix4201.component.ts
@@ -1,0 +1,31 @@
+import { Component } from "@angular/core";
+import { FormControl, FormsModule, ReactiveFormsModule } from "@angular/forms";
+import {
+  GoabBlock,
+  GoabDivider,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-fix-4201",
+  templateUrl: "./fix4201.component.html",
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    GoabBlock,
+    GoabDivider,
+    GoabRadioGroup,
+    GoabRadioItem,
+    GoabText,
+  ],
+})
+export class Fix4201Component {
+  templateDrivenValue = "one";
+
+  formControlDisabled = new FormControl({ value: "one", disabled: true });
+
+  componentDisabled = new FormControl("one");
+}

--- a/apps/prs/angular/src/routes/bugs/fix4201/fix4201.route.json
+++ b/apps/prs/angular/src/routes/bugs/fix4201/fix4201.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "4201",
+  "path": "bugs/fix4201",
+  "title": "Disabled state with Angular forms"
+}

--- a/docs/src/scripts/extract-api.ts
+++ b/docs/src/scripts/extract-api.ts
@@ -204,7 +204,12 @@ const WEB_COMPONENT_EVENT_TYPE_OVERRIDES: Record<string, Record<string, string>>
 const HIDE_SLOT = null;
 const SLOT_TYPE_OVERRIDES: Record<
   string,
-  Partial<Record<"react" | "angular" | "webComponents", Record<string, string | typeof HIDE_SLOT>>>
+  Partial<
+    Record<
+      "react" | "angular" | "webComponents",
+      Record<string, string | typeof HIDE_SLOT>
+    >
+  >
 > = {
   footer: {
     react: {
@@ -1203,18 +1208,34 @@ function extractAngularBaseComponentProps(): Map<string, ExtractedProp> {
 
   for (const classDecl of classDecls) {
     for (const member of classDecl.members) {
-      if (!ts.isPropertyDeclaration(member)) continue;
+      if (!ts.isPropertyDeclaration(member) && !ts.isSetAccessorDeclaration(member)) {
+        continue;
+      }
       if (!hasDecorator(member, "Input")) continue;
       if (!member.name || !ts.isIdentifier(member.name)) continue;
 
       const rawComment = findImmediateJsDocBefore(content, member.getStart(sourceFile));
       const propName = member.name.text;
       const inputDecorator = getDecoratorCall(member, "Input");
-      const rawDefault = member.initializer?.getText(sourceFile)?.trim();
+      const rawDefault = ts.isPropertyDeclaration(member)
+        ? member.initializer?.getText(sourceFile)?.trim()
+        : undefined;
+      const declaredType = ts.isPropertyDeclaration(member)
+        ? member.type?.getText(sourceFile)?.trim()
+        : member.parameters[0]?.type?.getText(sourceFile)?.trim();
+      const documentedType = ts.isSetAccessorDeclaration(member)
+        ? declaredType
+            ?.split("|")
+            .map((type) => type.trim())
+            .filter((type) => type !== "undefined")
+            .join(" | ")
+        : declaredType;
       const rawType = cleanType(
-        member.type?.getText(sourceFile)?.trim() || inferTypeFromDefault(rawDefault),
+        documentedType || declaredType || inferTypeFromDefault(rawDefault),
       );
-      const fullDescription = parseDescriptionFromJSDoc(rawComment);
+      const fullDescription = parseDescriptionFromJSDoc(rawComment)
+        .replace(/@param\s+\S+(?:\s*-\s*)?[^@]*/gi, "")
+        .trim();
       const { description, defaultValue: descriptionDefault } =
         extractDefaultFromDescription(fullDescription);
       const defaultValue = descriptionDefault ?? parseDefaultValue(rawDefault);
@@ -2613,7 +2634,11 @@ function extractComponentAPI(componentName: string): ExtractedComponentAPI | nul
     name: string,
   ): string | typeof HIDE_SLOT | undefined => {
     const frameworkOverrides = SLOT_TYPE_OVERRIDES[componentName]?.[framework];
-    if (!frameworkOverrides || !Object.prototype.hasOwnProperty.call(frameworkOverrides, name)) return undefined;
+    if (
+      !frameworkOverrides ||
+      !Object.prototype.hasOwnProperty.call(frameworkOverrides, name)
+    )
+      return undefined;
     return frameworkOverrides[name];
   };
 
@@ -2637,7 +2662,9 @@ function extractComponentAPI(componentName: string): ExtractedComponentAPI | nul
             : rawDescription;
         return {
           name: useAliasNames ? slotNameAliases[name] || name : name,
-          type: getSlotOverride(framework, name) ?? (type && hasWrapperSlotEvidence(name) ? type : undefined),
+          type:
+            getSlotOverride(framework, name) ??
+            (type && hasWrapperSlotEvidence(name) ? type : undefined),
           description,
           required: slotRequired[name] || false,
         };

--- a/libs/angular-components/src/lib/components/base.component.ts
+++ b/libs/angular-components/src/lib/components/base.component.ts
@@ -86,15 +86,15 @@ export abstract class GoabControlValueAccessor
 {
   /** Sets the id attribute of the underlying web component. */
   @Input() id?: string;
-  // supports disabled="true" instead of [disabled]="true"
-  /** Sets the disabled state for the control. */
-  @Input({ transform: booleanAttribute }) public disabled?: boolean;
   // supports error="true" instead of [error]="true"
   /** Sets the error state for the control. */
   @Input({ transform: booleanAttribute }) public error?: boolean;
   // this should be unknown (not string) as it might be an integer or a date or a boolean
   /** Sets the control value used by Angular forms and one-way binding. */
   @Input() value?: unknown | null | undefined;
+
+  private inputDisabled = false;
+  private formControlDisabled = false;
 
   // implement ControlValueAccessor
 
@@ -175,11 +175,25 @@ export abstract class GoabControlValueAccessor
   }
 
   /**
+   * Sets the disabled state for the control.
+   *
+   * @param isDisabled - A boolean indicating whether the component should be disabled.
+   */
+  @Input({ transform: booleanAttribute })
+  public set disabled(isDisabled: boolean | undefined) {
+    this.inputDisabled = isDisabled ?? false;
+  }
+
+  get disabled(): boolean {
+    return this.inputDisabled || this.formControlDisabled;
+  }
+
+  /**
    * Sets the disabled state of the component.
    *
    * @param isDisabled - A boolean indicating whether the component should be disabled.
    */
-  public setDisabledState?(isDisabled: boolean): void {
-    this.disabled = isDisabled;
+  public setDisabledState?(value: boolean): void {
+    this.formControlDisabled = value;
   }
 }

--- a/libs/web-components/src/components/checkbox-list/CheckboxList.spec.ts
+++ b/libs/web-components/src/components/checkbox-list/CheckboxList.spec.ts
@@ -83,14 +83,58 @@ describe("GoACheckboxList", () => {
       expect(container.querySelector(".root")).toBeTruthy();
     });
 
-    it("should handle disabled state", async () => {
-      const { container } = render(CheckboxList, {
+    it("should update child checkboxes when disabled changes", async () => {
+      const result = render(CheckboxList, defaultProps);
+      const checkboxContainer = result.container.querySelector(".checkbox-container");
+      const checkbox = document.createElement("goa-checkbox");
+      const slot = document.createElement("slot");
+      vi.spyOn(slot, "assignedElements").mockReturnValue([checkbox]);
+      checkboxContainer?.appendChild(slot);
+
+      expect(checkbox.hasAttribute("disabled")).toBe(false);
+
+      await result.rerender({
         ...defaultProps,
         disabled: "true",
       });
 
-      // When disabled, child checkboxes should also be disabled
-      expect(container).toBeTruthy();
+      await waitFor(() => {
+        expect(checkbox.getAttribute("disabled")).toBe("true");
+      });
+
+      await result.rerender({
+        ...defaultProps,
+        disabled: "false",
+      });
+
+      await waitFor(() => {
+        expect(checkbox.hasAttribute("disabled")).toBe(false);
+      });
+    });
+
+    it("should disable a child checkbox that mounts after the list", async () => {
+      const result = render(CheckboxList, defaultProps);
+      const checkboxContainer = result.container.querySelector(".checkbox-container");
+      const checkbox = document.createElement("goa-checkbox");
+      const checkboxRoot = document.createElement("div");
+      checkbox.attachShadow({ mode: "open" }).appendChild(checkboxRoot);
+      checkboxContainer?.appendChild(checkbox);
+
+      await result.rerender({
+        ...defaultProps,
+        disabled: "true",
+      });
+
+      relay<FormFieldMountRelayDetail>(
+        checkboxRoot,
+        FormFieldMountMsg,
+        { name: "option1", el: checkboxRoot },
+        { bubbles: true },
+      );
+
+      await waitFor(() => {
+        expect(checkbox.getAttribute("disabled")).toBe("true");
+      });
     });
   });
 

--- a/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
+++ b/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
@@ -64,7 +64,10 @@
 
   // Reactive bindings
   $: isDisabled = toBoolean(disabled);
-  $: updateState(value, error);
+  $: {
+    isDisabled;
+    updateState(value, error);
+  }
 
   onMount(async () => {
     await tick();
@@ -237,7 +240,9 @@
           onSetValue({ name, value: [] });
           break;
         case FormFieldMountMsg:
-          onChildCheckboxMount(data as FormFieldMountRelayDetail);
+          if (onChildCheckboxMount(data as FormFieldMountRelayDetail)) {
+            event.stopPropagation();
+          }
           break;
       }
     });
@@ -281,13 +286,13 @@
    * Register a newly mounted child checkbox that belongs to this list.
    * Also synchronizes its state and applies child-level styles.
    */
-  function onChildCheckboxMount(detail: FormFieldMountRelayDetail) {
+  function onChildCheckboxMount(detail: FormFieldMountRelayDetail): boolean {
     const checkboxElement = (detail.el.getRootNode() as any)?.host;
     if (
       !checkboxElement ||
       checkboxElement.tagName.toLowerCase() !== "goa-checkbox"
     ) {
-      return;
+      return false;
     }
 
     // Capture label
@@ -297,6 +302,7 @@
       { el: detail.el, name: detail.name, label },
     ];
     updateChildCheckboxState(detail.el, detail.name);
+    return true;
   }
 
   /**

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -185,15 +185,11 @@
   function sendMountedMessage() {
     if (!name) return;
 
-    const checkboxEl = (_rootEl?.getRootNode() as ShadowRoot)
-      ?.host as HTMLElement;
-    const fromCheckboxList = checkboxEl?.closest("goa-checkbox-list") !== null;
-
     relay<FormFieldMountRelayDetail>(
       _rootEl,
       FormFieldMountMsg,
       { name, el: _rootEl },
-      { bubbles: !fromCheckboxList, timeout: 10 },
+      { bubbles: true, timeout: 10 },
     );
   }
 


### PR DESCRIPTION
# Before (the change)

Using `[disabled]` on an input component that was also using FormControl, essentially did nothing. It only worked for Template driven component usage. This is mostly fine because if you're using FormControl, you should be setting the `disabled` property via the Form Control declaration, not via the `[disabled]` property. But this doesn't remove the fact that some people do things this way anyways.

# After (the change)

Using `[disabled]` should now work for both Template drive and Form Control based inputs. This wasn't working initially because both options were working with the same `isDisabled` value, so if you set it via the component, the Form Control would overwrite that. Now, it's being set independently and if either option is true, the component is disabled.

This also involved modifying the `extract-api.ts` script, because it only got properties based off of base variables, not getters and setters.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

You can test in the PR bug 4201 for Angular. This is not represented in React, as the problem was Angular specific.
