### PR TITLE
feat(#1731): Added a custom noResults property to Dropdown

### DIFF
--- a/apps/prs/angular/src/routes/docs/dropdown/dropdown.component.html
+++ b/apps/prs/angular/src/routes/docs/dropdown/dropdown.component.html
@@ -55,6 +55,20 @@
   </goab-dropdown>
 </goab-form-item>
 
+<h3>Custom no-results text</h3>
+<goab-form-item label="Program" mb="l">
+  <goab-dropdown
+    name="program"
+    [filterable]="true"
+    noResults="No programs found"
+    placeholder="Select a program"
+  >
+    <goab-dropdown-item value="Child care"></goab-dropdown-item>
+    <goab-dropdown-item value="Education"></goab-dropdown-item>
+    <goab-dropdown-item value="Health"></goab-dropdown-item>
+  </goab-dropdown>
+</goab-form-item>
+
 <h3>Native</h3>
 <goab-form-item label="Custom dropdown" mb="l">
   <goab-dropdown name="custom">

--- a/apps/prs/angular/src/routes/features/feat1731/feat1731.component.html
+++ b/apps/prs/angular/src/routes/features/feat1731/feat1731.component.html
@@ -1,0 +1,43 @@
+<goab-text tag="h1" mt="none"> Feature #1731: Custom dropdown no-results text </goab-text>
+
+<goab-text tag="p">
+  Filterable dropdowns can use the noResults property to provide an empty-state message
+  that matches the service context.
+</goab-text>
+
+<goab-text tag="h2">Custom no-results text</goab-text>
+<goab-text tag="p">
+  Open the dropdown and enter a value such as “xyz”. The empty state should read “No
+  programs found”.
+</goab-text>
+<goab-form-item label="Program">
+  <goab-dropdown
+    name="custom-no-results"
+    [filterable]="true"
+    noResults="No programs found"
+    placeholder="Select a program"
+    width="20rem"
+  >
+    <goab-dropdown-item value="child-care" label="Child care" />
+    <goab-dropdown-item value="education" label="Education" />
+    <goab-dropdown-item value="health" label="Health" />
+  </goab-dropdown>
+</goab-form-item>
+
+<goab-text tag="h2">Default no-results text</goab-text>
+<goab-text tag="p">
+  Open the dropdown and enter a value such as “xyz”. Without noResults, the empty state
+  should continue to read “No matches found”.
+</goab-text>
+<goab-form-item label="Program">
+  <goab-dropdown
+    name="default-no-results"
+    [filterable]="true"
+    placeholder="Select a program"
+    width="20rem"
+  >
+    <goab-dropdown-item value="child-care" label="Child care" />
+    <goab-dropdown-item value="education" label="Education" />
+    <goab-dropdown-item value="health" label="Health" />
+  </goab-dropdown>
+</goab-form-item>

--- a/apps/prs/angular/src/routes/features/feat1731/feat1731.component.ts
+++ b/apps/prs/angular/src/routes/features/feat1731/feat1731.component.ts
@@ -1,0 +1,15 @@
+import { Component } from "@angular/core";
+import {
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFormItem,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat1731",
+  templateUrl: "./feat1731.component.html",
+  imports: [GoabDropdown, GoabDropdownItem, GoabFormItem, GoabText],
+})
+export class Feat1731Component {}

--- a/apps/prs/angular/src/routes/features/feat1731/feat1731.route.json
+++ b/apps/prs/angular/src/routes/features/feat1731/feat1731.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Dropdown custom no-results text",
+  "path": "features/1731",
+  "id": "1731",
+  "type": "feature"
+}

--- a/apps/prs/react/src/app/routes/features/feat1731.route.ts
+++ b/apps/prs/react/src/app/routes/features/feat1731.route.ts
@@ -1,0 +1,10 @@
+import { Feat1731Route } from "../../../routes/features/feat1731";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "feature",
+  id: "1731",
+  path: "features/1731",
+  title: "Dropdown custom no-results text",
+  component: Feat1731Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/docs/dropdown/dropdown.tsx
+++ b/apps/prs/react/src/routes/docs/dropdown/dropdown.tsx
@@ -136,6 +136,20 @@ export function DocsDropdownRoute() {
         </GoabDropdown>
       </GoabFormItem>
 
+      <h3>Custom no-results text</h3>
+      <GoabFormItem label="Program" mb="l">
+        <GoabDropdown
+          name="program"
+          filterable
+          noResults="No programs found"
+          placeholder="Select a program"
+        >
+          <GoabDropdownItem value="Child care" />
+          <GoabDropdownItem value="Education" />
+          <GoabDropdownItem value="Health" />
+        </GoabDropdown>
+      </GoabFormItem>
+
       <h3>Native</h3>
       <GoabFormItem label="Custom dropdown" mb="l">
         <GoabDropdown

--- a/apps/prs/react/src/routes/features/feat1731.tsx
+++ b/apps/prs/react/src/routes/features/feat1731.tsx
@@ -1,0 +1,70 @@
+import {
+  GoabBlock,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFormItem,
+  GoabLink,
+  GoabText,
+} from "@abgov/react-components";
+
+const programOptions = [
+  { value: "child-care", label: "Child care" },
+  { value: "education", label: "Education" },
+  { value: "health", label: "Health" },
+];
+
+function ProgramItems() {
+  return programOptions.map((option) => (
+    <GoabDropdownItem key={option.value} value={option.value} label={option.label} />
+  ));
+}
+
+export function Feat1731Route() {
+  return (
+    <main>
+      <GoabText tag="h1" mt="none">
+        Feature #1731: Custom dropdown no-results text
+      </GoabText>
+
+      <GoabText tag="p">
+        Filterable dropdowns can use the noResults property to provide an empty-state
+        message that matches the service context.
+      </GoabText>
+
+      <GoabText tag="h2">Custom no-results text</GoabText>
+      <GoabText tag="p">
+        Open the dropdown and enter a value such as “xyz”. The empty state should read “No
+        programs found”.
+      </GoabText>
+      <GoabFormItem label="Program">
+        <GoabDropdown
+          name="custom-no-results"
+          filterable
+          noResults="No programs found"
+          placeholder="Select a program"
+          width="20rem"
+        >
+          <ProgramItems />
+        </GoabDropdown>
+      </GoabFormItem>
+
+      <GoabText tag="h2">Default no-results text</GoabText>
+      <GoabText tag="p">
+        Open the dropdown and enter a value such as “xyz”. Without noResults, the empty
+        state should continue to read “No matches found”.
+      </GoabText>
+      <GoabFormItem label="Program">
+        <GoabDropdown
+          name="default-no-results"
+          filterable
+          placeholder="Select a program"
+          width="20rem"
+        >
+          <ProgramItems />
+        </GoabDropdown>
+      </GoabFormItem>
+    </main>
+  );
+}
+
+export default Feat1731Route;

--- a/docs/generated/component-apis/dropdown.json
+++ b/docs/generated/component-apis/dropdown.json
@@ -117,6 +117,13 @@
           "description": "When true, renders the native select HTML element."
         },
         {
+          "name": "noResults",
+          "type": "string",
+          "required": false,
+          "default": "No matches found",
+          "description": "Sets the text displayed when filtering returns no results."
+        },
+        {
           "name": "placeholder",
           "type": "string",
           "required": false,
@@ -299,6 +306,13 @@
           "description": "When true will render the native select HTML element."
         },
         {
+          "name": "noResults",
+          "type": "string",
+          "required": false,
+          "default": "No matches found",
+          "description": "Sets the text displayed when filtering returns no results."
+        },
+        {
           "name": "placeholder",
           "type": "string",
           "required": false,
@@ -477,6 +491,13 @@
           "required": false,
           "default": "false",
           "description": "When true will render the native select HTML element."
+        },
+        {
+          "name": "noresults",
+          "type": "string",
+          "required": false,
+          "default": "No matches found",
+          "description": "Sets the text displayed when filtering returns no results."
         },
         {
           "name": "placeholder",

--- a/docs/src/data/configurations/dropdown.ts
+++ b/docs/src/data/configurations/dropdown.ts
@@ -449,6 +449,50 @@ export const dropdownConfigurations: ComponentConfigurations = {
       },
     },
     {
+      id: "custom-no-results",
+      name: "Custom no-results text",
+      description: "Filterable dropdown with a custom message when no options match",
+      code: {
+        react: `<GoabFormItem label="Program" mb="l">
+  <GoabDropdown
+    name="program"
+    filterable
+    noResults="No programs found"
+    placeholder="Select a program"
+  >
+    <GoabDropdownItem value="Child care" />
+    <GoabDropdownItem value="Education" />
+    <GoabDropdownItem value="Health" />
+  </GoabDropdown>
+</GoabFormItem>`,
+        angular: `<goab-form-item label="Program" mb="l">
+  <goab-dropdown
+    name="program"
+    [filterable]="true"
+    noResults="No programs found"
+    placeholder="Select a program"
+  >
+    <goab-dropdown-item value="Child care"></goab-dropdown-item>
+    <goab-dropdown-item value="Education"></goab-dropdown-item>
+    <goab-dropdown-item value="Health"></goab-dropdown-item>
+  </goab-dropdown>
+</goab-form-item>`,
+        webComponents: `<goa-form-item version="2" label="Program" mb="l">
+  <goa-dropdown
+    version="2"
+    name="program"
+    filterable
+    noresults="No programs found"
+    placeholder="Select a program"
+  >
+    <goa-dropdown-item value="Child care"></goa-dropdown-item>
+    <goa-dropdown-item value="Education"></goa-dropdown-item>
+    <goa-dropdown-item value="Health"></goa-dropdown-item>
+  </goa-dropdown>
+</goa-form-item>`,
+      },
+    },
+    {
       id: "rich-item-content",
       name: "Rich item content",
       description: "Dropdown items containing formatted content instead of a plain label",

--- a/libs/angular-components/src/lib/components/dropdown/dropdown.spec.ts
+++ b/libs/angular-components/src/lib/components/dropdown/dropdown.spec.ts
@@ -17,6 +17,7 @@ import { fireEvent } from "@testing-library/dom";
       [name]="name"
       [value]="value"
       [maxHeight]="maxHeight"
+      [noResults]="noResults"
       [placeholder]="placeholder"
       [filterable]="filterable"
       [disabled]="disabled"
@@ -57,6 +58,7 @@ class TestDropdownComponent {
   filterable?: boolean;
   leadingIcon?: GoabIconType;
   maxHeight?: string;
+  noResults?: string;
   multiselect?: boolean;
   native?: boolean;
   placeholder?: string;
@@ -105,6 +107,7 @@ describe("GoABDropdown", () => {
     component.name = "favColor";
     component.value = "blue";
     component.maxHeight = "100px";
+    component.noResults = "Nothing found";
     component.placeholder = "Select...";
     component.filterable = true;
     component.disabled = true;
@@ -138,6 +141,7 @@ describe("GoABDropdown", () => {
     expect(el?.getAttribute("arialabelledby")).toBe("foo-dropdown-label");
     expect(el?.getAttribute("autocomplete")).toBe("off");
     expect(el?.getAttribute("maxwidth")).toBe("400px");
+    expect(el?.getAttribute("noresults")).toBe("Nothing found");
 
     // Check options
     const dropdownItems = el.querySelectorAll("goa-dropdown-item");

--- a/libs/angular-components/src/lib/components/dropdown/dropdown.ts
+++ b/libs/angular-components/src/lib/components/dropdown/dropdown.ts
@@ -46,6 +46,7 @@ import { GoabControlValueAccessor } from "../base.component";
         [attr.mt]="mt"
         [attr.multiselect]="multiselect"
         [attr.native]="native"
+        [attr.noresults]="noResults"
         [attr.placeholder]="placeholder"
         [attr.testid]="testId"
         [attr.width]="width"
@@ -91,6 +92,8 @@ export class GoabDropdown extends GoabControlValueAccessor implements OnInit {
   @Input({ transform: booleanAttribute }) multiselect?: boolean;
   /** When true will render the native select HTML element. */
   @Input({ transform: booleanAttribute }) native?: boolean;
+  /** Sets the text displayed when filtering returns no results. @default "No matches found" */
+  @Input() noResults?: string;
   /** The text displayed for the dropdown before a selection is made. Non-native only. */
   @Input() placeholder?: string;
   /** Overrides the autosized menu width. Non-native only. */

--- a/libs/react-components/src/lib/dropdown/dropdown.spec.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown.spec.tsx
@@ -45,6 +45,7 @@ describe("GoabDropdown", () => {
         name="favColor"
         value={[""]}
         maxHeight="100px"
+        noResults="Nothing found"
         placeholder="Select..."
         disabled
         error
@@ -87,6 +88,7 @@ describe("GoabDropdown", () => {
     expect(el?.getAttribute("arialabelledby")).toBe("foo-dropdown-label");
     expect(el?.getAttribute("autocomplete")).toBe("off");
     expect(el?.getAttribute("maxwidth")).toBe("400px");
+    expect(el?.getAttribute("noresults")).toBe("Nothing found");
     expect(el?.getAttribute("size")).toBe("compact");
   });
 

--- a/libs/react-components/src/lib/dropdown/dropdown.tsx
+++ b/libs/react-components/src/lib/dropdown/dropdown.tsx
@@ -21,6 +21,7 @@ interface WCProps extends Margins {
   multiselect?: string;
   name?: string;
   native?: string;
+  noresults?: string;
   placeholder?: string;
   value?: string;
   width?: string;
@@ -79,6 +80,8 @@ export interface GoabDropdownProps extends Margins, DataAttributes {
   multiselect?: boolean;
   /** When true, renders the native select HTML element. */
   native?: boolean;
+  /** Sets the text displayed when filtering returns no results. @default "No matches found" */
+  noResults?: string;
   /** The text displayed in the dropdown before a selection is made. Non-native only. */
   placeholder?: string;
   /** Sets a data-testid attribute for automated testing. */

--- a/libs/web-components/src/components/dropdown/Dropdown.spec.ts
+++ b/libs/web-components/src/components/dropdown/Dropdown.spec.ts
@@ -339,6 +339,25 @@ describe("GoADropdown", () => {
       });
     });
 
+    it("should display the configured no results text", async () => {
+      const result = render(GoADropdownWrapper, {
+        name,
+        items,
+        filterable: true,
+        noresults: "Nothing found",
+      });
+
+      const input = result.getByTestId("input") as HTMLInputElement;
+      await fireEvent.focus(input);
+      await fireEvent.keyUp(input, { key: "z" });
+      await fireEvent.input(input, { target: { value: "z" } });
+
+      const notFoundOption = result.getByTestId("dropdown-item-not-found");
+      await waitFor(() => {
+        expect(notFoundOption).toHaveTextContent("Nothing found");
+      });
+    });
+
     // Pasting from clipboard into input simulates browser autofill/autocomplete
     it("select option value after paste from clipboard (only if there is no previously selected value)", async () => {
       const result = render(GoADropdownWrapper, {

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -65,6 +65,8 @@
   export let maxheight: string = "276px";
   /** The text displayed for the dropdown before a selection is made. Non-native only. */
   export let placeholder: string = "";
+  /** Sets the text displayed when filtering returns no results. */
+  export let noresults: string = "No matches found";
   /** Overrides the autosized menu width. Non-native only. */
   export let width: string = "";
   /** Sets the maximum width of the dropdown. Use a CSS unit (px, %, ch, rem, em). */
@@ -969,7 +971,7 @@
         {:else}
           {#if _filterable}
             <li class="dropdown-item" data-testid="dropdown-item-not-found">
-              No matches found
+              {noresults}
             </li>
           {/if}
         {/each}

--- a/libs/web-components/src/components/dropdown/DropdownWrapper.test.svelte
+++ b/libs/web-components/src/components/dropdown/DropdownWrapper.test.svelte
@@ -12,6 +12,7 @@
   export let value: string = "";
   export let leadingicon: GoAIconType | null = null;
   export let maxheight: string = "276px";
+  export let noresults: string = "No matches found";
   export let placeholder: string = "";
   export let disabled: string = "false";
   export let error: string = "false";
@@ -45,6 +46,7 @@
   {error}
   {leadingicon}
   {maxheight}
+  {noresults}
   {placeholder}
   {disabled}
   {width}


### PR DESCRIPTION
# Before (the change)

The default "No matches found" text when using `filterable` for the Dropdown component couldn't be changed.

# After (the change)

Now people can edit that message using the new `noResults` property.

Also added an example on the main Dropdown component documentation page.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use PRs feat1731 for both Angular and React to test.
