### PR TITLE
fix(#2697): Updated footer link spacing

### DIFF
--- a/libs/web-components/src/components/footer-nav-section/FooterNavSection.svelte
+++ b/libs/web-components/src/components/footer-nav-section/FooterNavSection.svelte
@@ -88,7 +88,7 @@
   }
 
   li:not(:last-child) {
-    margin-bottom: var(--goa-space-s);
+    margin-bottom: var(--goa-space-m);
   }
 
   @media not (--mobile) {


### PR DESCRIPTION
# Before (the change)

Spacing between links in the nav section of Footer was `--goa-space-s`

# After (the change)

Now the space is `--goa-space-m`

## Make sure that you've checked the boxes below before you submit the PR

- [ ] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the docs PR page for Footer to check the spacing now
