### PR TITLE
fix(#2456): Updated Details margin-top to use proper token

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -489,23 +489,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -568,36 +551,6 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    },
-    "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.7"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.22.4",

--- a/libs/web-components/src/components/details/Details.svelte
+++ b/libs/web-components/src/components/details/Details.svelte
@@ -58,11 +58,15 @@
   function updateAnnouncement() {
     _shouldAnnounce = false;
     // Give Safari time to expose the expanded content before adding the alert role.
-    _announcementTimeoutId = performOnce(_announcementTimeoutId, () => {
-      if (_isOpen) {
-        _shouldAnnounce = true;
-      }
-    }, 100);
+    _announcementTimeoutId = performOnce(
+      _announcementTimeoutId,
+      () => {
+        if (_isOpen) {
+          _shouldAnnounce = true;
+        }
+      },
+      100,
+    );
   }
 </script>
 
@@ -167,7 +171,7 @@
     padding-bottom: var(--goa-details-content-padding-bottom);
     padding-right: var(--goa-details-content-padding-right);
     margin-left: var(--goa-details-content-margin-left);
-    margin-top: var(--goa-details-margin-bottom);
+    margin-top: var(--goa-details-margin-top);
     margin-bottom: var(--goa-details-margin-bottom);
   }
   .content :global(::slotted(p:last-child)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       },
       "devDependencies": {
         "@abgov/design-tokens": "1.10.0",
-        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.12.0",
+        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.12.6",
         "@abgov/nx-release": "12.0.0",
         "@angular-devkit/build-angular": "21.2.16",
         "@angular-devkit/core": "21.2.6",
@@ -134,9 +134,9 @@
     },
     "node_modules/@abgov/design-tokens-v2": {
       "name": "@abgov/design-tokens",
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.12.0.tgz",
-      "integrity": "sha512-oDDb4iGfi5fmuh+hSL8icEmmA0iXrPNRqMMd1MmTLvliesDxLoXk35JcQOpbqRWOXJdJabQA9VtJuzMMpARN5w==",
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.12.6.tgz",
+      "integrity": "sha512-QeeFnzJv6O5d7daxrJdxQl6gaYgKXTGgGMl164CuOnzMg6r1fpVh7PSmqfUp3IXdNXXgE+m4eTb3IHXBrjTJ4g==",
       "dev": true
     },
     "node_modules/@abgov/nx-release": {
@@ -10552,9 +10552,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10569,9 +10566,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10586,9 +10580,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10603,9 +10594,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11871,9 +11859,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11888,9 +11873,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11905,9 +11887,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11922,9 +11901,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@abgov/design-tokens": "1.10.0",
-    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.12.0",
+    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.12.6",
     "@abgov/nx-release": "12.0.0",
     "@angular-devkit/build-angular": "21.2.16",
     "@angular-devkit/core": "21.2.6",


### PR DESCRIPTION
# Before (the change)

The Details component was using `--goa-details-margin-bottom` for it's `margin-top` property. This wasn't great, as people might change the margin-bottom and not expect the margin-top to also change.

# After (the change)

The details component now properly uses a new token `--goa-details-margin-top` for it's `margin-top` property.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Test using the Details docs PR for both Angular and React. There should be no difference for the actually calculated margin-top, but if you inspect it, it should be using `--goa-details-margin-top` instead.
