### PR TITLE
feat(#2760): Updated Text to allow for disabled and light colors

### DIFF
--- a/apps/prs/angular/src/routes/docs/text/text.component.html
+++ b/apps/prs/angular/src/routes/docs/text/text.component.html
@@ -30,8 +30,12 @@
 <goab-divider mb="none" mt="none"></goab-divider>
 
 <h3>Color</h3>
-<goab-text color="primary" mt="none" mb="none">Primary color text (default)</goab-text>
-<goab-text color="secondary" mb="none">Secondary color text</goab-text>
+<goab-text color="primary" mt="none" mb="none">Primary colour text (default)</goab-text>
+<goab-text color="secondary" mb="none">Secondary colour text</goab-text>
+<goab-text color="disabled" mb="none">Disabled colour text</goab-text>
+<div style="background-color: var(--goa-color-greyscale-700); padding: var(--goa-space-m);">
+  <goab-text color="light" mt="none" mb="none">Light colour text</goab-text>
+</div>
 
 <h2>Examples</h2>
 

--- a/apps/prs/react/src/routes/docs/text/text.tsx
+++ b/apps/prs/react/src/routes/docs/text/text.tsx
@@ -110,8 +110,12 @@ export function DocsTextRoute() {
       <GoabDivider mb="none" mt="none" />
 
       <h3>Color</h3>
-      <GoabText color="primary" mt="none" mb="none">Primary color text (default)</GoabText>
-      <GoabText color="secondary" mb="none">Secondary color text</GoabText>
+      <GoabText color="primary" mt="none" mb="none">Primary colour text (default)</GoabText>
+      <GoabText color="secondary" mb="none">Secondary colour text</GoabText>
+      <GoabText color="disabled" mb="none">Disabled colour text</GoabText>
+      <div style={{ backgroundColor: "var(--goa-color-greyscale-700)", padding: "var(--goa-space-m)" }}>
+        <GoabText color="light" mt="none" mb="none">Light colour text</GoabText>
+      </div>
 
       <h2>Examples</h2>
 

--- a/docs/generated/component-apis/text.json
+++ b/docs/generated/component-apis/text.json
@@ -9,7 +9,7 @@
           "type": "GoabTextColor",
           "required": false,
           "default": "primary",
-          "description": "Sets the text colour."
+          "description": "Sets the text colour to primary, secondary, light, or disabled."
         },
         {
           "name": "id",
@@ -81,8 +81,8 @@
           "name": "color",
           "type": "GoabTextColor",
           "required": false,
-          "default": null,
-          "description": "Sets the text colour."
+          "default": "primary",
+          "description": "Sets the text colour to primary, secondary, light, or disabled."
         },
         {
           "name": "id",
@@ -95,7 +95,7 @@
           "name": "maxWidth",
           "type": "GoabTextMaxWidth",
           "required": false,
-          "default": null,
+          "default": "65ch",
           "description": "Sets the max width."
         },
         {
@@ -169,14 +169,16 @@
         },
         {
           "name": "color",
-          "type": "\"primary\" | \"secondary\"",
+          "type": "\"primary\" | \"secondary\" | \"light\" | \"disabled\"",
           "values": [
             "primary",
-            "secondary"
+            "secondary",
+            "light",
+            "disabled"
           ],
           "required": false,
           "default": "primary",
-          "description": "Sets the text colour."
+          "description": "Sets the text colour to primary, secondary, light, or disabled."
         },
         {
           "name": "maxwidth",

--- a/docs/src/data/configurations/text.ts
+++ b/docs/src/data/configurations/text.ts
@@ -111,14 +111,26 @@ export const textConfigurations: ComponentConfigurations = {
     {
       id: "color",
       name: "Color",
-      description: "Primary and secondary text colors",
+      description: "Primary, secondary, light, and disabled text colours",
       code: {
-        react: `<GoabText color="primary" mt="none" mb="none">Primary color text (default)</GoabText>
-<GoabText color="secondary" mb="none">Secondary color text</GoabText>`,
-        angular: `<goab-text color="primary" mt="none" mb="none">Primary color text (default)</goab-text>
-<goab-text color="secondary" mb="none">Secondary color text</goab-text>`,
-        webComponents: `<goa-text color="primary" mt="none" mb="none">Primary color text (default)</goa-text>
-<goa-text color="secondary" mb="none">Secondary color text</goa-text>`,
+        react: `<GoabText color="primary" mt="none" mb="none">Primary colour text (default)</GoabText>
+<GoabText color="secondary" mb="none">Secondary colour text</GoabText>
+<GoabText color="disabled" mb="none">Disabled colour text</GoabText>
+<div style={{ backgroundColor: "var(--goa-color-greyscale-700)", padding: "var(--goa-space-m)" }}>
+  <GoabText color="light" mt="none" mb="none">Light colour text</GoabText>
+</div>`,
+        angular: `<goab-text color="primary" mt="none" mb="none">Primary colour text (default)</goab-text>
+<goab-text color="secondary" mb="none">Secondary colour text</goab-text>
+<goab-text color="disabled" mb="none">Disabled colour text</goab-text>
+<div style="background-color: var(--goa-color-greyscale-700); padding: var(--goa-space-m);">
+  <goab-text color="light" mt="none" mb="none">Light colour text</goab-text>
+</div>`,
+        webComponents: `<goa-text color="primary" mt="none" mb="none">Primary colour text (default)</goa-text>
+<goa-text color="secondary" mb="none">Secondary colour text</goa-text>
+<goa-text color="disabled" mb="none">Disabled colour text</goa-text>
+<div style="background-color: var(--goa-color-greyscale-700); padding: var(--goa-space-m);">
+  <goa-text color="light" mt="none" mb="none">Light colour text</goa-text>
+</div>`,
       },
     },
   ],

--- a/libs/angular-components/src/lib/components/text/text.spec.ts
+++ b/libs/angular-components/src/lib/components/text/text.spec.ts
@@ -68,6 +68,19 @@ describe("GoabText", () => {
     expect(element.getAttribute("size")).toBe("heading-2xl");
   }));
 
+  it.each(["light", "disabled"] as const)(
+    "should pass the %s color through to the web component",
+    fakeAsync((color) => {
+      component.color = color;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      const element = fixture.nativeElement.querySelector("goa-text");
+      expect(element.getAttribute("color")).toBe(color);
+    }),
+  );
+
   it("should handle undefined properties", fakeAsync(() => {
     fixture.detectChanges();
     tick();

--- a/libs/angular-components/src/lib/components/text/text.ts
+++ b/libs/angular-components/src/lib/components/text/text.ts
@@ -47,9 +47,9 @@ export class GoabText implements OnInit {
   @Input() tag?: GoabTextTextElement | GoabTextHeadingElement;
   /** Overrides the text size. */
   @Input() size?: GoabTextSize;
-  /** Sets the max width. */
+  /** Sets the max width. @default "65ch" */
   @Input() maxWidth?: GoabTextMaxWidth;
-  /** Sets the text colour. */
+  /** Sets the text colour to primary, secondary, light, or disabled. @default "primary" */
   @Input() color?: GoabTextColor;
   /** Sets the id attribute on the host element. */
   @Input() id?: string;

--- a/libs/common/src/lib/common.ts
+++ b/libs/common/src/lib/common.ts
@@ -1350,7 +1350,7 @@ export type GoabTextHeadingSize =
   | "heading-2xs";
 export type GoabTextBodySize = "body-l" | "body-m" | "body-s" | "body-xs";
 export type GoabTextSize = GoabTextHeadingSize | GoabTextBodySize;
-export type GoabTextColor = "primary" | "secondary";
+export type GoabTextColor = "primary" | "secondary" | "light" | "disabled";
 
 // Simple Form
 export type GoabFormField = {

--- a/libs/react-components/src/lib/text/text.spec.tsx
+++ b/libs/react-components/src/lib/text/text.spec.tsx
@@ -62,6 +62,16 @@ describe('GoabText', () => {
     expect(element?.getAttribute('size')).toBe('heading-2xl');
   });
 
+  it.each(["light", "disabled"] as const)(
+    "should pass the %s color through to the web component",
+    (color) => {
+      const { container } = render(<GoabText color={color}>Content</GoabText>);
+      const element = container.querySelector("goa-text");
+
+      expect(element?.getAttribute("color")).toBe(color);
+    },
+  );
+
   it('should handle different tag values', () => {
     const cases = [
       { tag: 'p', name: 'paragraph' },

--- a/libs/react-components/src/lib/text/text.tsx
+++ b/libs/react-components/src/lib/text/text.tsx
@@ -38,7 +38,7 @@ interface GoATextProps extends Margins, DataAttributes {
   size?: GoabTextSize;
   /** Sets the max width. @default "65ch" */
   maxWidth?: GoabTextMaxWidth;
-  /** Sets the text colour. @default "primary" */
+  /** Sets the text colour to primary, secondary, light, or disabled. @default "primary" */
   color?: GoabTextColor;
   /** Sets the id attribute on the element. */
   id?: string;

--- a/libs/web-components/src/components/text/Text.spec.ts
+++ b/libs/web-components/src/components/text/Text.spec.ts
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+
+import GoAText from "./Text.svelte";
+
+describe("GoAText", () => {
+  it.each([
+    ["primary", "--goa-color-text-default"],
+    ["secondary", "--goa-color-text-secondary"],
+    ["light", "--goa-color-text-light"],
+    ["disabled", "--goa-color-text-disabled"],
+  ] as const)("uses the %s color token", (color, token) => {
+    const result = render(GoAText, { color });
+    const element = result.container.firstElementChild;
+
+    expect(element?.getAttribute("style")).toContain(`color: var(${token})`);
+  });
+});

--- a/libs/web-components/src/components/text/Text.svelte
+++ b/libs/web-components/src/components/text/Text.svelte
@@ -16,6 +16,7 @@
   type BodySize = "body-l" | "body-m" | "body-s" | "body-xs";
 
   export type Size = HeadingSize | BodySize;
+  export type TextColor = "primary" | "secondary" | "light" | "disabled";
 </script>
 
 <script lang="ts">
@@ -30,8 +31,8 @@
   export let maxWidth: string | "none" = "65ch";
   /** Overrides the text size. */
   export let size: Size | undefined = undefined;
-  /** Sets the text colour. */
-  export let color: "primary" | "secondary" = "primary";
+  /** Sets the text colour to primary, secondary, light, or disabled. */
+  export let color: TextColor = "primary";
 
   /** Top margin. */
   export let mt: Spacing = null;
@@ -48,7 +49,9 @@
   /**
    * Returns a default size based on the heading tag when size is not explicitly set
    */
-  function getDefaultSizeForTag(tag: TextElement | HeadingElement): Size | undefined {
+  function getDefaultSizeForTag(
+    tag: TextElement | HeadingElement,
+  ): Size | undefined {
     switch (tag) {
       case "h1":
         return "heading-xl";
@@ -145,7 +148,7 @@
       "color",
       color === "primary"
         ? "var(--goa-color-text-default)"
-        : "var(--goa-color-text-secondary)",
+        : `var(--goa-color-text-${color})`,
     ),
     maxWidth === "none" ? "" : `max-width: ${maxWidth}`,
     calculateMargin(_marginTop, mr, _marginBottom, ml),
@@ -213,7 +216,10 @@
   @media (--mobile) {
     /* V2-only size; falls back to the nearest V1 size. See the note on the desktop .heading-2xl rule above. */
     .heading-2xl {
-      font: var(--goa-typography-mobile-heading-2xl, var(--goa-typography-mobile-heading-xl));
+      font: var(
+        --goa-typography-mobile-heading-2xl,
+        var(--goa-typography-mobile-heading-xl)
+      );
       letter-spacing: var(
         --goa-typography-mobile-heading-2xl-letter-spacing,
         var(--goa-typography-mobile-heading-xl-letter-spacing)
@@ -240,7 +246,10 @@
       letter-spacing: var(--goa-typography-mobile-heading-xs-letter-spacing);
     }
     .heading-2xs {
-      font: var(--goa-typography-mobile-heading-2xs, var(--goa-typography-mobile-heading-xs));
+      font: var(
+        --goa-typography-mobile-heading-2xs,
+        var(--goa-typography-mobile-heading-xs)
+      );
       letter-spacing: var(--goa-typography-mobile-heading-2xs-letter-spacing);
     }
     .body-l {


### PR DESCRIPTION
# Before (the change)

The `color` property of `GoabText` only allowed for `primary` and `secondary` as options

# After (the change)

The `color` property of `GoabText` now also allows `disabled` and `light` color options.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the Text docs PR for both Angular and React. Also check the updated component documentation on the website.
