### PR TITLE
fix(#2773): Removed the double tab from Tooltip

### DIFF
--- a/libs/react-components/specs/tooltip.browser.spec.tsx
+++ b/libs/react-components/specs/tooltip.browser.spec.tsx
@@ -1,11 +1,77 @@
 import { render } from "vitest-browser-react";
-import { page } from "@vitest/browser/context";
+import { page, userEvent } from "@vitest/browser/context";
 import { useState } from "react";
 
 import { GoabTooltip, GoabButton } from "../src";
 import { expect, describe, it, vi } from "vitest";
 
 describe("Tooltip Browser Tests", () => {
+  it("focuses an interactive trigger and shows its tooltip with one tab", async () => {
+    const onClick = vi.fn();
+    const Component = () => (
+      <div data-testid="container">
+        <button data-testid="before">Before</button>
+        <GoabTooltip content="This is a tooltip">
+          <GoabButton testId="trigger" onClick={onClick}>
+            Tooltip trigger
+          </GoabButton>
+        </GoabTooltip>
+        <button data-testid="after">After</button>
+      </div>
+    );
+
+    const result = render(<Component />);
+    const container = result.getByTestId("container");
+    const before = result.getByTestId("before");
+    const trigger = result.getByTestId("trigger");
+    const after = result.getByTestId("after");
+    const tooltipHost = container.element().querySelector("goa-tooltip") as HTMLElement;
+    const triggerHost = tooltipHost.querySelector("goa-button") as HTMLElement;
+
+    await vi.waitFor(() => {
+      expect(tooltipHost.shadowRoot).not.toBeNull();
+    });
+
+    const tooltipContainer = tooltipHost.shadowRoot?.querySelector(".tooltip");
+    const tooltipText = tooltipHost.shadowRoot?.querySelector(".tooltip-text");
+
+    await vi.waitFor(() => {
+      expect(tooltipContainer).not.toHaveAttribute("tabindex");
+    });
+
+    before.element().focus();
+    await userEvent.keyboard("{Tab}");
+
+    expect(triggerHost).toHaveFocus();
+    expect(triggerHost.shadowRoot?.activeElement).toBe(trigger.element());
+    expect(trigger.element()).toHaveAccessibleDescription("This is a tooltip");
+    await vi.waitFor(() => {
+      expect(tooltipText).toHaveAttribute("aria-hidden", "false");
+    });
+
+    await userEvent.keyboard("{Enter}");
+    expect(onClick).toHaveBeenCalledOnce();
+
+    await userEvent.tab();
+
+    expect(after).toHaveFocus();
+    await vi.waitFor(() => {
+      expect(tooltipText).toHaveAttribute("aria-hidden", "true");
+    });
+
+    await userEvent.tab({ shift: true });
+
+    expect(triggerHost).toHaveFocus();
+    expect(triggerHost.shadowRoot?.activeElement).toBe(trigger.element());
+    await vi.waitFor(() => {
+      expect(tooltipText).toHaveAttribute("aria-hidden", "false");
+    });
+
+    await userEvent.tab({ shift: true });
+
+    expect(before).toHaveFocus();
+  });
+
   it("should render tooltip component", async () => {
     const Component = () => {
       return (

--- a/libs/web-components/src/components/tooltip/Tooltip.svelte
+++ b/libs/web-components/src/components/tooltip/Tooltip.svelte
@@ -184,12 +184,13 @@
     reconcileTooltipLayout();
   }
 
-  // Mouse click also fires on:focus on a tabindex=0 element, but we only want
+  // Mouse click also fires focus events, but we only want
   // to reveal the tooltip on keyboard-driven focus so JS state stays aligned
   // with the CSS :focus-visible rule that drives opacity.
   function handleFocus(e: FocusEvent) {
-    const target = e.currentTarget as HTMLElement | null;
+    const target = e.composedPath()[0] as HTMLElement | undefined;
     if (!target?.matches?.(":focus-visible")) return;
+    target.setAttribute("aria-description", content);
     clearTimeout(_hideTooltipTimeout);
     showTooltip();
   }
@@ -388,7 +389,6 @@
 
 <svelte:window bind:innerWidth={_screenSize} />
 
-<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
   class="tooltip"
@@ -400,11 +400,10 @@
     showTooltip();
   }}
   on:mouseleave={hideTooltip}
-  on:focus={handleFocus}
-  on:blur={hideTooltip}
+  on:focusin={handleFocus}
+  on:focusout={hideTooltip}
   data-testid={testid}
   aria-describedby="{_tooltipInstanceId}-tooltip"
-  tabindex="0"
   style={calculateMargin(mt, mr, mb, ml)}
 >
   <div
@@ -441,12 +440,6 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
-  }
-
-  .tooltip:focus-visible {
-    outline: var(--goa-tooltip-border-focus);
-    outline-offset: -4px;
-    border-radius: 8px;
   }
 
   .tooltip-text {

--- a/libs/web-components/src/components/tooltip/tooltip.spec.ts
+++ b/libs/web-components/src/components/tooltip/tooltip.spec.ts
@@ -51,6 +51,18 @@ it("shows and hides tooltip on mouseenter/mouseleave", async () => {
   }
 });
 
+it("describes the focused trigger with the tooltip content", async () => {
+  const { container } = render(Tooltip, { content: "Tooltip description" });
+  const tooltipContainer = container.querySelector(".tooltip") as HTMLElement;
+  const target = container.querySelector(".tooltip-target") as HTMLElement;
+  vi.spyOn(target, "matches").mockReturnValue(true);
+
+  await fireEvent.focusIn(target);
+
+  expect(tooltipContainer.getAttribute("tabindex")).toBeNull();
+  expect(target.getAttribute("aria-description")).toBe("Tooltip description");
+});
+
 it("validates the props", async () => {
   const mock = vi.spyOn(console, "error").mockImplementation(() => {
     /* do nothing */
@@ -166,7 +178,7 @@ it("should render tooltip with maxwidth property", async () => {
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
     maxwidth: "300px",
   });
-    const tooltipContainer = container.querySelector(".tooltip");
+  const tooltipContainer = container.querySelector(".tooltip");
   const tooltipEl = container.querySelector(".tooltip-text") as HTMLElement;
 
   expect(tooltipContainer).toBeTruthy();


### PR DESCRIPTION
# Before (the change)

When using the Tooltip component with an interactive component, you had to tab once to the component to activate the tooltip and then tab a second time to actually activate the interactive component.

# After (the change)

Now with one tab it should active the Tooltip (show it) and allow you to interact with the interactive component.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the Tooltip docs PR for both Angular and React
