### PR TITLE
fix(#2314): Button width property respected on mobile

### DIFF
--- a/apps/prs/angular/src/routes/bugs/2314/bug2314.component.html
+++ b/apps/prs/angular/src/routes/bugs/2314/bug2314.component.html
@@ -1,0 +1,23 @@
+<goab-text tag="h1" size="heading-l" mb="m">Button: Mobile width</goab-text>
+
+<goab-text tag="p">
+  The width of the Button component was controllable on desktop (ie. the width property
+  was respected). But on mobile, it defaulted to and only used width="100%", despite any
+  width being set.
+</goab-text>
+
+<goab-text tag="p">
+  This fix should see the width property respected on mobile as well as desktop. Default
+  width for mobile will stay as 100%.
+</goab-text>
+
+<goab-divider></goab-divider>
+
+<goab-text tag="h2">Default (no width set)</goab-text>
+<goab-button>Default button</goab-button>
+
+<goab-text tag="h2">Width set to 50%</goab-text>
+<goab-button width="50%">50% Button</goab-button>
+
+<goab-text tag="h2">Width set to 100px</goab-text>
+<goab-button width="100px">100px Button</goab-button>

--- a/apps/prs/angular/src/routes/bugs/2314/bug2314.component.ts
+++ b/apps/prs/angular/src/routes/bugs/2314/bug2314.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabButton, GoabText, GoabDivider } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-icon",
+  templateUrl: "./bug2314.component.html",
+  imports: [GoabButton, GoabText, GoabDivider],
+})
+export class Bug2314Component {}

--- a/apps/prs/angular/src/routes/bugs/2314/bug2314.route.json
+++ b/apps/prs/angular/src/routes/bugs/2314/bug2314.route.json
@@ -1,0 +1,6 @@
+{
+    "title":  "Button: Mobile width",
+    "path":  "bugs/2314",
+    "id":  "2314",
+    "type":  "bug"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug2314.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug2314.route.ts
@@ -1,0 +1,9 @@
+import { Bug2314Route } from "../../../routes/bugs/bug2314";
+import type { PrRouteDefinition } from "../../route-manifest";
+export default {
+  type: "bug",
+  id: "2314",
+  path: "bugs/2314",
+  title: "Button: Mobile width",
+  component: Bug2314Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug2314.tsx
+++ b/apps/prs/react/src/routes/bugs/bug2314.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { GoabButton, GoabText, GoabDivider } from "@abgov/react-components";
+
+export function Bug2314Route() {
+  return (
+    <main>
+      <GoabText tag="h1" size="heading-l" mb="m">
+        Button: Mobile width
+      </GoabText>
+
+      <GoabText tag="p">
+        The width of the Button component was controllable on desktop (ie. the width
+        property was respected). But on mobile, it defaulted to and only used
+        width="100%", despite any width being set.
+      </GoabText>
+
+      <GoabText tag="p">
+        This fix should see the width property respected on mobile as well as desktop.
+        Default width for mobile will stay as 100%.
+      </GoabText>
+
+      <GoabDivider></GoabDivider>
+
+      <GoabText tag="h2">Default (no width set)</GoabText>
+      <GoabButton>Default button</GoabButton>
+
+      <GoabText tag="h2">Width set to 50%</GoabText>
+      <GoabButton width="50%">50% Button</GoabButton>
+
+      <GoabText tag="h2">Width set to 100px</GoabText>
+      <GoabButton width="100px">100px Button</GoabButton>
+    </main>
+  );
+}

--- a/docs/generated/component-apis/button.json
+++ b/docs/generated/component-apis/button.json
@@ -107,7 +107,7 @@
           "type": "string",
           "required": false,
           "default": null,
-          "description": "Sets a custom width for the button (e.g., \"200px\" or \"100%\")."
+          "description": "Sets a custom width for the button (e.g., \"200px\", \"100%\" or \"fit-content\")."
         }
       ],
       "events": [
@@ -227,7 +227,7 @@
           "type": "string",
           "required": false,
           "default": null,
-          "description": "Sets a custom width for the button (e.g., \"200px\" or \"100%\")."
+          "description": "Sets a custom width for the button (e.g., \"200px\", \"100%\" or \"fit-content\")."
         }
       ],
       "events": [
@@ -386,7 +386,7 @@
           "type": "string",
           "required": false,
           "default": "",
-          "description": "Sets a custom width for the button (e.g., \"200px\" or \"100%\")."
+          "description": "Sets a custom width for the button (e.g., \"200px\", \"100%\" or \"fit-content\")."
         }
       ],
       "events": [

--- a/libs/angular-components/src/lib/components/button/button.ts
+++ b/libs/angular-components/src/lib/components/button/button.ts
@@ -65,7 +65,7 @@ export class GoabButton extends GoabBaseComponent implements OnInit {
   @Input() leadingIcon?: GoabIconType;
   /** Icon displayed after the button text. */
   @Input() trailingIcon?: GoabIconType;
-  /** Sets a custom width for the button (e.g., "200px" or "100%"). */
+  /** Sets a custom width for the button (e.g., "200px", "100%" or "fit-content"). */
   @Input() width?: string;
   /** Action identifier passed in click events for event delegation patterns. */
   @Input() action?: string;

--- a/libs/react-components/specs/button.browser.spec.tsx
+++ b/libs/react-components/specs/button.browser.spec.tsx
@@ -1,7 +1,8 @@
 import { render } from "vitest-browser-react";
+import { page } from "vitest/browser";
 
 import { GoabButton } from "../src";
-import { expect, describe, it, vi } from "vitest";
+import { expect, describe, it, vi, afterEach } from "vitest";
 
 describe("Button", () => {
   it("should trigger the action with an arg", async () => {
@@ -67,4 +68,40 @@ describe("Button", () => {
       expect(spy).toBeCalledWith({foo: "bar"});
     })
   })
+
+  describe("mobile width", () => {
+    afterEach(async () => {
+      await page.viewport(1280, 800);
+    });
+
+    it("should default to the full container width", async () => {
+      await page.viewport(390, 800);
+      const result = render(
+        <div style={{ width: "300px" }}>
+          <GoabButton testId="button">Button</GoabButton>
+        </div>,
+      );
+      const button = result.getByTestId("button");
+
+      await vi.waitFor(() => {
+        expect(button.element().getBoundingClientRect().width).toBe(300);
+      });
+    });
+
+    it("should use the supplied width", async () => {
+      await page.viewport(390, 800);
+      const result = render(
+        <div style={{ width: "300px" }}>
+          <GoabButton testId="button" width="100px">
+            Button
+          </GoabButton>
+        </div>,
+      );
+      const button = result.getByTestId("button");
+
+      await vi.waitFor(() => {
+        expect(button.element().getBoundingClientRect().width).toBe(100);
+      });
+    });
+  });
 })

--- a/libs/react-components/src/lib/button/button.tsx
+++ b/libs/react-components/src/lib/button/button.tsx
@@ -29,9 +29,9 @@ declare module "react" {
   namespace JSX {
     interface IntrinsicElements {
       "goa-button": WCProps &
-      React.HTMLAttributes<HTMLElement> & {
-        ref: React.RefObject<HTMLElement | null>;
-      };
+        React.HTMLAttributes<HTMLElement> & {
+          ref: React.RefObject<HTMLElement | null>;
+        };
     }
   }
 }
@@ -49,7 +49,7 @@ export interface GoabButtonProps extends Margins, DataAttributes {
   leadingIcon?: GoabIconType;
   /** Icon displayed after the button text. */
   trailingIcon?: GoabIconType;
-  /** Sets a custom width for the button (e.g., "200px" or "100%"). */
+  /** Sets a custom width for the button (e.g., "200px", "100%" or "fit-content"). */
   width?: string;
   /** Callback fired when the button is clicked. */
   onClick?: () => void;

--- a/libs/web-components/src/components/button/Button.spec.ts
+++ b/libs/web-components/src/components/button/Button.spec.ts
@@ -131,4 +131,23 @@ describe("GoAButtonComponent", () => {
       });
     });
   });
+
+  describe("width", () => {
+    it("should set the width custom property when width is provided", async () => {
+      const result = render(GoAButton, {
+        testid: "button-test",
+        width: "12rem",
+      });
+      const button = await result.findByTestId("button-test");
+
+      expect(button.style.getPropertyValue("--width")).toBe("12rem");
+    });
+
+    it("should not set the width custom property by default", async () => {
+      const result = render(GoAButton, { testid: "button-test" });
+      const button = await result.findByTestId("button-test");
+
+      expect(button.style.getPropertyValue("--width")).toBe("");
+    });
+  });
 });

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -13,7 +13,13 @@
 
   import type { Spacing } from "../../common/styling";
   import { calculateMargin } from "../../common/styling";
-  import { typeValidator, toBoolean, dispatch } from "../../common/utils";
+  import {
+    typeValidator,
+    toBoolean,
+    dispatch,
+    style,
+    styles,
+  } from "../../common/utils";
   import type { GoAIconType } from "../icon/Icon.svelte";
 
   // Validators
@@ -65,7 +71,7 @@
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
-  /** Sets a custom width for the button (e.g., "200px" or "100%"). */
+  /** Sets a custom width for the button (e.g., "200px", "100%" or "fit-content"). */
   export let width: string = "";
 
   /** @internal Design system version for styling. */
@@ -110,7 +116,9 @@
     validateVersion(version);
 
     if (variant === "dark" && type !== "text") {
-      console.warn(`[GoabButton] The "dark" variant only applies to type="text". It has no effect on type="${type}".`);
+      console.warn(
+        `[GoabButton] The "dark" variant only applies to type="text". It has no effect on type="${type}".`,
+      );
     }
   });
 
@@ -136,10 +144,7 @@
 <button
   class="{type} {size} {variant}"
   class:v2={version === "2"}
-  style={`
-      ${calculateMargin(mt, mr, mb, ml)};
-      --width: ${width};
-    `}
+  style={styles(calculateMargin(mt, mr, mb, ml), style("--width", width))}
   disabled={isDisabled}
   on:click={clickHandler}
   data-testid={testid}
@@ -159,7 +164,7 @@
     {#if leadingicon}
       <goa-icon
         id="leading-icon"
-        size={ version === "2" && size === "normal" ? "4" : "3" }
+        size={version === "2" && size === "normal" ? "4" : "3"}
         type={leadingicon}
         inverted={isButtonDark}
       />
@@ -170,7 +175,7 @@
     {#if trailingicon}
       <goa-icon
         id="trailing-icon"
-        size={ version === "2" && size === "normal" ? "4" : "3" }
+        size={version === "2" && size === "normal" ? "4" : "3"}
         type={trailingicon}
         inverted={isButtonDark}
       />
@@ -217,6 +222,9 @@
       width: 100%;
       display: flex;
     }
+    button.v2 {
+      width: var(--width, 100%);
+    }
     button.tertiary {
       background-color: var(--goa-button-tertiary-color-bg-mobile) !important;
     }
@@ -238,7 +246,10 @@
   button.compact {
     height: var(--goa-button-height-compact);
     font: var(--goa-button-text-compact);
-    padding: var(--goa-button-padding-compact, var(--goa-button-padding-lr-compact));
+    padding: var(
+      --goa-button-padding-compact,
+      var(--goa-button-padding-lr-compact)
+    );
     gap: var(--goa-button-compact-gap);
   }
 
@@ -411,7 +422,7 @@
   }
 
   button.v2.primary:disabled {
-    background-color: var(--goa-button-primary-disabled-color-bg)
+    background-color: var(--goa-button-primary-disabled-color-bg);
   }
 
   button.v2.secondary.destructive {
@@ -435,7 +446,6 @@
     border: var(--goa-button-tertiary-inverse-border);
   }
 
-
   button.v2.tertiary.inverse:hover {
     border: var(--goa-button-tertiary-inverse-hover-border);
   }
@@ -445,7 +455,7 @@
   }
 
   button.v2.tertiary.destructive:hover {
-    border: var(--goa-button-tertiary-destructive-hover-border)
+    border: var(--goa-button-tertiary-destructive-hover-border);
   }
 
   button.v2.tertiary:disabled {


### PR DESCRIPTION
# Before (the change)

The `width` property for `GoabButton` wasn't respected on mobile, instead just defaulting to 100% no matter what was supplied.

# After (the change)

The `width` property on mobile is now respected and used, only defaulting to 100% width when no `width` property is given.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the PR bug2314 for both Angular and React

@twjeffery I'm not sure if this might be considered a breaking change. If people have been supplying width to their buttons, but still wanting and expecting them to be 100% on mobile, this would affect that.
