### PR TITLE
fix(#2819): headingContent can be null

### DIFF
--- a/apps/prs/angular/src/routes/bugs/2819/bug2819.component.html
+++ b/apps/prs/angular/src/routes/bugs/2819/bug2819.component.html
@@ -1,0 +1,24 @@
+<goab-block direction="column" gap="l">
+  <goab-text tag="h1">Bug #2819: Accordion heading content container</goab-text>
+  <goab-text tag="p">
+    The heading content container should only render when heading content is supplied.
+  </goab-text>
+
+  <goab-divider />
+
+  <goab-text tag="h2">No heading content</goab-text>
+  <goab-accordion heading="Application requirements">
+    This accordion does not have heading content. Inspect the heading to confirm that it
+    does not contain a heading content container.
+  </goab-accordion>
+
+  <goab-text tag="h2">With heading content</goab-text>
+  <goab-accordion heading="Application requirements" [headingContent]="headingContent">
+    This accordion has heading content. The Updated badge should appear beside the
+    heading.
+  </goab-accordion>
+
+  <ng-template #headingContent>
+    <goab-badge type="information" content="Updated" />
+  </ng-template>
+</goab-block>

--- a/apps/prs/angular/src/routes/bugs/2819/bug2819.component.ts
+++ b/apps/prs/angular/src/routes/bugs/2819/bug2819.component.ts
@@ -1,0 +1,16 @@
+import { Component } from "@angular/core";
+import {
+  GoabAccordion,
+  GoabBadge,
+  GoabBlock,
+  GoabDivider,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug2819",
+  templateUrl: "./bug2819.component.html",
+  imports: [GoabAccordion, GoabBadge, GoabBlock, GoabDivider, GoabText],
+})
+export class Bug2819Component {}

--- a/apps/prs/angular/src/routes/bugs/2819/bug2819.route.json
+++ b/apps/prs/angular/src/routes/bugs/2819/bug2819.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Accordion heading content container",
+  "path": "bugs/2819",
+  "id": "2819",
+  "type": "bug"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug2819.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug2819.route.ts
@@ -1,0 +1,10 @@
+import { Bug2819Route } from "../../../routes/bugs/bug2819";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "2819",
+  path: "bugs/2819",
+  title: "Accordion heading content container",
+  component: Bug2819Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug2819.tsx
+++ b/apps/prs/react/src/routes/bugs/bug2819.tsx
@@ -1,0 +1,37 @@
+import {
+  GoabAccordion,
+  GoabBadge,
+  GoabBlock,
+  GoabDivider,
+  GoabText,
+} from "@abgov/react-components";
+
+export function Bug2819Route() {
+  return (
+    <GoabBlock direction="column" gap="l">
+      <GoabText tag="h1">Bug #2819: Accordion heading content container</GoabText>
+      <GoabText tag="p">
+        The heading content container should only render when heading content is supplied.
+      </GoabText>
+
+      <GoabDivider />
+
+      <GoabText tag="h2">No heading content</GoabText>
+      <GoabAccordion heading="Application requirements">
+        This accordion does not have heading content. Inspect the heading to confirm that
+        it does not contain a heading content container.
+      </GoabAccordion>
+
+      <GoabText tag="h2">With heading content</GoabText>
+      <GoabAccordion
+        heading="Application requirements"
+        headingContent={<GoabBadge type="information" content="Updated" />}
+      >
+        This accordion has heading content. The Updated badge should appear beside the
+        heading.
+      </GoabAccordion>
+    </GoabBlock>
+  );
+}
+
+export default Bug2819Route;

--- a/docs/generated/component-apis/accordion.json
+++ b/docs/generated/component-apis/accordion.json
@@ -127,28 +127,28 @@
           "name": "headingSize",
           "type": "GoabAccordionHeadingSize",
           "required": false,
-          "default": null,
+          "default": "small",
           "description": "Sets the heading size of the accordion container heading."
         },
         {
           "name": "headingType",
           "type": "GoabAccordionHeadingType",
           "required": false,
-          "default": null,
+          "default": "normal",
           "description": "Sets the accordion style variant."
         },
         {
           "name": "iconPosition",
           "type": "GoabAccordionIconPosition",
           "required": false,
-          "default": null,
+          "default": "left",
           "description": "Sets the position of the expand/collapse icon."
         },
         {
           "name": "maxWidth",
           "type": "string",
           "required": false,
-          "default": null,
+          "default": "none",
           "description": "Sets the maximum width of the accordion."
         },
         {
@@ -245,7 +245,7 @@
           ],
           "required": false,
           "default": "normal",
-          "description": "Sets the accordion style variant. @default \"normal\""
+          "description": "Sets the accordion style variant."
         },
         {
           "name": "headingsize",

--- a/libs/angular-components/src/lib/components/accordion/accordion.spec.ts
+++ b/libs/angular-components/src/lib/components/accordion/accordion.spec.ts
@@ -46,6 +46,13 @@ class TestAccordionComponent {
 })
 class TestAccordionWithActionsComponent {}
 
+@Component({
+  standalone: true,
+  imports: [GoabAccordion],
+  template: ` <goab-accordion heading="Title">test content</goab-accordion> `,
+})
+class TestAccordionWithoutHeadingContentComponent {}
+
 describe("GoabAccordion", () => {
   let fixture: ComponentFixture<TestAccordionComponent>;
   let component: TestAccordionComponent;
@@ -84,6 +91,27 @@ describe("GoabAccordion", () => {
     const headingContent = accordionElement.querySelector("[slot='headingcontent']");
     expect(headingContent.textContent).toContain("This is the headingcontent");
   });
+});
+
+describe("GoabAccordion heading content slot", () => {
+  it("should not render the slot when heading content is not supplied", fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [GoabAccordion, TestAccordionWithoutHeadingContentComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestAccordionWithoutHeadingContentComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const accordionElement = fixture.debugElement.query(
+      By.css("goa-accordion"),
+    ).nativeElement;
+    const headingContent = accordionElement.querySelector("[slot='headingcontent']");
+
+    expect(headingContent).toBeNull();
+  }));
 });
 
 describe("GoabAccordion actions slot", () => {

--- a/libs/angular-components/src/lib/components/accordion/accordion.ts
+++ b/libs/angular-components/src/lib/components/accordion/accordion.ts
@@ -40,9 +40,11 @@ import { GoabBaseComponent } from "../base.component";
         [attr.mr]="mr"
         (_change)="_onChange($event)"
       >
-        <div slot="headingcontent">
-          <ng-container [ngTemplateOutlet]="headingContent"></ng-container>
-        </div>
+        @if (headingContent) {
+          <div slot="headingcontent">
+            <ng-container [ngTemplateOutlet]="headingContent"></ng-container>
+          </div>
+        }
         @if (actions) {
           <div slot="actions">
             <ng-container [ngTemplateOutlet]="actions"></ng-container>
@@ -64,17 +66,17 @@ export class GoabAccordion extends GoabBaseComponent implements OnInit {
   @Input() secondaryText?: string;
   /** Sets the state of the accordion container open or closed. */
   @Input({ transform: booleanAttribute }) open?: boolean;
-  /** Sets the heading size of the accordion container heading. */
+  /** Sets the heading size of the accordion container heading. @default "small" */
   @Input() headingSize?: GoabAccordionHeadingSize;
   /** Sets the heading content template reference. */
   @Input() headingContent!: TemplateRef<any>;
   /** Sets the actions content template reference, rendered right-aligned in the heading before the expand/collapse icon. */
   @Input() actions?: TemplateRef<any>;
-  /** Sets the maximum width of the accordion. */
+  /** Sets the maximum width of the accordion. @default "none" */
   @Input() maxWidth?: string;
-  /** Sets the position of the expand/collapse icon. */
+  /** Sets the position of the expand/collapse icon. @default "left" */
   @Input() iconPosition?: GoabAccordionIconPosition;
-  /** Sets the accordion style variant. */
+  /** Sets the accordion style variant. @default "normal" */
   @Input() headingType?: GoabAccordionHeadingType;
 
   /** Emits when the accordion opens or closes. Emits the new open state as a boolean. */

--- a/libs/web-components/src/components/accordion/Accordion.spec.ts
+++ b/libs/web-components/src/components/accordion/Accordion.spec.ts
@@ -101,6 +101,12 @@ describe("Accordion", () => {
     expect(actionsButton).toBeTruthy();
   });
 
+  it("does not render the heading content container when the heading content slot is empty", () => {
+    const { container } = render(Accordion, { heading: "Title" });
+    const headingContent = container.querySelector("summary .heading-content");
+    expect(headingContent).toBeNull();
+  });
+
   it("handle accessibility features", async () => {
     const { container } = render(Accordion, {
       heading: "Title",

--- a/libs/web-components/src/components/accordion/Accordion.svelte
+++ b/libs/web-components/src/components/accordion/Accordion.svelte
@@ -74,7 +74,7 @@
   export let ml: Spacing = null;
   /** Sets the position of the expand/collapse icon. */
   export let iconposition: IconPosition = "left";
-  /** Sets the accordion style variant. @default "normal" */
+  /** Sets the accordion style variant. */
   export let headingType: AccordionHeadingType = "normal";
 
   // Private
@@ -134,11 +134,15 @@
   function updateAnnouncement() {
     _shouldAnnounce = false;
     // Give Safari time to expose the expanded content before adding the alert role.
-    _announcementTimeoutId = performOnce(_announcementTimeoutId, () => {
-      if (isOpen) {
-        _shouldAnnounce = true;
-      }
-    }, 100);
+    _announcementTimeoutId = performOnce(
+      _announcementTimeoutId,
+      () => {
+        if (isOpen) {
+          _shouldAnnounce = true;
+        }
+      },
+      100,
+    );
   }
 
   function dispatchChangeEvent(accordionIsOpen: boolean) {
@@ -354,14 +358,16 @@
         {#if secondarytext}
           <span class="secondary-text">{secondarytext}</span>
         {/if}
-        <!-- svelte-ignore a11y-click-events-have-key-events because the enter and space handlers are blocked too-->
-        <div
-          class="heading-content"
-          class:heading-content-top={_headingSlotChildren.length}
-          on:click|stopPropagation
-        >
-          <slot name="headingcontent" />
-        </div>
+        {#if $$slots.headingcontent}
+          <!-- svelte-ignore a11y-click-events-have-key-events because the enter and space handlers are blocked too-->
+          <div
+            class="heading-content"
+            class:heading-content-top={_headingSlotChildren.length}
+            on:click|stopPropagation
+          >
+            <slot name="headingcontent" />
+          </div>
+        {/if}
       </div>
 
       <!-- svelte-ignore a11y-click-events-have-key-events -->


### PR DESCRIPTION
# Before (the change)

The div for heading content always existed and took up space regardless if `headingContent` was ever supplied or not

# After (the change)

Now the div for heading content only shows up and takes up space if `headingContent` is supplied.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the PR pages for bug2819 to review. You'll need to inspect the each container to very that the associated div for headingContent is shown when it's supplied and not shown when it's not supplied.


