### PR TITLE
fix(#2849): Removed Home and End key handling in Dropdown

### DIFF
--- a/libs/react-components/specs/dropdown.browser.spec.tsx
+++ b/libs/react-components/specs/dropdown.browser.spec.tsx
@@ -703,6 +703,32 @@ describe("Dropdown", () => {
       })
     });
 
+    it("preserves text selection when Shift+Home and Shift+End are pressed", async () => {
+      const Component = () => (
+        <GoabDropdown name="favcolor" onChange={noop} filterable={true}>
+          <GoabDropdownItem label="Red" value="red" />
+          <GoabDropdownItem label="Blue" value="blue" />
+          <GoabDropdownItem label="Green" value="green" />
+        </GoabDropdown>
+      );
+
+      const result = render(<Component />);
+      const filter = result.getByTestId("input");
+
+      await userEvent.type(filter, "Green");
+      const input = filter.element() as HTMLInputElement;
+
+      input.setSelectionRange(2, 2);
+      await userEvent.keyboard("{Shift>}{Home}{/Shift}");
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe(2);
+
+      input.setSelectionRange(2, 2);
+      await userEvent.keyboard("{Shift>}{End}{/Shift}");
+      expect(input.selectionStart).toBe(2);
+      expect(input.selectionEnd).toBe(input.value.length);
+    });
+
     it("clears the input and opens the menu when the clear icon is clicked", async () => {
       // Setup
 

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -704,13 +704,8 @@
           this.onArrow(e, "down");
           break;
         case "Home":
-          this.input.setSelectionRange(0, 0);
-          break;
         case "End":
-          this.input.setSelectionRange(
-            this.input.value.length,
-            this.input.value.length,
-          );
+          // Allow the input to position the caret or extend the text selection.
           break;
         case "Tab":
           // ignore tab


### PR DESCRIPTION
# Before (the change)

Pushing either the Home and End key in a Filterable Dropdown would move the cursor to the front or back of the text respectively. This was coded in. I don't know why this was coded in, as that's what those keys do normally anyways.

This had an effect on people using the Shift key alongside these keys. What it should do is select all the letters between the cursor and it's destination, but instead this was overwritten by the handling that was coded in.

# After (the change)

I removed the code that handled Home and End keys. Again, I don't know why it was there, I don't think it needed to be, so it's gone now and this works as expected.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the Dropdown Docs PR for either Angular or React, specifically the Filterable Dropdown example
