### PR TITLE
fix(#2981): Updated read only styling for Input and DatePicker

### DIFF
--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -11,7 +11,12 @@
   import { onMount, tick } from "svelte";
   import type { Spacing } from "../../common/styling";
   import { toBoolean } from "../../common/utils";
-  import { receive, dispatch, relay, watchFocusWithin } from "../../common/utils";
+  import {
+    receive,
+    dispatch,
+    relay,
+    watchFocusWithin,
+  } from "../../common/utils";
   import { isValidDimension } from "../../common/validators";
   import {
     FieldsetSetValueMsg,
@@ -438,5 +443,13 @@
     --goa-text-input-color-bg-readonly: var(--goa-text-input-color-bg);
     --goa-text-input-border-readonly: var(--goa-text-input-border);
     --goa-text-input-cursor-readonly: var(--goa-date-input-cursor);
+  }
+
+  .calendar-input:hover {
+    --goa-text-input-border-readonly: var(--goa-text-input-border-hover);
+  }
+
+  .calendar-input:focus-within {
+    --goa-text-input-border-readonly: var(--goa-text-input-border-focus);
   }
 </style>

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -572,7 +572,6 @@
     box-shadow: var(--goa-text-input-border-focus);
   }
 
-
   /* V2: Vertically center date/time input labels in Safari */
   .container.v2 input::-webkit-datetime-edit,
   .container.v2 input::-webkit-date-and-time-value {
@@ -725,8 +724,9 @@
   }
 
   /* V2: Read-only input field styling (exclude disabled inputs) */
-  .container.v2.goa-input:not(.error)::has(
-      input:read-only:not(:disabled):not(:focus-visible):not(:hover)
+  .container.v2
+    .goa-input:not(.error):has(
+      input:read-only:not(:disabled):not(:focus-visible)
     ) {
     box-shadow: var(--goa-text-input-border-readonly);
   }


### PR DESCRIPTION
# Before (the change)

Input read-only state was incorrectly providing a border on hover and on focus. This was happening because it was assumed it had to happen to allow Date Picker to continue to have a border (it uses input read-only state to function).

# After (the change)

The CSS targeting `box-shadow` for Input's read-only stated was corrected, which wasn't written correctly first off and incorrectly didn't target hover and focus modes. The CSS for Date Picker was expanded to target focus and hover modes specifically instead.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

You can test using the docs PRs for both Date Picker and Input, there's a Read Only state for Input in there.
