### PR TITLE
fix(#2911): Removed all interactive styling from AppHeader

### DIFF
--- a/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
+++ b/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
@@ -352,39 +352,6 @@
     ) !important;
   }
 
-  /* Menu items in collapsed menu --Interactive */
-  :global(::slotted(a.interactive)) {
-    color: var(--goa-app-header-nav-color-text-link-item) !important;
-    text-decoration: underline !important;
-    white-space: nowrap;
-  }
-  /* Menu items in collapsed menu --Interactive--Hover */
-  :global(::slotted(a.interactive:hover)) {
-    color: var(--goa-app-header-nav-color-text-link-item-hover) !important;
-  }
-  /* Menu items in collapsed menu --Interactive--Focus */
-  :global(::slotted(a.interactive:focus-visible)) {
-    color: var(--goa-app-header-nav-color-text-link-item-focus) !important;
-    background-color: var(--goa-app-header-color-bg-nav-item-focus);
-  }
-
-  /* Menu items in collapsed menu --Interactive--Current */
-  :global(::slotted(a.interactive.current)) {
-    color: var(
-      --goa-app-header-color-text-nav-item-in-menu-current-hover
-    ) !important;
-    background-color: var(--goa-app-header-color-bg-nav-item-in-menu-current);
-  }
-  /* Menu items in collapsed menu --Interactive--Current--Hover */
-  :global(::slotted(a.interactive.current:hover)) {
-    color: var(
-      --goa-app-header-color-text-nav-item-in-menu-current-hover
-    ) !important;
-    background-color: var(
-      --goa-app-header-color-bg-nav-item-in-menu-current-hover
-    );
-  }
-
   /* Menu headers (non-clickable group labels in More menu) */
   /* Need high specificity to override .desktop.v2-nav-menu styles */
   .desktop.v2-nav-menu :global(::slotted(a.menu-header)),

--- a/libs/web-components/src/components/app-header/AppHeader.svelte
+++ b/libs/web-components/src/components/app-header/AppHeader.svelte
@@ -761,26 +761,6 @@
     color: var(--goa-app-header-color-text-nav-item-focus) !important;
   }
 
-  /* Menu items in collapsed menu --Interactive */
-  :global(::slotted(a.interactive)) {
-    color: var(--goa-app-header-nav-color-text-link-item) !important;
-    text-decoration: underline !important;
-    white-space: nowrap;
-  }
-
-  /* Menu items in collapsed menu --Interactive--Hover */
-  :global(::slotted(a.interactive:hover)) {
-    color: var(--goa-app-header-nav-color-text-link-item-hover) !important;
-  }
-
-  /* Menu items in collapsed menu --Interactive--Focus */
-  :global(::slotted(a.interactive:focus-visible)) {
-    color: var(--goa-app-header-nav-color-text-link-item-focus) !important;
-    background-color: var(
-      --goa-app-header-color-bg-nav-item-child-focus
-    ) !important;
-  }
-
   /* Menu items in collapsed menu -- Current */
   :global(::slotted(a.inside-collapse-menu.current)) {
     color: var(--goa-app-header-color-text-nav-item-in-menu-current);
@@ -905,34 +885,6 @@
     color: var(--goa-app-header-color-text-nav-item-hover);
   }
 
-  /* Link item styling */
-  .desktop :global(::slotted(a.interactive)) {
-    font: var(--goa-app-header-typography-link-item);
-    padding: var(--goa-app-header-padding-link-item);
-  }
-
-  /* Link item styling --Hover */
-  .desktop :global(::slotted(a.interactive:hover)) {
-    border-top: var(--goa-app-header-border-nav-item-default);
-    border-bottom: var(--goa-app-header-border-nav-item-default);
-    background-color: var(--goa-app-header-nav-color-bg-link-item-hover);
-  }
-
-  /* Link item styling --Focus */
-  .desktop :global(::slotted(a.interactive:focus-visible)) {
-    border-top: var(--goa-app-header-border-nav-item-default) !important;
-    border-bottom: var(--goa-app-header-border-nav-item-default) !important;
-    background-color: var(
-      --goa-app-header-nav-color-bg-link-item-focus
-    ) !important;
-  }
-
-  /* Link item styling --Current */
-  .desktop :global(::slotted(a.interactive.current)) {
-    border-top: var(--goa-app-header-border-nav-item-default) !important;
-    border-bottom: var(--goa-app-header-border-nav-item-default) !important;
-  }
-
   /*------------------------------------------------*/
 
   /* TABLET -------------------------------------- */
@@ -1016,16 +968,6 @@
     height: 100%;
     display: flex;
     align-items: end;
-  }
-
-  /* Link menu items in collapsed menu --Focus */
-  :global(::slotted(a.interactive:focus-visible)) {
-    color: var(--goa-app-header-nav-color-text-link-item-focus) !important;
-    background-color: var(
-      --goa-app-header-nav-color-bg-link-item-in-menu-focus
-    ) !important;
-    border-top: none !important;
-    border-bottom: none;
   }
 
   /* Add top border to all menu items in popover menu (except first) */
@@ -1225,7 +1167,7 @@
   }
 
   /* Style links in utilities slot - medium link style without underline */
-  /* Need !important to override V1 .interactive styles and nav item styles */
+  /* Need !important to override V1 nav item styles */
   .v2 .v2-utilities-placeholder :global(::slotted(a)) {
     text-decoration: none !important;
     font-weight: 400 !important;


### PR DESCRIPTION
# Before (the change)

Class `interactive` was previously supported in both the GoabAppHeader and GoabAppHeaderMenu components. This class wasn't updated for 2.0, and has since been made irrelevant by people's abilities to overwrite tokens to style anything however they want.

# After (the change)

No more support for `interactive` inside GoabAppHeader or GoabAppHeaderMenu

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

There is nothing to test, can't really test that something doesn't exist. Just make sure that the current AppHeader and AppHeaderMenu continue to function and look as normal, using the docs PR for that.
