### PR TITLE
fix(#2957): Updated Checkbox to use token for fill colour

### DIFF
--- a/apps/prs/angular/src/routes/docs/checkbox/checkbox.component.html
+++ b/apps/prs/angular/src/routes/docs/checkbox/checkbox.component.html
@@ -28,20 +28,48 @@
 <goab-checkbox
   name="newsletter"
   text="Subscribe to newsletter"
-  description="Receive weekly updates about new features">
+  description="Receive weekly updates about new features"
+>
 </goab-checkbox>
 
 <h3>Indeterminate</h3>
-<goab-checkbox name="selectAll" text="Select all items" [indeterminate]="true"></goab-checkbox>
+<goab-checkbox
+  name="selectAll"
+  text="Select all items"
+  [indeterminate]="true"
+></goab-checkbox>
 
 <h3>Sizes</h3>
 <goab-checkbox name="default" text="Default size checkbox" mb="m"></goab-checkbox>
 <goab-checkbox name="compact" text="Compact size checkbox" size="compact"></goab-checkbox>
 
 <h3>States</h3>
-<goab-checkbox name="disabled" text="Cannot be changed" [disabled]="true" mb="m"></goab-checkbox>
-<goab-checkbox name="disabledChecked" text="Checked and disabled" [checked]="true" [disabled]="true" mb="m"></goab-checkbox>
-<goab-checkbox name="terms" text="Accept terms and conditions" [error]="true"></goab-checkbox>
+<goab-checkbox
+  name="disabled"
+  text="Cannot be changed"
+  [disabled]="true"
+  mb="m"
+></goab-checkbox>
+<goab-checkbox
+  name="disabledChecked"
+  text="Checked and disabled"
+  [checked]="true"
+  [disabled]="true"
+  mb="m"
+></goab-checkbox>
+<goab-checkbox
+  name="disabledCheckedError"
+  text="Checked, disabled and error"
+  [checked]="true"
+  [disabled]="true"
+  [error]="true"
+  mb="m"
+></goab-checkbox>
+<goab-checkbox
+  name="terms"
+  text="Accept terms and conditions"
+  [error]="true"
+></goab-checkbox>
 
 <h2>Examples</h2>
 
@@ -52,7 +80,8 @@
       name="email"
       text="Email"
       value="email"
-      [description]="descriptionTemplate">
+      [description]="descriptionTemplate"
+    >
       <ng-template #descriptionTemplate>
         <span>Help text with a <a href="#">link</a>.</span>
       </ng-template>
@@ -64,7 +93,10 @@
 
 <h3>Reveal input based on a selection</h3>
 <form [formGroup]="revealForm">
-  <goab-form-item label="How would you like to be contacted?" helpText="Select one option">
+  <goab-form-item
+    label="How would you like to be contacted?"
+    helpText="Select one option"
+  >
     <goab-radio-group name="contactMethod" formControlName="contactMethod">
       <goab-radio-item label="Email" value="email" [reveal]="emailReveal">
         <ng-template #emailReveal>
@@ -106,7 +138,12 @@
           </goab-form-item>
         </ng-template>
       </goab-checkbox>
-      <goab-checkbox name="text" text="Text message" value="text" [reveal]="checkTextReveal">
+      <goab-checkbox
+        name="text"
+        text="Text message"
+        value="text"
+        [reveal]="checkTextReveal"
+      >
         <ng-template #checkTextReveal>
           <goab-form-item label="Mobile phone number">
             <goab-input name="mobile" formControlName="phoneNumber"></goab-input>
@@ -120,11 +157,13 @@
 <h3>Select one or more from a list of options</h3>
 <goab-form-item
   label="How would you like to be contacted?"
-  helpText="Choose all that apply">
+  helpText="Choose all that apply"
+>
   <goab-checkbox-list
     name="contactPreferences"
     [value]="selectedOptions"
-    (onChange)="onSelectionChange($event)">
+    (onChange)="onSelectionChange($event)"
+  >
     <goab-checkbox name="email" text="Email" value="email"></goab-checkbox>
     <goab-checkbox name="phone" text="Phone" value="phone"></goab-checkbox>
     <goab-checkbox name="text" text="Text message" value="text"></goab-checkbox>

--- a/apps/prs/react/src/routes/docs/checkbox/checkbox.tsx
+++ b/apps/prs/react/src/routes/docs/checkbox/checkbox.tsx
@@ -36,7 +36,21 @@ export function DocsCheckboxRoute() {
 
       <h3>States</h3>
       <GoabCheckbox name="disabled" text="Cannot be changed" disabled mb="m" />
-      <GoabCheckbox name="disabledChecked" text="Checked and disabled" checked disabled mb="m" />
+      <GoabCheckbox
+        name="disabledChecked"
+        text="Checked and disabled"
+        checked
+        disabled
+        mb="m"
+      />
+      <GoabCheckbox
+        name="disabledCheckedError"
+        text="Checked, disabled and error"
+        checked
+        disabled
+        error
+        mb="m"
+      />
       <GoabCheckbox name="terms" text="Accept terms and conditions" error />
 
       <h2>Examples</h2>
@@ -74,7 +88,13 @@ export function DocsCheckboxRoute() {
             label="Email"
             reveal={
               <GoabFormItem label="Email address">
-                <GoabInput name="email" onChange={() => { /* no-op */ }} value="" />
+                <GoabInput
+                  name="email"
+                  onChange={() => {
+                    /* no-op */
+                  }}
+                  value=""
+                />
               </GoabFormItem>
             }
           />
@@ -83,7 +103,13 @@ export function DocsCheckboxRoute() {
             label="Phone"
             reveal={
               <GoabFormItem label="Phone number">
-                <GoabInput name="phoneNumber" onChange={() => { /* no-op */ }} value="" />
+                <GoabInput
+                  name="phoneNumber"
+                  onChange={() => {
+                    /* no-op */
+                  }}
+                  value=""
+                />
               </GoabFormItem>
             }
           />
@@ -92,7 +118,13 @@ export function DocsCheckboxRoute() {
             label="Text message"
             reveal={
               <GoabFormItem label="Mobile phone number">
-                <GoabInput name="mobilePhoneNumber" onChange={() => { /* no-op */ }} value="" />
+                <GoabInput
+                  name="mobilePhoneNumber"
+                  onChange={() => {
+                    /* no-op */
+                  }}
+                  value=""
+                />
               </GoabFormItem>
             }
           />
@@ -111,7 +143,13 @@ export function DocsCheckboxRoute() {
             value="email"
             reveal={
               <GoabFormItem label="Email address">
-                <GoabInput name="email" onChange={() => { /* no-op */ }} value="" />
+                <GoabInput
+                  name="email"
+                  onChange={() => {
+                    /* no-op */
+                  }}
+                  value=""
+                />
               </GoabFormItem>
             }
           />
@@ -121,7 +159,13 @@ export function DocsCheckboxRoute() {
             value="phone"
             reveal={
               <GoabFormItem label="Phone number">
-                <GoabInput name="phoneNumber" onChange={() => { /* no-op */ }} value="" />
+                <GoabInput
+                  name="phoneNumber"
+                  onChange={() => {
+                    /* no-op */
+                  }}
+                  value=""
+                />
               </GoabFormItem>
             }
           />
@@ -131,7 +175,13 @@ export function DocsCheckboxRoute() {
             value="text"
             reveal={
               <GoabFormItem label="Mobile phone number">
-                <GoabInput name="mobilePhoneNumber" onChange={() => { /* no-op */ }} value="" />
+                <GoabInput
+                  name="mobilePhoneNumber"
+                  onChange={() => {
+                    /* no-op */
+                  }}
+                  value=""
+                />
               </GoabFormItem>
             }
           />

--- a/docs/src/data/configurations/checkbox.ts
+++ b/docs/src/data/configurations/checkbox.ts
@@ -259,6 +259,7 @@ export const checkboxConfigurations: ComponentConfigurations = {
       code: {
         react: `<GoabCheckbox name="disabled" text="Cannot be changed" disabled mb="m" />
 <GoabCheckbox name="disabledChecked" text="Checked and disabled" checked disabled mb="m" />
+<GoabCheckbox name="disabledCheckedError" text="Checked, disabled and error" checked disabled error mb="m" />
 <GoabCheckbox name="terms" text="Accept terms and conditions" error />`,
         angular: [
           {
@@ -269,6 +270,7 @@ export const checkboxConfigurations: ComponentConfigurations = {
     this.form = this.fb.group({
       disabled: [{ value: false, disabled: true }],
       disabledChecked: [{ value: true, disabled: true }],
+      disabledCheckedError: [{ value: true, disabled: true }],
       terms: [false],
     });
   }
@@ -289,6 +291,14 @@ export const checkboxConfigurations: ComponentConfigurations = {
   >
   </goab-checkbox>
   <goab-checkbox
+    name="disabledCheckedError"
+    text="Checked, disabled and error"
+    formControlName="disabledCheckedError"
+    [error]="true"
+    mb="m"
+  >
+  </goab-checkbox>
+  <goab-checkbox
     name="terms"
     text="Accept terms and conditions"
     formControlName="terms"
@@ -302,6 +312,7 @@ export const checkboxConfigurations: ComponentConfigurations = {
             ts: `export class SomeOtherComponent {
   disabledItem = false;
   disabledCheckedItem = true;
+  disabledCheckedErrorItem = true;
   terms = false;
 
   checkboxOnChange(event: GoabCheckboxOnChangeDetail) {
@@ -326,6 +337,15 @@ export const checkboxConfigurations: ComponentConfigurations = {
   >
   </goab-checkbox>
   <goab-checkbox
+    name="disabledCheckedError"
+    text="Checked, disabled and error"
+    [disabled]="true"
+    [error]="true"
+    [(ngModel)]="disabledCheckedErrorItem"
+    mb="m"
+  >
+  </goab-checkbox>
+  <goab-checkbox
     name="terms"
     text="Accept terms and conditions"
     [error]="true"
@@ -338,6 +358,7 @@ export const checkboxConfigurations: ComponentConfigurations = {
         ],
         webComponents: `<goa-checkbox version="2" name="disabled" text="Cannot be changed" disabled mb="m"></goa-checkbox>
 <goa-checkbox version="2" name="disabledChecked" text="Checked and disabled" checked disabled mb="m"></goa-checkbox>
+<goa-checkbox version="2" name="disabledCheckedError" text="Checked, disabled and error" checked disabled error mb="m"></goa-checkbox>
 <goa-checkbox version="2" name="terms" text="Accept terms and conditions" error></goa-checkbox>`,
       },
     },

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -600,7 +600,7 @@ max-width: ${maxwidth};
     border: var(--goa-checkbox-border-disabled-error);
   }
   .disabled.error .container svg {
-    fill: #f58185;
+    fill: var(--goa-checkbox-color-bg-checked-error-disabled);
   }
 
   /* Version 2 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       },
       "devDependencies": {
         "@abgov/design-tokens": "1.10.0",
-        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.12.6",
+        "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.12.7",
         "@abgov/nx-release": "12.0.0",
         "@angular-devkit/build-angular": "21.2.16",
         "@angular-devkit/core": "21.2.6",
@@ -134,9 +134,9 @@
     },
     "node_modules/@abgov/design-tokens-v2": {
       "name": "@abgov/design-tokens",
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.12.6.tgz",
-      "integrity": "sha512-QeeFnzJv6O5d7daxrJdxQl6gaYgKXTGgGMl164CuOnzMg6r1fpVh7PSmqfUp3IXdNXXgE+m4eTb3IHXBrjTJ4g==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.12.7.tgz",
+      "integrity": "sha512-pnYI/G3598FYOVHISalV1CkJaa1e1GB1wmiV6wtjXRWwyozH/NsEbMJoP9tebYWE25pi61prCcUMkmx8tWcC7g==",
       "dev": true
     },
     "node_modules/@abgov/nx-release": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@abgov/design-tokens": "1.10.0",
-    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.12.6",
+    "@abgov/design-tokens-v2": "npm:@abgov/design-tokens@2.12.7",
     "@abgov/nx-release": "12.0.0",
     "@angular-devkit/build-angular": "21.2.16",
     "@angular-devkit/core": "21.2.6",


### PR DESCRIPTION
# Before (the change)

Checkbox used a standard hex colour for the fill colour CSS for a disabled, checked, and error Checkbox.

# After (the change)

Now it uses a token that can be changed.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

1. Check the Docs PR for Checkbox for both Angular and React, I added a new state for this one
2. Also updated documentation Checkbox States example with the new state as well
