### PR TITLE
chore(#3002): Updated error detection for FormItem

### DIFF
--- a/apps/prs/angular/src/routes/bugs/bug3002/bug3002.component.html
+++ b/apps/prs/angular/src/routes/bugs/bug3002/bug3002.component.html
@@ -1,0 +1,133 @@
+<goab-text tag="h1" mt="m">Bug #3002: Fix how FormItem detects errors</goab-text>
+
+<goab-link trailingIcon="open">
+  <a
+    href="https://github.com/GovAlta/ui-components/issues/3002"
+    target="_blank"
+    rel="noreferrer"
+  >
+    View on GitHub
+  </a>
+</goab-link>
+
+<goab-text mt="m">
+  These four scenarios cover every combination of the FormItem error message and the
+  nested control error state. Inspect each control's aria-invalid and aria-describedby
+  attributes as well as the visible message and error styling.
+</goab-text>
+
+@for (scenario of scenarios; track scenario.id) {
+  <section>
+    <goab-text tag="h2" mt="l" mb="xs">{{ scenario.heading }}</goab-text>
+    <goab-text mb="m">{{ scenario.description }}</goab-text>
+
+    <goab-form-item
+      label="Input"
+      [error]="errorMessage(scenario)"
+      helpText="Input helper text"
+      mb="l"
+    >
+      <goab-input
+        [name]="controlName(scenario, 'input')"
+        [error]="scenario.controlError"
+      ></goab-input>
+    </goab-form-item>
+
+    <goab-form-item
+      label="Textarea"
+      [error]="errorMessage(scenario)"
+      helpText="Textarea helper text"
+      mb="l"
+    >
+      <goab-textarea
+        [name]="controlName(scenario, 'textarea')"
+        [error]="scenario.controlError"
+      ></goab-textarea>
+    </goab-form-item>
+
+    <goab-form-item
+      label="Dropdown"
+      [error]="errorMessage(scenario)"
+      helpText="Dropdown helper text"
+      mb="l"
+    >
+      <goab-dropdown
+        [name]="controlName(scenario, 'dropdown')"
+        [error]="scenario.controlError"
+      >
+        <goab-dropdown-item value="one" label="Option one"></goab-dropdown-item>
+        <goab-dropdown-item value="two" label="Option two"></goab-dropdown-item>
+      </goab-dropdown>
+    </goab-form-item>
+
+    <goab-form-item
+      label="Checkbox"
+      [error]="errorMessage(scenario)"
+      helpText="Checkbox helper text"
+      mb="l"
+    >
+      <goab-checkbox
+        [name]="controlName(scenario, 'checkbox')"
+        text="Confirm this option"
+        [error]="scenario.controlError"
+      ></goab-checkbox>
+    </goab-form-item>
+
+    <goab-form-item
+      label="Radio group"
+      type="radio-group"
+      [error]="errorMessage(scenario)"
+      helpText="Radio group helper text"
+      mb="l"
+    >
+      <goab-radio-group
+        [name]="controlName(scenario, 'radio-group')"
+        [error]="scenario.controlError"
+      >
+        <goab-radio-item value="yes" label="Yes"></goab-radio-item>
+        <goab-radio-item value="no" label="No"></goab-radio-item>
+      </goab-radio-group>
+    </goab-form-item>
+
+    <goab-form-item
+      label="Checkbox list"
+      type="checkbox-list"
+      [error]="errorMessage(scenario)"
+      helpText="Checkbox list helper text"
+      mb="l"
+    >
+      <goab-checkbox-list
+        [name]="controlName(scenario, 'checkbox-list')"
+        [value]="emptyValues"
+        [error]="scenario.controlError"
+      >
+        <goab-checkbox
+          [name]="controlName(scenario, 'checkbox-list-one')"
+          value="one"
+          text="Option one"
+        ></goab-checkbox>
+        <goab-checkbox
+          [name]="controlName(scenario, 'checkbox-list-two')"
+          value="two"
+          text="Option two"
+        ></goab-checkbox>
+      </goab-checkbox-list>
+    </goab-form-item>
+
+    <goab-form-item
+      label="Dropdown multiselect"
+      [error]="errorMessage(scenario)"
+      helpText="Dropdown multiselect helper text"
+    >
+      <goab-dropdown-multiselect
+        [name]="controlName(scenario, 'dropdown-multiselect')"
+        [error]="scenario.controlError"
+      >
+        <goab-dropdown-item value="one" label="Option one"></goab-dropdown-item>
+        <goab-dropdown-item value="two" label="Option two"></goab-dropdown-item>
+      </goab-dropdown-multiselect>
+    </goab-form-item>
+
+    <goab-divider mt="xl"></goab-divider>
+  </section>
+}

--- a/apps/prs/angular/src/routes/bugs/bug3002/bug3002.component.ts
+++ b/apps/prs/angular/src/routes/bugs/bug3002/bug3002.component.ts
@@ -1,0 +1,92 @@
+import { Component } from "@angular/core";
+import {
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabDivider,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabDropdownMultiselect,
+  GoabFormItem,
+  GoabInput,
+  GoabLink,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabText,
+  GoabTextArea,
+} from "@abgov/angular-components";
+
+type ErrorScenario = {
+  id: string;
+  heading: string;
+  description: string;
+  formItemError: boolean;
+  controlError: boolean;
+};
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3002",
+  templateUrl: "./bug3002.component.html",
+  imports: [
+    GoabCheckbox,
+    GoabCheckboxList,
+    GoabDivider,
+    GoabDropdown,
+    GoabDropdownItem,
+    GoabDropdownMultiselect,
+    GoabFormItem,
+    GoabInput,
+    GoabLink,
+    GoabRadioGroup,
+    GoabRadioItem,
+    GoabText,
+    GoabTextArea,
+  ],
+})
+export class Bug3002Component {
+  readonly emptyValues: string[] = [];
+  readonly scenarios: ErrorScenario[] = [
+    {
+      id: "neither",
+      heading: "Neither component has an error",
+      description:
+        "No error message, error styling, or error reference should be present.",
+      formItemError: false,
+      controlError: false,
+    },
+    {
+      id: "form-item-only",
+      heading: "FormItem error only",
+      description:
+        "The message should be rendered and referenced by aria-describedby without error styling on the control.",
+      formItemError: true,
+      controlError: false,
+    },
+    {
+      id: "control-only",
+      heading: "Control error only",
+      description:
+        "The control should have error styling and aria-invalid, but FormItem should not render or reference an error message.",
+      formItemError: false,
+      controlError: true,
+    },
+    {
+      id: "both",
+      heading: "FormItem and control errors",
+      description:
+        "The control should have error styling and aria-invalid, and the rendered message should be referenced by aria-describedby.",
+      formItemError: true,
+      controlError: true,
+    },
+  ];
+
+  errorMessage(scenario: ErrorScenario): string | undefined {
+    return scenario.formItemError
+      ? `Error message from FormItem (${scenario.heading})`
+      : undefined;
+  }
+
+  controlName(scenario: ErrorScenario, component: string): string {
+    return `bug3002-${scenario.id}-${component}`;
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/bug3002/bug3002.route.json
+++ b/apps/prs/angular/src/routes/bugs/bug3002/bug3002.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3002",
+  "path": "bugs/bug3002",
+  "title": "FormItem error detection"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3002.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3002.route.ts
@@ -1,0 +1,10 @@
+import { Bug3002Route } from "../../../routes/bugs/bug3002";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3002",
+  path: "bugs/3002",
+  title: "FormItem error detection",
+  component: Bug3002Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3002.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3002.tsx
@@ -1,0 +1,183 @@
+import {
+  GoabBlock,
+  GoabCheckbox,
+  GoabCheckboxList,
+  GoabDivider,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabDropdownMultiselect,
+  GoabFormItem,
+  GoabInput,
+  GoabLink,
+  GoabRadioGroup,
+  GoabRadioItem,
+  GoabText,
+  GoabTextArea,
+} from "@abgov/react-components";
+
+type ErrorScenario = {
+  id: string;
+  heading: string;
+  description: string;
+  formItemError: boolean;
+  controlError: boolean;
+};
+
+const scenarios: ErrorScenario[] = [
+  {
+    id: "neither",
+    heading: "Neither component has an error",
+    description: "No error message, error styling, or error reference should be present.",
+    formItemError: false,
+    controlError: false,
+  },
+  {
+    id: "form-item-only",
+    heading: "FormItem error only",
+    description:
+      "The message should be rendered and referenced by aria-describedby without error styling on the control.",
+    formItemError: true,
+    controlError: false,
+  },
+  {
+    id: "control-only",
+    heading: "Control error only",
+    description:
+      "The control should have error styling and aria-invalid, but FormItem should not render or reference an error message.",
+    formItemError: false,
+    controlError: true,
+  },
+  {
+    id: "both",
+    heading: "FormItem and control errors",
+    description:
+      "The control should have error styling and aria-invalid, and the rendered message should be referenced by aria-describedby.",
+    formItemError: true,
+    controlError: true,
+  },
+];
+
+function Scenario({ scenario }: { scenario: ErrorScenario }) {
+  const error = scenario.formItemError
+    ? `Error message from FormItem (${scenario.heading})`
+    : undefined;
+  const name = (component: string) => `bug3002-${scenario.id}-${component}`;
+
+  return (
+    <section>
+      <GoabText tag="h2" mt="l" mb="xs">
+        {scenario.heading}
+      </GoabText>
+      <GoabText mb="m">{scenario.description}</GoabText>
+
+      <GoabBlock direction="column" gap="l">
+        <GoabFormItem label="Input" error={error} helpText="Input helper text">
+          <GoabInput name={name("input")} error={scenario.controlError} />
+        </GoabFormItem>
+
+        <GoabFormItem label="Textarea" error={error} helpText="Textarea helper text">
+          <GoabTextArea name={name("textarea")} error={scenario.controlError} />
+        </GoabFormItem>
+
+        <GoabFormItem label="Dropdown" error={error} helpText="Dropdown helper text">
+          <GoabDropdown name={name("dropdown")} error={scenario.controlError}>
+            <GoabDropdownItem value="one" label="Option one" />
+            <GoabDropdownItem value="two" label="Option two" />
+          </GoabDropdown>
+        </GoabFormItem>
+
+        <GoabFormItem label="Checkbox" error={error} helpText="Checkbox helper text">
+          <GoabCheckbox
+            name={name("checkbox")}
+            text="Confirm this option"
+            error={scenario.controlError}
+          />
+        </GoabFormItem>
+
+        <GoabFormItem
+          label="Radio group"
+          type="radio-group"
+          error={error}
+          helpText="Radio group helper text"
+        >
+          <GoabRadioGroup name={name("radio-group")} error={scenario.controlError}>
+            <GoabRadioItem value="yes" label="Yes" />
+            <GoabRadioItem value="no" label="No" />
+          </GoabRadioGroup>
+        </GoabFormItem>
+
+        <GoabFormItem
+          label="Checkbox list"
+          type="checkbox-list"
+          error={error}
+          helpText="Checkbox list helper text"
+        >
+          <GoabCheckboxList
+            name={name("checkbox-list")}
+            value={[]}
+            error={scenario.controlError}
+          >
+            <GoabCheckbox
+              name={name("checkbox-list-one")}
+              value="one"
+              text="Option one"
+            />
+            <GoabCheckbox
+              name={name("checkbox-list-two")}
+              value="two"
+              text="Option two"
+            />
+          </GoabCheckboxList>
+        </GoabFormItem>
+
+        <GoabFormItem
+          label="Dropdown multiselect"
+          error={error}
+          helpText="Dropdown multiselect helper text"
+        >
+          <GoabDropdownMultiselect
+            name={name("dropdown-multiselect")}
+            error={scenario.controlError}
+          >
+            <GoabDropdownItem value="one" label="Option one" />
+            <GoabDropdownItem value="two" label="Option two" />
+          </GoabDropdownMultiselect>
+        </GoabFormItem>
+      </GoabBlock>
+
+      <GoabDivider mt="xl" />
+    </section>
+  );
+}
+
+export function Bug3002Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Bug #3002: Fix how FormItem detects errors
+      </GoabText>
+
+      <GoabLink trailingIcon="open">
+        <a
+          href="https://github.com/GovAlta/ui-components/issues/3002"
+          target="_blank"
+          rel="noreferrer"
+        >
+          View on GitHub
+        </a>
+      </GoabLink>
+
+      <GoabText mt="m">
+        These four scenarios cover every combination of the FormItem error message and the
+        nested control error state. Inspect each control&apos;s aria-invalid and
+        aria-describedby attributes as well as the visible message and error styling.
+      </GoabText>
+
+      {scenarios.map((scenario) => (
+        <Scenario key={scenario.id} scenario={scenario} />
+      ))}
+    </div>
+  );
+}
+
+export default Bug3002Route;

--- a/libs/web-components/src/components/checkbox-list/CheckboxList.spec.ts
+++ b/libs/web-components/src/components/checkbox-list/CheckboxList.spec.ts
@@ -136,6 +136,37 @@ describe("GoACheckboxList", () => {
         expect(checkbox.getAttribute("disabled")).toBe("true");
       });
     });
+
+    it("should apply and clear errors on a child checkbox", async () => {
+      const result = render(CheckboxList, {
+        ...defaultProps,
+        error: "true",
+      });
+      const checkboxContainer = result.container.querySelector(".checkbox-container");
+      const checkbox = document.createElement("goa-checkbox");
+      const checkboxRoot = document.createElement("div");
+      checkbox.attachShadow({ mode: "open" }).appendChild(checkboxRoot);
+      checkboxContainer?.appendChild(checkbox);
+
+      await waitFor(() => {
+        relay<FormFieldMountRelayDetail>(
+          checkboxRoot,
+          FormFieldMountMsg,
+          { name: "option1", el: checkboxRoot },
+          { bubbles: true },
+        );
+        expect(checkbox.getAttribute("error")).toBe("true");
+      });
+
+      await result.rerender({
+        ...defaultProps,
+        error: "false",
+      });
+
+      await waitFor(() => {
+        expect(checkbox.hasAttribute("error")).toBe(false);
+      });
+    });
   });
 
   describe("Events", () => {

--- a/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
+++ b/libs/web-components/src/components/checkbox-list/CheckboxList.svelte
@@ -102,7 +102,7 @@
 
   /**
    * Synchronize component when external props change.
-   * - Emits error change events and propagates to children
+   * - Propagates error changes to children
    * - Syncs checkbox values after initialization
    */
   function updateState(newValue: string[], newError: string) {
@@ -114,15 +114,7 @@
     // Handle error state changes
     const currentError = toBoolean(newError);
     if (currentError !== _error) {
-      _rootEl?.dispatchEvent(
-        new CustomEvent("error::change", {
-          detail: { isError: currentError },
-          bubbles: true,
-          composed: true,
-        }),
-      );
       _error = currentError;
-      updateChildCheckboxesError();
     }
 
     // Sync Set when value changes externally (not from internal changes)
@@ -416,20 +408,13 @@
       } else {
         containerElement.removeAttribute("disabled");
       }
-    }
-  }
 
-  /** Propagate error state to all children via the relay bus. */
-  function updateChildCheckboxesError() {
-    for (const rec of _childRecords) {
       if (_error) {
-        relay(rec.el, FieldsetSetErrorMsg, { error: "true" });
+        containerElement.setAttribute("error", "true");
       } else {
-        relay(rec.el, FieldsetResetErrorsMsg);
+        containerElement.removeAttribute("error");
       }
     }
-
-    updateSlottedCheckboxesState();
   }
 
   // Announce help text for screen readers when the group receives focus.

--- a/libs/web-components/src/components/checkbox/Checkbox.svelte
+++ b/libs/web-components/src/components/checkbox/Checkbox.svelte
@@ -73,23 +73,11 @@
   let _checkboxRef: HTMLElement;
   let _descriptionId: string;
   let _error: boolean;
-  let _prevError: boolean;
   let _revealSlotHeight: number = 0;
 
   // Binding
   $: isDisabled = toBoolean(disabled);
-  $: {
-    _error = toBoolean(error);
-    if (_error !== _prevError) {
-      dispatch(
-        _rootEl,
-        "error::change",
-        { isError: _error },
-        { bubbles: true },
-      );
-      _prevError = _error;
-    }
-  }
+  $: _error = toBoolean(error);
   $: isChecked = toBoolean(checked);
   $: isIndeterminate = toBoolean(indeterminate);
   $: if (_checkboxRef) {

--- a/libs/web-components/src/components/dropdown-multiselect/DropdownMultiselect.svelte
+++ b/libs/web-components/src/components/dropdown-multiselect/DropdownMultiselect.svelte
@@ -147,7 +147,6 @@
   let _focusedIndex = -1;
   let _isTriggerMouseDown = false;
   let _skipNextTriggerFocusOpen = false;
-  let _prevError = error;
 
   // Reactive
   $: value = Array.isArray(value) ? value : [];
@@ -169,14 +168,6 @@
     filterable && _filterText.trim()
       ? _options.filter((o) => isFilterMatch(o, _filterText))
       : _options;
-
-  // When the error state changes, dispatch error::change to notify the fieldset
-  $: {
-    if (error !== _prevError) {
-      dispatch(_rootEl, "error::change", { isError: error }, { bubbles: true });
-      _prevError = error;
-    }
-  }
 
   onMount(async () => {
     await tick();

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -121,7 +121,6 @@
   let _bindTimeoutId: any;
 
   let _error = toBoolean(error);
-  let _prevError = _error;
 
   //
   // Reactive
@@ -151,19 +150,7 @@
     _popoverMaxWidth = getRenderedWidth();
   }
 
-  // TODO: Syed can you add a comment here describing what this does?
-  $: {
-    _error = toBoolean(error);
-    if (_error !== _prevError) {
-      dispatch(
-        _rootEl,
-        "error::change",
-        { isError: _error },
-        { bubbles: true },
-      );
-      _prevError = _error;
-    }
-  }
+  $: _error = toBoolean(error);
 
   //
   // Hooks

--- a/libs/web-components/src/components/form-item/FormItem.spec.ts
+++ b/libs/web-components/src/components/form-item/FormItem.spec.ts
@@ -234,31 +234,18 @@ describe("GoA FormItem", () => {
     expect(input.getAttribute("aria-describedby")).toBeTruthy();
     expect(input.getAttribute("aria-describedby")).toContain("helptext-");
 
-    // Simulate error state change
-    await fireEvent(
-      formItem,
-      new CustomEvent("error::change", {
-        detail: { isError: true },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    await component.$set({ error: "Error Message" });
 
     // Now both error and helptext should be in aria-describedby
     const describedBy = input.getAttribute("aria-describedby");
     expect(describedBy).toBeTruthy();
     expect(describedBy).toContain("error-");
     expect(describedBy).toContain("helptext-");
+    const errorMessage = formItem.querySelector(".error-msg");
+    expect(errorMessage?.id).toBe(describedBy?.split(" ")[0]);
+    expect(errorMessage?.textContent).toContain("Error Message");
 
-    // Simulate error state change back to no error
-    await fireEvent(
-      formItem,
-      new CustomEvent("error::change", {
-        detail: { isError: false },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    await component.$set({ error: "" });
 
     // Back to only helptext in aria-describedby
     expect(input.getAttribute("aria-describedby")).toBeTruthy();

--- a/libs/web-components/src/components/form-item/FormItem.svelte
+++ b/libs/web-components/src/components/form-item/FormItem.svelte
@@ -98,11 +98,11 @@
   let _inputEl: HTMLElement;
   let _errorId = `error-${generateRandomId()}`;
   let _helpTextId = `helptext-${generateRandomId()}`;
-  let _hasError = false;
 
   // Computed: Error icon size based on form item size
   // Compact: xsmall (16px), Regular/Large: small (18px)
   $: errorIconSize = labelsize === 'compact' ? 'xsmall' : 'small';
+  $: updateAriaDescribedBy(Boolean(error));
 
   onMount(() => {
     validateRequirementType(requirement);
@@ -125,7 +125,6 @@
     });
 
     _rootEl?.addEventListener("form-field::bind", handleInputMounted);
-    _rootEl?.addEventListener("error::change", handleErrorChange);
     _rootEl?.addEventListener("help-text::announce", handleAnnounceHelperText);
   });
 
@@ -145,29 +144,21 @@
       requirement === "required" ? "true" : "false",
     );
 
-    updateAriaDescribedBy();
-  }
-
-  function handleErrorChange(e: Event) {
-    const ce = e as CustomEvent<{ isError: boolean }>;
-    if (_hasError !== ce.detail.isError) {
-      _hasError = ce.detail.isError;
-      updateAriaDescribedBy();
-    }
+    updateAriaDescribedBy(Boolean(error));
   }
 
   function handleAnnounceHelperText() {
-    const message = _hasError ? error || helptext : helptext;
+    const message = error || helptext;
     if (message) {
       announceToScreenReader(message);
     }
   }
 
-  function updateAriaDescribedBy() {
+  function updateAriaDescribedBy(hasError: boolean) {
     if (!_inputEl) return;
 
     let describedBy = [];
-    if (_hasError || $$slots.error) describedBy.push(_errorId);
+    if (hasError || $$slots.error) describedBy.push(_errorId);
     if (helptext || $$slots.helptext) describedBy.push(_helpTextId);
 
     if (describedBy.length > 0) {

--- a/libs/web-components/src/components/input/Input.svelte
+++ b/libs/web-components/src/components/input/Input.svelte
@@ -141,7 +141,6 @@
   let _inputEl: HTMLInputElement;
   let _rootEl: HTMLElement;
   let _error = false;
-  let _prevError = false;
   // separate styles for input and input's container
   let _containerStyle = "";
   let _inputWidth = "";
@@ -154,18 +153,7 @@
   $: isFocused = toBoolean(focused);
   $: isReadonly = toBoolean(readonly);
   $: isDisabled = toBoolean(disabled);
-  $: {
-    _error = toBoolean(error);
-    if (_error !== _prevError) {
-      dispatch(
-        _rootEl,
-        "error::change",
-        { isError: _error },
-        { bubbles: true },
-      );
-      _prevError = _error;
-    }
-  }
+  $: _error = toBoolean(error);
 
   // TODO: determine if this and the next reactive statement need to be reactive, as they are both
   // things that should only be run once

--- a/libs/web-components/src/components/radio-group/RadioGroup.svelte
+++ b/libs/web-components/src/components/radio-group/RadioGroup.svelte
@@ -70,7 +70,6 @@
 
   // Private
   let _error = toBoolean(error);
-  let _prevError = _error;
 
   // Reactive
 
@@ -88,15 +87,6 @@
 
   $: {
     _error = toBoolean(error);
-    if (_error !== _prevError) {
-      dispatch(
-        _rootEl,
-        "error::change",
-        { isError: _error },
-        { bubbles: true },
-      );
-      _prevError = _error;
-    }
     bindOptions();
   }
 

--- a/libs/web-components/src/components/text-area/TextArea.svelte
+++ b/libs/web-components/src/components/text-area/TextArea.svelte
@@ -78,22 +78,10 @@
   export let ml: Spacing = null;
 
   let _error = false;
-  let _prevError = false;
 
   // reactive
 
-  $: {
-    _error = toBoolean(error);
-    if (_error !== _prevError) {
-      dispatch(
-        _rootEl,
-        "error::change",
-        { isError: _error },
-        { bubbles: true },
-      );
-      _prevError = _error;
-    }
-  }
+  $: _error = toBoolean(error);
   $: isDisabled = toBoolean(disabled);
   $: isReadonly = toBoolean(readonly);
   $: count =


### PR DESCRIPTION
This change should essentially make no difference to users of our components. This is just a simplification of error handling for our various input components and FormItem.

Previously when an error was given to an input component, it registered that error with an event that FormItem would see, and then update it's `aria-describedby` property. That could result in a FormItem updating it's `aria-describedby` property without actually providing an error.

Now, input's control their error property independently of FormItem. When FormItem's error property is updated, it updates it's `aria-describedby` property properly.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

You can manually test using PRs bug3002 for both Angular and React. There should be no difference for how the components are actually used.
