### PR TITLE
chore(#3056): Removed type property from AppHeaderMenu

### DIFF
--- a/docs/generated/component-apis/app-header-menu.json
+++ b/docs/generated/component-apis/app-header-menu.json
@@ -81,17 +81,6 @@
           "description": "Sets a data-testid attribute for automated testing."
         },
         {
-          "name": "type",
-          "type": "\"primary\" | \"secondary\"",
-          "values": [
-            "primary",
-            "secondary"
-          ],
-          "required": false,
-          "default": "primary",
-          "description": "The menu style variant. Primary uses bold text, secondary uses regular weight."
-        },
-        {
           "name": "version",
           "type": "\"1\" | \"2\"",
           "values": [

--- a/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
+++ b/libs/web-components/src/components/app-header-menu/AppHeaderMenu.svelte
@@ -24,8 +24,6 @@
 
   /** Icon displayed before the heading text. */
   export let leadingicon: GoAIconType;
-  /** The menu style variant. Primary uses bold text, secondary uses regular weight. */
-  export let type: "primary" | "secondary" = "primary";
   /** @internal Design system version for styling. */
   export let version: "1" | "2" = "1";
   /** Sets a data-testid attribute for automated testing. */
@@ -207,7 +205,6 @@
     >
       <button
         slot="target"
-        class={type}
         class:open={_open}
         class:current={_hasCurrentLink}
         class:v2-nav={_isV2Navigation}
@@ -235,7 +232,6 @@
     <button
       class:open={_open}
       on:click={toggleMenu}
-      class={type}
       class:v2-nav={_isV2Navigation}
     >
       {#if leadingicon}
@@ -483,9 +479,6 @@
     button[slot="target"] {
       font-weight: var(--goa-font-weight-bold);
       white-space: nowrap;
-    }
-    button.secondary {
-      font-weight: var(--goa-font-weight-regular);
     }
     button.open {
       background-color: var(--goa-app-header-color-bg-menu-button-focus);


### PR DESCRIPTION
Previously we had a `type` property included in `GoabAppHeaderMenu`. This property was only available to the default web component (so essentially only Vue users). The only effect it had was if you supplied the value `secondary`, it changed the font-weight of buttons to regular from bold. It only had this effect for v1 components, v2 components overwrote that property regardless so it didn't matter.

Technically this could be considered a breaking change for any Vue users that had implemented it and are still using v1 components. But the # of those teams doing that is likely very very small if it even exists.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [ ] I have tested the functionality in both React and Angular.

## Steps needed to test

There are no tests for this, there's no way to test that something doesn't exist anymore, when it couldn't be implemented anyways. The only thing to determine is if we think this is too much of a breaking change and should only be included as a major version update.
