### PR TITLE
fix(#3103): Modified Dropdown to not resize inside containers

### DIFF
--- a/apps/prs/angular/src/routes/bugs/bug3103/bug3103.component.html
+++ b/apps/prs/angular/src/routes/bugs/bug3103/bug3103.component.html
@@ -1,0 +1,70 @@
+<goab-text tag="h1" mt="m" mb="s">
+  Bug #3103: Pagination dropdown small inside Accordion
+</goab-text>
+<goab-text>
+  Compare the page-number dropdown outside and inside the Accordion. Both dropdowns should
+  be wide enough to display the current page number.
+</goab-text>
+<p>
+  <a
+    href="https://github.com/GovAlta/ui-components/issues/3103"
+    target="_blank"
+    rel="noopener"
+  >
+    View issue #3103 on GitHub
+  </a>
+</p>
+
+<goab-text tag="h2" mt="l" mb="s">Pagination outside Accordion</goab-text>
+<goab-table width="100%" mb="xl">
+  <thead>
+    <tr>
+      <th>First name</th>
+      <th>Last name</th>
+      <th>Age</th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (user of pageUsers; track user.id) {
+      <tr>
+        <td>{{ user.firstName }}</td>
+        <td>{{ user.lastName }}</td>
+        <td>{{ user.age }}</td>
+      </tr>
+    }
+  </tbody>
+</goab-table>
+<goab-pagination
+  [pageNumber]="page"
+  [itemCount]="users.length"
+  [perPageCount]="perPage"
+  (onChange)="handlePageChange($event)"
+/>
+
+<goab-text tag="h2" mt="l" mb="s">Pagination inside Accordion</goab-text>
+<goab-accordion heading="Pagination inside Accordion" [open]="true">
+  <goab-table width="100%" mb="xl">
+    <thead>
+      <tr>
+        <th>First name</th>
+        <th>Last name</th>
+        <th>Age</th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (user of pageUsers; track user.id) {
+        <tr>
+          <td>{{ user.firstName }}</td>
+          <td>{{ user.lastName }}</td>
+          <td>{{ user.age }}</td>
+        </tr>
+      }
+    </tbody>
+  </goab-table>
+  <goab-pagination
+    [pageNumber]="page"
+    [itemCount]="users.length"
+    [perPageCount]="perPage"
+    (onChange)="handlePageChange($event)"
+  />
+</goab-accordion>

--- a/apps/prs/angular/src/routes/bugs/bug3103/bug3103.component.ts
+++ b/apps/prs/angular/src/routes/bugs/bug3103/bug3103.component.ts
@@ -1,0 +1,48 @@
+import { Component } from "@angular/core";
+import {
+  GoabAccordion,
+  GoabPagination,
+  GoabTable,
+  GoabText,
+} from "@abgov/angular-components";
+import type { GoabPaginationOnChangeDetail } from "@abgov/ui-components-common";
+
+interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  age: number;
+}
+
+const firstNames = ["Emma", "Liam", "Olivia", "Noah", "Ava"];
+const lastNames = ["Smith", "Johnson", "Williams", "Brown", "Jones"];
+
+function generateUsers(): User[] {
+  return Array.from({ length: 100 }, (_, index) => ({
+    id: `user-${index + 1}`,
+    firstName: firstNames[index % firstNames.length],
+    lastName: lastNames[index % lastNames.length],
+    age: 20 + ((index + 1) % 40),
+  }));
+}
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3103",
+  templateUrl: "./bug3103.component.html",
+  imports: [GoabAccordion, GoabPagination, GoabTable, GoabText],
+})
+export class Bug3103Component {
+  readonly users = generateUsers();
+  readonly perPage = 10;
+  page = 1;
+
+  get pageUsers(): User[] {
+    const offset = (this.page - 1) * this.perPage;
+    return this.users.slice(offset, offset + this.perPage);
+  }
+
+  handlePageChange(event: GoabPaginationOnChangeDetail): void {
+    this.page = event.page;
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/bug3103/bug3103.route.json
+++ b/apps/prs/angular/src/routes/bugs/bug3103/bug3103.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "3103",
+  "path": "bugs/bug3103",
+  "title": "Pagination dropdown inside Accordion"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3103.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3103.route.ts
@@ -1,0 +1,10 @@
+import { Bug3103Route } from "../../../routes/bugs/bug3103";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3103",
+  path: "bugs/bug3103",
+  title: "Pagination dropdown inside Accordion",
+  component: Bug3103Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3103.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3103.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import {
+  GoabAccordion,
+  GoabPagination,
+  GoabTable,
+  GoabText,
+} from "@abgov/react-components";
+import type { GoabPaginationOnChangeDetail } from "@abgov/ui-components-common";
+
+interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  age: number;
+}
+
+const firstNames = ["Emma", "Liam", "Olivia", "Noah", "Ava"];
+const lastNames = ["Smith", "Johnson", "Williams", "Brown", "Jones"];
+
+function generateUsers(): User[] {
+  return Array.from({ length: 100 }, (_, index) => ({
+    id: `user-${index + 1}`,
+    firstName: firstNames[index % firstNames.length],
+    lastName: lastNames[index % lastNames.length],
+    age: 20 + ((index + 1) % 40),
+  }));
+}
+
+const users = generateUsers();
+const perPage = 10;
+
+function UserTable({ pageUsers }: { pageUsers: User[] }) {
+  return (
+    <GoabTable width="100%" mb="xl">
+      <thead>
+        <tr>
+          <th>First name</th>
+          <th>Last name</th>
+          <th>Age</th>
+        </tr>
+      </thead>
+      <tbody>
+        {pageUsers.map((user) => (
+          <tr key={user.id}>
+            <td>{user.firstName}</td>
+            <td>{user.lastName}</td>
+            <td>{user.age}</td>
+          </tr>
+        ))}
+      </tbody>
+    </GoabTable>
+  );
+}
+
+export function Bug3103Route() {
+  const [page, setPage] = useState(1);
+  const offset = (page - 1) * perPage;
+  const pageUsers = users.slice(offset, offset + perPage);
+  const handlePageChange = (event: GoabPaginationOnChangeDetail) => setPage(event.page);
+
+  return (
+    <div>
+      <GoabText tag="h1" mt="m" mb="s">
+        Bug #3103: Pagination dropdown small inside Accordion
+      </GoabText>
+      <GoabText>
+        Compare the page-number dropdown outside and inside the Accordion. Both dropdowns
+        should be wide enough to display the current page number.
+      </GoabText>
+      <p>
+        <a
+          href="https://github.com/GovAlta/ui-components/issues/3103"
+          target="_blank"
+          rel="noopener"
+        >
+          View issue #3103 on GitHub
+        </a>
+      </p>
+
+      <GoabText tag="h2" mt="l" mb="s">
+        Pagination outside Accordion
+      </GoabText>
+      <UserTable pageUsers={pageUsers} />
+      <GoabPagination
+        pageNumber={page}
+        itemCount={users.length}
+        perPageCount={perPage}
+        onChange={handlePageChange}
+      />
+
+      <GoabText tag="h2" mt="l" mb="s">
+        Pagination inside Accordion
+      </GoabText>
+      <GoabAccordion heading="Pagination inside Accordion" open>
+        <UserTable pageUsers={pageUsers} />
+        <GoabPagination
+          pageNumber={page}
+          itemCount={users.length}
+          perPageCount={perPage}
+          onChange={handlePageChange}
+        />
+      </GoabAccordion>
+    </div>
+  );
+}
+
+export default Bug3103Route;

--- a/libs/react-components/specs/dropdown.browser.spec.tsx
+++ b/libs/react-components/specs/dropdown.browser.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from "vitest-browser-react";
 
-import { GoabDropdown, GoabDropdownItem } from "../src";
+import { GoabAccordion, GoabDropdown, GoabDropdownItem } from "../src";
 import { expect, describe, it, vi } from "vitest";
 import { page, userEvent } from "@vitest/browser/context";
 
@@ -415,6 +415,48 @@ describe("Dropdown", () => {
           const dropdownWidth = parseFloat(computedStyle.width);
           expect(dropdownWidth).toBeGreaterThan(200); // Should be substantial width
           expect(dropdownWidth).toBeLessThan(600); // But not too large
+        });
+      });
+
+      it("keeps the input width aligned when nested in a query container", async () => {
+        const Component = () => (
+          <GoabAccordion heading="Dropdown container" open>
+            <GoabDropdown
+              name="page"
+              testId="nested-dropdown"
+              size="compact"
+              onChange={noop}
+            >
+              <GoabDropdownItem label="1" value="1" />
+              <GoabDropdownItem label="10" value="10" />
+            </GoabDropdown>
+          </GoabAccordion>
+        );
+
+        render(<Component />);
+        await vi.waitFor(() => {
+          expect(
+            document.querySelector("goa-dropdown"),
+          ).not.toBeNull();
+        });
+
+        const dropdownHost = document.querySelector<HTMLElement>("goa-dropdown");
+        const dropdown = dropdownHost?.shadowRoot?.querySelector<HTMLElement>(
+          '[data-testid="nested-dropdown"]',
+        );
+        const inputGroup = dropdownHost?.shadowRoot?.querySelector<HTMLElement>(
+          ".dropdown-input-group",
+        );
+
+        if (!dropdown || !inputGroup) {
+          throw new Error("Dropdown internals were not rendered");
+        }
+
+        await vi.waitFor(() => {
+          expect(inputGroup.getBoundingClientRect().width).toBeCloseTo(
+            dropdown.getBoundingClientRect().width,
+            0,
+          );
         });
       });
 

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -1022,12 +1022,6 @@
     box-shadow: var(--goa-dropdown-border-error);
   }
 
-  @container not (--mobile) {
-    .dropdown-input-group {
-      width: var(--width, 100%);
-    }
-  }
-
   .dropdown-icon--arrow,
   .dropdown-icon--clear {
     padding-right: var(--goa-dropdown-space-icon-text);


### PR DESCRIPTION
# Before (the change)

If you used a Dropdown inside of an Accordion, it would be sized differently to its counterpart outside of the Accordion. This was due to an old `@container` CSS property that was being applied to Dropdown's specifically inside of parent containers, which changed the width to use the supplied width parameter, the problem this caused was if the width parameter used something like `ch` values, because that ch would take the parent containers character size to calculate the width, which might be different.

# After (the change)

Dropdowns used inside of components (like Accordion) should now be sized the same as their equivalent outside of that component.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use PRs bug3103 for either Angular or React to test the difference.
