### PR TITLE
chore(#3136): Updated all Header, Footer, and Side Menu examples

### DIFF
--- a/apps/prs/angular/src/routes/docs/app-header/app-header.component.html
+++ b/apps/prs/angular/src/routes/docs/app-header/app-header.component.html
@@ -34,39 +34,53 @@
 <h2>App header</h2>
 
 <h3>Basic app header</h3>
-<goab-app-header heading="My Application"></goab-app-header>
+<header>
+  <goab-app-header heading="My Application"></goab-app-header>
+</header>
 
 <h3>With home link</h3>
-<goab-app-header heading="My Application" url="/"></goab-app-header>
+<header>
+  <goab-app-header heading="My Application" url="/"></goab-app-header>
+</header>
 
 <h3>With secondary text</h3>
-<goab-app-header heading="My Application" secondaryText="Supporting information" url="/"></goab-app-header>
+<header>
+  <goab-app-header heading="My Application" secondaryText="Supporting information" url="/"></goab-app-header>
+</header>
 
 <h3>With utilities</h3>
-<goab-app-header
-  heading="My Application"
-  url="/"
-  [utilities]="utilitiesTemplate1"
-></goab-app-header>
+<header>
+  <goab-app-header
+    heading="My Application"
+    url="/"
+    [utilities]="utilitiesTemplate1"
+  ></goab-app-header>
+</header>
 
 <h3>With phase badge</h3>
-<goab-app-header
-  heading="My Application"
-  url="/"
-  [phase]="phaseTemplate"
-></goab-app-header>
+<header>
+  <goab-app-header
+    heading="My Application"
+    url="/"
+    [phase]="phaseTemplate"
+  ></goab-app-header>
+</header>
 
 <h3>Internal testing banner</h3>
-<goab-app-header
-  heading="My Application"
-  url="/"
-  [banner]="bannerTemplate"
-></goab-app-header>
+<header>
+  <goab-app-header
+    heading="My Application"
+    url="/"
+    [banner]="bannerTemplate"
+  ></goab-app-header>
+</header>
 
 <h3>With navigation</h3>
-<goab-app-header
-  heading="Service Portal"
-  url="/"
-  [navigation]="navigationTemplate"
-  [utilities]="utilitiesTemplate2"
-></goab-app-header>
+<header>
+  <goab-app-header
+    heading="Service Portal"
+    url="/"
+    [navigation]="navigationTemplate"
+    [utilities]="utilitiesTemplate2"
+  ></goab-app-header>
+</header>

--- a/apps/prs/angular/src/routes/docs/footer/footer.component.html
+++ b/apps/prs/angular/src/routes/docs/footer/footer.component.html
@@ -1,58 +1,68 @@
 <h2>Footer</h2>
 
 <h3>Basic footer</h3>
-<goab-app-footer></goab-app-footer>
+<footer>
+  <goab-app-footer></goab-app-footer>
+</footer>
 
 <h3>With meta section</h3>
-<goab-app-footer>
-  <goab-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </goab-app-footer-meta-section>
-</goab-app-footer>
+<footer>
+  <goab-app-footer>
+    <goab-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </goab-app-footer-meta-section>
+  </goab-app-footer>
+</footer>
 
 <h3>With links</h3>
-<goab-app-footer>
-  <goab-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <goab-link trailingIcon="open">
-      <a href="https://www.alberta.ca/services">All services</a>
-    </goab-link>
-  </goab-app-footer-nav-section>
-  <goab-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <goab-link><a href="/accessibility">Accessibility</a></goab-link>
-  </goab-app-footer-meta-section>
-</goab-app-footer>
+<footer>
+  <goab-app-footer>
+    <goab-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <goab-link trailingIcon="open">
+        <a href="https://www.alberta.ca/services">All services</a>
+      </goab-link>
+    </goab-app-footer-nav-section>
+    <goab-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <goab-link><a href="/accessibility">Accessibility</a></goab-link>
+    </goab-app-footer-meta-section>
+  </goab-app-footer>
+</footer>
 
 <h3>With navigation</h3>
-<goab-app-footer>
-  <goab-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/status">Check status</a>
-  </goab-app-footer-nav-section>
-  <goab-app-footer-nav-section slot="nav" heading="Contact">
-    <a href="/help">Help center</a>
-    <a href="/feedback">Feedback</a>
-  </goab-app-footer-nav-section>
-</goab-app-footer>
+<footer>
+  <goab-app-footer>
+    <goab-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/status">Check status</a>
+    </goab-app-footer-nav-section>
+    <goab-app-footer-nav-section slot="nav" heading="Contact">
+      <a href="/help">Help center</a>
+      <a href="/feedback">Feedback</a>
+    </goab-app-footer-nav-section>
+  </goab-app-footer>
+</footer>
 
 <h3>With meta and nav sections</h3>
-<goab-app-footer>
-  <goab-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/status">Check status</a>
-  </goab-app-footer-nav-section>
-  <goab-app-footer-nav-section slot="nav" heading="Contact">
-    <a href="/help">Help center</a>
-    <a href="/feedback">Feedback</a>
-  </goab-app-footer-nav-section>
-  <goab-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </goab-app-footer-meta-section>
-</goab-app-footer>
+<footer>
+  <goab-app-footer>
+    <goab-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/status">Check status</a>
+    </goab-app-footer-nav-section>
+    <goab-app-footer-nav-section slot="nav" heading="Contact">
+      <a href="/help">Help center</a>
+      <a href="/feedback">Feedback</a>
+    </goab-app-footer-nav-section>
+    <goab-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </goab-app-footer-meta-section>
+  </goab-app-footer>
+</footer>

--- a/apps/prs/angular/src/routes/docs/page-block/page-block.component.html
+++ b/apps/prs/angular/src/routes/docs/page-block/page-block.component.html
@@ -19,9 +19,11 @@
 <h3>Basic page layout</h3>
 <goab-column-layout>
   <section slot="header">
-    <goab-app-header url="/" heading="Service name">
-      <a href="/login">Sign in</a>
-    </goab-app-header>
+    <header>
+      <goab-app-header url="/" heading="Service name">
+        <a href="/login">Sign in</a>
+      </goab-app-header>
+    </header>
   </section>
   <goab-page-block width="704px">
     <p>
@@ -38,6 +40,8 @@
     </goab-grid>
   </goab-page-block>
   <section slot="footer">
-    <goab-app-footer></goab-app-footer>
+    <footer>
+      <goab-app-footer></goab-app-footer>
+    </footer>
   </section>
 </goab-column-layout>

--- a/apps/prs/angular/src/routes/docs/side-menu/side-menu.component.html
+++ b/apps/prs/angular/src/routes/docs/side-menu/side-menu.component.html
@@ -2,36 +2,42 @@
 
 <h3>Basic side menu</h3>
 <div style="width: 200px">
-  <goab-side-menu>
-    <a href="/overview">Overview</a>
-    <a href="/details">Details</a>
-    <a href="/settings">Settings</a>
-  </goab-side-menu>
+  <nav>
+    <goab-side-menu>
+      <a href="/overview">Overview</a>
+      <a href="/details">Details</a>
+      <a href="/settings">Settings</a>
+    </goab-side-menu>
+  </nav>
 </div>
 
 <h3>With sections</h3>
 <div style="width: 200px">
-  <goab-side-menu>
-    <goab-side-menu-heading>Main</goab-side-menu-heading>
-    <a href="/dashboard">Dashboard</a>
-    <a href="/reports">Reports</a>
-    <goab-side-menu-heading>Settings</goab-side-menu-heading>
-    <a href="/profile">Profile</a>
-    <a href="/preferences">Preferences</a>
-  </goab-side-menu>
+  <nav>
+    <goab-side-menu>
+      <goab-side-menu-heading>Main</goab-side-menu-heading>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/reports">Reports</a>
+      <goab-side-menu-heading>Settings</goab-side-menu-heading>
+      <a href="/profile">Profile</a>
+      <a href="/preferences">Preferences</a>
+    </goab-side-menu>
+  </nav>
 </div>
 
 <h3>With groups</h3>
 <div style="width: 200px">
-  <goab-side-menu>
-    <goab-side-menu-group heading="Applications">
-      <a href="/apps/active">Active</a>
-      <a href="/apps/pending">Pending</a>
-      <a href="/apps/archived">Archived</a>
-    </goab-side-menu-group>
-    <goab-side-menu-group heading="Reports">
-      <a href="/reports/monthly">Monthly</a>
-      <a href="/reports/annual">Annual</a>
-    </goab-side-menu-group>
-  </goab-side-menu>
+  <nav>
+    <goab-side-menu>
+      <goab-side-menu-group heading="Applications">
+        <a href="/apps/active">Active</a>
+        <a href="/apps/pending">Pending</a>
+        <a href="/apps/archived">Archived</a>
+      </goab-side-menu-group>
+      <goab-side-menu-group heading="Reports">
+        <a href="/reports/monthly">Monthly</a>
+        <a href="/reports/annual">Annual</a>
+      </goab-side-menu-group>
+    </goab-side-menu>
+  </nav>
 </div>

--- a/apps/prs/angular/src/routes/docs/skeleton/skeleton.component.html
+++ b/apps/prs/angular/src/routes/docs/skeleton/skeleton.component.html
@@ -29,9 +29,11 @@
 <h3>Basic page layout</h3>
 <goab-column-layout>
   <section slot="header">
-    <goab-app-header url="/" heading="Service name">
-      <a href="/login">Sign in</a>
-    </goab-app-header>
+    <header>
+      <goab-app-header url="/" heading="Service name">
+        <a href="/login">Sign in</a>
+      </goab-app-header>
+    </header>
   </section>
   <goab-page-block width="704px">
     <p>
@@ -48,7 +50,9 @@
     </goab-grid>
   </goab-page-block>
   <section slot="footer">
-    <goab-app-footer></goab-app-footer>
+    <footer>
+      <goab-app-footer></goab-app-footer>
+    </footer>
   </section>
 </goab-column-layout>
 

--- a/apps/prs/angular/src/routes/docs/work-side-menu/work-side-menu.component.html
+++ b/apps/prs/angular/src/routes/docs/work-side-menu/work-side-menu.component.html
@@ -1,75 +1,85 @@
 <h2>Work side menu</h2>
 
 <h3>Basic work side menu</h3>
-<goab-work-side-menu heading="My Application" url="/" (onNavigate)="handleNavigate($event)" [primaryContent]="basicPrimaryTpl">
-  <ng-template #basicPrimaryTpl>
-    <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="document" label="Reports" url="/reports"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="settings" label="Admin" url="/admin"></goab-work-side-menu-item>
-  </ng-template>
-</goab-work-side-menu>
+<nav>
+  <goab-work-side-menu heading="My Application" url="/" (onNavigate)="handleNavigate($event)" [primaryContent]="basicPrimaryTpl">
+    <ng-template #basicPrimaryTpl>
+      <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
+      <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
+      <goab-work-side-menu-item icon="document" label="Reports" url="/reports"></goab-work-side-menu-item>
+      <goab-work-side-menu-item icon="settings" label="Admin" url="/admin"></goab-work-side-menu-item>
+    </ng-template>
+  </goab-work-side-menu>
+</nav>
 
 <h3>With user profile</h3>
-<goab-work-side-menu
-  heading="My Application"
-  url="/"
-  userName="Jane Smith"
-  userSecondaryText="Case Worker"
-  (onNavigate)="handleNavigate($event)"
-  [primaryContent]="profilePrimaryTpl">
-  <ng-template #profilePrimaryTpl>
-    <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
-  </ng-template>
-</goab-work-side-menu>
+<nav>
+  <goab-work-side-menu
+    heading="My Application"
+    url="/"
+    userName="Jane Smith"
+    userSecondaryText="Case Worker"
+    (onNavigate)="handleNavigate($event)"
+    [primaryContent]="profilePrimaryTpl">
+    <ng-template #profilePrimaryTpl>
+      <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
+      <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
+    </ng-template>
+  </goab-work-side-menu>
+</nav>
 
 <h3>With groups</h3>
-<goab-work-side-menu
-  heading="My Application"
-  url="/"
-  [primaryContent]="groupsPrimaryTpl"
-  [open]="true"
-  (onNavigate)="handleNavigate($event)">
-  <ng-template #groupsPrimaryTpl>
-    <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
-    <goab-work-side-menu-group icon="document" heading="Documents" [open]="true">
-      <goab-work-side-menu-item label="Invoices" url="/documents/invoices"></goab-work-side-menu-item>
-      <goab-work-side-menu-item label="Contracts" url="/documents/contracts"></goab-work-side-menu-item>
-      <goab-work-side-menu-item label="Reports" url="/documents/reports"></goab-work-side-menu-item>
-    </goab-work-side-menu-group>
-    <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
-  </ng-template>
-</goab-work-side-menu>
+<nav>
+  <goab-work-side-menu
+    heading="My Application"
+    url="/"
+    [primaryContent]="groupsPrimaryTpl"
+    [open]="true"
+    (onNavigate)="handleNavigate($event)">
+    <ng-template #groupsPrimaryTpl>
+      <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
+      <goab-work-side-menu-group icon="document" heading="Documents" [open]="true">
+        <goab-work-side-menu-item label="Invoices" url="/documents/invoices"></goab-work-side-menu-item>
+        <goab-work-side-menu-item label="Contracts" url="/documents/contracts"></goab-work-side-menu-item>
+        <goab-work-side-menu-item label="Reports" url="/documents/reports"></goab-work-side-menu-item>
+      </goab-work-side-menu-group>
+      <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
+    </ng-template>
+  </goab-work-side-menu>
+</nav>
 
 <h3>Secondary menu</h3>
-<goab-work-side-menu heading="Case Management" url="/cases" [open]="true" (onNavigate)="handleNavigate($event)" [primaryContent]="secondaryPrimaryTpl">
-  <ng-template #secondaryPrimaryTpl>
-    <goab-work-side-menu-item icon="arrow-back" label="All cases" url="/cases"></goab-work-side-menu-item>
-    <goab-work-side-menu-item label="Overview" url="/cases/123/overview"></goab-work-side-menu-item>
-    <goab-work-side-menu-item label="Documents" url="/cases/123/documents"></goab-work-side-menu-item>
-    <goab-work-side-menu-item label="Notes" url="/cases/123/notes"></goab-work-side-menu-item>
-    <goab-work-side-menu-item label="Activity log" url="/cases/123/activity"></goab-work-side-menu-item>
-    <goab-work-side-menu-item label="Payments" url="/cases/123/payments"></goab-work-side-menu-item>
-  </ng-template>
-</goab-work-side-menu>
+<nav>
+  <goab-work-side-menu heading="Case Management" url="/cases" [open]="true" (onNavigate)="handleNavigate($event)" [primaryContent]="secondaryPrimaryTpl">
+    <ng-template #secondaryPrimaryTpl>
+      <goab-work-side-menu-item icon="arrow-back" label="All cases" url="/cases"></goab-work-side-menu-item>
+      <goab-work-side-menu-item label="Overview" url="/cases/123/overview"></goab-work-side-menu-item>
+      <goab-work-side-menu-item label="Documents" url="/cases/123/documents"></goab-work-side-menu-item>
+      <goab-work-side-menu-item label="Notes" url="/cases/123/notes"></goab-work-side-menu-item>
+      <goab-work-side-menu-item label="Activity log" url="/cases/123/activity"></goab-work-side-menu-item>
+      <goab-work-side-menu-item label="Payments" url="/cases/123/payments"></goab-work-side-menu-item>
+    </ng-template>
+  </goab-work-side-menu>
+</nav>
 
 <h3>With notifications</h3>
-<goab-work-side-menu heading="My Application" url="/" [primaryContent]="notifPrimaryTpl" [secondaryContent]="notifSecondaryTpl">
-  <ng-template #notifPrimaryTpl>
-    <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
-  </ng-template>
-  <ng-template #notifSecondaryTpl>
-    <goab-work-side-menu-item
-      icon="notifications"
-      label="Notifications"
-      badge="3"
-      type="success"
-      [popoverContent]="notificationsTpl">
-    </goab-work-side-menu-item>
-  </ng-template>
-</goab-work-side-menu>
+<nav>
+  <goab-work-side-menu heading="My Application" url="/" [primaryContent]="notifPrimaryTpl" [secondaryContent]="notifSecondaryTpl">
+    <ng-template #notifPrimaryTpl>
+      <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
+      <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
+    </ng-template>
+    <ng-template #notifSecondaryTpl>
+      <goab-work-side-menu-item
+        icon="notifications"
+        label="Notifications"
+        badge="3"
+        type="success"
+        [popoverContent]="notificationsTpl">
+      </goab-work-side-menu-item>
+    </ng-template>
+  </goab-work-side-menu>
+</nav>
 
 <ng-template #notificationsTpl>
   <goab-work-side-notification-panel

--- a/apps/prs/angular/src/routes/docs/work-side-notification-panel/work-side-notification-panel.component.html
+++ b/apps/prs/angular/src/routes/docs/work-side-notification-panel/work-side-notification-panel.component.html
@@ -1,13 +1,15 @@
 <h2>Notification panel</h2>
 
 <h3>Basic notification panel</h3>
-<goab-work-side-menu
-  heading="My Application"
-  url="/"
-  (onNavigate)="handleNavigate($event)"
-  [primaryContent]="basicPrimaryTpl"
-  [secondaryContent]="basicSecondaryTpl">
-</goab-work-side-menu>
+<nav>
+  <goab-work-side-menu
+    heading="My Application"
+    url="/"
+    (onNavigate)="handleNavigate($event)"
+    [primaryContent]="basicPrimaryTpl"
+    [secondaryContent]="basicSecondaryTpl">
+  </goab-work-side-menu>
+</nav>
 
 <ng-template #basicPrimaryTpl>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -45,13 +47,15 @@
 </ng-template>
 
 <h3>With urgent notifications</h3>
-<goab-work-side-menu
-  heading="My Application"
-  url="/"
-  (onNavigate)="handleNavigate($event)"
-  [primaryContent]="urgentPrimaryTpl"
-  [secondaryContent]="urgentSecondaryTpl">
-</goab-work-side-menu>
+<nav>
+  <goab-work-side-menu
+    heading="My Application"
+    url="/"
+    (onNavigate)="handleNavigate($event)"
+    [primaryContent]="urgentPrimaryTpl"
+    [secondaryContent]="urgentSecondaryTpl">
+  </goab-work-side-menu>
+</nav>
 
 <ng-template #urgentPrimaryTpl>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -89,13 +93,15 @@
 </ng-template>
 
 <h3>Notification type badges</h3>
-<goab-work-side-menu
-  heading="My Application"
-  url="/"
-  (onNavigate)="handleNavigate($event)"
-  [primaryContent]="typesPrimaryTpl"
-  [secondaryContent]="typesSecondaryTpl">
-</goab-work-side-menu>
+<nav>
+  <goab-work-side-menu
+    heading="My Application"
+    url="/"
+    (onNavigate)="handleNavigate($event)"
+    [primaryContent]="typesPrimaryTpl"
+    [secondaryContent]="typesSecondaryTpl">
+  </goab-work-side-menu>
+</nav>
 
 <ng-template #typesPrimaryTpl>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>

--- a/apps/prs/angular/src/routes/docs/workspace-layout/workspace-layout-scroll-monitor.component.ts
+++ b/apps/prs/angular/src/routes/docs/workspace-layout/workspace-layout-scroll-monitor.component.ts
@@ -37,11 +37,13 @@ import {
     </ng-template>
 
     <ng-template #sideMenuTpl>
-      <goab-work-side-menu
-        heading="Workspace layout"
-        url="/"
-        [primaryContent]="menuItems"
-      ></goab-work-side-menu>
+      <nav>
+        <goab-work-side-menu
+          heading="Workspace layout"
+          url="/"
+          [primaryContent]="menuItems"
+        ></goab-work-side-menu>
+      </nav>
     </ng-template>
     <ng-template #menuItems>
       <goab-work-side-menu-item

--- a/apps/prs/angular/src/routes/docs/workspace-layout/workspace-layout.component.html
+++ b/apps/prs/angular/src/routes/docs/workspace-layout/workspace-layout.component.html
@@ -16,12 +16,14 @@
   </goab-workspace-layout>
 </div>
 <ng-template #basicSideMenu>
-  <goab-work-side-menu
-    heading="Workspace layout"
-    url="/"
-    [primaryContent]="basicMenuItems"
-    (onNavigate)="handleNavigate($event)"
-  ></goab-work-side-menu>
+  <nav>
+    <goab-work-side-menu
+      heading="Workspace layout"
+      url="/"
+      [primaryContent]="basicMenuItems"
+      (onNavigate)="handleNavigate($event)"
+    ></goab-work-side-menu>
+  </nav>
 </ng-template>
 <ng-template #basicMenuItems>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -40,12 +42,14 @@
   </goab-workspace-layout>
 </div>
 <ng-template #headerSideMenu>
-  <goab-work-side-menu
-    heading="Workspace layout"
-    url="/"
-    [primaryContent]="headerMenuItems"
-    (onNavigate)="handleNavigate($event)"
-  ></goab-work-side-menu>
+  <nav>
+    <goab-work-side-menu
+      heading="Workspace layout"
+      url="/"
+      [primaryContent]="headerMenuItems"
+      (onNavigate)="handleNavigate($event)"
+    ></goab-work-side-menu>
+  </nav>
 </ng-template>
 <ng-template #headerMenuItems>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -72,12 +76,14 @@
   </goab-workspace-layout>
 </div>
 <ng-template #footerSideMenu>
-  <goab-work-side-menu
-    heading="Workspace layout"
-    url="/"
-    [primaryContent]="footerMenuItems"
-    (onNavigate)="handleNavigate($event)"
-  ></goab-work-side-menu>
+  <nav>
+    <goab-work-side-menu
+      heading="Workspace layout"
+      url="/"
+      [primaryContent]="footerMenuItems"
+      (onNavigate)="handleNavigate($event)"
+    ></goab-work-side-menu>
+  </nav>
 </ng-template>
 <ng-template #footerMenuItems>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -108,12 +114,14 @@
   </goab-workspace-layout>
 </div>
 <ng-template #drawerSideMenu>
-  <goab-work-side-menu
-    heading="Workspace layout"
-    url="/"
-    [primaryContent]="drawerMenuItems"
-    (onNavigate)="handleNavigate($event)"
-  ></goab-work-side-menu>
+  <nav>
+    <goab-work-side-menu
+      heading="Workspace layout"
+      url="/"
+      [primaryContent]="drawerMenuItems"
+      (onNavigate)="handleNavigate($event)"
+    ></goab-work-side-menu>
+  </nav>
 </ng-template>
 <ng-template #drawerMenuItems>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>

--- a/apps/prs/react/src/routes/docs/app-header/app-header.tsx
+++ b/apps/prs/react/src/routes/docs/app-header/app-header.tsx
@@ -13,82 +13,96 @@ export function DocsAppHeaderRoute() {
       <h2>App header</h2>
 
       <h3>Basic app header</h3>
-      <GoabAppHeader heading="My Application" />
+      <header>
+        <GoabAppHeader heading="My Application" />
+      </header>
 
       <h3>With home link</h3>
-      <GoabAppHeader heading="My Application" url="/" />
+      <header>
+        <GoabAppHeader heading="My Application" url="/" />
+      </header>
 
       <h3>With secondary text</h3>
-      <GoabAppHeader
-        heading="My Application"
-        secondaryText="Supporting information"
-        url="/"
-      />
+      <header>
+        <GoabAppHeader
+          heading="My Application"
+          secondaryText="Supporting information"
+          url="/"
+        />
+      </header>
 
       <h3>With utilities</h3>
-      <GoabAppHeader
-        heading="My Application"
-        url="/"
-        utilities={
-          <>
-            <GoabButton type="tertiary" size="compact">
-              Help
-            </GoabButton>
-            <GoabButton type="tertiary" size="compact" leadingIcon="person">
-              Sign in
-            </GoabButton>
-          </>
-        }
-      />
+      <header>
+        <GoabAppHeader
+          heading="My Application"
+          url="/"
+          utilities={
+            <>
+              <GoabButton type="tertiary" size="compact">
+                Help
+              </GoabButton>
+              <GoabButton type="tertiary" size="compact" leadingIcon="person">
+                Sign in
+              </GoabButton>
+            </>
+          }
+        />
+      </header>
 
       <h3>With phase badge</h3>
-      <GoabAppHeader
-        heading="My Application"
-        url="/"
-        phase={<GoabBadge type="important" content="Service preview" />}
-      />
+      <header>
+        <GoabAppHeader
+          heading="My Application"
+          url="/"
+          phase={<GoabBadge type="important" content="Service preview" />}
+        />
+      </header>
 
       <h3>Internal testing banner</h3>
-      <GoabAppHeader
-        heading="My Application"
-        url="/"
-        banner={
-          <span
-            style={{
-              textAlign: "right",
-              width: "100%",
-              fontSize: "12px",
-              fontWeight: "normal",
-            }}
-          >
-            v2.3.1 | UAT Environment
-          </span>
-        }
-      />
+      <header>
+        <GoabAppHeader
+          heading="My Application"
+          url="/"
+          banner={
+            <span
+              style={{
+                textAlign: "right",
+                width: "100%",
+                fontSize: "12px",
+                fontWeight: "normal",
+              }}
+            >
+              v2.3.1 | UAT Environment
+            </span>
+          }
+        />
+      </header>
 
       <h3>With navigation</h3>
-      <GoabAppHeader
-        heading="Service Portal"
-        url="/"
-        navigation={
-          <>
-            <a href="#">Dashboard</a>
-            <GoabAppHeaderMenu heading="Applications">
-              <a href="#">New application</a>
-              <a href="#">Active</a>
-              <a href="#">Archived</a>
-            </GoabAppHeaderMenu>
-            <a href="#">Reports</a>
-            <a href="#">Settings</a>
-          </>
-        }
-        utilities={
-          <GoabMenuButton text="John Smith" type="tertiary" size="compact">
-            <GoabMenuAction text="User settings" action="user-settings" />
-            <GoabMenuAction text="Sign out" action="sign-out" />
-          </GoabMenuButton>
-        }
-      />
+      <header>
+        <GoabAppHeader
+          heading="Service Portal"
+          url="/"
+          navigation={
+            <>
+              <a href="#">Dashboard</a>
+              <GoabAppHeaderMenu heading="Applications">
+                <a href="#">New application</a>
+                <a href="#">Active</a>
+                <a href="#">Archived</a>
+              </GoabAppHeaderMenu>
+              <a href="#">Reports</a>
+              <a href="#">Settings</a>
+            </>
+          }
+          utilities={
+            <GoabMenuButton text="John Smith" type="tertiary" size="compact">
+              <GoabMenuAction text="User settings" action="user-settings" />
+              <GoabMenuAction text="Sign out" action="sign-out" />
+            </GoabMenuButton>
+          }
+        />
+      </header>
     </div>
   );
 }

--- a/apps/prs/react/src/routes/docs/footer/footer.tsx
+++ b/apps/prs/react/src/routes/docs/footer/footer.tsx
@@ -11,63 +11,73 @@ export function DocsFooterRoute() {
       <h2>Footer</h2>
 
       <h3>Basic footer</h3>
-      <GoabAppFooter />
+      <footer>
+        <GoabAppFooter />
+      </footer>
 
       <h3>With meta section</h3>
-      <GoabAppFooter>
-        <GoabAppFooterMetaSection>
-          <a href="/privacy">Privacy</a>
-          <a href="/terms">Terms of use</a>
-          <a href="/accessibility">Accessibility</a>
-        </GoabAppFooterMetaSection>
-      </GoabAppFooter>
+      <footer>
+        <GoabAppFooter>
+          <GoabAppFooterMetaSection>
+            <a href="/privacy">Privacy</a>
+            <a href="/terms">Terms of use</a>
+            <a href="/accessibility">Accessibility</a>
+          </GoabAppFooterMetaSection>
+        </GoabAppFooter>
+      </footer>
 
       <h3>With navigation</h3>
-      <GoabAppFooter>
-        <GoabAppFooterNavSection heading="Services">
-          <a href="/apply">Apply online</a>
-          <a href="/renew">Renew</a>
-          <a href="/status">Check status</a>
-        </GoabAppFooterNavSection>
-        <GoabAppFooterNavSection heading="Contact">
-          <a href="/help">Help center</a>
-          <a href="/feedback">Feedback</a>
-        </GoabAppFooterNavSection>
-      </GoabAppFooter>
+      <footer>
+        <GoabAppFooter>
+          <GoabAppFooterNavSection heading="Services">
+            <a href="/apply">Apply online</a>
+            <a href="/renew">Renew</a>
+            <a href="/status">Check status</a>
+          </GoabAppFooterNavSection>
+          <GoabAppFooterNavSection heading="Contact">
+            <a href="/help">Help center</a>
+            <a href="/feedback">Feedback</a>
+          </GoabAppFooterNavSection>
+        </GoabAppFooter>
+      </footer>
 
       <h3>With meta and nav sections</h3>
-      <GoabAppFooter>
-        <GoabAppFooterNavSection heading="Services">
-          <a href="/apply">Apply online</a>
-          <a href="/renew">Renew</a>
-          <a href="/status">Check status</a>
-        </GoabAppFooterNavSection>
-        <GoabAppFooterNavSection heading="Contact">
-          <a href="/help">Help center</a>
-          <a href="/feedback">Feedback</a>
-        </GoabAppFooterNavSection>
-        <GoabAppFooterMetaSection>
-          <a href="/privacy">Privacy</a>
-          <a href="/terms">Terms of use</a>
-          <a href="/accessibility">Accessibility</a>
-        </GoabAppFooterMetaSection>
-      </GoabAppFooter>
+      <footer>
+        <GoabAppFooter>
+          <GoabAppFooterNavSection heading="Services">
+            <a href="/apply">Apply online</a>
+            <a href="/renew">Renew</a>
+            <a href="/status">Check status</a>
+          </GoabAppFooterNavSection>
+          <GoabAppFooterNavSection heading="Contact">
+            <a href="/help">Help center</a>
+            <a href="/feedback">Feedback</a>
+          </GoabAppFooterNavSection>
+          <GoabAppFooterMetaSection>
+            <a href="/privacy">Privacy</a>
+            <a href="/terms">Terms of use</a>
+            <a href="/accessibility">Accessibility</a>
+          </GoabAppFooterMetaSection>
+        </GoabAppFooter>
+      </footer>
 
       <h3>With links</h3>
-      <GoabAppFooter>
-        <GoabAppFooterNavSection heading="Services">
-          <a href="/apply">Apply online</a>
-          <GoabLink trailingIcon="open">
-            <a href="https://www.alberta.ca/services">All services</a>
-          </GoabLink>
-        </GoabAppFooterNavSection>
-        <GoabAppFooterMetaSection>
-          <a href="/privacy">Privacy</a>
-          <GoabLink>
-            <a href="/accessibility">Accessibility</a>
-          </GoabLink>
-        </GoabAppFooterMetaSection>
-      </GoabAppFooter>
+      <footer>
+        <GoabAppFooter>
+          <GoabAppFooterNavSection heading="Services">
+            <a href="/apply">Apply online</a>
+            <GoabLink trailingIcon="open">
+              <a href="https://www.alberta.ca/services">All services</a>
+            </GoabLink>
+          </GoabAppFooterNavSection>
+          <GoabAppFooterMetaSection>
+            <a href="/privacy">Privacy</a>
+            <GoabLink>
+              <a href="/accessibility">Accessibility</a>
+            </GoabLink>
+          </GoabAppFooterMetaSection>
+        </GoabAppFooter>
+      </footer>
     </div>
   );
 }

--- a/apps/prs/react/src/routes/docs/page-block/page-block.tsx
+++ b/apps/prs/react/src/routes/docs/page-block/page-block.tsx
@@ -32,9 +32,11 @@ export function DocsPageBlockRoute() {
       <h3>Basic page layout</h3>
       <GoabOneColumnLayout>
         <section slot="header">
-          <GoabAppHeader url="/" heading="Service name">
-            <a href="/login">Sign in</a>
-          </GoabAppHeader>
+          <header>
+            <GoabAppHeader url="/" heading="Service name">
+              <a href="/login">Sign in</a>
+            </GoabAppHeader>
+          </header>
         </section>
         <GoabPageBlock width="704px">
           <p>
@@ -51,7 +53,9 @@ export function DocsPageBlockRoute() {
           </GoabGrid>
         </GoabPageBlock>
         <section slot="footer">
-          <GoabAppFooter />
+          <footer>
+            <GoabAppFooter />
+          </footer>
         </section>
       </GoabOneColumnLayout>
     </div>

--- a/apps/prs/react/src/routes/docs/side-menu/side-menu.tsx
+++ b/apps/prs/react/src/routes/docs/side-menu/side-menu.tsx
@@ -11,38 +11,44 @@ export function DocsSideMenuRoute() {
 
       <h3>Basic side menu</h3>
       <div style={{ width: "200px" }}>
-        <GoabSideMenu>
-          <a href="/overview">Overview</a>
-          <a href="/details">Details</a>
-          <a href="/settings">Settings</a>
-        </GoabSideMenu>
+        <nav>
+          <GoabSideMenu>
+            <a href="/overview">Overview</a>
+            <a href="/details">Details</a>
+            <a href="/settings">Settings</a>
+          </GoabSideMenu>
+        </nav>
       </div>
 
       <h3>With sections</h3>
       <div style={{ width: "200px" }}>
-        <GoabSideMenu>
-          <GoabSideMenuHeading>Main</GoabSideMenuHeading>
-          <a href="/dashboard">Dashboard</a>
-          <a href="/reports">Reports</a>
-          <GoabSideMenuHeading>Settings</GoabSideMenuHeading>
-          <a href="/profile">Profile</a>
-          <a href="/preferences">Preferences</a>
-        </GoabSideMenu>
+        <nav>
+          <GoabSideMenu>
+            <GoabSideMenuHeading>Main</GoabSideMenuHeading>
+            <a href="/dashboard">Dashboard</a>
+            <a href="/reports">Reports</a>
+            <GoabSideMenuHeading>Settings</GoabSideMenuHeading>
+            <a href="/profile">Profile</a>
+            <a href="/preferences">Preferences</a>
+          </GoabSideMenu>
+        </nav>
       </div>
 
       <h3>With groups</h3>
       <div style={{ width: "200px" }}>
-        <GoabSideMenu>
-          <GoabSideMenuGroup heading="Applications">
-            <a href="/apps/active">Active</a>
-            <a href="/apps/pending">Pending</a>
-            <a href="/apps/archived">Archived</a>
-          </GoabSideMenuGroup>
-          <GoabSideMenuGroup heading="Reports">
-            <a href="/reports/monthly">Monthly</a>
-            <a href="/reports/annual">Annual</a>
-          </GoabSideMenuGroup>
-        </GoabSideMenu>
+        <nav>
+          <GoabSideMenu>
+            <GoabSideMenuGroup heading="Applications">
+              <a href="/apps/active">Active</a>
+              <a href="/apps/pending">Pending</a>
+              <a href="/apps/archived">Archived</a>
+            </GoabSideMenuGroup>
+            <GoabSideMenuGroup heading="Reports">
+              <a href="/reports/monthly">Monthly</a>
+              <a href="/reports/annual">Annual</a>
+            </GoabSideMenuGroup>
+          </GoabSideMenu>
+        </nav>
       </div>
     </div>
   );

--- a/apps/prs/react/src/routes/docs/skeleton/skeleton.tsx
+++ b/apps/prs/react/src/routes/docs/skeleton/skeleton.tsx
@@ -55,9 +55,11 @@ export function DocsSkeletonRoute() {
       <h3>Basic page layout</h3>
       <GoabOneColumnLayout>
         <section slot="header">
-          <GoabAppHeader url="/" heading="Service name">
-            <a href="/login">Sign in</a>
-          </GoabAppHeader>
+          <header>
+            <GoabAppHeader url="/" heading="Service name">
+              <a href="/login">Sign in</a>
+            </GoabAppHeader>
+          </header>
         </section>
         <GoabPageBlock width="704px">
           <p>
@@ -74,7 +76,9 @@ export function DocsSkeletonRoute() {
           </GoabGrid>
         </GoabPageBlock>
         <section slot="footer">
-          <GoabAppFooter />
+          <footer>
+            <GoabAppFooter />
+          </footer>
         </section>
       </GoabOneColumnLayout>
 

--- a/apps/prs/react/src/routes/docs/work-side-menu/work-side-menu.tsx
+++ b/apps/prs/react/src/routes/docs/work-side-menu/work-side-menu.tsx
@@ -28,120 +28,130 @@ export function DocsWorkSideMenuRoute() {
       <h2>Work side menu</h2>
 
       <h3>Basic work side menu</h3>
-      <GoabWorkSideMenu
-        heading="My Application"
-        url="/"
-        onNavigate={(path: string) => navigate(path)}
-        primaryContent={
-          <>
-            <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-            <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-            <GoabWorkSideMenuItem icon="document" label="Reports" url="/reports" />
-            <GoabWorkSideMenuItem icon="settings" label="Admin" url="/admin" />
-          </>
-        }
-      />
+      <nav>
+        <GoabWorkSideMenu
+          heading="My Application"
+          url="/"
+          onNavigate={(path: string) => navigate(path)}
+          primaryContent={
+            <>
+              <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+              <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+              <GoabWorkSideMenuItem icon="document" label="Reports" url="/reports" />
+              <GoabWorkSideMenuItem icon="settings" label="Admin" url="/admin" />
+            </>
+          }
+        />
+      </nav>
 
       <h3>With user profile</h3>
-      <GoabWorkSideMenu
-        heading="My Application"
-        url="/"
-        userName="Jane Smith"
-        userSecondaryText="Case Worker"
-        onNavigate={(path: string) => navigate(path)}
-        primaryContent={
-          <>
-            <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-            <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-          </>
-        }
-      />
+      <nav>
+        <GoabWorkSideMenu
+          heading="My Application"
+          url="/"
+          userName="Jane Smith"
+          userSecondaryText="Case Worker"
+          onNavigate={(path: string) => navigate(path)}
+          primaryContent={
+            <>
+              <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+              <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+            </>
+          }
+        />
+      </nav>
 
       <h3>With groups</h3>
-      <GoabWorkSideMenu
-        heading="My Application"
-        url="/"
-        open={true}
-        onNavigate={(path: string) => navigate(path)}
-        primaryContent={
-          <>
-            <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-            <GoabWorkSideMenuGroup icon="document" heading="Documents" open={true}>
-              <GoabWorkSideMenuItem label="Invoices" url="/documents/invoices" />
-              <GoabWorkSideMenuItem label="Contracts" url="/documents/contracts" />
-              <GoabWorkSideMenuItem label="Reports" url="/documents/reports" />
-            </GoabWorkSideMenuGroup>
-            <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-          </>
-        }
-      />
+      <nav>
+        <GoabWorkSideMenu
+          heading="My Application"
+          url="/"
+          open={true}
+          onNavigate={(path: string) => navigate(path)}
+          primaryContent={
+            <>
+              <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+              <GoabWorkSideMenuGroup icon="document" heading="Documents" open={true}>
+                <GoabWorkSideMenuItem label="Invoices" url="/documents/invoices" />
+                <GoabWorkSideMenuItem label="Contracts" url="/documents/contracts" />
+                <GoabWorkSideMenuItem label="Reports" url="/documents/reports" />
+              </GoabWorkSideMenuGroup>
+              <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+            </>
+          }
+        />
+      </nav>
 
       <h3>Secondary menu</h3>
-      <GoabWorkSideMenu
-        heading="Case Management"
-        url="/cases"
-        open={true}
-        onNavigate={(path: string) => navigate(path)}
-        primaryContent={
-          <>
-            <GoabWorkSideMenuItem icon="arrow-back" label="All cases" url="/cases" />
-            <GoabWorkSideMenuItem label="Overview" url="/cases/123/overview" />
-            <GoabWorkSideMenuItem label="Documents" url="/cases/123/documents" />
-            <GoabWorkSideMenuItem label="Notes" url="/cases/123/notes" />
-            <GoabWorkSideMenuItem label="Activity log" url="/cases/123/activity" />
-            <GoabWorkSideMenuItem label="Payments" url="/cases/123/payments" />
-          </>
-        }
-      />
+      <nav>
+        <GoabWorkSideMenu
+          heading="Case Management"
+          url="/cases"
+          open={true}
+          onNavigate={(path: string) => navigate(path)}
+          primaryContent={
+            <>
+              <GoabWorkSideMenuItem icon="arrow-back" label="All cases" url="/cases" />
+              <GoabWorkSideMenuItem label="Overview" url="/cases/123/overview" />
+              <GoabWorkSideMenuItem label="Documents" url="/cases/123/documents" />
+              <GoabWorkSideMenuItem label="Notes" url="/cases/123/notes" />
+              <GoabWorkSideMenuItem label="Activity log" url="/cases/123/activity" />
+              <GoabWorkSideMenuItem label="Payments" url="/cases/123/payments" />
+            </>
+          }
+        />
+      </nav>
 
       <h3>With notifications</h3>
-      <GoabWorkSideMenu
-        heading="My Application"
-        url="/"
-        primaryContent={
-          <>
-            <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-            <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-          </>
-        }
-        secondaryContent={
-          <>
-            <GoabWorkSideMenuItem
-              icon="notifications"
-              label="Notifications"
-              badge="3"
-              type="success"
-              popoverContent={
-                <GoabWorkSideNotificationPanel
-                  heading="Notifications"
-                  activeTab="unread"
-                  onMarkAllRead={() => handleMarkAllRead()}
-                  onViewAll={() => handleViewAll()}
-                >
-                  <GoabWorkSideNotificationItem
-                    title="New case assigned"
-                    description="Case #12345 has been assigned to you."
-                    timestamp="2025-02-09T10:30:00Z"
-                    type="info"
-                    readStatus="unread"
-                    priority="normal"
-                    onClick={() => handleClick("1")}
-                  />
-                  <GoabWorkSideNotificationItem
-                    title="System maintenance"
-                    description="Scheduled maintenance tonight at 11 PM."
-                    timestamp="2025-02-09T09:00:00Z"
-                    type="critical"
-                    readStatus="unread"
-                    priority="urgent"
-                    onClick={() => handleClick("2")}
-                  />
-                </GoabWorkSideNotificationPanel>
-              }
-            />
-          </>
-        }
-      />
+      <nav>
+        <GoabWorkSideMenu
+          heading="My Application"
+          url="/"
+          primaryContent={
+            <>
+              <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+              <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+            </>
+          }
+          secondaryContent={
+            <>
+              <GoabWorkSideMenuItem
+                icon="notifications"
+                label="Notifications"
+                badge="3"
+                type="success"
+                popoverContent={
+                  <GoabWorkSideNotificationPanel
+                    heading="Notifications"
+                    activeTab="unread"
+                    onMarkAllRead={() => handleMarkAllRead()}
+                    onViewAll={() => handleViewAll()}
+                  >
+                    <GoabWorkSideNotificationItem
+                      title="New case assigned"
+                      description="Case #12345 has been assigned to you."
+                      timestamp="2025-02-09T10:30:00Z"
+                      type="info"
+                      readStatus="unread"
+                      priority="normal"
+                      onClick={() => handleClick("1")}
+                    />
+                    <GoabWorkSideNotificationItem
+                      title="System maintenance"
+                      description="Scheduled maintenance tonight at 11 PM."
+                      timestamp="2025-02-09T09:00:00Z"
+                      type="critical"
+                      readStatus="unread"
+                      priority="urgent"
+                      onClick={() => handleClick("2")}
+                    />
+                  </GoabWorkSideNotificationPanel>
+                }
+              />
+            </>
+          }
+        />
+      </nav>
     </div>
   );
 }

--- a/apps/prs/react/src/routes/docs/work-side-notification-panel/work-side-notification-panel.tsx
+++ b/apps/prs/react/src/routes/docs/work-side-notification-panel/work-side-notification-panel.tsx
@@ -188,112 +188,118 @@ export function DocsWorkSideNotificationPanelRoute() {
       <h2>Notification panel</h2>
 
       <h3>Basic notification panel</h3>
-      <GoabWorkSideMenu
-        heading="My Application"
-        url="/"
-        onNavigate={(path: string) => navigate(path)}
-        primaryContent={
-          <>
-            <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-            <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-          </>
-        }
-        secondaryContent={
-          <GoabWorkSideMenuItem
-            icon="notifications"
-            label="Notifications"
-            badge="2"
-            type="success"
-            popoverContent={
-              <GoabWorkSideNotificationPanel
-                heading="Notifications"
-                activeTab="unread"
-                onMarkAllRead={() => handleMarkAllBasicNotificationsRead()}
-                onViewAll={() => handleViewAllBasicNotifications()}
-              >
-                {basicItems.map(({ id, ...item }) => (
-                  <GoabWorkSideNotificationItem
-                    key={id}
-                    {...item}
-                    onClick={() => handleClickBasicNotification(id)}
-                  />
-                ))}
-              </GoabWorkSideNotificationPanel>
-            }
-          />
-        }
-      />
+      <nav>
+        <GoabWorkSideMenu
+          heading="My Application"
+          url="/"
+          onNavigate={(path: string) => navigate(path)}
+          primaryContent={
+            <>
+              <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+              <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+            </>
+          }
+          secondaryContent={
+            <GoabWorkSideMenuItem
+              icon="notifications"
+              label="Notifications"
+              badge="2"
+              type="success"
+              popoverContent={
+                <GoabWorkSideNotificationPanel
+                  heading="Notifications"
+                  activeTab="unread"
+                  onMarkAllRead={() => handleMarkAllBasicNotificationsRead()}
+                  onViewAll={() => handleViewAllBasicNotifications()}
+                >
+                  {basicItems.map(({ id, ...item }) => (
+                    <GoabWorkSideNotificationItem
+                      key={id}
+                      {...item}
+                      onClick={() => handleClickBasicNotification(id)}
+                    />
+                  ))}
+                </GoabWorkSideNotificationPanel>
+              }
+            />
+          }
+        />
+      </nav>
 
       <h3>With urgent notifications</h3>
-      <GoabWorkSideMenu
-        heading="My Application"
-        url="/"
-        onNavigate={(path: string) => navigate(path)}
-        primaryContent={
-          <>
-            <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-            <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-          </>
-        }
-        secondaryContent={
-          <GoabWorkSideMenuItem
-            icon="notifications"
-            label="Notifications"
-            badge="2"
-            type="emergency"
-            popoverContent={
-              <GoabWorkSideNotificationPanel
-                heading="Notifications"
-                activeTab="urgent"
-                onMarkAllRead={() => handleMarkAllUrgentNotificationsRead()}
-                onViewAll={() => handleViewAllUrgentNotifications()}
-              >
-                {urgentItems.map(({ id, ...item }) => (
-                  <GoabWorkSideNotificationItem
-                    key={id}
-                    {...item}
-                    onClick={() => handleClickUrgentNotification(id)}
-                  />
-                ))}
-              </GoabWorkSideNotificationPanel>
-            }
-          />
-        }
-      />
+      <nav>
+        <GoabWorkSideMenu
+          heading="My Application"
+          url="/"
+          onNavigate={(path: string) => navigate(path)}
+          primaryContent={
+            <>
+              <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+              <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+            </>
+          }
+          secondaryContent={
+            <GoabWorkSideMenuItem
+              icon="notifications"
+              label="Notifications"
+              badge="2"
+              type="emergency"
+              popoverContent={
+                <GoabWorkSideNotificationPanel
+                  heading="Notifications"
+                  activeTab="urgent"
+                  onMarkAllRead={() => handleMarkAllUrgentNotificationsRead()}
+                  onViewAll={() => handleViewAllUrgentNotifications()}
+                >
+                  {urgentItems.map(({ id, ...item }) => (
+                    <GoabWorkSideNotificationItem
+                      key={id}
+                      {...item}
+                      onClick={() => handleClickUrgentNotification(id)}
+                    />
+                  ))}
+                </GoabWorkSideNotificationPanel>
+              }
+            />
+          }
+        />
+      </nav>
 
       <h3>Notification type badges</h3>
-      <GoabWorkSideMenu
-        heading="My Application"
-        url="/"
-        onNavigate={(path: string) => navigate(path)}
-        primaryContent={
-          <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-        }
-        secondaryContent={
-          <GoabWorkSideMenuItem
-            icon="notifications"
-            label="Notifications"
-            badge="5"
-            type="success"
-            popoverContent={
-              <GoabWorkSideNotificationPanel
-                heading="Notifications"
-                activeTab="all"
-                onMarkAllRead={() => handleMarkAllNotificationTypesRead()}
-                onViewAll={() => handleViewAllNotificationTypes()}
-              >
-                {allTypeItems.map(({ id, ...item }) => (
-                  <GoabWorkSideNotificationItem
-                    key={id}
-                    {...item}
-                    onClick={() => handleClickNotificationType(id)}
-                  />
-                ))}
-              </GoabWorkSideNotificationPanel>
-            }
-          />
-        }
-      />
+      <nav>
+        <GoabWorkSideMenu
+          heading="My Application"
+          url="/"
+          onNavigate={(path: string) => navigate(path)}
+          primaryContent={
+            <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+          }
+          secondaryContent={
+            <GoabWorkSideMenuItem
+              icon="notifications"
+              label="Notifications"
+              badge="5"
+              type="success"
+              popoverContent={
+                <GoabWorkSideNotificationPanel
+                  heading="Notifications"
+                  activeTab="all"
+                  onMarkAllRead={() => handleMarkAllNotificationTypesRead()}
+                  onViewAll={() => handleViewAllNotificationTypes()}
+                >
+                  {allTypeItems.map(({ id, ...item }) => (
+                    <GoabWorkSideNotificationItem
+                      key={id}
+                      {...item}
+                      onClick={() => handleClickNotificationType(id)}
+                    />
+                  ))}
+                </GoabWorkSideNotificationPanel>
+              }
+            />
+          }
+        />
+      </nav>
     </div>
   );
 }

--- a/apps/prs/react/src/routes/docs/workspace-layout/workspace-layout.tsx
+++ b/apps/prs/react/src/routes/docs/workspace-layout/workspace-layout.tsx
@@ -19,17 +19,19 @@ function navigate(path: string) {
 }
 
 const sideMenu = (
-  <GoabWorkSideMenu
-    heading="Workspace layout"
-    url="/"
-    onNavigate={(path: string) => navigate(path)}
-    primaryContent={
-      <>
-        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-      </>
-    }
-  />
+  <nav>
+    <GoabWorkSideMenu
+      heading="Workspace layout"
+      url="/"
+      onNavigate={(path: string) => navigate(path)}
+      primaryContent={
+        <>
+          <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+          <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+        </>
+      }
+    />
+  </nav>
 );
 
 const pageHeader = (

--- a/docs/src/content/examples/basic-page-layout/angular.html
+++ b/docs/src/content/examples/basic-page-layout/angular.html
@@ -1,8 +1,10 @@
 <goab-column-layout>
   <section slot="header">
-    <goab-app-header url="/" heading="Service name">
-      <a href="/login">Sign in</a>
-    </goab-app-header>
+    <header>
+      <goab-app-header url="/" heading="Service name">
+        <a href="/login">Sign in</a>
+      </goab-app-header>
+    </header>
   </section>
   <goab-page-block width="704px">
     <p>
@@ -19,6 +21,8 @@
     </goab-grid>
   </goab-page-block>
   <section slot="footer">
-    <goab-app-footer></goab-app-footer>
+    <footer>
+      <goab-app-footer></goab-app-footer>
+    </footer>
   </section>
 </goab-column-layout>

--- a/docs/src/content/examples/basic-page-layout/react.tsx
+++ b/docs/src/content/examples/basic-page-layout/react.tsx
@@ -11,9 +11,11 @@ export function BasicPageLayout() {
   return (
     <GoabOneColumnLayout>
       <section slot="header">
-        <GoabAppHeader url="/" heading="Service name">
-          <a href="/login">Sign in</a>
-        </GoabAppHeader>
+        <header>
+          <GoabAppHeader url="/" heading="Service name">
+            <a href="/login">Sign in</a>
+          </GoabAppHeader>
+        </header>
       </section>
       <GoabPageBlock width="full">
         <p>
@@ -30,7 +32,9 @@ export function BasicPageLayout() {
         </GoabGrid>
       </GoabPageBlock>
       <section slot="footer">
-        <GoabAppFooter />
+        <footer>
+          <GoabAppFooter />
+        </footer>
       </section>
     </GoabOneColumnLayout>
   );

--- a/docs/src/content/examples/basic-page-layout/web-components.html
+++ b/docs/src/content/examples/basic-page-layout/web-components.html
@@ -1,8 +1,10 @@
 <goa-one-column-layout>
   <section slot="header">
-    <goa-app-header version="2" url="/" heading="Service name">
-      <a href="/login">Sign in</a>
-    </goa-app-header>
+    <header>
+      <goa-app-header version="2" url="/" heading="Service name">
+        <a href="/login">Sign in</a>
+      </goa-app-header>
+    </header>
   </section>
   <goa-page-block width="704px">
     <p>
@@ -19,6 +21,8 @@
     </goa-grid>
   </goa-page-block>
   <section slot="footer">
-    <goa-app-footer version="2"></goa-app-footer>
+    <footer>
+      <goa-app-footer version="2"></goa-app-footer>
+    </footer>
   </section>
 </goa-one-column-layout>

--- a/docs/src/content/examples/header-with-navigation/angular.html
+++ b/docs/src/content/examples/header-with-navigation/angular.html
@@ -1,9 +1,11 @@
-<goab-app-header
-  url="https://example.com"
-  heading="Service name"
-  [navigation]="navigationTemplate"
-  [utilities]="utilitiesTemplate"
-></goab-app-header>
+<header>
+  <goab-app-header
+    url="https://example.com"
+    heading="Service name"
+    [navigation]="navigationTemplate"
+    [utilities]="utilitiesTemplate"
+  ></goab-app-header>
+</header>
 
 <ng-template #navigationTemplate>
   <a href="#">Dashboard</a>

--- a/docs/src/content/examples/header-with-navigation/react.tsx
+++ b/docs/src/content/examples/header-with-navigation/react.tsx
@@ -8,27 +8,29 @@ import {
 export function HeaderWithNavigation() {
   return (
     <>
-      <GoabAppHeader
-        url="https://www.alberta.ca"
-        heading="Service name"
-        navigation={
-          <>
-            <a href="#">Dashboard</a>
-            <GoabAppHeaderMenu heading="Search">
-              <a href="#">Cases</a>
-              <a href="#">Payments</a>
-              <a href="#">Outstanding</a>
-            </GoabAppHeaderMenu>
-            <a href="#">Support</a>
-          </>
-        }
-        utilities={
-          <GoabMenuButton text="John Smith" type="tertiary" size="compact">
-            <GoabMenuAction text="User settings" action="user-settings" />
-            <GoabMenuAction text="Sign out" action="sign-out" />
-          </GoabMenuButton>
-        }
-      />
+      <header>
+        <GoabAppHeader
+          url="https://www.alberta.ca"
+          heading="Service name"
+          navigation={
+            <>
+              <a href="#">Dashboard</a>
+              <GoabAppHeaderMenu heading="Search">
+                <a href="#">Cases</a>
+                <a href="#">Payments</a>
+                <a href="#">Outstanding</a>
+              </GoabAppHeaderMenu>
+              <a href="#">Support</a>
+            </>
+          }
+          utilities={
+            <GoabMenuButton text="John Smith" type="tertiary" size="compact">
+              <GoabMenuAction text="User settings" action="user-settings" />
+              <GoabMenuAction text="Sign out" action="sign-out" />
+            </GoabMenuButton>
+          }
+        />
+      </header>
     </>
   );
 }

--- a/docs/src/content/examples/header-with-navigation/web-components.html
+++ b/docs/src/content/examples/header-with-navigation/web-components.html
@@ -1,19 +1,21 @@
-<goa-app-header version="2" url="https://example.com" heading="Service name">
-  <a slot="navigation" href="#">Dashboard</a>
-  <goa-app-header-menu slot="navigation" version="2" heading="Search">
-    <a href="#">Cases</a>
-    <a href="#">Payments</a>
-    <a href="#">Outstanding</a>
-  </goa-app-header-menu>
-  <a slot="navigation" href="#">Support</a>
-  <goa-menu-button
-    slot="utilities"
-    version="2"
-    text="John Smith"
-    type="tertiary"
-    size="compact"
-  >
-    <goa-menu-action text="User settings" action="user-settings"></goa-menu-action>
-    <goa-menu-action text="Sign out" action="sign-out"></goa-menu-action>
-  </goa-menu-button>
-</goa-app-header>
+<header>
+  <goa-app-header version="2" url="https://example.com" heading="Service name">
+    <a slot="navigation" href="#">Dashboard</a>
+    <goa-app-header-menu slot="navigation" version="2" heading="Search">
+      <a href="#">Cases</a>
+      <a href="#">Payments</a>
+      <a href="#">Outstanding</a>
+    </goa-app-header-menu>
+    <a slot="navigation" href="#">Support</a>
+    <goa-menu-button
+      slot="utilities"
+      version="2"
+      text="John Smith"
+      type="tertiary"
+      size="compact"
+    >
+      <goa-menu-action text="User settings" action="user-settings"></goa-menu-action>
+      <goa-menu-action text="Sign out" action="sign-out"></goa-menu-action>
+    </goa-menu-button>
+  </goa-app-header>
+</header>

--- a/docs/src/content/examples/show-links-to-navigation-items/angular.html
+++ b/docs/src/content/examples/show-links-to-navigation-items/angular.html
@@ -1,20 +1,22 @@
-<goab-app-footer maxContentWidth="100%">
-  <goab-app-footer-nav-section slot="nav" [maxColumnCount]="1">
-    <a href="a.html">Arts and culture</a>
-    <a href="b.html">Education and training</a>
-    <a href="c.html">Family and social supports</a>
-    <a href="d.html">Housing and community</a>
-    <a href="e.html">Life events</a>
-    <a href="f.html">Business and economy</a>
-    <a href="g.html">Emergencies and public safety</a>
-    <a href="h.html">Government</a>
-    <a href="i.html">Jobs and employment</a>
-    <a href="j.html">Moving to Alberta</a>
-  </goab-app-footer-nav-section>
-  <goab-app-footer-meta-section slot="meta">
-    <a href="privacy.html">Privacy</a>
-    <a href="disclaimer.html">Disclaimer</a>
-    <a href="accessibility.html">Accessibility</a>
-    <a href="using-alberta.html">Using Alberta.ca</a>
-  </goab-app-footer-meta-section>
-</goab-app-footer>
+<footer>
+  <goab-app-footer maxContentWidth="100%">
+    <goab-app-footer-nav-section slot="nav" [maxColumnCount]="1">
+      <a href="a.html">Arts and culture</a>
+      <a href="b.html">Education and training</a>
+      <a href="c.html">Family and social supports</a>
+      <a href="d.html">Housing and community</a>
+      <a href="e.html">Life events</a>
+      <a href="f.html">Business and economy</a>
+      <a href="g.html">Emergencies and public safety</a>
+      <a href="h.html">Government</a>
+      <a href="i.html">Jobs and employment</a>
+      <a href="j.html">Moving to Alberta</a>
+    </goab-app-footer-nav-section>
+    <goab-app-footer-meta-section slot="meta">
+      <a href="privacy.html">Privacy</a>
+      <a href="disclaimer.html">Disclaimer</a>
+      <a href="accessibility.html">Accessibility</a>
+      <a href="using-alberta.html">Using Alberta.ca</a>
+    </goab-app-footer-meta-section>
+  </goab-app-footer>
+</footer>

--- a/docs/src/content/examples/show-links-to-navigation-items/react.tsx
+++ b/docs/src/content/examples/show-links-to-navigation-items/react.tsx
@@ -6,25 +6,27 @@ import {
 
 export function ShowLinksToNavigationItems() {
   return (
-    <GoabAppFooter maxContentWidth="100%">
-      <GoabAppFooterNavSection maxColumnCount={1}>
-        <a href="a.html">Arts and culture</a>
-        <a href="b.html">Education and training</a>
-        <a href="c.html">Family and social supports</a>
-        <a href="d.html">Housing and community</a>
-        <a href="e.html">Life events</a>
-        <a href="f.html">Business and economy</a>
-        <a href="g.html">Emergencies and public safety</a>
-        <a href="h.html">Government</a>
-        <a href="i.html">Jobs and employment</a>
-        <a href="j.html">Moving to Alberta</a>
-      </GoabAppFooterNavSection>
-      <GoabAppFooterMetaSection>
-        <a href="privacy.html">Privacy</a>
-        <a href="disclaimer.html">Disclaimer</a>
-        <a href="accessibility.html">Accessibility</a>
-        <a href="using-alberta.html">Using Alberta.ca</a>
-      </GoabAppFooterMetaSection>
-    </GoabAppFooter>
+    <footer>
+      <GoabAppFooter maxContentWidth="100%">
+        <GoabAppFooterNavSection maxColumnCount={1}>
+          <a href="a.html">Arts and culture</a>
+          <a href="b.html">Education and training</a>
+          <a href="c.html">Family and social supports</a>
+          <a href="d.html">Housing and community</a>
+          <a href="e.html">Life events</a>
+          <a href="f.html">Business and economy</a>
+          <a href="g.html">Emergencies and public safety</a>
+          <a href="h.html">Government</a>
+          <a href="i.html">Jobs and employment</a>
+          <a href="j.html">Moving to Alberta</a>
+        </GoabAppFooterNavSection>
+        <GoabAppFooterMetaSection>
+          <a href="privacy.html">Privacy</a>
+          <a href="disclaimer.html">Disclaimer</a>
+          <a href="accessibility.html">Accessibility</a>
+          <a href="using-alberta.html">Using Alberta.ca</a>
+        </GoabAppFooterMetaSection>
+      </GoabAppFooter>
+    </footer>
   );
 }

--- a/docs/src/content/examples/show-links-to-navigation-items/web-components.html
+++ b/docs/src/content/examples/show-links-to-navigation-items/web-components.html
@@ -1,20 +1,22 @@
-<goa-app-footer version="2" maxcontentwidth="100%">
-  <goa-app-footer-nav-section slot="nav" maxcolumncount="1">
-    <a href="a.html">Arts and culture</a>
-    <a href="b.html">Education and training</a>
-    <a href="c.html">Family and social supports</a>
-    <a href="d.html">Housing and community</a>
-    <a href="e.html">Life events</a>
-    <a href="f.html">Business and economy</a>
-    <a href="g.html">Emergencies and public safety</a>
-    <a href="h.html">Government</a>
-    <a href="i.html">Jobs and employment</a>
-    <a href="j.html">Moving to Alberta</a>
-  </goa-app-footer-nav-section>
-  <goa-app-footer-meta-section slot="meta">
-    <a href="privacy.html">Privacy</a>
-    <a href="disclaimer.html">Disclaimer</a>
-    <a href="accessibility.html">Accessibility</a>
-    <a href="using-alberta.html">Using Alberta.ca</a>
-  </goa-app-footer-meta-section>
-</goa-app-footer>
+<footer>
+  <goa-app-footer version="2" maxcontentwidth="100%">
+    <goa-app-footer-nav-section slot="nav" maxcolumncount="1">
+      <a href="a.html">Arts and culture</a>
+      <a href="b.html">Education and training</a>
+      <a href="c.html">Family and social supports</a>
+      <a href="d.html">Housing and community</a>
+      <a href="e.html">Life events</a>
+      <a href="f.html">Business and economy</a>
+      <a href="g.html">Emergencies and public safety</a>
+      <a href="h.html">Government</a>
+      <a href="i.html">Jobs and employment</a>
+      <a href="j.html">Moving to Alberta</a>
+    </goa-app-footer-nav-section>
+    <goa-app-footer-meta-section slot="meta">
+      <a href="privacy.html">Privacy</a>
+      <a href="disclaimer.html">Disclaimer</a>
+      <a href="accessibility.html">Accessibility</a>
+      <a href="using-alberta.html">Using Alberta.ca</a>
+    </goa-app-footer-meta-section>
+  </goa-app-footer>
+</footer>

--- a/docs/src/content/examples/show-quick-links/angular.html
+++ b/docs/src/content/examples/show-quick-links/angular.html
@@ -1,8 +1,10 @@
-<goab-app-footer maxContentWidth="100%">
-  <goab-app-footer-meta-section slot="meta">
-    <a href="#">Give feedback</a>
-    <a href="#">Accessibility</a>
-    <a href="#">Privacy</a>
-    <a href="#">Contact us</a>
-  </goab-app-footer-meta-section>
-</goab-app-footer>
+<footer>
+  <goab-app-footer maxContentWidth="100%">
+    <goab-app-footer-meta-section slot="meta">
+      <a href="#">Give feedback</a>
+      <a href="#">Accessibility</a>
+      <a href="#">Privacy</a>
+      <a href="#">Contact us</a>
+    </goab-app-footer-meta-section>
+  </goab-app-footer>
+</footer>

--- a/docs/src/content/examples/show-quick-links/react.tsx
+++ b/docs/src/content/examples/show-quick-links/react.tsx
@@ -2,13 +2,15 @@ import { GoabAppFooter, GoabAppFooterMetaSection } from "@abgov/react-components
 
 export function ShowQuickLinks() {
   return (
-    <GoabAppFooter maxContentWidth="100%">
-      <GoabAppFooterMetaSection>
-        <a href="#">Give feedback</a>
-        <a href="#">Accessibility</a>
-        <a href="#">Privacy</a>
-        <a href="#">Contact us</a>
-      </GoabAppFooterMetaSection>
-    </GoabAppFooter>
+    <footer>
+      <GoabAppFooter maxContentWidth="100%">
+        <GoabAppFooterMetaSection>
+          <a href="#">Give feedback</a>
+          <a href="#">Accessibility</a>
+          <a href="#">Privacy</a>
+          <a href="#">Contact us</a>
+        </GoabAppFooterMetaSection>
+      </GoabAppFooter>
+    </footer>
   );
 }

--- a/docs/src/content/examples/show-quick-links/web-components.html
+++ b/docs/src/content/examples/show-quick-links/web-components.html
@@ -1,8 +1,10 @@
-<goa-app-footer version="2" maxcontentwidth="100%">
-  <goa-app-footer-meta-section slot="meta">
-    <a href="#">Give feedback</a>
-    <a href="#">Accessibility</a>
-    <a href="#">Privacy</a>
-    <a href="#">Contact us</a>
-  </goa-app-footer-meta-section>
-</goa-app-footer>
+<footer>
+  <goa-app-footer version="2" maxcontentwidth="100%">
+    <goa-app-footer-meta-section slot="meta">
+      <a href="#">Give feedback</a>
+      <a href="#">Accessibility</a>
+      <a href="#">Privacy</a>
+      <a href="#">Contact us</a>
+    </goa-app-footer-meta-section>
+  </goa-app-footer>
+</footer>

--- a/docs/src/content/guidance/footer-dont-customize-links.mdx
+++ b/docs/src/content/guidance/footer-dont-customize-links.mdx
@@ -9,10 +9,12 @@ tags:
   - styling
 appliesTo:
   components:
-    - app-footer
+    - footer
 status: published
 ---
 
 <Preview>
-  <goa-app-footer></goa-app-footer>
+  <footer>
+    <goa-app-footer></goa-app-footer>
+  </footer>
 </Preview>

--- a/docs/src/content/guidance/footer-no-white-space-below.mdx
+++ b/docs/src/content/guidance/footer-no-white-space-below.mdx
@@ -8,10 +8,12 @@ tags:
   - layout
 appliesTo:
   components:
-    - app-footer
+    - footer
 status: published
 ---
 
 <Preview>
-  <goa-app-footer></goa-app-footer>
+  <footer>
+    <goa-app-footer></goa-app-footer>
+  </footer>
 </Preview>

--- a/docs/src/content/guidance/page-requires-one-column-layout.mdx
+++ b/docs/src/content/guidance/page-requires-one-column-layout.mdx
@@ -6,13 +6,19 @@ topic: other
 tags:
   - layout
   - page-structure
+appliesTo:
+  components:
+    - app-header
+    - footer
 status: published
 ---
 
 <Preview>
   <goa-one-column-layout>
     <section slot="header">
-      <goa-app-header heading="My Service"></goa-app-header>
+      <header>
+        <goa-app-header heading="My Service"></goa-app-header>
+      </header>
     </section>
     <goa-page-block width="704px">
       <p>Main content goes here</p>

--- a/docs/src/data/configurations/app-header-menu.ts
+++ b/docs/src/data/configurations/app-header-menu.ts
@@ -17,20 +17,24 @@ export const appHeaderMenuConfigurations: ComponentConfigurations = {
       name: "Basic app header menu",
       description: "Navigation menu within AppHeader",
       code: {
-        react: `<GoabAppHeader
-  heading="My Application"
-  navigation={
-    <GoabAppHeaderMenu heading="Applications">
-      <a href="/dashboard">Dashboard</a>
-      <a href="/reports">Reports</a>
-      <a href="/settings">Settings</a>
-    </GoabAppHeaderMenu>
-  }
-/>`,
-        angular: `<goab-app-header
-  heading="My Application"
-  [navigation]="navigationTemplate"
-></goab-app-header>
+        react: `<header>
+  <GoabAppHeader
+    heading="My Application"
+    navigation={
+      <GoabAppHeaderMenu heading="Applications">
+        <a href="/dashboard">Dashboard</a>
+        <a href="/reports">Reports</a>
+        <a href="/settings">Settings</a>
+      </GoabAppHeaderMenu>
+    }
+  />
+</header>`,
+        angular: `<header>
+  <goab-app-header
+    heading="My Application"
+    [navigation]="navigationTemplate"
+  ></goab-app-header>
+</header>
 <ng-template #navigationTemplate>
   <goab-app-header-menu heading="Applications">
     <a href="/dashboard">Dashboard</a>
@@ -38,13 +42,15 @@ export const appHeaderMenuConfigurations: ComponentConfigurations = {
     <a href="/settings">Settings</a>
   </goab-app-header-menu>
 </ng-template>`,
-        webComponents: `<goa-app-header version="2" heading="My Application">
-  <goa-app-header-menu slot="navigation" version="2" heading="Menu">
-    <a href="/dashboard">Dashboard</a>
-    <a href="/reports">Reports</a>
-    <a href="/settings">Settings</a>
-  </goa-app-header-menu>
-</goa-app-header>`,
+        webComponents: `<header>
+  <goa-app-header version="2" heading="My Application">
+    <goa-app-header-menu slot="navigation" version="2" heading="Menu">
+      <a href="/dashboard">Dashboard</a>
+      <a href="/reports">Reports</a>
+      <a href="/settings">Settings</a>
+    </goa-app-header-menu>
+  </goa-app-header>
+</header>`,
       },
     },
   ],

--- a/docs/src/data/configurations/app-header.ts
+++ b/docs/src/data/configurations/app-header.ts
@@ -17,9 +17,15 @@ export const appHeaderConfigurations: ComponentConfigurations = {
       name: "Basic app header",
       description: "Simple application header with service name",
       code: {
-        react: `<GoabAppHeader heading="My Application" />`,
-        angular: `<goab-app-header heading="My Application"></goab-app-header>`,
-        webComponents: `<goa-app-header version="2" heading="My Application"></goa-app-header>`,
+        react: `<header>
+  <GoabAppHeader heading="My Application" />
+</header>`,
+        angular: `<header>
+  <goab-app-header heading="My Application"></goab-app-header>
+</header>`,
+        webComponents: `<header>
+  <goa-app-header version="2" heading="My Application"></goa-app-header>
+</header>`,
       },
     },
     {
@@ -27,9 +33,15 @@ export const appHeaderConfigurations: ComponentConfigurations = {
       name: "With home link",
       description: "Header with clickable logo linking to home",
       code: {
-        react: `<GoabAppHeader heading="My Application" url="/" />`,
-        angular: `<goab-app-header heading="My Application" url="/"></goab-app-header>`,
-        webComponents: `<goa-app-header version="2" heading="My Application" url="/"></goa-app-header>`,
+        react: `<header>
+  <GoabAppHeader heading="My Application" url="/" />
+</header>`,
+        angular: `<header>
+  <goab-app-header heading="My Application" url="/"></goab-app-header>
+</header>`,
+        webComponents: `<header>
+  <goa-app-header version="2" heading="My Application" url="/"></goa-app-header>
+</header>`,
       },
     },
     {
@@ -37,9 +49,15 @@ export const appHeaderConfigurations: ComponentConfigurations = {
       name: "With secondary text",
       description: "Header with secondary text below the service name",
       code: {
-        react: `<GoabAppHeader heading="My Application" secondaryText="Supporting information" url="/" />`,
-        angular: `<goab-app-header heading="My Application" secondaryText="Supporting information" url="/"></goab-app-header>`,
-        webComponents: `<goa-app-header version="2" heading="My Application" secondarytext="Supporting information" url="/"></goa-app-header>`,
+        react: `<header>
+  <GoabAppHeader heading="My Application" secondaryText="Supporting information" url="/" />
+</header>`,
+        angular: `<header>
+  <goab-app-header heading="My Application" secondaryText="Supporting information" url="/"></goab-app-header>
+</header>`,
+        webComponents: `<header>
+  <goa-app-header version="2" heading="My Application" secondarytext="Supporting information" url="/"></goa-app-header>
+</header>`,
       },
     },
     {
@@ -47,33 +65,39 @@ export const appHeaderConfigurations: ComponentConfigurations = {
       name: "With utilities",
       description: "Header with utility actions",
       code: {
-        react: `<GoabAppHeader
-  heading="My Application"
-  url="/"
-  utilities={
-    <>
-      <GoabButton type="tertiary" size="compact">
-        Help
-      </GoabButton>
-      <GoabButton type="tertiary" size="compact" leadingIcon="person">
-        Sign in
-      </GoabButton>
-    </>
-  }
-/>`,
-        angular: `<goab-app-header
-  heading="My Application"
-  url="/"
-  [utilities]="utilitiesTemplate1"
-></goab-app-header>
+        react: `<header>
+  <GoabAppHeader
+    heading="My Application"
+    url="/"
+    utilities={
+      <>
+        <GoabButton type="tertiary" size="compact">
+          Help
+        </GoabButton>
+        <GoabButton type="tertiary" size="compact" leadingIcon="person">
+          Sign in
+        </GoabButton>
+      </>
+    }
+  />
+</header>`,
+        angular: `<header>
+  <goab-app-header
+    heading="My Application"
+    url="/"
+    [utilities]="utilitiesTemplate1"
+  ></goab-app-header>
+</header>
 <ng-template #utilitiesTemplate1>
   <goab-button type="tertiary" size="compact">Help</goab-button>
   <goab-button type="tertiary" size="compact" leadingIcon="person">Sign in</goab-button>
 </ng-template>`,
-        webComponents: `<goa-app-header version="2" heading="My Application" url="/">
-  <goa-button slot="utilities" version="2" type="tertiary" size="compact">Help</goa-button>
-  <goa-button slot="utilities" version="2" type="tertiary" size="compact" leadingicon="person">Sign in</goa-button>
-</goa-app-header>`,
+        webComponents: `<header>
+  <goa-app-header version="2" heading="My Application" url="/">
+    <goa-button slot="utilities" version="2" type="tertiary" size="compact">Help</goa-button>
+    <goa-button slot="utilities" version="2" type="tertiary" size="compact" leadingicon="person">Sign in</goa-button>
+  </goa-app-header>
+</header>`,
       },
     },
     {
@@ -81,22 +105,28 @@ export const appHeaderConfigurations: ComponentConfigurations = {
       name: "With phase badge",
       description: "Header with a phase badge indicating service status",
       code: {
-        react: `<GoabAppHeader
-  heading="My Application"
-  url="/"
-  phase={<GoabBadge type="important" content="Service preview" />}
-/>`,
-        angular: `<goab-app-header
-  heading="My Application"
-  url="/"
-  [phase]="phaseTemplate"
-></goab-app-header>
+        react: `<header>
+  <GoabAppHeader
+    heading="My Application"
+    url="/"
+    phase={<GoabBadge type="important" content="Service preview" />}
+  />
+</header>`,
+        angular: `<header>
+  <goab-app-header
+    heading="My Application"
+    url="/"
+    [phase]="phaseTemplate"
+  ></goab-app-header>
+</header>
 <ng-template #phaseTemplate>
   <goab-badge type="important" content="Service preview"></goab-badge>
 </ng-template>`,
-        webComponents: `<goa-app-header version="2" heading="My Application" url="/">
-  <goa-badge slot="phase" version="2" type="important" content="Service preview" icon="false"></goa-badge>
-</goa-app-header>`,
+        webComponents: `<header>
+  <goa-app-header version="2" heading="My Application" url="/">
+    <goa-badge slot="phase" version="2" type="important" content="Service preview" icon="false"></goa-badge>
+  </goa-app-header>
+</header>`,
       },
     },
     {
@@ -104,35 +134,41 @@ export const appHeaderConfigurations: ComponentConfigurations = {
       name: "Internal testing banner",
       description: "Header with a custom banner for environment or version info",
       code: {
-        react: `<GoabAppHeader
-  heading="My Application"
-  url="/"
-  banner={
-    <span
-      style={{
-        textAlign: "right",
-        width: "100%",
-        fontSize: "12px",
-        fontWeight: "normal",
-      }}
-    >
-      v2.3.1 | UAT Environment
-    </span>
-  }
-/>`,
-        angular: `<goab-app-header
-  heading="My Application"
-  url="/"
-  [banner]="bannerTemplate"
-></goab-app-header>
+        react: `<header>
+  <GoabAppHeader
+    heading="My Application"
+    url="/"
+    banner={
+      <span
+        style={{
+          textAlign: "right",
+          width: "100%",
+          fontSize: "12px",
+          fontWeight: "normal",
+        }}
+      >
+        v2.3.1 | UAT Environment
+      </span>
+    }
+  />
+</header>`,
+        angular: `<header>
+  <goab-app-header
+    heading="My Application"
+    url="/"
+    [banner]="bannerTemplate"
+  ></goab-app-header>
+</header>
 <ng-template #bannerTemplate>
   <span style="text-align: right; width: 100%; font-size: 12px; font-weight: normal">
     v2.3.1 | UAT Environment
   </span>
 </ng-template>`,
-        webComponents: `<goa-app-header version="2" heading="My Application" url="/">
-  <span slot="banner" style="text-align: right; width: 100%; font-size: 12px; font-weight: normal">v2.3.1 | UAT Environment</span>
-</goa-app-header>`,
+        webComponents: `<header>
+  <goa-app-header version="2" heading="My Application" url="/">
+    <span slot="banner" style="text-align: right; width: 100%; font-size: 12px; font-weight: normal">v2.3.1 | UAT Environment</span>
+  </goa-app-header>
+</header>`,
       },
     },
     {
@@ -140,34 +176,38 @@ export const appHeaderConfigurations: ComponentConfigurations = {
       name: "With navigation",
       description: "Header with navigation, groups, and utilities",
       code: {
-        react: `<GoabAppHeader
-  heading="Service Portal"
-  url="/"
-  navigation={
-    <>
-      <a href="#">Dashboard</a>
-      <GoabAppHeaderMenu heading="Applications">
-        <a href="#">New application</a>
-        <a href="#">Active</a>
-        <a href="#">Archived</a>
-      </GoabAppHeaderMenu>
-      <a href="#">Reports</a>
-      <a href="#">Settings</a>
-    </>
-  }
-  utilities={
-    <GoabMenuButton text="John Smith" type="tertiary" size="compact">
-      <GoabMenuAction text="User settings" action="user-settings" />
-      <GoabMenuAction text="Sign out" action="sign-out" />
-    </GoabMenuButton>
-  }
-/>`,
-        angular: `<goab-app-header
-  heading="Service Portal"
-  url="/"
-  [navigation]="navigationTemplate"
-  [utilities]="utilitiesTemplate2"
-></goab-app-header>
+        react: `<header>
+  <GoabAppHeader
+    heading="Service Portal"
+    url="/"
+    navigation={
+      <>
+        <a href="#">Dashboard</a>
+        <GoabAppHeaderMenu heading="Applications">
+          <a href="#">New application</a>
+          <a href="#">Active</a>
+          <a href="#">Archived</a>
+        </GoabAppHeaderMenu>
+        <a href="#">Reports</a>
+        <a href="#">Settings</a>
+      </>
+    }
+    utilities={
+      <GoabMenuButton text="John Smith" type="tertiary" size="compact">
+        <GoabMenuAction text="User settings" action="user-settings" />
+        <GoabMenuAction text="Sign out" action="sign-out" />
+      </GoabMenuButton>
+    }
+  />
+</header>`,
+        angular: `<header>
+  <goab-app-header
+    heading="Service Portal"
+    url="/"
+    [navigation]="navigationTemplate"
+    [utilities]="utilitiesTemplate2"
+  ></goab-app-header>
+</header>
 <ng-template #navigationTemplate>
   <a href="#">Dashboard</a>
   <goab-app-header-menu heading="Applications">
@@ -184,20 +224,22 @@ export const appHeaderConfigurations: ComponentConfigurations = {
     <goab-menu-action text="Sign out" action="sign-out"></goab-menu-action>
   </goab-menu-button>
 </ng-template>`,
-        webComponents: `<goa-app-header version="2" heading="Service Portal" url="/">
-  <a slot="navigation" href="#">Dashboard</a>
-  <goa-app-header-menu slot="navigation" version="2" heading="Applications">
-    <a href="#">New application</a>
-    <a href="#">Active</a>
-    <a href="#">Archived</a>
-  </goa-app-header-menu>
-  <a slot="navigation" href="#">Reports</a>
-  <a slot="navigation" href="#">Settings</a>
-  <goa-menu-button slot="utilities" version="2" text="John Smith" type="tertiary" size="compact">
-    <goa-menu-action text="User settings" action="user-settings"></goa-menu-action>
-    <goa-menu-action text="Sign out" action="sign-out"></goa-menu-action>
-  </goa-menu-button>
-</goa-app-header>`,
+        webComponents: `<header>
+  <goa-app-header version="2" heading="Service Portal" url="/">
+    <a slot="navigation" href="#">Dashboard</a>
+    <goa-app-header-menu slot="navigation" version="2" heading="Applications">
+      <a href="#">New application</a>
+      <a href="#">Active</a>
+      <a href="#">Archived</a>
+    </goa-app-header-menu>
+    <a slot="navigation" href="#">Reports</a>
+    <a slot="navigation" href="#">Settings</a>
+    <goa-menu-button slot="utilities" version="2" text="John Smith" type="tertiary" size="compact">
+      <goa-menu-action text="User settings" action="user-settings"></goa-menu-action>
+      <goa-menu-action text="Sign out" action="sign-out"></goa-menu-action>
+    </goa-menu-button>
+  </goa-app-header>
+</header>`,
       },
     },
   ],

--- a/docs/src/data/configurations/footer-meta-section.ts
+++ b/docs/src/data/configurations/footer-meta-section.ts
@@ -17,27 +17,33 @@ export const footerMetaSectionConfigurations: ComponentConfigurations = {
       name: "Basic footer meta section",
       description: "Meta links section within Footer",
       code: {
-        react: `<GoabAppFooter>
-  <GoabAppFooterMetaSection>
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </GoabAppFooterMetaSection>
-</GoabAppFooter>`,
-        angular: `<goab-app-footer>
-  <goab-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </goab-app-footer-meta-section>
-</goab-app-footer>`,
-        webComponents: `<goa-app-footer version="2">
-  <goa-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </goa-app-footer-meta-section>
-</goa-app-footer>`,
+        react: `<footer>
+  <GoabAppFooter>
+    <GoabAppFooterMetaSection>
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </GoabAppFooterMetaSection>
+  </GoabAppFooter>
+</footer>`,
+        angular: `<footer>
+  <goab-app-footer>
+    <goab-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </goab-app-footer-meta-section>
+  </goab-app-footer>
+</footer>`,
+        webComponents: `<footer>
+  <goa-app-footer version="2">
+    <goa-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </goa-app-footer-meta-section>
+  </goa-app-footer>
+</footer>`,
       },
     },
   ],

--- a/docs/src/data/configurations/footer-nav-section.ts
+++ b/docs/src/data/configurations/footer-nav-section.ts
@@ -17,27 +17,33 @@ export const footerNavSectionConfigurations: ComponentConfigurations = {
       name: "Basic footer nav section",
       description: "Navigation section within Footer",
       code: {
-        react: `<GoabAppFooter>
-  <GoabAppFooterNavSection heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/check-status">Check status</a>
-  </GoabAppFooterNavSection>
-</GoabAppFooter>`,
-        angular: `<goab-app-footer>
-  <goab-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/check-status">Check status</a>
-  </goab-app-footer-nav-section>
-</goab-app-footer>`,
-        webComponents: `<goa-app-footer version="2">
-  <goa-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/check-status">Check status</a>
-  </goa-app-footer-nav-section>
-</goa-app-footer>`,
+        react: `<footer>
+  <GoabAppFooter>
+    <GoabAppFooterNavSection heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/check-status">Check status</a>
+    </GoabAppFooterNavSection>
+  </GoabAppFooter>
+</footer>`,
+        angular: `<footer>
+  <goab-app-footer>
+    <goab-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/check-status">Check status</a>
+    </goab-app-footer-nav-section>
+  </goab-app-footer>
+</footer>`,
+        webComponents: `<footer>
+  <goa-app-footer version="2">
+    <goa-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/check-status">Check status</a>
+    </goa-app-footer-nav-section>
+  </goa-app-footer>
+</footer>`,
       },
     },
     {
@@ -45,45 +51,51 @@ export const footerNavSectionConfigurations: ComponentConfigurations = {
       name: "Multi-column layout",
       description: "Navigation links in multiple columns",
       code: {
-        react: `<GoabAppFooter>
-  <GoabAppFooterNavSection heading="All services" maxColumnCount={3}>
-    <a href="/health">Health</a>
-    <a href="/education">Education</a>
-    <a href="/jobs">Jobs and employment</a>
-    <a href="/housing">Housing</a>
-    <a href="/transportation">Transportation</a>
-    <a href="/environment">Environment</a>
-    <a href="/business">Business</a>
-    <a href="/taxes">Taxes and finance</a>
-    <a href="/legal">Legal services</a>
-  </GoabAppFooterNavSection>
-</GoabAppFooter>`,
-        angular: `<goab-app-footer>
-  <goab-app-footer-nav-section slot="nav" heading="All services" [maxColumnCount]="3">
-    <a href="/health">Health</a>
-    <a href="/education">Education</a>
-    <a href="/jobs">Jobs and employment</a>
-    <a href="/housing">Housing</a>
-    <a href="/transportation">Transportation</a>
-    <a href="/environment">Environment</a>
-    <a href="/business">Business</a>
-    <a href="/taxes">Taxes and finance</a>
-    <a href="/legal">Legal services</a>
-  </goab-app-footer-nav-section>
-</goab-app-footer>`,
-        webComponents: `<goa-app-footer version="2">
-  <goa-app-footer-nav-section slot="nav" heading="All services" maxcolumncount="3">
-    <a href="/health">Health</a>
-    <a href="/education">Education</a>
-    <a href="/jobs">Jobs and employment</a>
-    <a href="/housing">Housing</a>
-    <a href="/transportation">Transportation</a>
-    <a href="/environment">Environment</a>
-    <a href="/business">Business</a>
-    <a href="/taxes">Taxes and finance</a>
-    <a href="/legal">Legal services</a>
-  </goa-app-footer-nav-section>
-</goa-app-footer>`,
+        react: `<footer>
+  <GoabAppFooter>
+    <GoabAppFooterNavSection heading="All services" maxColumnCount={3}>
+      <a href="/health">Health</a>
+      <a href="/education">Education</a>
+      <a href="/jobs">Jobs and employment</a>
+      <a href="/housing">Housing</a>
+      <a href="/transportation">Transportation</a>
+      <a href="/environment">Environment</a>
+      <a href="/business">Business</a>
+      <a href="/taxes">Taxes and finance</a>
+      <a href="/legal">Legal services</a>
+    </GoabAppFooterNavSection>
+  </GoabAppFooter>
+</footer>`,
+        angular: `<footer>
+  <goab-app-footer>
+    <goab-app-footer-nav-section slot="nav" heading="All services" [maxColumnCount]="3">
+      <a href="/health">Health</a>
+      <a href="/education">Education</a>
+      <a href="/jobs">Jobs and employment</a>
+      <a href="/housing">Housing</a>
+      <a href="/transportation">Transportation</a>
+      <a href="/environment">Environment</a>
+      <a href="/business">Business</a>
+      <a href="/taxes">Taxes and finance</a>
+      <a href="/legal">Legal services</a>
+    </goab-app-footer-nav-section>
+  </goab-app-footer>
+</footer>`,
+        webComponents: `<footer>
+  <goa-app-footer version="2">
+    <goa-app-footer-nav-section slot="nav" heading="All services" maxcolumncount="3">
+      <a href="/health">Health</a>
+      <a href="/education">Education</a>
+      <a href="/jobs">Jobs and employment</a>
+      <a href="/housing">Housing</a>
+      <a href="/transportation">Transportation</a>
+      <a href="/environment">Environment</a>
+      <a href="/business">Business</a>
+      <a href="/taxes">Taxes and finance</a>
+      <a href="/legal">Legal services</a>
+    </goa-app-footer-nav-section>
+  </goa-app-footer>
+</footer>`,
       },
     },
   ],

--- a/docs/src/data/configurations/footer.ts
+++ b/docs/src/data/configurations/footer.ts
@@ -17,9 +17,15 @@ export const footerConfigurations: ComponentConfigurations = {
       name: "Basic footer",
       description: "Simple page footer",
       code: {
-        react: `<GoabAppFooter />`,
-        angular: `<goab-app-footer></goab-app-footer>`,
-        webComponents: `<goa-app-footer version="2"></goa-app-footer>`,
+        react: `<footer>
+  <GoabAppFooter />
+</footer>`,
+        angular: `<footer>
+  <goab-app-footer></goab-app-footer>
+</footer>`,
+        webComponents: `<footer>
+  <goa-app-footer version="2"></goa-app-footer>
+</footer>`,
       },
     },
     {
@@ -27,27 +33,33 @@ export const footerConfigurations: ComponentConfigurations = {
       name: "With meta section",
       description: "Footer with copyright and links",
       code: {
-        react: `<GoabAppFooter>
-  <GoabAppFooterMetaSection>
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </GoabAppFooterMetaSection>
-</GoabAppFooter>`,
-        angular: `<goab-app-footer>
-  <goab-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </goab-app-footer-meta-section>
-</goab-app-footer>`,
-        webComponents: `<goa-app-footer version="2">
-  <goa-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </goa-app-footer-meta-section>
-</goa-app-footer>`,
+        react: `<footer>
+  <GoabAppFooter>
+    <GoabAppFooterMetaSection>
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </GoabAppFooterMetaSection>
+  </GoabAppFooter>
+</footer>`,
+        angular: `<footer>
+  <goab-app-footer>
+    <goab-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </goab-app-footer-meta-section>
+  </goab-app-footer>
+</footer>`,
+        webComponents: `<footer>
+  <goa-app-footer version="2">
+    <goa-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </goa-app-footer-meta-section>
+  </goa-app-footer>
+</footer>`,
       },
     },
     {
@@ -55,39 +67,45 @@ export const footerConfigurations: ComponentConfigurations = {
       name: "With navigation",
       description: "Footer with navigation sections",
       code: {
-        react: `<GoabAppFooter>
-  <GoabAppFooterNavSection heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/status">Check status</a>
-  </GoabAppFooterNavSection>
-  <GoabAppFooterNavSection heading="Contact">
-    <a href="/help">Help center</a>
-    <a href="/feedback">Feedback</a>
-  </GoabAppFooterNavSection>
-</GoabAppFooter>`,
-        angular: `<goab-app-footer>
-  <goab-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/status">Check status</a>
-  </goab-app-footer-nav-section>
-  <goab-app-footer-nav-section slot="nav" heading="Contact">
-    <a href="/help">Help center</a>
-    <a href="/feedback">Feedback</a>
-  </goab-app-footer-nav-section>
-</goab-app-footer>`,
-        webComponents: `<goa-app-footer version="2">
-  <goa-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/status">Check status</a>
-  </goa-app-footer-nav-section>
-  <goa-app-footer-nav-section slot="nav" heading="Contact">
-    <a href="/help">Help center</a>
-    <a href="/feedback">Feedback</a>
-  </goa-app-footer-nav-section>
-</goa-app-footer>`,
+        react: `<footer>
+  <GoabAppFooter>
+    <GoabAppFooterNavSection heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/status">Check status</a>
+    </GoabAppFooterNavSection>
+    <GoabAppFooterNavSection heading="Contact">
+      <a href="/help">Help center</a>
+      <a href="/feedback">Feedback</a>
+    </GoabAppFooterNavSection>
+  </GoabAppFooter>
+</footer>`,
+        angular: `<footer>
+  <goab-app-footer>
+    <goab-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/status">Check status</a>
+    </goab-app-footer-nav-section>
+    <goab-app-footer-nav-section slot="nav" heading="Contact">
+      <a href="/help">Help center</a>
+      <a href="/feedback">Feedback</a>
+    </goab-app-footer-nav-section>
+  </goab-app-footer>
+</footer>`,
+        webComponents: `<footer>
+  <goa-app-footer version="2">
+    <goa-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/status">Check status</a>
+    </goa-app-footer-nav-section>
+    <goa-app-footer-nav-section slot="nav" heading="Contact">
+      <a href="/help">Help center</a>
+      <a href="/feedback">Feedback</a>
+    </goa-app-footer-nav-section>
+  </goa-app-footer>
+</footer>`,
       },
     },
     {
@@ -95,54 +113,60 @@ export const footerConfigurations: ComponentConfigurations = {
       name: "With meta and nav sections",
       description: "Footer with navigation and meta sections",
       code: {
-        react: `<GoabAppFooter>
-  <GoabAppFooterNavSection heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/status">Check status</a>
-  </GoabAppFooterNavSection>
-  <GoabAppFooterNavSection heading="Contact">
-    <a href="/help">Help center</a>
-    <a href="/feedback">Feedback</a>
-  </GoabAppFooterNavSection>
-  <GoabAppFooterMetaSection>
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </GoabAppFooterMetaSection>
-</GoabAppFooter>`,
-        angular: `<goab-app-footer>
-  <goab-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/status">Check status</a>
-  </goab-app-footer-nav-section>
-  <goab-app-footer-nav-section slot="nav" heading="Contact">
-    <a href="/help">Help center</a>
-    <a href="/feedback">Feedback</a>
-  </goab-app-footer-nav-section>
-  <goab-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </goab-app-footer-meta-section>
-</goab-app-footer>`,
-        webComponents: `<goa-app-footer version="2">
-  <goa-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <a href="/renew">Renew</a>
-    <a href="/status">Check status</a>
-  </goa-app-footer-nav-section>
-  <goa-app-footer-nav-section slot="nav" heading="Contact">
-    <a href="/help">Help center</a>
-    <a href="/feedback">Feedback</a>
-  </goa-app-footer-nav-section>
-  <goa-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <a href="/terms">Terms of use</a>
-    <a href="/accessibility">Accessibility</a>
-  </goa-app-footer-meta-section>
-</goa-app-footer>`,
+        react: `<footer>
+  <GoabAppFooter>
+    <GoabAppFooterNavSection heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/status">Check status</a>
+    </GoabAppFooterNavSection>
+    <GoabAppFooterNavSection heading="Contact">
+      <a href="/help">Help center</a>
+      <a href="/feedback">Feedback</a>
+    </GoabAppFooterNavSection>
+    <GoabAppFooterMetaSection>
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </GoabAppFooterMetaSection>
+  </GoabAppFooter>
+</footer>`,
+        angular: `<footer>
+  <goab-app-footer>
+    <goab-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/status">Check status</a>
+    </goab-app-footer-nav-section>
+    <goab-app-footer-nav-section slot="nav" heading="Contact">
+      <a href="/help">Help center</a>
+      <a href="/feedback">Feedback</a>
+    </goab-app-footer-nav-section>
+    <goab-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </goab-app-footer-meta-section>
+  </goab-app-footer>
+</footer>`,
+        webComponents: `<footer>
+  <goa-app-footer version="2">
+    <goa-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <a href="/renew">Renew</a>
+      <a href="/status">Check status</a>
+    </goa-app-footer-nav-section>
+    <goa-app-footer-nav-section slot="nav" heading="Contact">
+      <a href="/help">Help center</a>
+      <a href="/feedback">Feedback</a>
+    </goa-app-footer-nav-section>
+    <goa-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms of use</a>
+      <a href="/accessibility">Accessibility</a>
+    </goa-app-footer-meta-section>
+  </goa-app-footer>
+</footer>`,
       },
     },
     {
@@ -150,42 +174,48 @@ export const footerConfigurations: ComponentConfigurations = {
       name: "With links",
       description: "Footer sections with standard links and link components",
       code: {
-        react: `<GoabAppFooter>
-  <GoabAppFooterNavSection heading="Services">
-    <a href="/apply">Apply online</a>
-    <GoabLink trailingIcon="open">
-      <a href="https://www.alberta.ca/services">All services</a>
-    </GoabLink>
-  </GoabAppFooterNavSection>
-  <GoabAppFooterMetaSection>
-    <a href="/privacy">Privacy</a>
-    <GoabLink><a href="/accessibility">Accessibility</a></GoabLink>
-  </GoabAppFooterMetaSection>
-</GoabAppFooter>`,
-        angular: `<goab-app-footer>
-  <goab-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <goab-link trailingIcon="open">
-      <a href="https://www.alberta.ca/services">All services</a>
-    </goab-link>
-  </goab-app-footer-nav-section>
-  <goab-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <goab-link><a href="/accessibility">Accessibility</a></goab-link>
-  </goab-app-footer-meta-section>
-</goab-app-footer>`,
-        webComponents: `<goa-app-footer version="2">
-  <goa-app-footer-nav-section slot="nav" heading="Services">
-    <a href="/apply">Apply online</a>
-    <goa-link trailingicon="open">
-      <a href="https://www.alberta.ca/services">All services</a>
-    </goa-link>
-  </goa-app-footer-nav-section>
-  <goa-app-footer-meta-section slot="meta">
-    <a href="/privacy">Privacy</a>
-    <goa-link><a href="/accessibility">Accessibility</a></goa-link>
-  </goa-app-footer-meta-section>
-</goa-app-footer>`,
+        react: `<footer>
+  <GoabAppFooter>
+    <GoabAppFooterNavSection heading="Services">
+      <a href="/apply">Apply online</a>
+      <GoabLink trailingIcon="open">
+        <a href="https://www.alberta.ca/services">All services</a>
+      </GoabLink>
+    </GoabAppFooterNavSection>
+    <GoabAppFooterMetaSection>
+      <a href="/privacy">Privacy</a>
+      <GoabLink><a href="/accessibility">Accessibility</a></GoabLink>
+    </GoabAppFooterMetaSection>
+  </GoabAppFooter>
+</footer>`,
+        angular: `<footer>
+  <goab-app-footer>
+    <goab-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <goab-link trailingIcon="open">
+        <a href="https://www.alberta.ca/services">All services</a>
+      </goab-link>
+    </goab-app-footer-nav-section>
+    <goab-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <goab-link><a href="/accessibility">Accessibility</a></goab-link>
+    </goab-app-footer-meta-section>
+  </goab-app-footer>
+</footer>`,
+        webComponents: `<footer>
+  <goa-app-footer version="2">
+    <goa-app-footer-nav-section slot="nav" heading="Services">
+      <a href="/apply">Apply online</a>
+      <goa-link trailingicon="open">
+        <a href="https://www.alberta.ca/services">All services</a>
+      </goa-link>
+    </goa-app-footer-nav-section>
+    <goa-app-footer-meta-section slot="meta">
+      <a href="/privacy">Privacy</a>
+      <goa-link><a href="/accessibility">Accessibility</a></goa-link>
+    </goa-app-footer-meta-section>
+  </goa-app-footer>
+</footer>`,
       },
     },
   ],

--- a/docs/src/data/configurations/side-menu-group.ts
+++ b/docs/src/data/configurations/side-menu-group.ts
@@ -17,39 +17,45 @@ export const sideMenuGroupConfigurations: ComponentConfigurations = {
       name: "Basic side menu group",
       description: "Collapsible group within SideMenu",
       code: {
-        react: `<GoabSideMenu>
-  <GoabSideMenuGroup heading="Applications">
-    <a href="/apps/active">Active</a>
-    <a href="/apps/pending">Pending</a>
-    <a href="/apps/archived">Archived</a>
-  </GoabSideMenuGroup>
-  <GoabSideMenuGroup heading="Reports">
-    <a href="/reports/monthly">Monthly</a>
-    <a href="/reports/annual">Annual</a>
-  </GoabSideMenuGroup>
-</GoabSideMenu>`,
-        angular: `<goab-side-menu>
-  <goab-side-menu-group heading="Applications">
-    <a href="/apps/active">Active</a>
-    <a href="/apps/pending">Pending</a>
-    <a href="/apps/archived">Archived</a>
-  </goab-side-menu-group>
-  <goab-side-menu-group heading="Reports">
-    <a href="/reports/monthly">Monthly</a>
-    <a href="/reports/annual">Annual</a>
-  </goab-side-menu-group>
-</goab-side-menu>`,
-        webComponents: `<goa-side-menu version="2">
-  <goa-side-menu-group version="2" heading="Applications">
-    <a href="/apps/active">Active</a>
-    <a href="/apps/pending">Pending</a>
-    <a href="/apps/archived">Archived</a>
-  </goa-side-menu-group>
-  <goa-side-menu-group version="2" heading="Reports">
-    <a href="/reports/monthly">Monthly</a>
-    <a href="/reports/annual">Annual</a>
-  </goa-side-menu-group>
-</goa-side-menu>`,
+        react: `<nav>
+  <GoabSideMenu>
+    <GoabSideMenuGroup heading="Applications">
+      <a href="/apps/active">Active</a>
+      <a href="/apps/pending">Pending</a>
+      <a href="/apps/archived">Archived</a>
+    </GoabSideMenuGroup>
+    <GoabSideMenuGroup heading="Reports">
+      <a href="/reports/monthly">Monthly</a>
+      <a href="/reports/annual">Annual</a>
+    </GoabSideMenuGroup>
+  </GoabSideMenu>
+</nav>`,
+        angular: `<nav>
+  <goab-side-menu>
+    <goab-side-menu-group heading="Applications">
+      <a href="/apps/active">Active</a>
+      <a href="/apps/pending">Pending</a>
+      <a href="/apps/archived">Archived</a>
+    </goab-side-menu-group>
+    <goab-side-menu-group heading="Reports">
+      <a href="/reports/monthly">Monthly</a>
+      <a href="/reports/annual">Annual</a>
+    </goab-side-menu-group>
+  </goab-side-menu>
+</nav>`,
+        webComponents: `<nav>
+  <goa-side-menu version="2">
+    <goa-side-menu-group version="2" heading="Applications">
+      <a href="/apps/active">Active</a>
+      <a href="/apps/pending">Pending</a>
+      <a href="/apps/archived">Archived</a>
+    </goa-side-menu-group>
+    <goa-side-menu-group version="2" heading="Reports">
+      <a href="/reports/monthly">Monthly</a>
+      <a href="/reports/annual">Annual</a>
+    </goa-side-menu-group>
+  </goa-side-menu>
+</nav>`,
       },
     },
     {
@@ -57,36 +63,42 @@ export const sideMenuGroupConfigurations: ComponentConfigurations = {
       name: "With icon",
       description: "Group headings with icons",
       code: {
-        react: `<GoabSideMenu>
-  <GoabSideMenuGroup heading="Applications" icon="document">
-    <a href="/apps/active">Active</a>
-    <a href="/apps/pending">Pending</a>
-  </GoabSideMenuGroup>
-  <GoabSideMenuGroup heading="Settings" icon="settings">
-    <a href="/settings/profile">Profile</a>
-    <a href="/settings/security">Security</a>
-  </GoabSideMenuGroup>
-</GoabSideMenu>`,
-        angular: `<goab-side-menu>
-  <goab-side-menu-group heading="Applications" icon="document">
-    <a href="/apps/active">Active</a>
-    <a href="/apps/pending">Pending</a>
-  </goab-side-menu-group>
-  <goab-side-menu-group heading="Settings" icon="settings">
-    <a href="/settings/profile">Profile</a>
-    <a href="/settings/security">Security</a>
-  </goab-side-menu-group>
-</goab-side-menu>`,
-        webComponents: `<goa-side-menu version="2">
-  <goa-side-menu-group version="2" heading="Applications" icon="document">
-    <a href="/apps/active">Active</a>
-    <a href="/apps/pending">Pending</a>
-  </goa-side-menu-group>
-  <goa-side-menu-group version="2" heading="Settings" icon="settings">
-    <a href="/settings/profile">Profile</a>
-    <a href="/settings/security">Security</a>
-  </goa-side-menu-group>
-</goa-side-menu>`,
+        react: `<nav>
+  <GoabSideMenu>
+    <GoabSideMenuGroup heading="Applications" icon="document">
+      <a href="/apps/active">Active</a>
+      <a href="/apps/pending">Pending</a>
+    </GoabSideMenuGroup>
+    <GoabSideMenuGroup heading="Settings" icon="settings">
+      <a href="/settings/profile">Profile</a>
+      <a href="/settings/security">Security</a>
+    </GoabSideMenuGroup>
+  </GoabSideMenu>
+</nav>`,
+        angular: `<nav>
+  <goab-side-menu>
+    <goab-side-menu-group heading="Applications" icon="document">
+      <a href="/apps/active">Active</a>
+      <a href="/apps/pending">Pending</a>
+    </goab-side-menu-group>
+    <goab-side-menu-group heading="Settings" icon="settings">
+      <a href="/settings/profile">Profile</a>
+      <a href="/settings/security">Security</a>
+    </goab-side-menu-group>
+  </goab-side-menu>
+</nav>`,
+        webComponents: `<nav>
+  <goa-side-menu version="2">
+    <goa-side-menu-group version="2" heading="Applications" icon="document">
+      <a href="/apps/active">Active</a>
+      <a href="/apps/pending">Pending</a>
+    </goa-side-menu-group>
+    <goa-side-menu-group version="2" heading="Settings" icon="settings">
+      <a href="/settings/profile">Profile</a>
+      <a href="/settings/security">Security</a>
+    </goa-side-menu-group>
+  </goa-side-menu>
+</nav>`,
       },
     },
   ],

--- a/docs/src/data/configurations/side-menu-heading.ts
+++ b/docs/src/data/configurations/side-menu-heading.ts
@@ -17,30 +17,36 @@ export const sideMenuHeadingConfigurations: ComponentConfigurations = {
       name: "Basic side menu heading",
       description: "Section heading within SideMenu",
       code: {
-        react: `<GoabSideMenu>
-  <GoabSideMenuHeading>Main Menu</GoabSideMenuHeading>
-  <a href="/dashboard">Dashboard</a>
-  <a href="/reports">Reports</a>
-  <GoabSideMenuHeading>Settings</GoabSideMenuHeading>
-  <a href="/profile">Profile</a>
-  <a href="/preferences">Preferences</a>
-</GoabSideMenu>`,
-        angular: `<goab-side-menu>
-  <goab-side-menu-heading>Main Menu</goab-side-menu-heading>
-  <a href="/dashboard">Dashboard</a>
-  <a href="/reports">Reports</a>
-  <goab-side-menu-heading>Settings</goab-side-menu-heading>
-  <a href="/profile">Profile</a>
-  <a href="/preferences">Preferences</a>
-</goab-side-menu>`,
-        webComponents: `<goa-side-menu version="2">
-  <goa-side-menu-heading version="2">Main Menu</goa-side-menu-heading>
-  <a href="/dashboard">Dashboard</a>
-  <a href="/reports">Reports</a>
-  <goa-side-menu-heading version="2">Settings</goa-side-menu-heading>
-  <a href="/profile">Profile</a>
-  <a href="/preferences">Preferences</a>
-</goa-side-menu>`,
+        react: `<nav>
+  <GoabSideMenu>
+    <GoabSideMenuHeading>Main Menu</GoabSideMenuHeading>
+    <a href="/dashboard">Dashboard</a>
+    <a href="/reports">Reports</a>
+    <GoabSideMenuHeading>Settings</GoabSideMenuHeading>
+    <a href="/profile">Profile</a>
+    <a href="/preferences">Preferences</a>
+  </GoabSideMenu>
+</nav>`,
+        angular: `<nav>
+  <goab-side-menu>
+    <goab-side-menu-heading>Main Menu</goab-side-menu-heading>
+    <a href="/dashboard">Dashboard</a>
+    <a href="/reports">Reports</a>
+    <goab-side-menu-heading>Settings</goab-side-menu-heading>
+    <a href="/profile">Profile</a>
+    <a href="/preferences">Preferences</a>
+  </goab-side-menu>
+</nav>`,
+        webComponents: `<nav>
+  <goa-side-menu version="2">
+    <goa-side-menu-heading version="2">Main Menu</goa-side-menu-heading>
+    <a href="/dashboard">Dashboard</a>
+    <a href="/reports">Reports</a>
+    <goa-side-menu-heading version="2">Settings</goa-side-menu-heading>
+    <a href="/profile">Profile</a>
+    <a href="/preferences">Preferences</a>
+  </goa-side-menu>
+</nav>`,
       },
     },
     {
@@ -48,30 +54,36 @@ export const sideMenuHeadingConfigurations: ComponentConfigurations = {
       name: "With icon",
       description: "Section headings with icons",
       code: {
-        react: `<GoabSideMenu>
-  <GoabSideMenuHeading icon="grid">Navigation</GoabSideMenuHeading>
-  <a href="/dashboard">Dashboard</a>
-  <a href="/reports">Reports</a>
-  <GoabSideMenuHeading icon="settings">Configuration</GoabSideMenuHeading>
-  <a href="/profile">Profile</a>
-  <a href="/preferences">Preferences</a>
-</GoabSideMenu>`,
-        angular: `<goab-side-menu>
-  <goab-side-menu-heading icon="grid">Navigation</goab-side-menu-heading>
-  <a href="/dashboard">Dashboard</a>
-  <a href="/reports">Reports</a>
-  <goab-side-menu-heading icon="settings">Configuration</goab-side-menu-heading>
-  <a href="/profile">Profile</a>
-  <a href="/preferences">Preferences</a>
-</goab-side-menu>`,
-        webComponents: `<goa-side-menu version="2">
-  <goa-side-menu-heading version="2" icon="grid">Navigation</goa-side-menu-heading>
-  <a href="/dashboard">Dashboard</a>
-  <a href="/reports">Reports</a>
-  <goa-side-menu-heading version="2" icon="settings">Configuration</goa-side-menu-heading>
-  <a href="/profile">Profile</a>
-  <a href="/preferences">Preferences</a>
-</goa-side-menu>`,
+        react: `<nav>
+  <GoabSideMenu>
+    <GoabSideMenuHeading icon="grid">Navigation</GoabSideMenuHeading>
+    <a href="/dashboard">Dashboard</a>
+    <a href="/reports">Reports</a>
+    <GoabSideMenuHeading icon="settings">Configuration</GoabSideMenuHeading>
+    <a href="/profile">Profile</a>
+    <a href="/preferences">Preferences</a>
+  </GoabSideMenu>
+</nav>`,
+        angular: `<nav>
+  <goab-side-menu>
+    <goab-side-menu-heading icon="grid">Navigation</goab-side-menu-heading>
+    <a href="/dashboard">Dashboard</a>
+    <a href="/reports">Reports</a>
+    <goab-side-menu-heading icon="settings">Configuration</goab-side-menu-heading>
+    <a href="/profile">Profile</a>
+    <a href="/preferences">Preferences</a>
+  </goab-side-menu>
+</nav>`,
+        webComponents: `<nav>
+  <goa-side-menu version="2">
+    <goa-side-menu-heading version="2" icon="grid">Navigation</goa-side-menu-heading>
+    <a href="/dashboard">Dashboard</a>
+    <a href="/reports">Reports</a>
+    <goa-side-menu-heading version="2" icon="settings">Configuration</goa-side-menu-heading>
+    <a href="/profile">Profile</a>
+    <a href="/preferences">Preferences</a>
+  </goa-side-menu>
+</nav>`,
       },
     },
   ],

--- a/docs/src/data/configurations/side-menu.ts
+++ b/docs/src/data/configurations/side-menu.ts
@@ -18,25 +18,31 @@ export const sideMenuConfigurations: ComponentConfigurations = {
       description: "Simple navigation menu",
       code: {
         react: `<div style={{ width: '200px' }}>
-  <GoabSideMenu>
-    <a href="/overview">Overview</a>
-    <a href="/details">Details</a>
-    <a href="/settings">Settings</a>
-  </GoabSideMenu>
+  <nav>
+    <GoabSideMenu>
+      <a href="/overview">Overview</a>
+      <a href="/details">Details</a>
+      <a href="/settings">Settings</a>
+    </GoabSideMenu>
+  </nav>
 </div>`,
         angular: `<div style="width: 200px">
-  <goab-side-menu>
-    <a href="/overview">Overview</a>
-    <a href="/details">Details</a>
-    <a href="/settings">Settings</a>
-  </goab-side-menu>
+  <nav>
+    <goab-side-menu>
+      <a href="/overview">Overview</a>
+      <a href="/details">Details</a>
+      <a href="/settings">Settings</a>
+    </goab-side-menu>
+  </nav>
 </div>`,
         webComponents: `<div style="width: 200px">
-  <goa-side-menu version="2">
-    <a href="/overview">Overview</a>
-    <a href="/details">Details</a>
-    <a href="/settings">Settings</a>
-  </goa-side-menu>
+  <nav>
+    <goa-side-menu version="2">
+      <a href="/overview">Overview</a>
+      <a href="/details">Details</a>
+      <a href="/settings">Settings</a>
+    </goa-side-menu>
+  </nav>
 </div>`,
       },
     },
@@ -46,34 +52,40 @@ export const sideMenuConfigurations: ComponentConfigurations = {
       description: "Menu items organized into sections",
       code: {
         react: `<div style={{ width: '200px' }}>
-  <GoabSideMenu>
-    <GoabSideMenuHeading>Main</GoabSideMenuHeading>
-    <a href="/dashboard">Dashboard</a>
-    <a href="/reports">Reports</a>
-    <GoabSideMenuHeading>Settings</GoabSideMenuHeading>
-    <a href="/profile">Profile</a>
-    <a href="/preferences">Preferences</a>
-  </GoabSideMenu>
+  <nav>
+    <GoabSideMenu>
+      <GoabSideMenuHeading>Main</GoabSideMenuHeading>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/reports">Reports</a>
+      <GoabSideMenuHeading>Settings</GoabSideMenuHeading>
+      <a href="/profile">Profile</a>
+      <a href="/preferences">Preferences</a>
+    </GoabSideMenu>
+  </nav>
 </div>`,
         angular: `<div style="width: 200px">
-  <goab-side-menu>
-    <goab-side-menu-heading>Main</goab-side-menu-heading>
-    <a href="/dashboard">Dashboard</a>
-    <a href="/reports">Reports</a>
-    <goab-side-menu-heading>Settings</goab-side-menu-heading>
-    <a href="/profile">Profile</a>
-    <a href="/preferences">Preferences</a>
-  </goab-side-menu>
+  <nav>
+    <goab-side-menu>
+      <goab-side-menu-heading>Main</goab-side-menu-heading>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/reports">Reports</a>
+      <goab-side-menu-heading>Settings</goab-side-menu-heading>
+      <a href="/profile">Profile</a>
+      <a href="/preferences">Preferences</a>
+    </goab-side-menu>
+  </nav>
 </div>`,
         webComponents: `<div style="width: 200px">
-  <goa-side-menu version="2">
-    <goa-side-menu-heading version="2">Main</goa-side-menu-heading>
-    <a href="/dashboard">Dashboard</a>
-    <a href="/reports">Reports</a>
-    <goa-side-menu-heading version="2">Settings</goa-side-menu-heading>
-    <a href="/profile">Profile</a>
-    <a href="/preferences">Preferences</a>
-  </goa-side-menu>
+  <nav>
+    <goa-side-menu version="2">
+      <goa-side-menu-heading version="2">Main</goa-side-menu-heading>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/reports">Reports</a>
+      <goa-side-menu-heading version="2">Settings</goa-side-menu-heading>
+      <a href="/profile">Profile</a>
+      <a href="/preferences">Preferences</a>
+    </goa-side-menu>
+  </nav>
 </div>`,
       },
     },
@@ -83,43 +95,49 @@ export const sideMenuConfigurations: ComponentConfigurations = {
       description: "Collapsible menu groups",
       code: {
         react: `<div style={{ width: '200px' }}>
-  <GoabSideMenu>
-    <GoabSideMenuGroup heading="Applications">
-      <a href="/apps/active">Active</a>
-      <a href="/apps/pending">Pending</a>
-      <a href="/apps/archived">Archived</a>
-    </GoabSideMenuGroup>
-    <GoabSideMenuGroup heading="Reports">
-      <a href="/reports/monthly">Monthly</a>
-      <a href="/reports/annual">Annual</a>
-    </GoabSideMenuGroup>
-  </GoabSideMenu>
+  <nav>
+    <GoabSideMenu>
+      <GoabSideMenuGroup heading="Applications">
+        <a href="/apps/active">Active</a>
+        <a href="/apps/pending">Pending</a>
+        <a href="/apps/archived">Archived</a>
+      </GoabSideMenuGroup>
+      <GoabSideMenuGroup heading="Reports">
+        <a href="/reports/monthly">Monthly</a>
+        <a href="/reports/annual">Annual</a>
+      </GoabSideMenuGroup>
+    </GoabSideMenu>
+  </nav>
 </div>`,
         angular: `<div style="width: 200px">
-  <goab-side-menu>
-    <goab-side-menu-group heading="Applications">
-      <a href="/apps/active">Active</a>
-      <a href="/apps/pending">Pending</a>
-      <a href="/apps/archived">Archived</a>
-    </goab-side-menu-group>
-    <goab-side-menu-group heading="Reports">
-      <a href="/reports/monthly">Monthly</a>
-      <a href="/reports/annual">Annual</a>
-    </goab-side-menu-group>
-  </goab-side-menu>
+  <nav>
+    <goab-side-menu>
+      <goab-side-menu-group heading="Applications">
+        <a href="/apps/active">Active</a>
+        <a href="/apps/pending">Pending</a>
+        <a href="/apps/archived">Archived</a>
+      </goab-side-menu-group>
+      <goab-side-menu-group heading="Reports">
+        <a href="/reports/monthly">Monthly</a>
+        <a href="/reports/annual">Annual</a>
+      </goab-side-menu-group>
+    </goab-side-menu>
+  </nav>
 </div>`,
         webComponents: `<div style="width: 200px">
-  <goa-side-menu version="2">
-    <goa-side-menu-group version="2" heading="Applications">
-      <a href="/apps/active">Active</a>
-      <a href="/apps/pending">Pending</a>
-      <a href="/apps/archived">Archived</a>
-    </goa-side-menu-group>
-    <goa-side-menu-group version="2" heading="Reports">
-      <a href="/reports/monthly">Monthly</a>
-      <a href="/reports/annual">Annual</a>
-    </goa-side-menu-group>
-  </goa-side-menu>
+  <nav>
+    <goa-side-menu version="2">
+      <goa-side-menu-group version="2" heading="Applications">
+        <a href="/apps/active">Active</a>
+        <a href="/apps/pending">Pending</a>
+        <a href="/apps/archived">Archived</a>
+      </goa-side-menu-group>
+      <goa-side-menu-group version="2" heading="Reports">
+        <a href="/reports/monthly">Monthly</a>
+        <a href="/reports/annual">Annual</a>
+      </goa-side-menu-group>
+    </goa-side-menu>
+  </nav>
 </div>`,
       },
     },

--- a/docs/src/data/configurations/work-side-menu.ts
+++ b/docs/src/data/configurations/work-side-menu.ts
@@ -20,33 +20,39 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
       name: "Basic work side menu",
       description: "Side navigation for internal apps",
       code: {
-        react: `<GoabWorkSideMenu
-  heading="My Application"
-  url="/"
-  onNavigate={(path: string) => navigate(path)}
-  primaryContent={
-    <>
-      <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-      <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-      <GoabWorkSideMenuItem icon="document" label="Reports" url="/reports" />
-      <GoabWorkSideMenuItem icon="settings" label="Admin" url="/admin" />
-    </>
-  }
-/>`,
-        angular: `<goab-work-side-menu heading="My Application" url="/" (onNavigate)="handleNavigate($event)">
-  <div slot="primary-content">
-    <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="document" label="Reports" url="/reports"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="settings" label="Admin" url="/admin"></goab-work-side-menu-item>
-  </div>
-</goab-work-side-menu>`,
-        webComponents: `<goa-work-side-menu heading="My Application" url="/" open="true">
-    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-    <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-    <goa-work-side-menu-item slot="primary" icon="document" label="Reports" url="/reports"></goa-work-side-menu-item>
-    <goa-work-side-menu-item slot="primary" icon="settings" label="Admin" url="/admin"></goa-work-side-menu-item>
-  </goa-work-side-menu>`,
+        react: `<nav>
+  <GoabWorkSideMenu
+    heading="My Application"
+    url="/"
+    onNavigate={(path: string) => navigate(path)}
+    primaryContent={
+      <>
+        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+        <GoabWorkSideMenuItem icon="document" label="Reports" url="/reports" />
+        <GoabWorkSideMenuItem icon="settings" label="Admin" url="/admin" />
+      </>
+    }
+  />
+</nav>`,
+        angular: `<nav>
+  <goab-work-side-menu heading="My Application" url="/" (onNavigate)="handleNavigate($event)">
+    <div slot="primary-content">
+      <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
+      <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
+      <goab-work-side-menu-item icon="document" label="Reports" url="/reports"></goab-work-side-menu-item>
+      <goab-work-side-menu-item icon="settings" label="Admin" url="/admin"></goab-work-side-menu-item>
+    </div>
+  </goab-work-side-menu>
+</nav>`,
+        webComponents: `<nav>
+  <goa-work-side-menu heading="My Application" url="/" open="true">
+      <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+      <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+      <goa-work-side-menu-item slot="primary" icon="document" label="Reports" url="/reports"></goa-work-side-menu-item>
+      <goa-work-side-menu-item slot="primary" icon="settings" label="Admin" url="/admin"></goa-work-side-menu-item>
+    </goa-work-side-menu>
+</nav>`,
       },
     },
     {
@@ -54,35 +60,39 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
       name: "With user profile",
       description: "Menu showing user name and role with an account menu",
       code: {
-        react: `<GoabWorkSideMenu
-  heading="My Application"
-  url="/"
-  userName="Jane Smith"
-  userSecondaryText="Case Worker"
-  onNavigate={(path: string) => navigate(path)}
-  primaryContent={
-    <>
-      <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-      <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-    </>
-  }
-  accountContent={
-    <>
-      <GoabWorkSideMenuItem icon="person-circle" label="Profile" url="/profile" />
-      <GoabWorkSideMenuItem icon="settings" label="Settings" url="/settings" />
-      <GoabWorkSideMenuItem icon="log-out" label="Sign out" url="/sign-out" />
-    </>
-  }
-/>`,
-        angular: `<goab-work-side-menu
-  heading="My Application"
-  url="/"
-  userName="Jane Smith"
-  userSecondaryText="Case Worker"
-  [primaryContent]="primaryTpl"
-  [accountContent]="accountTpl"
-  (onNavigate)="handleNavigate($event)"
-></goab-work-side-menu>
+        react: `<nav>
+  <GoabWorkSideMenu
+    heading="My Application"
+    url="/"
+    userName="Jane Smith"
+    userSecondaryText="Case Worker"
+    onNavigate={(path: string) => navigate(path)}
+    primaryContent={
+      <>
+        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+      </>
+    }
+    accountContent={
+      <>
+        <GoabWorkSideMenuItem icon="person-circle" label="Profile" url="/profile" />
+        <GoabWorkSideMenuItem icon="settings" label="Settings" url="/settings" />
+        <GoabWorkSideMenuItem icon="log-out" label="Sign out" url="/sign-out" />
+      </>
+    }
+  />
+</nav>`,
+        angular: `<nav>
+  <goab-work-side-menu
+    heading="My Application"
+    url="/"
+    userName="Jane Smith"
+    userSecondaryText="Case Worker"
+    [primaryContent]="primaryTpl"
+    [accountContent]="accountTpl"
+    (onNavigate)="handleNavigate($event)"
+  ></goab-work-side-menu>
+</nav>
 
 <ng-template #primaryTpl>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -94,13 +104,15 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
   <goab-work-side-menu-item icon="settings" label="Settings" url="/settings"></goab-work-side-menu-item>
   <goab-work-side-menu-item icon="log-out" label="Sign out" url="/sign-out"></goab-work-side-menu-item>
 </ng-template>`,
-        webComponents: `<goa-work-side-menu heading="My Application" url="/" user-name="Jane Smith" user-secondary-text="Case Worker" open="true">
-  <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="account" icon="person-circle" label="Profile" url="/profile"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="account" icon="settings" label="Settings" url="/settings"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="account" icon="log-out" label="Sign out" url="/sign-out"></goa-work-side-menu-item>
-</goa-work-side-menu>`,
+        webComponents: `<nav>
+  <goa-work-side-menu heading="My Application" url="/" user-name="Jane Smith" user-secondary-text="Case Worker" open="true">
+    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="account" icon="person-circle" label="Profile" url="/profile"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="account" icon="settings" label="Settings" url="/settings"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="account" icon="log-out" label="Sign out" url="/sign-out"></goa-work-side-menu-item>
+  </goa-work-side-menu>
+</nav>`,
       },
     },
     {
@@ -109,54 +121,60 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
       description: "Work menu with expandable groups of items",
       code: {
         react: `
-<GoabWorkSideMenu
-  heading="My Application"
-  url="/"
-  open={true}
-  onNavigate={(path: string) => navigate(path)}
-  primaryContent={
-    <>
-      <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-      <GoabWorkSideMenuGroup  icon="document" heading="Documents" open={true} >
-        <GoabWorkSideMenuItem label="Invoices" url="/documents/invoices" />
-        <GoabWorkSideMenuItem label="Contracts" url="/documents/contracts" />
-        <GoabWorkSideMenuItem label="Reports" url="/documents/reports" />
-      </GoabWorkSideMenuGroup>
-      <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-    </>
-  }
-/>
+<nav>
+  <GoabWorkSideMenu
+    heading="My Application"
+    url="/"
+    open={true}
+    onNavigate={(path: string) => navigate(path)}
+    primaryContent={
+      <>
+        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+        <GoabWorkSideMenuGroup  icon="document" heading="Documents" open={true} >
+          <GoabWorkSideMenuItem label="Invoices" url="/documents/invoices" />
+          <GoabWorkSideMenuItem label="Contracts" url="/documents/contracts" />
+          <GoabWorkSideMenuItem label="Reports" url="/documents/reports" />
+        </GoabWorkSideMenuGroup>
+        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+      </>
+    }
+  />
+</nav>
         `,
         angular: `
-<goab-work-side-menu
-  heading="My Application"
-  url="/"
-  [primaryContent]="primaryTemplate"
-  [open]="true"
-  (onNavigate)="handleNavigate($event)"
->
-  <ng-template #primaryTemplate>
-    <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard" />
-    <goab-work-side-menu-group icon="document" heading="Documents" [open]="true">
-      <goab-work-side-menu-item label="Invoices" url="/documents/invoices" />
-      <goab-work-side-menu-item label="Contracts" url="/documents/contracts" />
-      <goab-work-side-menu-item label="Reports" url="/documents/reports" />
-    </goab-work-side-menu-group>
-    <goab-work-side-menu-item icon="list" label="Cases" url="/cases" />
-  </ng-template>
-</goab-work-side-menu>
+<nav>
+  <goab-work-side-menu
+    heading="My Application"
+    url="/"
+    [primaryContent]="primaryTemplate"
+    [open]="true"
+    (onNavigate)="handleNavigate($event)"
+  >
+    <ng-template #primaryTemplate>
+      <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard" />
+      <goab-work-side-menu-group icon="document" heading="Documents" [open]="true">
+        <goab-work-side-menu-item label="Invoices" url="/documents/invoices" />
+        <goab-work-side-menu-item label="Contracts" url="/documents/contracts" />
+        <goab-work-side-menu-item label="Reports" url="/documents/reports" />
+      </goab-work-side-menu-group>
+      <goab-work-side-menu-item icon="list" label="Cases" url="/cases" />
+    </ng-template>
+  </goab-work-side-menu>
+</nav>
         `,
-        webComponents: `<goa-work-side-menu heading="My Application" url="/" open="true">
-    <div slot="primary">
-      <goa-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-      <goa-work-side-menu-group icon="document" heading="Documents" open="true">
-        <goa-work-side-menu-item label="Invoices" url="/documents/invoices"></goa-work-side-menu-item>
-        <goa-work-side-menu-item label="Contracts" url="/documents/contracts"></goa-work-side-menu-item>
-        <goa-work-side-menu-item label="Reports" url="/documents/reports"></goa-work-side-menu-item>
-      </goa-work-side-menu-group>
-      <goa-work-side-menu-item icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-    </div>
-  </goa-work-side-menu>`,
+        webComponents: `<nav>
+  <goa-work-side-menu heading="My Application" url="/" open="true">
+      <div slot="primary">
+        <goa-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+        <goa-work-side-menu-group icon="document" heading="Documents" open="true">
+          <goa-work-side-menu-item label="Invoices" url="/documents/invoices"></goa-work-side-menu-item>
+          <goa-work-side-menu-item label="Contracts" url="/documents/contracts"></goa-work-side-menu-item>
+          <goa-work-side-menu-item label="Reports" url="/documents/reports"></goa-work-side-menu-item>
+        </goa-work-side-menu-group>
+        <goa-work-side-menu-item icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+      </div>
+    </goa-work-side-menu>
+</nav>`,
       },
     },
     {
@@ -164,40 +182,46 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
       name: "Secondary menu",
       description: "Drilled-in menu with back navigation",
       code: {
-        react: `<GoabWorkSideMenu
-  heading="Case Management"
-  url="/cases"
-  open={true}
-  onNavigate={(path: string) => navigate(path)}
-  primaryContent={
-    <>
-      <GoabWorkSideMenuItem icon="arrow-back" label="All cases" url="/cases" />
-      <GoabWorkSideMenuItem label="Overview" url="/cases/123/overview" />
-      <GoabWorkSideMenuItem label="Documents" url="/cases/123/documents" />
-      <GoabWorkSideMenuItem label="Notes" url="/cases/123/notes" />
-      <GoabWorkSideMenuItem label="Activity log" url="/cases/123/activity" />
-      <GoabWorkSideMenuItem label="Payments" url="/cases/123/payments" />
-    </>
-  }
-/>`,
-        angular: `<goab-work-side-menu heading="Case Management" url="/cases" [open]="true" (onNavigate)="handleNavigate($event)" [primaryContent]="primaryTpl">
-  <ng-template #primaryTpl>
-    <goab-work-side-menu-item icon="arrow-back" label="All cases" url="/cases"></goab-work-side-menu-item>
-    <goab-work-side-menu-item label="Overview" url="/cases/123/overview"></goab-work-side-menu-item>
-    <goab-work-side-menu-item label="Documents" url="/cases/123/documents"></goab-work-side-menu-item>
-    <goab-work-side-menu-item label="Notes" url="/cases/123/notes"></goab-work-side-menu-item>
-    <goab-work-side-menu-item label="Activity log" url="/cases/123/activity"></goab-work-side-menu-item>
-    <goab-work-side-menu-item label="Payments" url="/cases/123/payments"></goab-work-side-menu-item>
-  </ng-template>
-</goab-work-side-menu>`,
-        webComponents: `<goa-work-side-menu heading="Case Management" url="/cases" open="true">
-  <goa-work-side-menu-item slot="primary" icon="arrow-back" label="All cases" url="/cases"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="primary" label="Overview" url="/cases/123/overview"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="primary" label="Documents" url="/cases/123/documents"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="primary" label="Notes" url="/cases/123/notes"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="primary" label="Activity log" url="/cases/123/activity"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="primary" label="Payments" url="/cases/123/payments"></goa-work-side-menu-item>
-</goa-work-side-menu>`,
+        react: `<nav>
+  <GoabWorkSideMenu
+    heading="Case Management"
+    url="/cases"
+    open={true}
+    onNavigate={(path: string) => navigate(path)}
+    primaryContent={
+      <>
+        <GoabWorkSideMenuItem icon="arrow-back" label="All cases" url="/cases" />
+        <GoabWorkSideMenuItem label="Overview" url="/cases/123/overview" />
+        <GoabWorkSideMenuItem label="Documents" url="/cases/123/documents" />
+        <GoabWorkSideMenuItem label="Notes" url="/cases/123/notes" />
+        <GoabWorkSideMenuItem label="Activity log" url="/cases/123/activity" />
+        <GoabWorkSideMenuItem label="Payments" url="/cases/123/payments" />
+      </>
+    }
+  />
+</nav>`,
+        angular: `<nav>
+  <goab-work-side-menu heading="Case Management" url="/cases" [open]="true" (onNavigate)="handleNavigate($event)" [primaryContent]="primaryTpl">
+    <ng-template #primaryTpl>
+      <goab-work-side-menu-item icon="arrow-back" label="All cases" url="/cases"></goab-work-side-menu-item>
+      <goab-work-side-menu-item label="Overview" url="/cases/123/overview"></goab-work-side-menu-item>
+      <goab-work-side-menu-item label="Documents" url="/cases/123/documents"></goab-work-side-menu-item>
+      <goab-work-side-menu-item label="Notes" url="/cases/123/notes"></goab-work-side-menu-item>
+      <goab-work-side-menu-item label="Activity log" url="/cases/123/activity"></goab-work-side-menu-item>
+      <goab-work-side-menu-item label="Payments" url="/cases/123/payments"></goab-work-side-menu-item>
+    </ng-template>
+  </goab-work-side-menu>
+</nav>`,
+        webComponents: `<nav>
+  <goa-work-side-menu heading="Case Management" url="/cases" open="true">
+    <goa-work-side-menu-item slot="primary" icon="arrow-back" label="All cases" url="/cases"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="primary" label="Overview" url="/cases/123/overview"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="primary" label="Documents" url="/cases/123/documents"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="primary" label="Notes" url="/cases/123/notes"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="primary" label="Activity log" url="/cases/123/activity"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="primary" label="Payments" url="/cases/123/payments"></goa-work-side-menu-item>
+  </goa-work-side-menu>
+</nav>`,
       },
     },
     {
@@ -205,68 +229,72 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
       name: "With notifications",
       description: "Work menu with notification popover panel",
       code: {
-        react: `<GoabWorkSideMenu
-  heading="My Application"
-  url="/"
-  primaryContent={
-    <>
-      <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-      <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-    </>
-  }
-  secondaryContent={
-    <>
-      <GoabWorkSideMenuItem
+        react: `<nav>
+  <GoabWorkSideMenu
+    heading="My Application"
+    url="/"
+    primaryContent={
+      <>
+        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+      </>
+    }
+    secondaryContent={
+      <>
+        <GoabWorkSideMenuItem
+          icon="notifications"
+          label="Notifications"
+          badge="3"
+          type="success"
+          popoverContent={
+            <GoabWorkSideNotificationPanel
+              heading="Notifications"
+              activeTab="unread"
+              onMarkAllRead={() => handleMarkAllRead()}
+              onViewAll={() => handleViewAll()}
+            >
+              <GoabWorkSideNotificationItem
+                title="New case assigned"
+                description="Case #12345 has been assigned to you."
+                timestamp="2025-02-09T10:30:00Z"
+                type="info"
+                readStatus="unread"
+                priority="normal"
+                onClick={() => handleClick("1")}
+              />
+              <GoabWorkSideNotificationItem
+                title="System maintenance"
+                description="Scheduled maintenance tonight at 11 PM."
+                timestamp="2025-02-09T09:00:00Z"
+                type="critical"
+                readStatus="unread"
+                priority="urgent"
+                onClick={() => handleClick("2")}
+              />
+            </GoabWorkSideNotificationPanel>
+          }
+        />
+      </>
+    }
+  />
+</nav>`,
+        angular: `<nav>
+  <goab-work-side-menu heading="My Application" url="/">
+    <div slot="primary-content">
+      <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
+      <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
+    </div>
+    <div slot="secondary-content">
+      <goab-work-side-menu-item
         icon="notifications"
         label="Notifications"
         badge="3"
         type="success"
-        popoverContent={
-          <GoabWorkSideNotificationPanel
-            heading="Notifications"
-            activeTab="unread"
-            onMarkAllRead={() => handleMarkAllRead()}
-            onViewAll={() => handleViewAll()}
-          >
-            <GoabWorkSideNotificationItem
-              title="New case assigned"
-              description="Case #12345 has been assigned to you."
-              timestamp="2025-02-09T10:30:00Z"
-              type="info"
-              readStatus="unread"
-              priority="normal"
-              onClick={() => handleClick("1")}
-            />
-            <GoabWorkSideNotificationItem
-              title="System maintenance"
-              description="Scheduled maintenance tonight at 11 PM."
-              timestamp="2025-02-09T09:00:00Z"
-              type="critical"
-              readStatus="unread"
-              priority="urgent"
-              onClick={() => handleClick("2")}
-            />
-          </GoabWorkSideNotificationPanel>
-        }
-      />
-    </>
-  }
-/>`,
-        angular: `<goab-work-side-menu heading="My Application" url="/">
-  <div slot="primary-content">
-    <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
-    <goab-work-side-menu-item icon="list" label="Cases" url="/cases"></goab-work-side-menu-item>
-  </div>
-  <div slot="secondary-content">
-    <goab-work-side-menu-item
-      icon="notifications"
-      label="Notifications"
-      badge="3"
-      type="success"
-      [popoverContent]="notificationsTpl"
-    ></goab-work-side-menu-item>
-  </div>
-</goab-work-side-menu>
+        [popoverContent]="notificationsTpl"
+      ></goab-work-side-menu-item>
+    </div>
+  </goab-work-side-menu>
+</nav>
 
 <ng-template #notificationsTpl>
   <goab-work-side-notification-panel
@@ -295,30 +323,32 @@ export const workSideMenuConfigurations: ComponentConfigurations = {
     ></goab-work-side-notification-item>
   </goab-work-side-notification-panel>
 </ng-template>`,
-        webComponents: `<goa-work-side-menu heading="My Application" url="/" open="true">
-  <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="secondary" icon="notifications" label="Notifications" badge="3" type="success">
-    <goa-work-side-notification-panel slot="popoverContent" heading="Notifications" active-tab="unread">
-      <goa-work-side-notification-item
-        title="New case assigned"
-        description="Case #12345 has been assigned to you."
-        timestamp="2025-02-09T10:30:00Z"
-        type="info"
-        read-status="unread"
-        priority="normal"
-      ></goa-work-side-notification-item>
-      <goa-work-side-notification-item
-        title="System maintenance"
-        description="Scheduled maintenance tonight at 11 PM."
-        timestamp="2025-02-09T09:00:00Z"
-        type="critical"
-        read-status="unread"
-        priority="urgent"
-      ></goa-work-side-notification-item>
-    </goa-work-side-notification-panel>
-  </goa-work-side-menu-item>
-</goa-work-side-menu>`,
+        webComponents: `<nav>
+  <goa-work-side-menu heading="My Application" url="/" open="true">
+    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="secondary" icon="notifications" label="Notifications" badge="3" type="success">
+      <goa-work-side-notification-panel slot="popoverContent" heading="Notifications" active-tab="unread">
+        <goa-work-side-notification-item
+          title="New case assigned"
+          description="Case #12345 has been assigned to you."
+          timestamp="2025-02-09T10:30:00Z"
+          type="info"
+          read-status="unread"
+          priority="normal"
+        ></goa-work-side-notification-item>
+        <goa-work-side-notification-item
+          title="System maintenance"
+          description="Scheduled maintenance tonight at 11 PM."
+          timestamp="2025-02-09T09:00:00Z"
+          type="critical"
+          read-status="unread"
+          priority="urgent"
+        ></goa-work-side-notification-item>
+      </goa-work-side-notification-panel>
+    </goa-work-side-menu-item>
+  </goa-work-side-menu>
+</nav>`,
       },
     },
   ],

--- a/docs/src/data/configurations/work-side-notification-panel.ts
+++ b/docs/src/data/configurations/work-side-notification-panel.ts
@@ -67,41 +67,43 @@ const handleClick = (id: string) => {
     items.map((item) => (item.id === id ? { ...item, readStatus: "read" } : item)),
   );
 };`,
-          jsx: `<GoabWorkSideMenu
-  heading="My Application"
-  url="/"
-  onNavigate={(path: string) => navigate(path)}
-  primaryContent={
-    <>
-      <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-      <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-    </>
-  }
-  secondaryContent={
-    <GoabWorkSideMenuItem
-      icon="notifications"
-      label="Notifications"
-      badge="2"
-      type="success"
-      popoverContent={
-        <GoabWorkSideNotificationPanel
-          heading="Notifications"
-          activeTab="unread"
-          onMarkAllRead={handleMarkAllRead}
-          onViewAll={handleViewAll}
-        >
-          {items.map(({ id, ...item }) => (
-            <GoabWorkSideNotificationItem
-              key={id}
-              {...item}
-              onClick={() => handleClick(id)}
-            />
-          ))}
-        </GoabWorkSideNotificationPanel>
-      }
-    />
-  }
-/>`,
+          jsx: `<nav>
+  <GoabWorkSideMenu
+    heading="My Application"
+    url="/"
+    onNavigate={(path: string) => navigate(path)}
+    primaryContent={
+      <>
+        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+      </>
+    }
+    secondaryContent={
+      <GoabWorkSideMenuItem
+        icon="notifications"
+        label="Notifications"
+        badge="2"
+        type="success"
+        popoverContent={
+          <GoabWorkSideNotificationPanel
+            heading="Notifications"
+            activeTab="unread"
+            onMarkAllRead={handleMarkAllRead}
+            onViewAll={handleViewAll}
+          >
+            {items.map(({ id, ...item }) => (
+              <GoabWorkSideNotificationItem
+                key={id}
+                {...item}
+                onClick={() => handleClick(id)}
+              />
+            ))}
+          </GoabWorkSideNotificationPanel>
+        }
+      />
+    }
+  />
+</nav>`,
         },
         angular: {
           ts: `interface NotificationItem {
@@ -159,13 +161,15 @@ export class SomeOtherComponent {
     );
   }
 }`,
-          template: `<goab-work-side-menu
-  heading="My Application"
-  url="/"
-  [primaryContent]="primaryTpl"
-  [secondaryContent]="secondaryTpl"
-  (onNavigate)="handleNavigate($event)"
-></goab-work-side-menu>
+          template: `<nav>
+  <goab-work-side-menu
+    heading="My Application"
+    url="/"
+    [primaryContent]="primaryTpl"
+    [secondaryContent]="secondaryTpl"
+    (onNavigate)="handleNavigate($event)"
+  ></goab-work-side-menu>
+</nav>
 
 <ng-template #primaryTpl>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -204,38 +208,40 @@ export class SomeOtherComponent {
 </ng-template>`,
         },
         webComponents: {
-          html: `<goa-work-side-menu heading="My Application" url="/" open="true">
-  <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="secondary" icon="notifications" label="Notifications" badge="2" type="success">
-    <goa-work-side-notification-panel slot="popoverContent" heading="Notifications" active-tab="unread">
-      <goa-work-side-notification-item
-        title="New case assigned"
-        description="Case #12345 has been assigned to you for review."
-        timestamp="2025-03-15T10:30:00Z"
-        type="info"
-        read-status="unread"
-        priority="normal"
-      ></goa-work-side-notification-item>
-      <goa-work-side-notification-item
-        title="Document uploaded"
-        description="A new document was uploaded to Case #12340."
-        timestamp="2025-03-15T09:15:00Z"
-        type="default"
-        read-status="unread"
-        priority="normal"
-      ></goa-work-side-notification-item>
-      <goa-work-side-notification-item
-        title="Case resolved"
-        description="Case #12330 has been marked as resolved."
-        timestamp="2025-03-14T16:00:00Z"
-        type="success"
-        read-status="read"
-        priority="normal"
-      ></goa-work-side-notification-item>
-    </goa-work-side-notification-panel>
-  </goa-work-side-menu-item>
-</goa-work-side-menu>`,
+          html: `<nav>
+  <goa-work-side-menu heading="My Application" url="/" open="true">
+    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="secondary" icon="notifications" label="Notifications" badge="2" type="success">
+      <goa-work-side-notification-panel slot="popoverContent" heading="Notifications" active-tab="unread">
+        <goa-work-side-notification-item
+          title="New case assigned"
+          description="Case #12345 has been assigned to you for review."
+          timestamp="2025-03-15T10:30:00Z"
+          type="info"
+          read-status="unread"
+          priority="normal"
+        ></goa-work-side-notification-item>
+        <goa-work-side-notification-item
+          title="Document uploaded"
+          description="A new document was uploaded to Case #12340."
+          timestamp="2025-03-15T09:15:00Z"
+          type="default"
+          read-status="unread"
+          priority="normal"
+        ></goa-work-side-notification-item>
+        <goa-work-side-notification-item
+          title="Case resolved"
+          description="Case #12330 has been marked as resolved."
+          timestamp="2025-03-14T16:00:00Z"
+          type="success"
+          read-status="read"
+          priority="normal"
+        ></goa-work-side-notification-item>
+      </goa-work-side-notification-panel>
+    </goa-work-side-menu-item>
+  </goa-work-side-menu>
+</nav>`,
           js: `const panel = container.querySelector("goa-work-side-notification-panel");
 const items = container.querySelectorAll("goa-work-side-notification-item");
 
@@ -306,41 +312,43 @@ const handleClick = (id: string) => {
     items.map((item) => (item.id === id ? { ...item, readStatus: "read" } : item)),
   );
 };`,
-          jsx: `<GoabWorkSideMenu
-  heading="My Application"
-  url="/"
-  onNavigate={(path: string) => navigate(path)}
-  primaryContent={
-    <>
-      <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-      <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-    </>
-  }
-  secondaryContent={
-    <GoabWorkSideMenuItem
-      icon="notifications"
-      label="Notifications"
-      badge="2"
-      type="emergency"
-      popoverContent={
-        <GoabWorkSideNotificationPanel
-          heading="Notifications"
-          activeTab="urgent"
-          onMarkAllRead={handleMarkAllRead}
-          onViewAll={handleViewAll}
-        >
-          {items.map(({ id, ...item }) => (
-            <GoabWorkSideNotificationItem
-              key={id}
-              {...item}
-              onClick={() => handleClick(id)}
-            />
-          ))}
-        </GoabWorkSideNotificationPanel>
-      }
-    />
-  }
-/>`,
+          jsx: `<nav>
+  <GoabWorkSideMenu
+    heading="My Application"
+    url="/"
+    onNavigate={(path: string) => navigate(path)}
+    primaryContent={
+      <>
+        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+      </>
+    }
+    secondaryContent={
+      <GoabWorkSideMenuItem
+        icon="notifications"
+        label="Notifications"
+        badge="2"
+        type="emergency"
+        popoverContent={
+          <GoabWorkSideNotificationPanel
+            heading="Notifications"
+            activeTab="urgent"
+            onMarkAllRead={handleMarkAllRead}
+            onViewAll={handleViewAll}
+          >
+            {items.map(({ id, ...item }) => (
+              <GoabWorkSideNotificationItem
+                key={id}
+                {...item}
+                onClick={() => handleClick(id)}
+              />
+            ))}
+          </GoabWorkSideNotificationPanel>
+        }
+      />
+    }
+  />
+</nav>`,
         },
         angular: {
           ts: `interface NotificationItem {
@@ -398,13 +406,15 @@ export class SomeOtherComponent {
     );
   }
 }`,
-          template: `<goab-work-side-menu
-  heading="My Application"
-  url="/"
-  [primaryContent]="primaryTpl"
-  [secondaryContent]="secondaryTpl"
-  (onNavigate)="handleNavigate($event)"
-></goab-work-side-menu>
+          template: `<nav>
+  <goab-work-side-menu
+    heading="My Application"
+    url="/"
+    [primaryContent]="primaryTpl"
+    [secondaryContent]="secondaryTpl"
+    (onNavigate)="handleNavigate($event)"
+  ></goab-work-side-menu>
+</nav>
 
 <ng-template #primaryTpl>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -443,38 +453,40 @@ export class SomeOtherComponent {
 </ng-template>`,
         },
         webComponents: {
-          html: `<goa-work-side-menu heading="My Application" url="/" open="true">
-  <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="secondary" icon="notifications" label="Notifications" badge="2" type="emergency">
-    <goa-work-side-notification-panel slot="popoverContent" heading="Notifications" active-tab="urgent">
-      <goa-work-side-notification-item
-        title="System maintenance"
-        description="Scheduled maintenance tonight at 11 PM. All services will be unavailable."
-        timestamp="2025-03-15T14:00:00Z"
-        type="critical"
-        read-status="unread"
-        priority="urgent"
-      ></goa-work-side-notification-item>
-      <goa-work-side-notification-item
-        title="Deadline approaching"
-        description="Case #12345 response is due in 2 hours."
-        timestamp="2025-03-15T12:00:00Z"
-        type="warning"
-        read-status="unread"
-        priority="urgent"
-      ></goa-work-side-notification-item>
-      <goa-work-side-notification-item
-        title="New comment on case"
-        description="A team member commented on Case #12340."
-        timestamp="2025-03-15T11:00:00Z"
-        type="default"
-        read-status="unread"
-        priority="normal"
-      ></goa-work-side-notification-item>
-    </goa-work-side-notification-panel>
-  </goa-work-side-menu-item>
-</goa-work-side-menu>`,
+          html: `<nav>
+  <goa-work-side-menu heading="My Application" url="/" open="true">
+    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="secondary" icon="notifications" label="Notifications" badge="2" type="emergency">
+      <goa-work-side-notification-panel slot="popoverContent" heading="Notifications" active-tab="urgent">
+        <goa-work-side-notification-item
+          title="System maintenance"
+          description="Scheduled maintenance tonight at 11 PM. All services will be unavailable."
+          timestamp="2025-03-15T14:00:00Z"
+          type="critical"
+          read-status="unread"
+          priority="urgent"
+        ></goa-work-side-notification-item>
+        <goa-work-side-notification-item
+          title="Deadline approaching"
+          description="Case #12345 response is due in 2 hours."
+          timestamp="2025-03-15T12:00:00Z"
+          type="warning"
+          read-status="unread"
+          priority="urgent"
+        ></goa-work-side-notification-item>
+        <goa-work-side-notification-item
+          title="New comment on case"
+          description="A team member commented on Case #12340."
+          timestamp="2025-03-15T11:00:00Z"
+          type="default"
+          read-status="unread"
+          priority="normal"
+        ></goa-work-side-notification-item>
+      </goa-work-side-notification-panel>
+    </goa-work-side-menu-item>
+  </goa-work-side-menu>
+</nav>`,
           js: `const panel = container.querySelector("goa-work-side-notification-panel");
 const items = container.querySelectorAll("goa-work-side-notification-item");
 
@@ -563,38 +575,40 @@ const handleClick = (id: string) => {
     items.map((item) => (item.id === id ? { ...item, readStatus: "read" } : item)),
   );
 };`,
-          jsx: `<GoabWorkSideMenu
-  heading="My Application"
-  url="/"
-  onNavigate={(path: string) => navigate(path)}
-  primaryContent={
-    <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-  }
-  secondaryContent={
-    <GoabWorkSideMenuItem
-      icon="notifications"
-      label="Notifications"
-      badge="5"
-      type="success"
-      popoverContent={
-        <GoabWorkSideNotificationPanel
-          heading="Notifications"
-          activeTab="all"
-          onMarkAllRead={handleMarkAllRead}
-          onViewAll={handleViewAll}
-        >
-          {items.map(({ id, ...item }) => (
-            <GoabWorkSideNotificationItem
-              key={id}
-              {...item}
-              onClick={() => handleClick(id)}
-            />
-          ))}
-        </GoabWorkSideNotificationPanel>
-      }
-    />
-  }
-/>`,
+          jsx: `<nav>
+  <GoabWorkSideMenu
+    heading="My Application"
+    url="/"
+    onNavigate={(path: string) => navigate(path)}
+    primaryContent={
+      <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+    }
+    secondaryContent={
+      <GoabWorkSideMenuItem
+        icon="notifications"
+        label="Notifications"
+        badge="5"
+        type="success"
+        popoverContent={
+          <GoabWorkSideNotificationPanel
+            heading="Notifications"
+            activeTab="all"
+            onMarkAllRead={handleMarkAllRead}
+            onViewAll={handleViewAll}
+          >
+            {items.map(({ id, ...item }) => (
+              <GoabWorkSideNotificationItem
+                key={id}
+                {...item}
+                onClick={() => handleClick(id)}
+              />
+            ))}
+          </GoabWorkSideNotificationPanel>
+        }
+      />
+    }
+  />
+</nav>`,
         },
         angular: {
           ts: `interface NotificationItem {
@@ -670,13 +684,15 @@ export class SomeOtherComponent {
     );
   }
 }`,
-          template: `<goab-work-side-menu
-  heading="My Application"
-  url="/"
-  [primaryContent]="primaryTpl"
-  [secondaryContent]="secondaryTpl"
-  (onNavigate)="handleNavigate($event)"
-></goab-work-side-menu>
+          template: `<nav>
+  <goab-work-side-menu
+    heading="My Application"
+    url="/"
+    [primaryContent]="primaryTpl"
+    [secondaryContent]="secondaryTpl"
+    (onNavigate)="handleNavigate($event)"
+  ></goab-work-side-menu>
+</nav>
 
 <ng-template #primaryTpl>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -714,53 +730,55 @@ export class SomeOtherComponent {
 </ng-template>`,
         },
         webComponents: {
-          html: `<goa-work-side-menu heading="My Application" url="/" open="true">
-  <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-  <goa-work-side-menu-item slot="secondary" icon="notifications" label="Notifications" badge="5" type="success">
-    <goa-work-side-notification-panel slot="popoverContent" heading="Notifications" active-tab="all">
-      <goa-work-side-notification-item
-        title="New comment on case"
-        description="A team member commented on Case #12340."
-        timestamp="2025-03-15T10:00:00Z"
-        type="default"
-        read-status="unread"
-        priority="normal"
-      ></goa-work-side-notification-item>
-      <goa-work-side-notification-item
-        title="Case #12345 assigned"
-        description="Case #12345 has been assigned to you for review."
-        timestamp="2025-03-15T09:00:00Z"
-        type="info"
-        read-status="unread"
-        priority="normal"
-      ></goa-work-side-notification-item>
-      <goa-work-side-notification-item
-        title="Case resolved"
-        description="Case #12330 has been marked as resolved."
-        timestamp="2025-03-15T08:00:00Z"
-        type="success"
-        read-status="unread"
-        priority="normal"
-      ></goa-work-side-notification-item>
-      <goa-work-side-notification-item
-        title="Deadline approaching"
-        description="Case #12345 response is due in 2 hours."
-        timestamp="2025-03-15T07:00:00Z"
-        type="warning"
-        read-status="unread"
-        priority="normal"
-      ></goa-work-side-notification-item>
-      <goa-work-side-notification-item
-        title="System maintenance"
-        description="Scheduled maintenance tonight at 11 PM. All services will be unavailable."
-        timestamp="2025-03-15T06:00:00Z"
-        type="critical"
-        read-status="unread"
-        priority="normal"
-      ></goa-work-side-notification-item>
-    </goa-work-side-notification-panel>
-  </goa-work-side-menu-item>
-</goa-work-side-menu>`,
+          html: `<nav>
+  <goa-work-side-menu heading="My Application" url="/" open="true">
+    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+    <goa-work-side-menu-item slot="secondary" icon="notifications" label="Notifications" badge="5" type="success">
+      <goa-work-side-notification-panel slot="popoverContent" heading="Notifications" active-tab="all">
+        <goa-work-side-notification-item
+          title="New comment on case"
+          description="A team member commented on Case #12340."
+          timestamp="2025-03-15T10:00:00Z"
+          type="default"
+          read-status="unread"
+          priority="normal"
+        ></goa-work-side-notification-item>
+        <goa-work-side-notification-item
+          title="Case #12345 assigned"
+          description="Case #12345 has been assigned to you for review."
+          timestamp="2025-03-15T09:00:00Z"
+          type="info"
+          read-status="unread"
+          priority="normal"
+        ></goa-work-side-notification-item>
+        <goa-work-side-notification-item
+          title="Case resolved"
+          description="Case #12330 has been marked as resolved."
+          timestamp="2025-03-15T08:00:00Z"
+          type="success"
+          read-status="unread"
+          priority="normal"
+        ></goa-work-side-notification-item>
+        <goa-work-side-notification-item
+          title="Deadline approaching"
+          description="Case #12345 response is due in 2 hours."
+          timestamp="2025-03-15T07:00:00Z"
+          type="warning"
+          read-status="unread"
+          priority="normal"
+        ></goa-work-side-notification-item>
+        <goa-work-side-notification-item
+          title="System maintenance"
+          description="Scheduled maintenance tonight at 11 PM. All services will be unavailable."
+          timestamp="2025-03-15T06:00:00Z"
+          type="critical"
+          read-status="unread"
+          priority="normal"
+        ></goa-work-side-notification-item>
+      </goa-work-side-notification-panel>
+    </goa-work-side-menu-item>
+  </goa-work-side-menu>
+</nav>`,
           js: `const panel = container.querySelector("goa-work-side-notification-panel");
 const items = container.querySelectorAll("goa-work-side-notification-item");
 

--- a/docs/src/data/configurations/workspace-layout.ts
+++ b/docs/src/data/configurations/workspace-layout.ts
@@ -31,18 +31,20 @@ export const workspaceLayoutConfigurations: ComponentConfigurations = {
           ts: `const rows = Array.from({ length: 16 }, (_, i) => i + 1);
 
 const sideMenu = (
-  <GoabWorkSideMenu
-    heading="Workspace layout"
-    url="/"
-    onNavigate={(path: string) => navigate(path)}
-    primaryContent={
-      <>
-        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-        <GoabWorkSideMenuItem icon="document" label="Reports" url="/reports" />
-      </>
-    }
-  />
+  <nav>
+    <GoabWorkSideMenu
+      heading="Workspace layout"
+      url="/"
+      onNavigate={(path: string) => navigate(path)}
+      primaryContent={
+        <>
+          <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+          <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+          <GoabWorkSideMenuItem icon="document" label="Reports" url="/reports" />
+        </>
+      }
+    />
+  </nav>
 );`,
           jsx: `<GoabWorkspaceLayout sideMenu={sideMenu}>
   <div style={{ padding: "24px" }}>
@@ -70,7 +72,9 @@ const sideMenu = (
 </goab-workspace-layout>
 
 <ng-template #sideMenuTpl>
-  <goab-work-side-menu heading="Workspace layout" url="/" [primaryContent]="menuItems" (onNavigate)="handleNavigate($event)"></goab-work-side-menu>
+  <nav>
+    <goab-work-side-menu heading="Workspace layout" url="/" [primaryContent]="menuItems" (onNavigate)="handleNavigate($event)"></goab-work-side-menu>
+  </nav>
 </ng-template>
 <ng-template #menuItems>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -79,11 +83,13 @@ const sideMenu = (
 </ng-template>`,
         },
         webComponents: `<goa-workspace-layout style="height: 600px;">
-  <goa-work-side-menu slot="side-menu" heading="Workspace layout" url="/" open="true">
-    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-    <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-    <goa-work-side-menu-item slot="primary" icon="document" label="Reports" url="/reports"></goa-work-side-menu-item>
-  </goa-work-side-menu>
+  <nav slot="side-menu">
+    <goa-work-side-menu heading="Workspace layout" url="/" open="true">
+      <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+      <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+      <goa-work-side-menu-item slot="primary" icon="document" label="Reports" url="/reports"></goa-work-side-menu-item>
+    </goa-work-side-menu>
+  </nav>
 
   <div id="wsl-basic-body" style="padding: 24px"></div>
 </goa-workspace-layout>
@@ -105,17 +111,19 @@ const sideMenu = (
           ts: `const rows = Array.from({ length: 16 }, (_, i) => i + 1);
 
 const sideMenu = (
-  <GoabWorkSideMenu
-    heading="Workspace layout"
-    url="/"
-    onNavigate={(path: string) => navigate(path)}
-    primaryContent={
-      <>
-        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-      </>
-    }
-  />
+  <nav>
+    <GoabWorkSideMenu
+      heading="Workspace layout"
+      url="/"
+      onNavigate={(path: string) => navigate(path)}
+      primaryContent={
+        <>
+          <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+          <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+        </>
+      }
+    />
+  </nav>
 );
 
 const pageHeader = (
@@ -153,7 +161,9 @@ const pageHeader = (
 </goab-workspace-layout>
 
 <ng-template #sideMenuTpl>
-  <goab-work-side-menu heading="Workspace layout" url="/" [primaryContent]="menuItems" (onNavigate)="handleNavigate($event)"></goab-work-side-menu>
+  <nav>
+    <goab-work-side-menu heading="Workspace layout" url="/" [primaryContent]="menuItems" (onNavigate)="handleNavigate($event)"></goab-work-side-menu>
+  </nav>
 </ng-template>
 <ng-template #menuItems>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -170,10 +180,12 @@ const pageHeader = (
 </ng-template>`,
         },
         webComponents: `<goa-workspace-layout style="height: 600px;">
-  <goa-work-side-menu slot="side-menu" heading="Workspace layout" url="/" open="true">
-    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-    <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-  </goa-work-side-menu>
+  <nav slot="side-menu">
+    <goa-work-side-menu heading="Workspace layout" url="/" open="true">
+      <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+      <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+    </goa-work-side-menu>
+  </nav>
 
   <div slot="page-header" style="display:flex;align-items:center;justify-content:space-between;width:100%">
     <goa-text tag="h1" size="heading-m" mt="none" mb="none">My cases</goa-text>
@@ -203,17 +215,19 @@ const pageHeader = (
           ts: `const rows = Array.from({ length: 16 }, (_, i) => i + 1);
 
 const sideMenu = (
-  <GoabWorkSideMenu
-    heading="Workspace layout"
-    url="/"
-    onNavigate={(path: string) => navigate(path)}
-    primaryContent={
-      <>
-        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-      </>
-    }
-  />
+  <nav>
+    <GoabWorkSideMenu
+      heading="Workspace layout"
+      url="/"
+      onNavigate={(path: string) => navigate(path)}
+      primaryContent={
+        <>
+          <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+          <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+        </>
+      }
+    />
+  </nav>
 );
 
 const pageFooter = (
@@ -251,7 +265,9 @@ const pageFooter = (
 </goab-workspace-layout>
 
 <ng-template #sideMenuTpl>
-  <goab-work-side-menu heading="Workspace layout" url="/" [primaryContent]="menuItems" (onNavigate)="handleNavigate($event)"></goab-work-side-menu>
+  <nav>
+    <goab-work-side-menu heading="Workspace layout" url="/" [primaryContent]="menuItems" (onNavigate)="handleNavigate($event)"></goab-work-side-menu>
+  </nav>
 </ng-template>
 <ng-template #menuItems>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -268,10 +284,12 @@ const pageFooter = (
 </ng-template>`,
         },
         webComponents: `<goa-workspace-layout style="height: 600px;">
-  <goa-work-side-menu slot="side-menu" heading="Workspace layout" url="/" open="true">
-    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-    <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-  </goa-work-side-menu>
+  <nav slot="side-menu">
+    <goa-work-side-menu heading="Workspace layout" url="/" open="true">
+      <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+      <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+    </goa-work-side-menu>
+  </nav>
 
   <div id="wsl-footer-body" style="padding: 24px"></div>
 
@@ -301,17 +319,19 @@ const pageFooter = (
           ts: `const [open, setOpen] = useState(false);
 
 const sideMenu = (
-  <GoabWorkSideMenu
-    heading="Workspace layout"
-    url="/"
-    onNavigate={(path: string) => navigate(path)}
-    primaryContent={
-      <>
-        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-      </>
-    }
-  />
+  <nav>
+    <GoabWorkSideMenu
+      heading="Workspace layout"
+      url="/"
+      onNavigate={(path: string) => navigate(path)}
+      primaryContent={
+        <>
+          <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+          <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+        </>
+      }
+    />
+  </nav>
 );
 
 const drawer = (
@@ -341,7 +361,9 @@ const drawer = (
 </goab-workspace-layout>
 
 <ng-template #sideMenuTpl>
-  <goab-work-side-menu heading="Workspace layout" url="/" [primaryContent]="menuItems" (onNavigate)="handleNavigate($event)"></goab-work-side-menu>
+  <nav>
+    <goab-work-side-menu heading="Workspace layout" url="/" [primaryContent]="menuItems" (onNavigate)="handleNavigate($event)"></goab-work-side-menu>
+  </nav>
 </ng-template>
 <ng-template #menuItems>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -354,10 +376,12 @@ const drawer = (
 </ng-template>`,
         },
         webComponents: `<goa-workspace-layout style="height: 600px;">
-  <goa-work-side-menu slot="side-menu" heading="Workspace layout" url="/" open="true">
-    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-    <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-  </goa-work-side-menu>
+  <nav slot="side-menu">
+    <goa-work-side-menu heading="Workspace layout" url="/" open="true">
+      <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+      <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+    </goa-work-side-menu>
+  </nav>
 
   <div style="padding: 24px">
     <goa-button id="wsl-open-drawer" type="primary" size="compact" version="2">Open</goa-button>
@@ -402,16 +426,18 @@ const drawer = (
 const rows = Array.from({ length: 20 }, (_, i) => i + 1);
 
 const sideMenu = (
-  <GoabWorkSideMenu
-    heading="Workspace layout"
-    url="/"
-    primaryContent={
-      <>
-        <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
-        <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
-      </>
-    }
-  />
+  <nav>
+    <GoabWorkSideMenu
+      heading="Workspace layout"
+      url="/"
+      primaryContent={
+        <>
+          <GoabWorkSideMenuItem icon="grid" label="Dashboard" url="/dashboard" />
+          <GoabWorkSideMenuItem icon="list" label="Cases" url="/cases" />
+        </>
+      }
+    />
+  </nav>
 );
 
 function PageHeader() {
@@ -467,7 +493,9 @@ export class SomeComponent {
 </ng-template>
 
 <ng-template #sideMenuTpl>
-  <goab-work-side-menu heading="Workspace layout" url="/" [primaryContent]="menuItems"></goab-work-side-menu>
+  <nav>
+    <goab-work-side-menu heading="Workspace layout" url="/" [primaryContent]="menuItems"></goab-work-side-menu>
+  </nav>
 </ng-template>
 <ng-template #menuItems>
   <goab-work-side-menu-item icon="grid" label="Dashboard" url="/dashboard"></goab-work-side-menu-item>
@@ -475,10 +503,12 @@ export class SomeComponent {
 </ng-template>`,
         },
         webComponents: `<goa-workspace-layout id="wsl-scroll" style="height: 600px;">
-  <goa-work-side-menu slot="side-menu" heading="Workspace layout" url="/" open="true">
-    <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
-    <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
-  </goa-work-side-menu>
+  <nav slot="side-menu">
+    <goa-work-side-menu heading="Workspace layout" url="/" open="true">
+      <goa-work-side-menu-item slot="primary" icon="grid" label="Dashboard" url="/dashboard"></goa-work-side-menu-item>
+      <goa-work-side-menu-item slot="primary" icon="list" label="Cases" url="/cases"></goa-work-side-menu-item>
+    </goa-work-side-menu>
+  </nav>
 
   <div slot="page-header">
     <goa-text tag="h1" size="heading-m" mt="none" mb="none">My cases</goa-text>


### PR DESCRIPTION
# After (the change)

All of our `GoabAppHeader` examples are now surrounded by `<header>` tags. All of our `GoabAppFooter` examples are now surrounded by `<footer>` tags. And all of our `GoabSideMenu` and `GoabWorkSideMenu` examples are surrounded by `<nav>` tags. This is how they likely should be used, so that they are using the correct tags for accessibility reasons.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

The following documentation has been updated:
* App Header
* App Footer
* Side Menu
* Work Side Menu
* Notification Panel
* Workspace Layout

The following examples have been updated:
* Basic Page Layout
* Header with Navigation
* Show links to navigation items
* Show quick links

The following usage guideline examples have been updated:
* Footer (these weren't visible previously because they were linked to App Footer, not footer, they are now visible as well)

The following PR examples have been updated:
* App Header
* Footer
* Page Block
* Side Menu
* Skeleton
* Work Side Menu
* Work Side Notification Panel
* Workspace Layout
