### PR TITLE
feat(#3153): Added ariaLabel property to GoabButton

### DIFF
--- a/apps/prs/angular/src/routes/features/feat3153/feat3153.component.html
+++ b/apps/prs/angular/src/routes/features/feat3153/feat3153.component.html
@@ -1,0 +1,32 @@
+<goab-text tag="h1" mt="m">Feature #3153: Button aria label</goab-text>
+
+<goab-link trailingIcon="open">
+  <a
+    href="https://github.com/GovAlta/ui-components/issues/3153"
+    target="_blank"
+    rel="noopener"
+  >
+    View on GitHub
+  </a>
+</goab-link>
+
+<goab-text tag="p">
+  Button supports an optional ariaLabel that replaces the accessible name while preserving
+  the visible button text.
+</goab-text>
+
+<goab-divider mt="l" mb="l" />
+
+<goab-text tag="h2">Test cases</goab-text>
+
+<goab-text tag="h3">With ariaLabel</goab-text>
+<goab-text tag="p"
+  >A screen reader should announce “Remove Jane Smith, button.”</goab-text
+>
+<goab-button ariaLabel="Remove Jane Smith">Remove</goab-button>
+
+<goab-text tag="h3" mt="l">Without ariaLabel</goab-text>
+<goab-text tag="p"
+  >A screen reader should announce the visible text: “Remove, button.”</goab-text
+>
+<goab-button>Remove</goab-button>

--- a/apps/prs/angular/src/routes/features/feat3153/feat3153.component.ts
+++ b/apps/prs/angular/src/routes/features/feat3153/feat3153.component.ts
@@ -1,0 +1,10 @@
+import { Component } from "@angular/core";
+import { GoabButton, GoabDivider, GoabText, GoabLink } from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-feat3153",
+  templateUrl: "./feat3153.component.html",
+  imports: [GoabButton, GoabDivider, GoabText, GoabLink],
+})
+export class Feat3153Component {}

--- a/apps/prs/angular/src/routes/features/feat3153/feat3153.route.json
+++ b/apps/prs/angular/src/routes/features/feat3153/feat3153.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Button aria label",
+  "path": "features/3153",
+  "id": "3153",
+  "type": "feature"
+}

--- a/apps/prs/react/src/app/routes/features/feat3153.route.ts
+++ b/apps/prs/react/src/app/routes/features/feat3153.route.ts
@@ -1,0 +1,10 @@
+import { Feat3153Route } from "../../../routes/features/feat3153";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "feature",
+  id: "3153",
+  path: "features/3153",
+  title: "Button aria label",
+  component: Feat3153Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/features/feat3153.tsx
+++ b/apps/prs/react/src/routes/features/feat3153.tsx
@@ -1,0 +1,46 @@
+import { GoabButton, GoabDivider, GoabLink, GoabText } from "@abgov/react-components";
+
+export function Feat3153Route() {
+  return (
+    <div>
+      <GoabText tag="h1" mt="m">
+        Feature #3153: Button aria label
+      </GoabText>
+
+      <GoabLink trailingIcon="open">
+        <a
+          href="https://github.com/GovAlta/ui-components/issues/3153"
+          target="_blank"
+          rel="noopener"
+        >
+          View on GitHub
+        </a>
+      </GoabLink>
+
+      <GoabText tag="p">
+        Button supports an optional ariaLabel that replaces the accessible name while
+        preserving the visible button text.
+      </GoabText>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Test cases</GoabText>
+
+      <GoabText tag="h3">With ariaLabel</GoabText>
+      <GoabText tag="p">
+        A screen reader should announce “Remove Jane Smith, button.”
+      </GoabText>
+      <GoabButton ariaLabel="Remove Jane Smith">Remove</GoabButton>
+
+      <GoabText tag="h3" mt="l">
+        Without ariaLabel
+      </GoabText>
+      <GoabText tag="p">
+        A screen reader should announce the visible text: “Remove, button.”
+      </GoabText>
+      <GoabButton>Remove</GoabButton>
+    </div>
+  );
+}
+
+export default Feat3153Route;

--- a/docs/generated/component-apis/button.json
+++ b/docs/generated/component-apis/button.json
@@ -26,6 +26,13 @@
           "description": "Multiple argument values passed with the action in click events."
         },
         {
+          "name": "ariaLabel",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Sets the accessible name. Include the visible button text in the value."
+        },
+        {
           "name": "disabled",
           "type": "boolean",
           "required": false,
@@ -146,6 +153,13 @@
           "description": "Multiple argument values passed with the action in click events."
         },
         {
+          "name": "ariaLabel",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Sets the accessible name. Include the visible button text in the value."
+        },
+        {
           "name": "disabled",
           "type": "boolean",
           "required": false,
@@ -264,6 +278,13 @@
           "required": false,
           "default": "{}",
           "description": "Multiple argument values passed with the action in click events."
+        },
+        {
+          "name": "arialabel",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Sets the accessible name. Include the visible button text in the value."
         },
         {
           "name": "disabled",

--- a/libs/angular-components/src/lib/components/button/button.spec.ts
+++ b/libs/angular-components/src/lib/components/button/button.spec.ts
@@ -22,6 +22,7 @@ import { fireEvent } from "@testing-library/dom";
       [disabled]="disabled"
       [leadingIcon]="leadingIcon"
       [trailingIcon]="trailingIcon"
+      [ariaLabel]="ariaLabel"
       [testId]="testId"
       [mt]="mt"
       [mb]="mb"
@@ -40,6 +41,7 @@ class TestButtonComponent {
   disabled?: boolean;
   leadingIcon?: GoabIconType;
   trailingIcon?: GoabIconType;
+  ariaLabel?: string;
   testId?: string;
   mt?: Spacing;
   mb?: Spacing;
@@ -101,4 +103,18 @@ describe("GoABButton", () => {
     fireEvent(buttonElement, new CustomEvent("_click"));
     expect(onClick).toHaveBeenCalled();
   }));
+
+  it("should set arialabel when ariaLabel is provided", () => {
+    component.ariaLabel = "Remove Jane Smith";
+    fixture.detectChanges();
+    const buttonElement = fixture.debugElement.query(By.css("goa-button")).nativeElement;
+
+    expect(buttonElement.getAttribute("arialabel")).toBe("Remove Jane Smith");
+  });
+
+  it("should not set arialabel when ariaLabel is not provided", () => {
+    const buttonElement = fixture.debugElement.query(By.css("goa-button")).nativeElement;
+
+    expect(buttonElement.hasAttribute("arialabel")).toBe(false);
+  });
 });

--- a/libs/angular-components/src/lib/components/button/button.ts
+++ b/libs/angular-components/src/lib/components/button/button.ts
@@ -32,6 +32,7 @@ import { GoabBaseComponent } from "../base.component";
         [disabled]="disabled"
         [attr.leadingicon]="leadingIcon"
         [attr.trailingicon]="trailingIcon"
+        [attr.arialabel]="ariaLabel || null"
         [attr.width]="width"
         [attr.testid]="testId"
         [attr.action]="action"
@@ -65,6 +66,8 @@ export class GoabButton extends GoabBaseComponent implements OnInit {
   @Input() leadingIcon?: GoabIconType;
   /** Icon displayed after the button text. */
   @Input() trailingIcon?: GoabIconType;
+  /** Sets the accessible name. Include the visible button text in the value. */
+  @Input() ariaLabel?: string;
   /** Sets a custom width for the button (e.g., "200px", "100%" or "fit-content"). */
   @Input() width?: string;
   /** Action identifier passed in click events for event delegation patterns. */

--- a/libs/react-components/src/lib/button/button.spec.tsx
+++ b/libs/react-components/src/lib/button/button.spec.tsx
@@ -117,6 +117,22 @@ describe("GoabButton", () => {
     const el = container.querySelector("goa-button");
     expect(el?.getAttribute("data-grid")).toBe("cell");
   });
+
+  it("should set arialabel when ariaLabel is provided", () => {
+    const { container } = render(
+      <GoabButton ariaLabel="Remove Jane Smith">Remove</GoabButton>,
+    );
+    const el = container.querySelector("goa-button");
+
+    expect(el?.getAttribute("arialabel")).toBe("Remove Jane Smith");
+  });
+
+  it("should not set arialabel when ariaLabel is not provided", () => {
+    const { container } = render(<GoabButton>Remove</GoabButton>);
+    const el = container.querySelector("goa-button");
+
+    expect(el?.hasAttribute("arialabel")).toBe(false);
+  });
 });
 
 describe("GoabButton disabled attribute", () => {

--- a/libs/react-components/src/lib/button/button.tsx
+++ b/libs/react-components/src/lib/button/button.tsx
@@ -16,6 +16,7 @@ interface WCProps extends Margins {
   disabled?: string;
   leadingicon?: string;
   trailingicon?: string;
+  arialabel?: string;
   width?: string;
   testid?: string;
   action?: string;
@@ -49,6 +50,8 @@ export interface GoabButtonProps extends Margins, DataAttributes {
   leadingIcon?: GoabIconType;
   /** Icon displayed after the button text. */
   trailingIcon?: GoabIconType;
+  /** Sets the accessible name. Include the visible button text in the value. */
+  ariaLabel?: string;
   /** Sets a custom width for the button (e.g., "200px", "100%" or "fit-content"). */
   width?: string;
   /** Callback fired when the button is clicked. */
@@ -71,6 +74,7 @@ export function GoabButton({
   onClick,
   actionArgs,
   actionArg,
+  ariaLabel,
   children,
   ...rest
 }: GoabButtonProps): JSX.Element {
@@ -102,6 +106,7 @@ export function GoabButton({
       disabled={disabled ? "true" : undefined}
       action-arg={actionArg}
       action-args={JSON.stringify(actionArgs)}
+      arialabel={ariaLabel || undefined}
       {..._props}
       version="2"
     >

--- a/libs/web-components/src/components/button/Button.spec.ts
+++ b/libs/web-components/src/components/button/Button.spec.ts
@@ -150,4 +150,23 @@ describe("GoAButtonComponent", () => {
       expect(button.style.getPropertyValue("--width")).toBe("");
     });
   });
+
+  describe("aria label", () => {
+    it("should set aria-label when arialabel is provided", async () => {
+      const result = render(GoAButton, {
+        testid: "button-test",
+        arialabel: "Remove Jane Smith",
+      });
+      const button = await result.findByTestId("button-test");
+
+      expect(button.getAttribute("aria-label")).toBe("Remove Jane Smith");
+    });
+
+    it("should not set aria-label when arialabel is not provided", async () => {
+      const result = render(GoAButton, { testid: "button-test" });
+      const button = await result.findByTestId("button-test");
+
+      expect(button.hasAttribute("aria-label")).toBe(false);
+    });
+  });
 });

--- a/libs/web-components/src/components/button/Button.svelte
+++ b/libs/web-components/src/components/button/Button.svelte
@@ -68,6 +68,9 @@
   /** Icon displayed after the button text. */
   export let trailingicon: GoAIconType | null = null;
 
+  /** Sets the accessible name. Include the visible button text in the value. */
+  export let arialabel: string | undefined = undefined;
+
   /** Sets a data-testid attribute for automated testing. */
   export let testid: string = "";
 
@@ -149,6 +152,7 @@
   on:click={clickHandler}
   data-testid={testid}
   type={type === "submit" ? type : "button"}
+  aria-label={arialabel || undefined}
 >
   {#if type === "start"}
     <span class="text">


### PR DESCRIPTION
# After (the change)

There's a new property `ariaLabel` added to the `GoabButton` component. This property if supplied (it is not required) will replace the text in the button as what's read by a screen reader.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Check the PR "feat3153" for either Angular and/or React. There are two options, one with the property supplied, one not supplied. For the supplied one, it should read out the aria label by a screen reader, for the not supplied button, the text on the button should be read out.
