### PR TITLE
fix(#3161): Dropdown filterable now focuses input

### DIFF
--- a/libs/react-components/specs/dropdown.browser.spec.tsx
+++ b/libs/react-components/specs/dropdown.browser.spec.tsx
@@ -618,6 +618,39 @@ describe("Dropdown", () => {
   })
 
   describe("Filterable Dropdown", () => {
+    it("focuses the input when the caret opens the menu", async () => {
+      const Component = () => (
+        <GoabDropdown name="favcolor" onChange={noop} filterable={true}>
+          <GoabDropdownItem label="Red" value="red" />
+          <GoabDropdownItem label="Blue" value="blue" />
+          <GoabDropdownItem label="Green" value="green" />
+        </GoabDropdown>
+      );
+
+      const result = render(<Component />);
+      const caret = result.getByTestId("chevron");
+      const input = result.getByRole("combobox");
+
+      await vi.waitFor(() => {
+        expect(input).toBeVisible();
+      });
+
+      const inputEl = input.element() as HTMLInputElement;
+
+      await caret.click();
+
+      await vi.waitFor(() => {
+        expect(inputEl.getAttribute("aria-expanded")).toBe("true");
+        expect(inputEl.matches(":focus")).toBe(true);
+      });
+
+      await userEvent.keyboard("B");
+
+      await vi.waitFor(() => {
+        expect(inputEl.value).toBe("B");
+      });
+    });
+
     it("should render with the default props", async () => {
       // Setup
       const Component = () => {

--- a/libs/web-components/src/components/dropdown/Dropdown.svelte
+++ b/libs/web-components/src/components/dropdown/Dropdown.svelte
@@ -6,7 +6,7 @@
 />
 
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
 
   import type { GoAIconType } from "../icon/Icon.svelte";
   import type { Spacing } from "../../common/styling";
@@ -227,6 +227,10 @@
   function setupPopoverListeners() {
     _popoverEl?.addEventListener("_open", (e) => {
       _isMenuVisible = true;
+      if (_filterable) {
+        // Queue input focus after the popover focus trap has handled opening.
+        tick().then(() => setTimeout(() => _inputEl?.focus(), 0));
+      }
     });
 
     _popoverEl?.addEventListener("_close", (e) => {


### PR DESCRIPTION
# Before (the change)

When you clicked the caret on a filterable Dropdown, it would just expand the Dropdown, it wouldn't focus the Input.

# After (the change)

Now when you click the caret on a filterable Dropdown, it focuses the input immediately to allow for typing right away. This is identical to how the HTML datalist component functions, as well as uses the same method our DropdownMultiselect component uses to make this work.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the Dropdown docs PR to test
