### PR TITLE
fix(#3342): Update DatePicker documentation to only allow for strings

### DIFF
--- a/apps/prs/angular/src/routes/docs/container/container.component.ts
+++ b/apps/prs/angular/src/routes/docs/container/container.component.ts
@@ -25,7 +25,7 @@ export class DocsContainerComponent {
   private fb = inject(FormBuilder);
 
   open = false;
-  effectiveDate = new Date();
+  effectiveDate = this.formatDate(new Date());
   form: FormGroup = this.fb.group({
     case: [""],
     reason: [""],
@@ -37,7 +37,14 @@ export class DocsContainerComponent {
   }
 
   onChangeEffectiveDate(event: GoabDatePickerOnChangeDetail): void {
-    this.effectiveDate = event.value as Date;
+    this.effectiveDate = event.valueStr;
+  }
+
+  private formatDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
   }
 
   onAddToCalendar(): void {

--- a/apps/prs/angular/src/routes/docs/date-picker/date-picker.component.ts
+++ b/apps/prs/angular/src/routes/docs/date-picker/date-picker.component.ts
@@ -19,13 +19,13 @@ export class DocsDatePickerComponent {
   private fb = inject(FormBuilder);
 
   basicForm = new FormGroup({
-    date: new FormControl<Date | null>(null),
+    date: new FormControl<string | null>(null),
   });
 
-  ngModelDate: Date | undefined;
+  ngModelDate: string | undefined;
 
   withValueForm: FormGroup = this.fb.group({
-    startDate: [new Date("2024-01-15")],
+    startDate: ["2024-01-15"],
   });
   rangeForm: FormGroup = this.fb.group({
     appointment: [null],
@@ -35,30 +35,28 @@ export class DocsDatePickerComponent {
     birthday: [null],
   });
   statesForm: FormGroup = this.fb.group({
-    locked: [{ value: new Date("2024-01-01"), disabled: true }],
+    locked: [{ value: "2024-01-01", disabled: true }],
     errorDate: [null],
   });
 
   // Examples
-  exampleBirthday: Date | undefined;
-  resetItem: Date | undefined;
+  exampleBirthday: string | undefined;
+  resetItem: string | undefined;
 
   onDateChange(event: GoabDatePickerOnChangeDetail): void {
-    this.ngModelDate = event.valueStr ? new Date(event.valueStr) : undefined;
+    this.ngModelDate = event.valueStr || undefined;
   }
 
   onBirthdayChange(event: GoabDatePickerOnChangeDetail): void {
-    this.exampleBirthday = event.valueStr ? new Date(event.valueStr) : undefined;
+    this.exampleBirthday = event.valueStr || undefined;
   }
 
   onResetChange(event: GoabDatePickerOnChangeDetail): void {
-    this.resetItem = event.valueStr ? new Date(event.valueStr) : undefined;
+    this.resetItem = event.valueStr || undefined;
   }
 
   setResetValue(): void {
-    const d = new Date();
-    d.setDate(d.getDate() - 7);
-    this.resetItem = d;
+    this.resetItem = "2024-01-15";
   }
 
   clearResetValue(): void {

--- a/apps/prs/react/src/routes/docs/container/container.tsx
+++ b/apps/prs/react/src/routes/docs/container/container.tsx
@@ -26,12 +26,16 @@ import "./container.css";
 
 export function DocsContainerRoute() {
   const [open, setOpen] = useState(false);
-  const [effectiveDate, setEffectiveDate] = useState<Date | undefined>(new Date());
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const day = String(today.getDate()).padStart(2, "0");
+  const [effectiveDate, setEffectiveDate] = useState(`${year}-${month}-${day}`);
   const [typedChips, setTypedChips] = useState<string[]>([]);
   const [inputValue, setInputValue] = useState("");
 
   const onChangeEffectiveDate = (detail: GoabDatePickerOnChangeDetail) => {
-    setEffectiveDate(detail.value as Date);
+    setEffectiveDate(detail.valueStr);
   };
 
   const addChip = () => {

--- a/apps/prs/react/src/routes/docs/date-picker/date-picker.tsx
+++ b/apps/prs/react/src/routes/docs/date-picker/date-picker.tsx
@@ -7,21 +7,19 @@ import {
 } from "@abgov/react-components";
 
 export function DocsDatePickerRoute() {
-  const [date, setDate] = useState<Date | undefined>();
-  const [startDate, setStartDate] = useState<Date | undefined>(new Date("2024-01-15"));
-  const [appointment, setAppointment] = useState<Date | undefined>();
-  const [incident, setIncident] = useState<Date | undefined>();
-  const [birthday, setBirthday] = useState<Date | undefined>();
-  const [errorDate, setErrorDate] = useState<Date | undefined>();
+  const [date, setDate] = useState<string | undefined>();
+  const [startDate, setStartDate] = useState<string | undefined>("2024-01-15");
+  const [appointment, setAppointment] = useState<string | undefined>();
+  const [incident, setIncident] = useState<string | undefined>();
+  const [birthday, setBirthday] = useState<string | undefined>();
+  const [errorDate, setErrorDate] = useState<string | undefined>();
 
   // Examples
-  const [exampleBirthday, setExampleBirthday] = useState<Date | undefined>();
-  const [resetDate, setResetDate] = useState<Date | undefined>();
+  const [exampleBirthday, setExampleBirthday] = useState<string | undefined>();
+  const [resetDate, setResetDate] = useState<string | undefined>();
 
   const setValue = () => {
-    const d = new Date();
-    d.setDate(d.getDate() - 7);
-    setResetDate(d);
+    setResetDate("2024-01-15");
   };
 
   const clearValue = () => setResetDate(undefined);
@@ -35,7 +33,7 @@ export function DocsDatePickerRoute() {
         <GoabDatePicker
           name="date"
           value={date}
-          onChange={(detail) => setDate(detail.value)}
+          onChange={(detail) => setDate(detail.valueStr || undefined)}
         />
       </GoabFormItem>
 
@@ -44,18 +42,22 @@ export function DocsDatePickerRoute() {
         <GoabDatePicker
           name="startDate"
           value={startDate}
-          onChange={(detail) => setStartDate(detail.value)}
+          onChange={(detail) => setStartDate(detail.valueStr || undefined)}
         />
       </GoabFormItem>
 
       <h3>With date range</h3>
-      <GoabFormItem label="Appointment date" helpText="Select a date within the next 7 days" mb="l">
+      <GoabFormItem
+        label="Appointment date"
+        helpText="Select a date within the next 7 days"
+        mb="l"
+      >
         <GoabDatePicker
           name="appointment"
           min="2024-03-01"
           max="2024-03-07"
           value={appointment}
-          onChange={(detail) => setAppointment(detail.value)}
+          onChange={(detail) => setAppointment(detail.valueStr || undefined)}
         />
       </GoabFormItem>
 
@@ -65,7 +67,7 @@ export function DocsDatePickerRoute() {
           name="incident"
           type="calendar"
           value={incident}
-          onChange={(detail) => setIncident(detail.value)}
+          onChange={(detail) => setIncident(detail.valueStr || undefined)}
         />
       </GoabFormItem>
       <GoabFormItem label="What is your birthday?" mb="l">
@@ -73,20 +75,20 @@ export function DocsDatePickerRoute() {
           name="birthday"
           type="input"
           value={birthday}
-          onChange={(detail) => setBirthday(detail.value)}
+          onChange={(detail) => setBirthday(detail.valueStr || undefined)}
         />
       </GoabFormItem>
 
       <h3>States</h3>
       <GoabFormItem label="Locked date" mb="l">
-        <GoabDatePicker name="locked" value={new Date("2024-01-01")} disabled />
+        <GoabDatePicker name="locked" value="2024-01-01" disabled />
       </GoabFormItem>
       <GoabFormItem label="Date with error" error="Please select a valid date" mb="l">
         <GoabDatePicker
           name="error"
           error
           value={errorDate}
-          onChange={(detail) => setErrorDate(detail.value)}
+          onChange={(detail) => setErrorDate(detail.valueStr || undefined)}
         />
       </GoabFormItem>
 
@@ -98,7 +100,7 @@ export function DocsDatePickerRoute() {
           name="birthdate"
           type="input"
           value={exampleBirthday}
-          onChange={(e) => setExampleBirthday(e.value)}
+          onChange={(e) => setExampleBirthday(e.valueStr || undefined)}
         />
       </GoabFormItem>
 
@@ -107,7 +109,7 @@ export function DocsDatePickerRoute() {
         <GoabDatePicker
           name="item"
           value={resetDate}
-          onChange={(e) => setResetDate(e.value as Date)}
+          onChange={(e) => setResetDate(e.valueStr || undefined)}
           mb="xl"
         />
       </GoabFormItem>

--- a/apps/prs/react/src/routes/docs/drawer/drawer.tsx
+++ b/apps/prs/react/src/routes/docs/drawer/drawer.tsx
@@ -177,7 +177,7 @@ export function DocsDrawerRoute() {
           </GoabRadioGroup>
         </GoabFormItem>
         <GoabFormItem label="Start date" mt="l">
-          <GoabDatePicker onChange={() => { /* no-op */ }} value={new Date("2022-09-01")} />
+          <GoabDatePicker onChange={() => { /* no-op */ }} value="2022-09-01" />
           <GoabCheckbox
             name="startDateApproximate"
             text="Approximate date"

--- a/docs/generated/component-apis/date-picker.json
+++ b/docs/generated/component-apis/date-picker.json
@@ -20,14 +20,10 @@
         },
         {
           "name": "max",
-          "type": "Date | string",
-          "values": [
-            "Date",
-            "string"
-          ],
+          "type": "string",
           "required": false,
           "default": null,
-          "description": "Maximum date value allowed."
+          "description": "Sets the latest allowed date as an ISO date string (yyyy-mm-dd)."
         },
         {
           "name": "mb",
@@ -38,14 +34,10 @@
         },
         {
           "name": "min",
-          "type": "Date | string",
-          "values": [
-            "Date",
-            "string"
-          ],
+          "type": "string",
           "required": false,
           "default": null,
-          "description": "Minimum date value allowed."
+          "description": "Sets the earliest allowed date as an ISO date string (yyyy-mm-dd)."
         },
         {
           "name": "ml",
@@ -91,14 +83,10 @@
         },
         {
           "name": "value",
-          "type": "Date | string | undefined",
-          "values": [
-            "Date",
-            "string"
-          ],
+          "type": "string",
           "required": false,
           "default": null,
-          "description": "Value of the calendar date, as a Date object or an ISO date string (yyyy-mm-dd)."
+          "description": "Sets the calendar date as an ISO date string (yyyy-mm-dd)."
         },
         {
           "name": "width",
@@ -161,14 +149,10 @@
         },
         {
           "name": "max",
-          "type": "Date | string",
-          "values": [
-            "Date",
-            "string"
-          ],
+          "type": "string",
           "required": false,
           "default": null,
-          "description": "Sets the maximum date value allowed."
+          "description": "Sets the latest allowed date as an ISO date string (yyyy-mm-dd)."
         },
         {
           "name": "mb",
@@ -179,14 +163,10 @@
         },
         {
           "name": "min",
-          "type": "Date | string",
-          "values": [
-            "Date",
-            "string"
-          ],
+          "type": "string",
           "required": false,
           "default": null,
-          "description": "Sets the minimum date value allowed."
+          "description": "Sets the earliest allowed date as an ISO date string (yyyy-mm-dd)."
         },
         {
           "name": "ml",
@@ -232,14 +212,10 @@
         },
         {
           "name": "value",
-          "type": "Date | string | null | undefined",
-          "values": [
-            "Date",
-            "string"
-          ],
+          "type": "string",
           "required": false,
           "default": null,
-          "description": "Sets the value of the calendar date."
+          "description": "Sets the calendar date as an ISO date string (yyyy-mm-dd)."
         },
         {
           "name": "width",
@@ -298,7 +274,7 @@
           "type": "string",
           "required": false,
           "default": "",
-          "description": "Maximum date value allowed."
+          "description": "Sets the latest allowed date as an ISO date string (yyyy-mm-dd)."
         },
         {
           "name": "mb",
@@ -313,7 +289,7 @@
           "type": "string",
           "required": false,
           "default": "",
-          "description": "Minimum date value allowed."
+          "description": "Sets the earliest allowed date as an ISO date string (yyyy-mm-dd)."
         },
         {
           "name": "ml",
@@ -380,7 +356,7 @@
           "type": "string",
           "required": false,
           "default": "",
-          "description": "Value of the calendar date."
+          "description": "Sets the calendar date as an ISO date string (yyyy-mm-dd)."
         },
         {
           "name": "version",

--- a/docs/src/content/examples/add-a-record-using-a-drawer/react.tsx
+++ b/docs/src/content/examples/add-a-record-using-a-drawer/react.tsx
@@ -65,7 +65,7 @@ export function AddARecordUsingADrawer() {
           </GoabRadioGroup>
         </GoabFormItem>
         <GoabFormItem label="Start date" mt="l">
-          <GoabDatePicker onChange={() => {}} value={new Date("2022-09-01")} />
+          <GoabDatePicker onChange={() => {}} value="2022-09-01" />
           <GoabCheckbox
             name="startDateApproximate"
             text="Approximate date"

--- a/docs/src/content/examples/ask-a-user-for-a-birthday/angular.ts
+++ b/docs/src/content/examples/ask-a-user-for-a-birthday/angular.ts
@@ -6,9 +6,9 @@ import type { GoabDatePickerOnChangeDetail } from "@abgov/ui-components-common";
   templateUrl: "./angular.html",
 })
 export class AskForBirthdayComponent {
-  birthdate: Date | undefined;
+  birthdate: string | undefined;
 
   onDateChange(event: GoabDatePickerOnChangeDetail): void {
-    this.birthdate = event.valueStr ? new Date(event.valueStr) : undefined;
+    this.birthdate = event.valueStr || undefined;
   }
 }

--- a/docs/src/content/examples/ask-a-user-for-a-birthday/react.tsx
+++ b/docs/src/content/examples/ask-a-user-for-a-birthday/react.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { GoabDatePicker, GoabFormItem } from "@abgov/react-components";
 
 export function AskForBirthday() {
-  const [birthdate, setBirthdate] = useState<Date | undefined>(undefined);
+  const [birthdate, setBirthdate] = useState<string | undefined>();
 
   return (
     <GoabFormItem label="What is your date of birth?">
@@ -10,7 +10,7 @@ export function AskForBirthday() {
         name="birthdate"
         type="input"
         value={birthdate}
-        onChange={(e) => setBirthdate(e.value)}
+        onChange={(e) => setBirthdate(e.valueStr || undefined)}
       />
     </GoabFormItem>
   );

--- a/docs/src/content/examples/confirm-a-change/angular.ts
+++ b/docs/src/content/examples/confirm-a-change/angular.ts
@@ -7,13 +7,20 @@ import { GoabDatePickerOnChangeDetail } from "@abgov/ui-components-common";
 })
 export class ConfirmAChangeComponent {
   open = false;
-  effectiveDate = new Date();
+  effectiveDate = this.formatDate(new Date());
 
   toggleModal(): void {
     this.open = !this.open;
   }
 
   onChangeEffectiveDate(event: GoabDatePickerOnChangeDetail): void {
-    this.effectiveDate = event.value as Date;
+    this.effectiveDate = event.valueStr;
+  }
+
+  private formatDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
   }
 }

--- a/docs/src/content/examples/confirm-a-change/react.tsx
+++ b/docs/src/content/examples/confirm-a-change/react.tsx
@@ -13,10 +13,14 @@ import { GoabDatePickerOnChangeDetail } from "@abgov/ui-components-common";
 
 export function ConfirmAChange() {
   const [open, setOpen] = useState(false);
-  const [effectiveDate, setEffectiveDate] = useState<Date | undefined>(new Date());
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const day = String(today.getDate()).padStart(2, "0");
+  const [effectiveDate, setEffectiveDate] = useState(`${year}-${month}-${day}`);
 
   const onChangeEffectiveDate = (detail: GoabDatePickerOnChangeDetail) => {
-    setEffectiveDate(detail.value as Date);
+    setEffectiveDate(detail.valueStr);
   };
 
   return (

--- a/docs/src/content/examples/reset-date-picker-field/angular.ts
+++ b/docs/src/content/examples/reset-date-picker-field/angular.ts
@@ -6,16 +6,14 @@ import type { GoabDatePickerOnChangeDetail } from "@abgov/ui-components-common";
   templateUrl: "./angular.html",
 })
 export class ResetDatePickerFieldComponent {
-  item: Date | undefined = undefined;
+  item: string | undefined;
 
   onChange(event: GoabDatePickerOnChangeDetail): void {
-    this.item = event.valueStr ? new Date(event.valueStr) : undefined;
+    this.item = event.valueStr || undefined;
   }
 
   setValue(): void {
-    const d = new Date();
-    d.setDate(d.getDate() - 7);
-    this.item = d;
+    this.item = "2024-01-15";
   }
 
   clearValue(): void {

--- a/docs/src/content/examples/reset-date-picker-field/react.tsx
+++ b/docs/src/content/examples/reset-date-picker-field/react.tsx
@@ -7,16 +7,10 @@ import {
 } from "@abgov/react-components";
 
 export function ResetDatePickerField() {
-  const [date, setDate] = useState<Date | undefined>();
-
-  const setNewDate = (value: Date | undefined) => {
-    setDate(value);
-  };
+  const [date, setDate] = useState<string | undefined>();
 
   function setValue() {
-    const d = new Date();
-    d.setDate(d.getDate() - 7);
-    setDate(d);
+    setDate("2024-01-15");
   }
 
   function clearValue() {
@@ -29,7 +23,7 @@ export function ResetDatePickerField() {
         <GoabDatePicker
           name="item"
           value={date}
-          onChange={(e) => setNewDate(e.value as Date)}
+          onChange={(e) => setDate(e.valueStr || undefined)}
           mb="xl"
         />
       </GoabFormItem>

--- a/docs/src/data/configurations/date-picker.ts
+++ b/docs/src/data/configurations/date-picker.ts
@@ -17,13 +17,13 @@ export const datePickerConfigurations: ComponentConfigurations = {
       name: "Basic date picker",
       description: "Simple date selection",
       code: {
-        react: `const [date, setDate] = useState<Date | undefined>();
+        react: `const [date, setDate] = useState<string | undefined>();
 
 <GoabFormItem label="Date" mb="l">
   <GoabDatePicker
     name="date"
     value={date}
-    onChange={(detail) => setDate(detail.valueStr ? new Date(detail.valueStr) : undefined)}
+    onChange={(detail) => setDate(detail.valueStr || undefined)}
   />
 </GoabFormItem>`,
         angular: [
@@ -46,10 +46,10 @@ export const datePickerConfigurations: ComponentConfigurations = {
           {
             title: "Template driven (ngModel)",
             ts: `export class SomeOtherComponent {
-  date: Date | undefined;
+  date: string | undefined;
 
   onDateChange(event: GoabDatePickerOnChangeDetail) {
-    this.date = event.valueStr ? new Date(event.valueStr) : undefined;
+    this.date = event.valueStr || undefined;
   }
 }`,
             template: `<form>
@@ -74,13 +74,13 @@ export const datePickerConfigurations: ComponentConfigurations = {
       name: "With initial value",
       description: "Date picker with preset date",
       code: {
-        react: `const [startDate, setStartDate] = useState<Date | undefined>(new Date("2024-01-15"));
+        react: `const [startDate, setStartDate] = useState<string | undefined>("2024-01-15");
 
 <GoabFormItem label="Start date" mb="l">
   <GoabDatePicker
     name="startDate"
     value={startDate}
-    onChange={(detail) => setStartDate(detail.valueStr ? new Date(detail.valueStr) : undefined)}
+    onChange={(detail) => setStartDate(detail.valueStr || undefined)}
   />
 </GoabFormItem>`,
         angular: [
@@ -90,7 +90,7 @@ export const datePickerConfigurations: ComponentConfigurations = {
   form!: FormGroup;
   constructor(private fb: FormBuilder) {
     this.form = this.fb.group({
-      startDate: [new Date("2024-01-15")],
+      startDate: ["2024-01-15"],
     });
   }
 }`,
@@ -106,10 +106,10 @@ export const datePickerConfigurations: ComponentConfigurations = {
           {
             title: "Template driven (ngModel)",
             ts: `export class SomeOtherComponent {
-  startDate: Date | undefined = new Date("2024-01-15");
+  startDate: string | undefined = "2024-01-15";
 
   onDateChange(event: GoabDatePickerOnChangeDetail) {
-    this.startDate = event.valueStr ? new Date(event.valueStr) : undefined;
+    this.startDate = event.valueStr || undefined;
   }
 }`,
             template: `<form>
@@ -134,7 +134,7 @@ export const datePickerConfigurations: ComponentConfigurations = {
       name: "With date range",
       description: "Restrict selectable dates",
       code: {
-        react: `const [appointment, setAppointment] = useState<Date | undefined>();
+        react: `const [appointment, setAppointment] = useState<string | undefined>();
 
 <GoabFormItem label="Appointment date" helpText="Select a date within the next 7 days" mb="l">
   <GoabDatePicker
@@ -142,7 +142,7 @@ export const datePickerConfigurations: ComponentConfigurations = {
     min="2024-03-01"
     max="2024-03-07"
     value={appointment}
-    onChange={(detail) => setAppointment(detail.valueStr ? new Date(detail.valueStr) : undefined)}
+    onChange={(detail) => setAppointment(detail.valueStr || undefined)}
   />
 </GoabFormItem>`,
         angular: [
@@ -175,10 +175,10 @@ export const datePickerConfigurations: ComponentConfigurations = {
           {
             title: "Template driven (ngModel)",
             ts: `export class SomeOtherComponent {
-  appointment: Date | undefined;
+  appointment: string | undefined;
 
   onDateChange(event: GoabDatePickerOnChangeDetail) {
-    this.appointment = event.valueStr ? new Date(event.valueStr) : undefined;
+    this.appointment = event.valueStr || undefined;
   }
 }`,
             template: `<form>
@@ -241,15 +241,15 @@ export const datePickerConfigurations: ComponentConfigurations = {
       name: "Input type",
       description: "Date picker rendered as a simple date input without calendar popup",
       code: {
-        react: `const [incident, setIncident] = useState<Date | undefined>();
-const [birthday, setBirthday] = useState<Date | undefined>();
+        react: `const [incident, setIncident] = useState<string | undefined>();
+const [birthday, setBirthday] = useState<string | undefined>();
 
 <GoabFormItem label="What day was the incident?" mb="l">
   <GoabDatePicker
     name="incident"
     type="calendar"
     value={incident}
-    onChange={(detail) => setIncident(detail.valueStr ? new Date(detail.valueStr) : undefined)}
+    onChange={(detail) => setIncident(detail.valueStr || undefined)}
   />
 </GoabFormItem>
 <GoabFormItem label="What is your birthday?" mb="l">
@@ -257,7 +257,7 @@ const [birthday, setBirthday] = useState<Date | undefined>();
     name="birthday"
     type="input"
     value={birthday}
-    onChange={(detail) => setBirthday(detail.valueStr ? new Date(detail.valueStr) : undefined)}
+    onChange={(detail) => setBirthday(detail.valueStr || undefined)}
   />
 </GoabFormItem>`,
         angular: [
@@ -292,8 +292,8 @@ const [birthday, setBirthday] = useState<Date | undefined>();
           {
             title: "Template driven (ngModel)",
             ts: `export class SomeOtherComponent {
-  incident: Date | undefined;
-  birthday: Date | undefined;
+  incident: string | undefined;
+  birthday: string | undefined;
 
   onDateChange(event: GoabDatePickerOnChangeDetail) {
     console.log(event);
@@ -334,17 +334,17 @@ const [birthday, setBirthday] = useState<Date | undefined>();
       name: "States",
       description: "Disabled and error states",
       code: {
-        react: `const [errorDate, setErrorDate] = useState<Date | undefined>();
+        react: `const [errorDate, setErrorDate] = useState<string | undefined>();
 
 <GoabFormItem label="Locked date" mb="l">
-  <GoabDatePicker name="locked" value={new Date("2024-01-01")} disabled />
+  <GoabDatePicker name="locked" value="2024-01-01" disabled />
 </GoabFormItem>
 <GoabFormItem label="Date with error" error="Please select a valid date" mb="l">
   <GoabDatePicker
     name="error"
     error
     value={errorDate}
-    onChange={(detail) => setErrorDate(detail.valueStr ? new Date(detail.valueStr) : undefined)}
+    onChange={(detail) => setErrorDate(detail.valueStr || undefined)}
   />
 </GoabFormItem>`,
         angular: [
@@ -354,7 +354,7 @@ const [birthday, setBirthday] = useState<Date | undefined>();
   form!: FormGroup;
   constructor(private fb: FormBuilder) {
     this.form = this.fb.group({
-      locked: [{ value: new Date("2024-01-01"), disabled: true }],
+      locked: [{ value: "2024-01-01", disabled: true }],
       errorDate: [null],
     });
   }
@@ -379,11 +379,11 @@ const [birthday, setBirthday] = useState<Date | undefined>();
           {
             title: "Template driven (ngModel)",
             ts: `export class SomeOtherComponent {
-  locked: Date = new Date("2024-01-01");
-  errorDate: Date | undefined;
+  locked = "2024-01-01";
+  errorDate: string | undefined;
 
   onDateChange(event: GoabDatePickerOnChangeDetail) {
-    this.errorDate = event.valueStr ? new Date(event.valueStr) : undefined;
+    this.errorDate = event.valueStr || undefined;
   }
 }`,
             template: `<form>

--- a/docs/src/scripts/extract-api.ts
+++ b/docs/src/scripts/extract-api.ts
@@ -198,6 +198,25 @@ const WEB_COMPONENT_EVENT_TYPE_OVERRIDES: Record<string, Record<string, string>>
       "CustomEvent<{ state: 'no-scroll' | 'at-top' | 'middle' | 'at-bottom'; isScrollable: boolean }>",
   },
 };
+// Keep backward-compatible wrapper types in source while documenting only the
+// preferred public input types. Date picker still accepts Date values at runtime.
+const PROP_TYPE_OVERRIDES: Record<
+  string,
+  Partial<Record<"react" | "angular" | "webComponents", Record<string, string>>>
+> = {
+  "date-picker": {
+    react: {
+      value: "string",
+      min: "string",
+      max: "string",
+    },
+    angular: {
+      value: "string",
+      min: "string",
+      max: "string",
+    },
+  },
+};
 // Slots consumed as dedicated sub-components (e.g. GoabAppFooterMetaSection) rather than
 // typed props/inputs: documenting them as ReactNode/TemplateRef props would be wrong since
 // consumers never bind a value to them, they nest the sub-component instead.
@@ -282,6 +301,24 @@ function specializeAngularValuePropFromReact(
 
   angularValueProp.type = reactValueProp.type;
   angularValueProp.values = reactValueProp.values;
+}
+
+function applyPropTypeOverrides(
+  componentName: string,
+  framework: "react" | "angular" | "webComponents",
+  props: ExtractedProp[],
+): void {
+  const overrides = PROP_TYPE_OVERRIDES[componentName]?.[framework];
+  if (!overrides) return;
+
+  for (const prop of props) {
+    const type = overrides[prop.name];
+    if (!type) continue;
+
+    prop.type = type;
+    delete prop.typeLabel;
+    delete prop.values;
+  }
 }
 
 // =============================================================================
@@ -2680,6 +2717,10 @@ function extractComponentAPI(componentName: string): ExtractedComponentAPI | nul
     : [];
 
   specializeAngularValuePropFromReact(angularProps, reactProps);
+
+  applyPropTypeOverrides(componentName, "react", reactProps);
+  applyPropTypeOverrides(componentName, "angular", angularProps);
+  applyPropTypeOverrides(componentName, "webComponents", webComponentProps);
 
   const webComponentVersionProp = webComponentProps.find(
     (prop) => prop.name.toLowerCase() === "version",

--- a/libs/angular-components/src/lib/components/date-picker/date-picker.ts
+++ b/libs/angular-components/src/lib/components/date-picker/date-picker.ts
@@ -69,11 +69,11 @@ export class GoabDatePicker extends GoabControlValueAccessor implements OnInit {
 
   /** Sets the name of the date field. */
   @Input() name?: string;
-  /** Sets the value of the calendar date. */
+  /** Sets the calendar date as an ISO date string (yyyy-mm-dd). */
   @Input() override value?: Date | string | null | undefined;
-  /** Sets the minimum date value allowed. */
+  /** Sets the earliest allowed date as an ISO date string (yyyy-mm-dd). */
   @Input() min?: Date | string;
-  /** Sets the maximum date value allowed. */
+  /** Sets the latest allowed date as an ISO date string (yyyy-mm-dd). */
   @Input() max?: Date | string;
   /** Sets the date picker type. 'calendar' shows a calendar popup, 'input' shows just a date input. @default "calendar" */
   @Input() type?: GoabDatePickerInputType;

--- a/libs/react-components/src/lib/date-picker/date-picker.tsx
+++ b/libs/react-components/src/lib/date-picker/date-picker.tsx
@@ -41,13 +41,13 @@ export interface GoabDatePickerProps extends Margins, DataAttributes {
   type?: GoabDatePickerInputType;
   /** Name of the date field. */
   name?: string;
-  /** Value of the calendar date, as a Date object or an ISO date string (yyyy-mm-dd). */
+  /** Sets the calendar date as an ISO date string (yyyy-mm-dd). */
   value?: Date | string | undefined;
   /** Sets the input to an error state. */
   error?: boolean;
-  /** Minimum date value allowed. */
+  /** Sets the earliest allowed date as an ISO date string (yyyy-mm-dd). */
   min?: Date | string;
-  /** Maximum date value allowed. */
+  /** Sets the latest allowed date as an ISO date string (yyyy-mm-dd). */
   max?: Date | string;
   /** Sets a data-testid attribute for automated testing. */
   testId?: string;

--- a/libs/web-components/src/components/date-picker/DatePicker.svelte
+++ b/libs/web-components/src/components/date-picker/DatePicker.svelte
@@ -36,13 +36,13 @@
   export let type: "calendar" | "input" = "calendar";
   /** Name of the date field. */
   export let name: string = "";
-  /** Value of the calendar date. */
+  /** Sets the calendar date as an ISO date string (yyyy-mm-dd). */
   export let value: string = "";
   /** Sets the input to an error state. */
   export let error: string = "false";
-  /** Minimum date value allowed. */
+  /** Sets the earliest allowed date as an ISO date string (yyyy-mm-dd). */
   export let min: string = "";
-  /** Maximum date value allowed. */
+  /** Sets the latest allowed date as an ISO date string (yyyy-mm-dd). */
   export let max: string = "";
   /** @deprecated This property has no effect and will be removed in a future version. */
   export let relative: string = "";


### PR DESCRIPTION
# Before (the change)

Date Picker documentation was a little mixed between React, Angular, and Web. It also listed Date as an accepted value in places for `value`, `min`, and `max`.

# After (the change)

Date Picker documentation for properties has been aligned between React, Angular, and Web. `string` is now the only accepted property for `value`, `min`, and `max`. In addition each of those properties specifies the arrangement of that string that's needed to work.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Check the Date Picker documentation
