### PR TITLE
feat(#3364): Removed the need for closable with Angular Modal

### DIFF
--- a/apps/prs/angular/src/routes/docs/modal/modal.component.html
+++ b/apps/prs/angular/src/routes/docs/modal/modal.component.html
@@ -5,30 +5,44 @@
 <goab-modal heading="Confirm action" [open]="basicOpen">
   <p>Are you sure you want to proceed with this action?</p>
   <goab-button-group alignment="end" mt="l">
-    <goab-button type="secondary" size="compact" (onClick)="closeBasic()">Cancel</goab-button>
+    <goab-button type="secondary" size="compact" (onClick)="closeBasic()"
+      >Cancel</goab-button
+    >
     <goab-button size="compact" (onClick)="closeBasic()">Confirm</goab-button>
   </goab-button-group>
 </goab-modal>
 
 <h3>Dismissable</h3>
 <goab-button (onClick)="openDismissable()">Open dismissable modal</goab-button>
-<goab-modal heading="Information" [open]="dismissableOpen" [closable]="true" (onClose)="closeDismissable()">
+<goab-modal heading="Information" [open]="dismissableOpen" (onClose)="closeDismissable()">
   <p>You can close this modal with the X button or by clicking the backdrop.</p>
 </goab-modal>
 
 <h3>Destructive action</h3>
 <goab-button (onClick)="openDestructive()">Open destructive modal</goab-button>
-<goab-modal heading="Are you sure you want to delete this item?" [open]="destructiveOpen" calloutVariant="emergency">
+<goab-modal
+  heading="Are you sure you want to delete this item?"
+  [open]="destructiveOpen"
+  calloutVariant="emergency"
+>
   <p>This action cannot be undone. The item will be permanently removed.</p>
   <goab-button-group alignment="end" mt="l">
-    <goab-button type="secondary" size="compact" (onClick)="closeDestructive()">Cancel</goab-button>
-    <goab-button variant="destructive" size="compact" (onClick)="closeDestructive()">Delete</goab-button>
+    <goab-button type="secondary" size="compact" (onClick)="closeDestructive()"
+      >Cancel</goab-button
+    >
+    <goab-button variant="destructive" size="compact" (onClick)="closeDestructive()"
+      >Delete</goab-button
+    >
   </goab-button-group>
 </goab-modal>
 
 <h3>Important callout</h3>
 <goab-button (onClick)="openImportant()">Open important modal</goab-button>
-<goab-modal heading="Your session is about to expire" [open]="importantOpen" calloutVariant="important">
+<goab-modal
+  heading="Your session is about to expire"
+  [open]="importantOpen"
+  calloutVariant="important"
+>
   <p>You will be logged out in 5 minutes due to inactivity.</p>
   <goab-button-group alignment="end" mt="l">
     <goab-button size="compact" (onClick)="closeImportant()">Stay logged in</goab-button>
@@ -37,33 +51,68 @@
 
 <h3>Information callout</h3>
 <goab-button (onClick)="openInfo()">Open info modal</goab-button>
-<goab-modal heading="New features available" [open]="infoOpen" [closable]="true" calloutVariant="information" (onClose)="closeInfo()">
-  <p>We have updated the application with new features. Review the changes to get started.</p>
+<goab-modal
+  heading="New features available"
+  [open]="infoOpen"
+  calloutVariant="information"
+  (onClose)="closeInfo()"
+>
+  <p>
+    We have updated the application with new features. Review the changes to get started.
+  </p>
 </goab-modal>
 
 <h3>Success callout</h3>
 <goab-button (onClick)="openSuccess()">Open success modal</goab-button>
-<goab-modal heading="Application submitted" [open]="successOpen" [closable]="true" calloutVariant="success" (onClose)="closeSuccess()">
-  <p>Your application has been successfully submitted. You will receive a confirmation email shortly.</p>
+<goab-modal
+  heading="Application submitted"
+  [open]="successOpen"
+  calloutVariant="success"
+  (onClose)="closeSuccess()"
+>
+  <p>
+    Your application has been successfully submitted. You will receive a confirmation
+    email shortly.
+  </p>
 </goab-modal>
 
 <h3>Event callout</h3>
 <goab-button (onClick)="openEvent()">Open event modal</goab-button>
-<goab-modal heading="Scheduled maintenance" [open]="eventOpen" [closable]="true" calloutVariant="event" (onClose)="closeEvent()">
-  <p>The system will be unavailable on March 28 from 10:00 PM to 2:00 AM for scheduled maintenance.</p>
+<goab-modal
+  heading="Scheduled maintenance"
+  [open]="eventOpen"
+  calloutVariant="event"
+  (onClose)="closeEvent()"
+>
+  <p>
+    The system will be unavailable on March 28 from 10:00 PM to 2:00 AM for scheduled
+    maintenance.
+  </p>
 </goab-modal>
 
 <h3>Custom width</h3>
 <goab-button (onClick)="openWide()">Open wide modal</goab-button>
-<goab-modal heading="Wide modal" [open]="wideOpen" maxWidth="80ch" [closable]="true" (onClose)="closeWide()">
+<goab-modal
+  heading="Wide modal"
+  [open]="wideOpen"
+  maxWidth="80ch"
+  (onClose)="closeWide()"
+>
   <p>This modal has a wider maximum width for more content.</p>
 </goab-modal>
 
 <h2>Examples</h2>
 
 <h3>Add another item in a modal</h3>
-<goab-button type="tertiary" leadingIcon="add" (onClick)="toggleAddItemModal()">Add another item</goab-button>
-<goab-modal [open]="addItemOpen" (onClose)="toggleAddItemModal()" heading="Add a new item" [actions]="addItemActions">
+<goab-button type="tertiary" leadingIcon="add" (onClick)="toggleAddItemModal()"
+  >Add another item</goab-button
+>
+<goab-modal
+  [open]="addItemOpen"
+  (onClose)="toggleAddItemModal()"
+  heading="Add a new item"
+  [actions]="addItemActions"
+>
   <p>Fill in the information to create a new item</p>
   <goab-form-item label="Type" mt="l">
     <goab-dropdown (onChange)="updateType($event)" [value]="itemType">
@@ -72,38 +121,76 @@
     </goab-dropdown>
   </goab-form-item>
   <goab-form-item label="Name" mt="l">
-    <goab-input name="name" width="100%" (onChange)="updateName($event)" [value]="itemName"></goab-input>
+    <goab-input
+      name="name"
+      width="100%"
+      (onChange)="updateName($event)"
+      [value]="itemName"
+    ></goab-input>
   </goab-form-item>
   <goab-form-item label="Description" mt="l">
-    <goab-textarea name="description" width="100%" [rows]="3" (onChange)="updateDescription($event)" [value]="itemDescription"></goab-textarea>
+    <goab-textarea
+      name="description"
+      width="100%"
+      [rows]="3"
+      (onChange)="updateDescription($event)"
+      [value]="itemDescription"
+    ></goab-textarea>
   </goab-form-item>
   <ng-template #addItemActions>
     <goab-button-group alignment="end">
-      <goab-button type="tertiary" size="compact" (onClick)="toggleAddItemModal()">Cancel</goab-button>
-      <goab-button type="primary" size="compact" (onClick)="toggleAddItemModal()">Save new item</goab-button>
+      <goab-button type="tertiary" size="compact" (onClick)="toggleAddItemModal()"
+        >Cancel</goab-button
+      >
+      <goab-button type="primary" size="compact" (onClick)="toggleAddItemModal()"
+        >Save new item</goab-button
+      >
     </goab-button-group>
   </ng-template>
 </goab-modal>
 
 <h3>Confirm a destructive action</h3>
-<goab-button type="tertiary" leadingIcon="trash" (onClick)="toggleDeleteModal()">Delete record</goab-button>
-<goab-modal [open]="deleteOpen" (onClose)="toggleDeleteModal()" heading="Are you sure you want to delete this record?" [actions]="deleteActions">
+<goab-button type="tertiary" leadingIcon="trash" (onClick)="toggleDeleteModal()"
+  >Delete record</goab-button
+>
+<goab-modal
+  [open]="deleteOpen"
+  (onClose)="toggleDeleteModal()"
+  heading="Are you sure you want to delete this record?"
+  [actions]="deleteActions"
+>
   <p>This action cannot be undone.</p>
   <ng-template #deleteActions>
     <goab-button-group alignment="end">
-      <goab-button type="tertiary" size="compact" (onClick)="toggleDeleteModal()">Cancel</goab-button>
-      <goab-button type="primary" variant="destructive" size="compact" (onClick)="toggleDeleteModal()">Delete record</goab-button>
+      <goab-button type="tertiary" size="compact" (onClick)="toggleDeleteModal()"
+        >Cancel</goab-button
+      >
+      <goab-button
+        type="primary"
+        variant="destructive"
+        size="compact"
+        (onClick)="toggleDeleteModal()"
+        >Delete record</goab-button
+      >
     </goab-button-group>
   </ng-template>
 </goab-modal>
 
 <h3>Confirm before navigating away</h3>
 <goab-button (onClick)="openNavigate()">Open</goab-button>
-<goab-modal [open]="navigateOpen" heading="Are you sure you want to change route?" [actions]="navigateActions">
+<goab-modal
+  [open]="navigateOpen"
+  heading="Are you sure you want to change route?"
+  [actions]="navigateActions"
+>
   <ng-template #navigateActions>
     <goab-button-group alignment="end">
-      <goab-button type="secondary" size="compact" (onClick)="closeNavigate()">Cancel</goab-button>
-      <goab-button type="primary" size="compact" (onClick)="onChangeRoute()">Change route</goab-button>
+      <goab-button type="secondary" size="compact" (onClick)="closeNavigate()"
+        >Cancel</goab-button
+      >
+      <goab-button type="primary" size="compact" (onClick)="onChangeRoute()"
+        >Change route</goab-button
+      >
     </goab-button-group>
   </ng-template>
 </goab-modal>
@@ -114,12 +201,17 @@
   [open]="requireOpen"
   (onClose)="toggleRequireModal()"
   heading="Are you sure you want to continue?"
-  [actions]="requireActions">
+  [actions]="requireActions"
+>
   <p>You cannot return to this page.</p>
   <ng-template #requireActions>
     <goab-button-group alignment="end">
-      <goab-button type="secondary" size="compact" (onClick)="toggleRequireModal()">Back</goab-button>
-      <goab-button type="primary" size="compact" (onClick)="toggleRequireModal()">Continue</goab-button>
+      <goab-button type="secondary" size="compact" (onClick)="toggleRequireModal()"
+        >Back</goab-button
+      >
+      <goab-button type="primary" size="compact" (onClick)="toggleRequireModal()"
+        >Continue</goab-button
+      >
     </goab-button-group>
   </ng-template>
 </goab-modal>

--- a/apps/prs/angular/src/routes/docs/modal/modal.component.ts
+++ b/apps/prs/angular/src/routes/docs/modal/modal.component.ts
@@ -1,7 +1,13 @@
 import { Component } from "@angular/core";
 import {
-  GoabButton, GoabButtonGroup, GoabDropdown, GoabDropdownItem,
-  GoabFormItem, GoabInput, GoabModal, GoabTextArea,
+  GoabButton,
+  GoabButtonGroup,
+  GoabDropdown,
+  GoabDropdownItem,
+  GoabFormItem,
+  GoabInput,
+  GoabModal,
+  GoabTextArea,
 } from "@abgov/angular-components";
 
 @Component({
@@ -9,8 +15,14 @@ import {
   selector: "abgov-docs-modal",
   templateUrl: "./modal.component.html",
   imports: [
-    GoabButton, GoabButtonGroup, GoabDropdown, GoabDropdownItem,
-    GoabFormItem, GoabInput, GoabModal, GoabTextArea,
+    GoabButton,
+    GoabButtonGroup,
+    GoabDropdown,
+    GoabDropdownItem,
+    GoabFormItem,
+    GoabInput,
+    GoabModal,
+    GoabTextArea,
   ],
 })
 export class DocsModalComponent {
@@ -31,44 +43,97 @@ export class DocsModalComponent {
   deleteOpen = false;
   navigateOpen = false;
   requireOpen = false;
+  closableModal = false;
 
-  openBasic(): void { this.basicOpen = true; }
-  closeBasic(): void { this.basicOpen = false; }
+  openBasic(): void {
+    this.basicOpen = true;
+  }
+  closeBasic(): void {
+    this.basicOpen = false;
+  }
 
-  openDismissable(): void { this.dismissableOpen = true; }
-  closeDismissable(): void { this.dismissableOpen = false; }
+  openDismissable(): void {
+    this.dismissableOpen = true;
+  }
+  closeDismissable(): void {
+    this.dismissableOpen = false;
+  }
 
-  openDestructive(): void { this.destructiveOpen = true; }
-  closeDestructive(): void { this.destructiveOpen = false; }
+  openDestructive(): void {
+    this.destructiveOpen = true;
+  }
+  closeDestructive(): void {
+    this.destructiveOpen = false;
+  }
 
-  openImportant(): void { this.importantOpen = true; }
-  closeImportant(): void { this.importantOpen = false; }
+  openImportant(): void {
+    this.importantOpen = true;
+  }
+  closeImportant(): void {
+    this.importantOpen = false;
+  }
 
-  openInfo(): void { this.infoOpen = true; }
-  closeInfo(): void { this.infoOpen = false; }
+  openInfo(): void {
+    this.infoOpen = true;
+  }
+  closeInfo(): void {
+    this.infoOpen = false;
+  }
 
-  openSuccess(): void { this.successOpen = true; }
-  closeSuccess(): void { this.successOpen = false; }
+  openSuccess(): void {
+    this.successOpen = true;
+  }
+  closeSuccess(): void {
+    this.successOpen = false;
+  }
 
-  openEvent(): void { this.eventOpen = true; }
-  closeEvent(): void { this.eventOpen = false; }
+  openEvent(): void {
+    this.eventOpen = true;
+  }
+  closeEvent(): void {
+    this.eventOpen = false;
+  }
 
-  openWide(): void { this.wideOpen = true; }
-  closeWide(): void { this.wideOpen = false; }
+  openWide(): void {
+    this.wideOpen = true;
+  }
+  closeWide(): void {
+    this.wideOpen = false;
+  }
 
-  toggleAddItemModal(): void { this.addItemOpen = !this.addItemOpen; }
-  updateType(event: any): void { this.itemType = event.value; }
-  updateName(event: any): void { this.itemName = event.value; }
-  updateDescription(event: any): void { this.itemDescription = event.value; }
+  toggleAddItemModal(): void {
+    this.addItemOpen = !this.addItemOpen;
+  }
+  updateType(event: any): void {
+    this.itemType = event.value;
+  }
+  updateName(event: any): void {
+    this.itemName = event.value;
+  }
+  updateDescription(event: any): void {
+    this.itemDescription = event.value;
+  }
 
-  toggleDeleteModal(): void { this.deleteOpen = !this.deleteOpen; }
+  toggleDeleteModal(): void {
+    this.deleteOpen = !this.deleteOpen;
+  }
 
-  openNavigate(): void { this.navigateOpen = true; }
-  closeNavigate(): void { this.navigateOpen = false; }
+  openNavigate(): void {
+    this.navigateOpen = true;
+  }
+  closeNavigate(): void {
+    this.navigateOpen = false;
+  }
   onChangeRoute(): void {
     this.navigateOpen = false;
     console.log("Navigating to new route...");
   }
 
-  toggleRequireModal(): void { this.requireOpen = !this.requireOpen; }
+  toggleRequireModal(): void {
+    this.requireOpen = !this.requireOpen;
+  }
+
+  toggleClosableModal(): void {
+    this.closableModal = !this.closableModal;
+  }
 }

--- a/docs/generated/component-apis/modal.json
+++ b/docs/generated/component-apis/modal.json
@@ -75,13 +75,6 @@
           "description": "Define the context and colour of the callout modal. It is required when type is set to callout."
         },
         {
-          "name": "closable",
-          "type": "boolean",
-          "required": false,
-          "default": "false",
-          "description": "Show close icon and allow clicking the background to close the modal."
-        },
-        {
           "name": "heading",
           "type": "string | TemplateRef<any>",
           "values": [

--- a/docs/src/data/configurations/modal.ts
+++ b/docs/src/data/configurations/modal.ts
@@ -155,7 +155,7 @@ export const modalConfigurations: ComponentConfigurations = {
         },
         angular: {
           ts: angularModalSetup,
-          template: `<goab-modal heading="Information" [open]="isOpen" [closable]="true" (onClose)="handleClose()">
+          template: `<goab-modal heading="Information" [open]="isOpen" (onClose)="handleClose()">
   <p>You can close this modal with the X button or by clicking the backdrop.</p>
 </goab-modal>`,
         },
@@ -248,7 +248,7 @@ export const modalConfigurations: ComponentConfigurations = {
         },
         angular: {
           ts: angularModalSetup,
-          template: `<goab-modal heading="New features available" [open]="isOpen" [closable]="true" calloutVariant="information" (onClose)="handleClose()">
+          template: `<goab-modal heading="New features available" [open]="isOpen" calloutVariant="information" (onClose)="handleClose()">
   <p>We have updated the application with new features. Review the changes to get started.</p>
 </goab-modal>`,
         },
@@ -272,7 +272,7 @@ export const modalConfigurations: ComponentConfigurations = {
         },
         angular: {
           ts: angularModalSetup,
-          template: `<goab-modal heading="Application submitted" [open]="isOpen" [closable]="true" calloutVariant="success" (onClose)="handleClose()">
+          template: `<goab-modal heading="Application submitted" [open]="isOpen" calloutVariant="success" (onClose)="handleClose()">
   <p>Your application has been successfully submitted. You will receive a confirmation email shortly.</p>
 </goab-modal>`,
         },
@@ -296,7 +296,7 @@ export const modalConfigurations: ComponentConfigurations = {
         },
         angular: {
           ts: angularModalSetup,
-          template: `<goab-modal heading="Wide modal" [open]="isOpen" maxWidth="80ch" [closable]="true" (onClose)="handleClose()">
+          template: `<goab-modal heading="Wide modal" [open]="isOpen" maxWidth="80ch" (onClose)="handleClose()">
   <p>This modal has a wider maximum width for more content.</p>
 </goab-modal>`,
         },

--- a/libs/angular-components/src/lib/components/modal/modal.spec.ts
+++ b/libs/angular-components/src/lib/components/modal/modal.spec.ts
@@ -40,7 +40,7 @@ class TestModalComponent {
   callOutVariant = "information" as GoabModalCalloutVariant;
   role = "alertdialog" as GoabModalRole;
   testId = "testId";
-  closable = true;
+  closable = false;
   transition = "fast" as GoabModalTransition;
   heading = "Modal Heading";
   actions = "Close";
@@ -77,11 +77,42 @@ describe("GoABModal", () => {
     expect(headingContent?.textContent).toContain("Heading");
     expect(modal?.getAttribute("open")).toBe(`${component.open}`);
     expect(modal?.getAttribute("maxwidth")).toBe(component.maxWidth);
-    expect(modal?.getAttribute("closable")).toBe(`${component.closable}`);
+    expect(modal?.getAttribute("closable")).toBe("true");
     expect(modal?.textContent).toContain(component.content);
     expect(modal?.getAttribute("calloutvariant")).toBe(component.callOutVariant);
     expect(modal?.getAttribute("testid")).toBe(component.testId);
     expect(modal?.getAttribute("transition")).toBe(component.transition);
     expect(modal?.getAttribute("role")).toBe(component.role);
   });
+
+  it("should be closable when an onClose handler is provided", () => {
+    const modal = fixture.debugElement.query(By.css("goa-modal")).nativeElement;
+
+    expect(component.closable).toBe(false);
+    expect(modal.getAttribute("closable")).toBe("true");
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [GoabModal],
+  template: `<goab-modal [closable]="true" heading="Modal Heading" />`,
+})
+class TestModalWithoutCloseHandlerComponent {}
+
+describe("GoABModal without an onClose handler", () => {
+  it("should not be closable when the compatibility input is supplied", fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [TestModalWithoutCloseHandlerComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestModalWithoutCloseHandlerComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const modal = fixture.debugElement.query(By.css("goa-modal")).nativeElement;
+    expect(modal.getAttribute("closable")).toBe("false");
+  }));
 });

--- a/libs/angular-components/src/lib/components/modal/modal.ts
+++ b/libs/angular-components/src/lib/components/modal/modal.ts
@@ -29,7 +29,7 @@ import { NgTemplateOutlet } from "@angular/common";
         [attr.maxwidth]="maxWidth"
         [attr.testid]="testId"
         [attr.role]="role"
-        [attr.closable]="closable"
+        [attr.closable]="onClose.observed ? 'true' : 'false'"
         [attr.transition]="transition"
         [attr.heading]="getHeadingAsString()"
         (_close)="_onClose($event)"
@@ -74,7 +74,10 @@ export class GoabModal implements OnInit {
   @Input({ transform: booleanAttribute }) open?: boolean;
   /** Set the max allowed width of the modal. */
   @Input() maxWidth?: string;
-  /** Show close icon and allow clicking the background to close the modal. */
+  /**
+   * @deprecated The modal is closable when an onClose handler is provided.
+   * This input is retained for backwards compatibility and has no effect.
+   */
   @Input() closable = false;
   /** Sets the animation transition when opening/closing. 'fast' or 'slow' for animated, 'none' for instant. */
   @Input() transition?: GoabModalTransition;


### PR DESCRIPTION
# Before (the change)

The `closable` property had to be provided for an Angular modal to be closable. Whereas with React modal's, you only had to provide the `onClose` event.

# After (the change)

Angular now aligns with React's Modal component, if you provide an `onClose` event, it is now automatically `closable`.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use the Modal docs PR, all examples have been updated to remove the use of `closable`
