### PR TITLE
fix(#3447): Updated margins to work with none

### DIFF
--- a/apps/prs/angular/src/routes/bugs/3447/bug3447.component.html
+++ b/apps/prs/angular/src/routes/bugs/3447/bug3447.component.html
@@ -1,0 +1,55 @@
+<goab-block direction="column" gap="l">
+  <goab-text tag="h1">Bug 3447: Browser styling for p tags</goab-text>
+
+  <goab-link trailingIcon="open">
+    <a
+      href="https://github.com/GovAlta/ui-components/issues/3447"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      View on GitHub
+    </a>
+  </goab-link>
+
+  <goab-text tag="p">
+    When GoabText renders a paragraph, setting mt or mb to none should explicitly apply a
+    zero margin and override the browser's default paragraph styling.
+  </goab-text>
+
+  <goab-divider />
+
+  <goab-text tag="h3">1. Margins set to s</goab-text>
+  <goab-text tag="p" mt="none" mb="m">
+    The paragraph should have small top and bottom margins between the dividers.
+  </goab-text>
+  <goab-container mb="none">
+    <goab-divider mt="none" mb="none" />
+    <goab-text tag="p" mt="s" mb="s">
+      Paragraph with mt=&quot;s&quot; and mb=&quot;s&quot;
+    </goab-text>
+    <goab-divider mt="none" mb="none" />
+  </goab-container>
+
+  <goab-text tag="h3">2. Margins not set</goab-text>
+  <goab-text tag="p" mt="none" mb="m">
+    The paragraph should use the Text component defaults: s on top and l on the bottom.
+  </goab-text>
+  <goab-container mb="none">
+    <goab-divider mt="none" mb="none" />
+    <goab-text tag="p">Paragraph without mt or mb</goab-text>
+    <goab-divider mt="none" mb="none" />
+  </goab-container>
+
+  <goab-text tag="h3">3. Margins set to none</goab-text>
+  <goab-text tag="p" mt="none" mb="m">
+    The paragraph should touch both dividers because none resolves to zero and overrides
+    the browser's native 1em paragraph margins.
+  </goab-text>
+  <goab-container mb="none">
+    <goab-divider mt="none" mb="none" />
+    <goab-text tag="p" mt="none" mb="none">
+      Paragraph with mt=&quot;none&quot; and mb=&quot;none&quot;
+    </goab-text>
+    <goab-divider mt="none" mb="none" />
+  </goab-container>
+</goab-block>

--- a/apps/prs/angular/src/routes/bugs/3447/bug3447.component.ts
+++ b/apps/prs/angular/src/routes/bugs/3447/bug3447.component.ts
@@ -1,0 +1,17 @@
+import { Component } from "@angular/core";
+
+import {
+  GoabBlock,
+  GoabContainer,
+  GoabDivider,
+  GoabLink,
+  GoabText,
+} from "@abgov/angular-components";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug3447",
+  templateUrl: "./bug3447.component.html",
+  imports: [GoabBlock, GoabContainer, GoabDivider, GoabLink, GoabText],
+})
+export class Bug3447Component {}

--- a/apps/prs/angular/src/routes/bugs/3447/bug3447.route.json
+++ b/apps/prs/angular/src/routes/bugs/3447/bug3447.route.json
@@ -1,0 +1,6 @@
+{
+  "title": "Browser styling for p tags",
+  "path": "bugs/3447",
+  "id": "3447",
+  "type": "bug"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug3447.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug3447.route.ts
@@ -1,0 +1,10 @@
+import { Bug3447Route } from "../../../routes/bugs/bug3447";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "3447",
+  path: "bugs/3447",
+  title: "Browser styling for p tags",
+  component: Bug3447Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug3447.tsx
+++ b/apps/prs/react/src/routes/bugs/bug3447.tsx
@@ -1,0 +1,70 @@
+import {
+  GoabBlock,
+  GoabContainer,
+  GoabDivider,
+  GoabLink,
+  GoabText,
+} from "@abgov/react-components";
+
+export function Bug3447Route() {
+  return (
+    <GoabBlock direction="column" gap="l">
+      <GoabText tag="h1">Bug 3447: Browser styling for p tags</GoabText>
+
+      <GoabLink trailingIcon="open">
+        <a
+          href="https://github.com/GovAlta/ui-components/issues/3447"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View on GitHub
+        </a>
+      </GoabLink>
+
+      <GoabText tag="p">
+        When GoabText renders a paragraph, setting mt or mb to none should explicitly
+        apply a zero margin and override the browser&apos;s default paragraph styling.
+      </GoabText>
+
+      <GoabDivider />
+
+      <GoabText tag="h3">1. Margins set to s</GoabText>
+      <GoabText tag="p" mt="none" mb="m">
+        The paragraph should have small top and bottom margins between the dividers.
+      </GoabText>
+      <GoabContainer mb="none">
+        <GoabDivider mt="none" mb="none" />
+        <GoabText tag="p" mt="s" mb="s">
+          Paragraph with mt=&quot;s&quot; and mb=&quot;s&quot;
+        </GoabText>
+        <GoabDivider mt="none" mb="none" />
+      </GoabContainer>
+
+      <GoabText tag="h3">2. Margins not set</GoabText>
+      <GoabText tag="p" mt="none" mb="m">
+        The paragraph should use the Text component defaults: s on top and l on the
+        bottom.
+      </GoabText>
+      <GoabContainer mb="none">
+        <GoabDivider mt="none" mb="none" />
+        <GoabText tag="p">Paragraph without mt or mb</GoabText>
+        <GoabDivider mt="none" mb="none" />
+      </GoabContainer>
+
+      <GoabText tag="h3">3. Margins set to none</GoabText>
+      <GoabText tag="p" mt="none" mb="m">
+        The paragraph should touch both dividers because none resolves to zero and
+        overrides the browser&apos;s native 1em paragraph margins.
+      </GoabText>
+      <GoabContainer mb="none">
+        <GoabDivider mt="none" mb="none" />
+        <GoabText tag="p" mt="none" mb="none">
+          Paragraph with mt=&quot;none&quot; and mb=&quot;none&quot;
+        </GoabText>
+        <GoabDivider mt="none" mb="none" />
+      </GoabContainer>
+    </GoabBlock>
+  );
+}
+
+export default Bug3447Route;

--- a/libs/web-components/src/common/styling.spec.ts
+++ b/libs/web-components/src/common/styling.spec.ts
@@ -29,4 +29,22 @@ describe("Styling", () => {
     expect(val).not.toContain("margin-bottom");
     expect(val).not.toContain("margin-left");
   });
+
+  it("should create zero margins when set to none", () => {
+    const val = calculateMargin("none", "none", "none", "none");
+
+    expect(val).toContain("margin-top:var(--goa-space-none);");
+    expect(val).toContain("margin-right:var(--goa-space-none);");
+    expect(val).toContain("margin-bottom:var(--goa-space-none);");
+    expect(val).toContain("margin-left:var(--goa-space-none);");
+  });
+
+  it("should convert numeric spacing aliases", () => {
+    const val = calculateMargin("1", "2", "3", "0");
+
+    expect(val).toContain("margin-top:var(--goa-space-3xs);");
+    expect(val).toContain("margin-right:var(--goa-space-2xs);");
+    expect(val).toContain("margin-bottom:var(--goa-space-xs);");
+    expect(val).toContain("margin-left:var(--goa-space-none);");
+  });
 });

--- a/libs/web-components/src/common/styling.ts
+++ b/libs/web-components/src/common/styling.ts
@@ -55,7 +55,7 @@ const conversions: Record<string, TShirtSpacing> = {
  * Allow for 0-10 values to be used along side the existing Spacing values
  */
 function convertSpacing(size: Spacing): Spacing {
-  if (!size) return "none";
+  if (size === null) return null;
   if (!Number.isInteger(+size)) {
     return size;
   }
@@ -85,10 +85,10 @@ export function calculateMargin(
   ml = convertSpacing(ml);
   mr = convertSpacing(mr);
   return [
-    mt && mt !== "none" && `margin-top:var(--goa-space-${mt});` || "",
-    mr && mr !== "none" && `margin-right:var(--goa-space-${mr});` || "",
-    mb && mb !== "none" && `margin-bottom:var(--goa-space-${mb});` || "",
-    ml && ml !== "none" && `margin-left:var(--goa-space-${ml});` || "",
+    mt ? `margin-top:var(--goa-space-${mt});` : "",
+    mr ? `margin-right:var(--goa-space-${mr});` : "",
+    mb ? `margin-bottom:var(--goa-space-${mb});` : "",
+    ml ? `margin-left:var(--goa-space-${ml});` : "",
   ].join(" ").trim();
 }
 


### PR DESCRIPTION
# After (the change)

You can now use "none" for the properties `mt`, `mr`, `mb`, and `ml`, and it will actually calculate none or 0rem instead of just not outputting a margin. This allows people to actually set no margin, and have that override actual browser styles.

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use PR bug3447 for both Angular and React
