### PR TITLE
fix(#4243): Removed hidden field from generated MCP and Markdown records

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,6 +150,7 @@ relatedComponents: [button-group, icon-button]
 figmaUrl: https://www.figma.com/...
 hidden: true # optional — hide from nav (used for subcomponents, deprecated, internal)
 subcomponent: true # optional — show API on parent component page
+internal: true # optional — rendered inside other components, not for direct use (included in the generated data)
 hideTabs: [examples] # optional, hide tabs on this page (examples, usage, accessibility); Properties always shows
 ---
 ```
@@ -157,6 +158,8 @@ hideTabs: [examples] # optional, hide tabs on this page (examples, usage, access
 The MDX body is usually empty. Any content you add appears at the bottom of the "Usage guidelines" tab.
 
 **Subcomponents:** Some components are children that developers compose with a parent (e.g., Tab inside Tabs, Footer Nav Section inside Footer). These have `hidden: true` (not in nav) and `subcomponent: true` (API shown on parent page). The parent discovers subcomponents via its `relatedComponents` array. See "Add a subcomponent" below for how this works.
+
+**Internal components:** A few components exist only to be rendered inside other components (Calendar inside DatePicker, Focus Trap inside Modal and Drawer, Spinner inside Circular Progress). These have `hidden: true` and `internal: true`. Unlike `hidden`, which is a docs site concern, `internal` travels into the generated MCP and Markdown data so AI tools know these components are not for direct use.
 
 ### Guidance (`src/content/guidance/*.mdx`)
 

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -34,6 +34,7 @@ const components = defineCollection({
     // Visibility
     hidden: z.boolean().optional(), // Hide from navigation and public views
     subcomponent: z.boolean().optional(), // Show API on parent component page
+    internal: z.boolean().optional(), // Rendered inside other components; not for direct use
     hideTabs: z
       .array(z.enum(["examples", "usage", "accessibility"]))
       .optional(), // Hide specific tabs on this component's page

--- a/docs/src/content/components/calendar.mdx
+++ b/docs/src/content/components/calendar.mdx
@@ -4,6 +4,7 @@ description: Visual calendar for date selection.
 status: stable
 category: utilities
 hidden: true
+internal: true
 relatedComponents:
   - date-picker
 ---

--- a/docs/src/content/components/focus-trap.mdx
+++ b/docs/src/content/components/focus-trap.mdx
@@ -4,5 +4,6 @@ description: Trap focus within a container for accessibility.
 status: stable
 category: utilities
 hidden: true
+internal: true
 
 ---

--- a/docs/src/content/components/pages.mdx
+++ b/docs/src/content/components/pages.mdx
@@ -4,5 +4,6 @@ description: Container for paginated content views.
 status: stable
 category: structure-and-navigation
 hidden: true
+subcomponent: true
 
 ---

--- a/docs/src/content/components/scrollable.mdx
+++ b/docs/src/content/components/scrollable.mdx
@@ -4,5 +4,6 @@ description: Container with overflow scrolling.
 status: stable
 category: utilities
 hidden: true
+internal: true
 
 ---

--- a/docs/src/content/components/spinner.mdx
+++ b/docs/src/content/components/spinner.mdx
@@ -4,6 +4,7 @@ description: Loading indicator for async operations.
 status: stable
 category: feedback-and-alerts
 hidden: true
+internal: true
 relatedComponents:
   - circular-progress
   - linear-progress

--- a/docs/src/scripts/content-generators/loaders/components.ts
+++ b/docs/src/scripts/content-generators/loaders/components.ts
@@ -24,7 +24,6 @@ export function loadComponents(): ComponentRecord[] {
       aliases: [],
       relatedComponents: asStringArray(data.relatedComponents),
       figmaUrl: asString(data.figmaUrl),
-      hidden: data.hidden === true ? true : undefined,
       subcomponent: data.subcomponent === true ? true : undefined,
       body: body.trim(),
     });

--- a/docs/src/scripts/content-generators/loaders/components.ts
+++ b/docs/src/scripts/content-generators/loaders/components.ts
@@ -25,6 +25,7 @@ export function loadComponents(): ComponentRecord[] {
       relatedComponents: asStringArray(data.relatedComponents),
       figmaUrl: asString(data.figmaUrl),
       subcomponent: data.subcomponent === true ? true : undefined,
+      internal: data.internal === true ? true : undefined,
       body: body.trim(),
     });
   }

--- a/docs/src/scripts/content-generators/loaders/examples.ts
+++ b/docs/src/scripts/content-generators/loaders/examples.ts
@@ -57,7 +57,6 @@ export function loadExamples(): ExampleRecord[] {
       previewImage: asString(data.previewImage),
       figmaUrl: asString(data.figmaUrl),
       accessibilityNotes: asString(data.accessibilityNotes),
-      hidden: data.hidden === true ? true : undefined,
       previewUrl: asString(data.previewUrl),
       reactSourceUrl: asString(data.reactSourceUrl),
       angularSourceUrl: asString(data.angularSourceUrl),

--- a/docs/src/scripts/content-generators/outputs/md-bundle.ts
+++ b/docs/src/scripts/content-generators/outputs/md-bundle.ts
@@ -251,6 +251,7 @@ export function renderComponent(
     ["tags", c.tags],
   ];
   if (c.subcomponent) fm.push(["subcomponent", true]);
+  if (c.internal) fm.push(["internal", true]);
   if (identifier) fm.push([target.frontmatterKey, identifier]);
   if (c.figmaUrl) fm.push(["figma", c.figmaUrl]);
 
@@ -955,6 +956,7 @@ function renderIndex(
       .map((c) => {
         const marks: string[] = [];
         if (c.subcomponent) marks.push("subcomponent");
+        if (c.internal) marks.push("internal");
         if (c.status === "deprecated") marks.push("deprecated");
         const tag = marks.length ? ` (${marks.join(", ")})` : "";
         const desc = c.description ? ` — ${c.description}` : "";

--- a/docs/src/scripts/content-generators/types.ts
+++ b/docs/src/scripts/content-generators/types.ts
@@ -17,6 +17,7 @@ export interface ComponentRecord extends BaseRecord {
   relatedComponents: string[];
   figmaUrl?: string;
   subcomponent?: boolean;
+  internal?: boolean;
   webComponentTag?: string;
   reactClassName?: string;
   angularSelector?: string;

--- a/docs/src/scripts/content-generators/types.ts
+++ b/docs/src/scripts/content-generators/types.ts
@@ -16,7 +16,6 @@ export interface ComponentRecord extends BaseRecord {
   aliases: string[];
   relatedComponents: string[];
   figmaUrl?: string;
-  hidden?: boolean;
   subcomponent?: boolean;
   webComponentTag?: string;
   reactClassName?: string;
@@ -43,7 +42,6 @@ export interface ExampleRecord extends BaseRecord {
   previewImage?: string;
   figmaUrl?: string;
   accessibilityNotes?: string;
-  hidden?: boolean;
   // Page-like fields (page, task, product sizes only)
   previewUrl?: string;
   reactSourceUrl?: string;


### PR DESCRIPTION
Closes #4243.

The content generator was passing a `hidden` flag through to the MCP data and the Markdown bundle. It means "no page in the docs site nav." Arriving in an AI tool under that name with no explanation, assistants read it as "do not use this component" and say so.

Seen in a real session, unprompted, while answering a question about something else:

> There's a separate scrollable component ("Container with overflow scrolling"), but it's flagged `hidden: true` in the catalog, so it isn't for consumption.

For scrollable that conclusion happens to be right. The same inference on dropdown item or tab is wrong, and that is the actual problem: one flag carrying two meanings, with no way for a reader to tell which one it got.

## What hidden was covering

24 files set the flag, and review showed they are not one kind of thing:

| Group | Count | What travels in the AI data after this PR |
|---|---|---|
| Subcomponents people write in their own markup (dropdown item, tab, radio item, the footer and side menu sections) | 15 | `subcomponent: true`, already present and kept |
| Deprecated (chip, link button, form stepper) | 3 | `status: deprecated` |
| Internal, rendered inside a parent component (calendar, focus trap, spinner, scrollable) | 4 | `internal: true`, new in the second commit |
| pages, written directly by people in their own markup | 1 | `subcomponent: true`, was missing, added |
| form, the experimental public form work | 1 | nothing for now |

The first commit stops `hidden` travelling. The second commit, prompted by review, adds the explicit `internal` flag for the four components where "not for direct use" is genuinely true, so removing the ambiguous flag does not silence the one true signal it was accidentally carrying. An assistant that finds nothing invents an answer; one that finds `internal` can point at circular progress instead of spinner.

## What this does not change

Hidden records still ship in both outputs. Only the flags change.

The website is unaffected. The docs site does not read generator output, and the nav and search index read `hidden` from the source frontmatter, which keeps it everywhere it is today. The site does not read the new `internal` field.

## Verified

Both commits regenerated and compared every record against the previous output:

- First commit: 371 records before and after, record sets identical, `hidden` gone from all, `subcomponent` retained on 15, zero other differences
- Second commit: exactly five records change, calendar, focus trap, spinner and scrollable gain `internal: true`, pages gains `subcomponent: true`, zero other differences
- The Markdown bundle index now marks the four as (internal)
- Generator and `extract-api` exit clean, docs tests pass 53 of 53 after each commit
