### PR TITLE
fix(#4249): Updated ScrollPanel to allow for a height attribute

### DIFF
--- a/apps/prs/angular/src/routes/bugs/bug4249/bug4249.component.html
+++ b/apps/prs/angular/src/routes/bugs/bug4249/bug4249.component.html
@@ -1,0 +1,239 @@
+<goab-text tag="h1" mt="m" mb="s">
+  Bug 4249 - Drawer, Modal, and ScrollPanel sizing
+</goab-text>
+<goab-link trailingIcon="open">
+  <a
+    href="https://github.com/GovAlta/ui-components/issues/4249"
+    target="_blank"
+    rel="noopener"
+  >
+    View issue 4249 on GitHub
+  </a>
+</goab-link>
+<goab-text tag="p">
+  Verify content-sized, overflowing, and fixed-height layouts. In scrolling examples, the
+  final numbered row must be reachable while the heading and actions remain visible.
+</goab-text>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<goab-text tag="h2">Drawer examples</goab-text>
+
+<goab-text tag="h3">Content-sized Drawers</goab-text>
+<goab-text tag="p">
+  These should be only as tall as their content. The right Drawer omits its heading, and
+  the bottom Drawer omits its actions.
+</goab-text>
+<goab-block direction="row" gap="s">
+  <goab-button type="secondary" (onClick)="openDrawer('content-left')">
+    Open left
+  </goab-button>
+  <goab-button type="secondary" (onClick)="openDrawer('content-right')">
+    Open right, no heading
+  </goab-button>
+  <goab-button type="secondary" (onClick)="openDrawer('content-bottom')">
+    Open bottom, no actions
+  </goab-button>
+</goab-block>
+
+<goab-text tag="h3" mt="l">Drawers requiring scrolling</goab-text>
+<goab-text tag="p">
+  Each Drawer contains 30 rows. Scroll to row 30 and confirm the page behind the Drawer
+  remains stationary.
+</goab-text>
+<goab-block direction="row" gap="s">
+  <goab-button type="secondary" (onClick)="openDrawer('overflow-left')">
+    Scroll left
+  </goab-button>
+  <goab-button type="secondary" (onClick)="openDrawer('overflow-right')">
+    Scroll right
+  </goab-button>
+  <goab-button type="secondary" (onClick)="openDrawer('overflow-bottom')">
+    Scroll bottom
+  </goab-button>
+</goab-block>
+
+<goab-text tag="h3" mt="l">Drawers with fixed-height content</goab-text>
+<goab-text tag="p">
+  Each Drawer contains an explicitly 18rem-tall body and should size around it.
+</goab-text>
+<goab-block direction="row" gap="s">
+  <goab-button type="secondary" (onClick)="openDrawer('fixed-left')">
+    Fixed left
+  </goab-button>
+  <goab-button type="secondary" (onClick)="openDrawer('fixed-right')">
+    Fixed right
+  </goab-button>
+  <goab-button type="secondary" (onClick)="openDrawer('fixed-bottom')">
+    Fixed bottom
+  </goab-button>
+</goab-block>
+
+@if (drawerExample) {
+  @if (drawerHasActions) {
+    <goab-drawer
+      [open]="true"
+      [position]="drawerPosition"
+      [heading]="drawerHasHeading ? drawerPosition + ' Drawer' : ''"
+      [actions]="drawerActions"
+      (onClose)="closeDrawer()"
+    >
+      <ng-container *ngTemplateOutlet="drawerBody"></ng-container>
+    </goab-drawer>
+  } @else {
+    <goab-drawer
+      [open]="true"
+      [position]="drawerPosition"
+      [heading]="drawerHasHeading ? drawerPosition + ' Drawer' : ''"
+      (onClose)="closeDrawer()"
+    >
+      <ng-container *ngTemplateOutlet="drawerBody"></ng-container>
+    </goab-drawer>
+  }
+}
+
+<ng-template #drawerBody>
+  @if (drawerHasOverflow) {
+    @for (row of overflowRows; track row) {
+      <p>Drawer row {{ row }} - row 30 must be reachable by scrolling.</p>
+    }
+  } @else if (drawerHasFixedContent) {
+    <div style="height: 18rem">
+      <p>This body has a fixed height of 18rem.</p>
+      <p>The Drawer should include the complete body, heading, and actions.</p>
+    </div>
+  } @else {
+    <p>This Drawer should remain content-sized.</p>
+    <p>There should be no unnecessary empty space or scrollbar.</p>
+  }
+</ng-template>
+
+<ng-template #drawerActions>
+  <goab-button-group alignment="end">
+    <goab-button type="primary" (onClick)="closeDrawer()">Done</goab-button>
+  </goab-button-group>
+</ng-template>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<goab-text tag="h2">Modal examples</goab-text>
+<goab-block direction="row" gap="s">
+  <goab-button type="secondary" (onClick)="openModal('content')">
+    Content-sized Modal
+  </goab-button>
+  <goab-button type="secondary" (onClick)="openModal('overflow')">
+    Scrolling Modal
+  </goab-button>
+  <goab-button type="secondary" (onClick)="openModal('fixed')">
+    Fixed-height content
+  </goab-button>
+  <goab-button type="secondary" (onClick)="openModal('missing-slots')">
+    No heading or actions
+  </goab-button>
+</goab-block>
+
+@if (modalExample) {
+  @if (modalExample === "missing-slots") {
+    <goab-modal [open]="true" [closable]="true" (onClose)="closeModal()">
+      <p>This Modal should remain content-sized without heading or action slots.</p>
+    </goab-modal>
+  } @else {
+    <goab-modal
+      [open]="true"
+      [closable]="true"
+      heading="Modal sizing test"
+      [actions]="modalActions"
+      (onClose)="closeModal()"
+    >
+      @if (modalExample === "overflow") {
+        @for (row of overflowRows; track row) {
+          <p>Modal row {{ row }} - row 30 must be reachable by scrolling.</p>
+        }
+      } @else if (modalExample === "fixed") {
+        <div style="height: 18rem">
+          <p>This Modal body has a fixed height of 18rem.</p>
+        </div>
+      } @else {
+        <p>This Modal should remain content-sized.</p>
+        <p>There should be no unnecessary empty space or scrollbar.</p>
+      }
+    </goab-modal>
+  }
+}
+
+<ng-template #modalActions>
+  <goab-button-group alignment="end">
+    <goab-button type="primary" (onClick)="closeModal()">Done</goab-button>
+  </goab-button-group>
+</ng-template>
+
+<goab-divider mt="l" mb="l"></goab-divider>
+
+<goab-text tag="h2">Standalone ScrollPanel examples</goab-text>
+
+<goab-text tag="h3">Content-sized</goab-text>
+<goab-scroll-panel
+  height="auto"
+  [header]="contentPanelHeader"
+  [footer]="contentPanelFooter"
+>
+  <p>This panel uses height="auto" and should fit its short content.</p>
+</goab-scroll-panel>
+<ng-template #contentPanelHeader>
+  <div
+    style="padding: var(--goa-space-m); background-color: var(--goa-color-greyscale-100)"
+  >
+    <strong>Header:</strong> content-sized panel
+  </div>
+</ng-template>
+<ng-template #contentPanelFooter>
+  <div
+    style="padding: var(--goa-space-m); background-color: var(--goa-color-greyscale-200)"
+  >
+    <strong>Footer:</strong> content-sized panel
+  </div>
+</ng-template>
+
+<goab-text tag="h3" mt="l">Fixed height</goab-text>
+<goab-scroll-panel height="18rem" [header]="fixedPanelHeader" [footer]="fixedPanelFooter">
+  @for (row of overflowRows; track row) {
+    <p>Fixed panel row {{ row }}</p>
+  }
+</goab-scroll-panel>
+<ng-template #fixedPanelHeader>
+  <div
+    style="padding: var(--goa-space-m); background-color: var(--goa-color-greyscale-100)"
+  >
+    <strong>Header:</strong> fixed-height panel
+  </div>
+</ng-template>
+<ng-template #fixedPanelFooter>
+  <div
+    style="padding: var(--goa-space-m); background-color: var(--goa-color-greyscale-200)"
+  >
+    <strong>Footer:</strong> fixed-height panel
+  </div>
+</ng-template>
+
+<goab-text tag="h3" mt="l">Missing header and footer</goab-text>
+<goab-scroll-panel height="12rem">
+  @for (row of overflowRows.slice(0, 12); track row) {
+    <p>No-slots row {{ row }}</p>
+  }
+</goab-scroll-panel>
+
+<goab-text tag="h3" mt="l">Horizontal scrolling</goab-text>
+<goab-scroll-panel height="10rem" direction="horizontal">
+  <div
+    style="
+      width: calc(100% + 40rem);
+      display: flex;
+      justify-content: space-between;
+      white-space: nowrap;
+    "
+  >
+    <strong>Start of horizontal content</strong>
+    <span>Middle marker</span>
+    <strong>End of horizontal content</strong>
+  </div>
+</goab-scroll-panel>

--- a/apps/prs/angular/src/routes/bugs/bug4249/bug4249.component.ts
+++ b/apps/prs/angular/src/routes/bugs/bug4249/bug4249.component.ts
@@ -1,0 +1,87 @@
+import { Component } from "@angular/core";
+import { NgTemplateOutlet } from "@angular/common";
+import {
+  GoabBlock,
+  GoabButton,
+  GoabButtonGroup,
+  GoabDivider,
+  GoabDrawer,
+  GoabLink,
+  GoabModal,
+  GoabScrollPanel,
+  GoabText,
+} from "@abgov/angular-components";
+
+type DrawerExample =
+  | "content-left"
+  | "content-right"
+  | "content-bottom"
+  | "overflow-left"
+  | "overflow-right"
+  | "overflow-bottom"
+  | "fixed-left"
+  | "fixed-right"
+  | "fixed-bottom";
+
+type ModalExample = "content" | "overflow" | "fixed" | "missing-slots";
+
+@Component({
+  standalone: true,
+  selector: "abgov-bug4249",
+  templateUrl: "./bug4249.component.html",
+  imports: [
+    GoabBlock,
+    GoabButton,
+    GoabButtonGroup,
+    GoabDivider,
+    GoabDrawer,
+    GoabLink,
+    GoabModal,
+    GoabScrollPanel,
+    GoabText,
+    NgTemplateOutlet,
+  ],
+})
+export class Bug4249Component {
+  drawerExample: DrawerExample | null = null;
+  modalExample: ModalExample | null = null;
+  readonly overflowRows = Array.from({ length: 30 }, (_, index) => index + 1);
+
+  get drawerPosition(): "left" | "right" | "bottom" {
+    if (this.drawerExample?.endsWith("left")) return "left";
+    if (this.drawerExample?.endsWith("bottom")) return "bottom";
+    return "right";
+  }
+
+  get drawerHasHeading(): boolean {
+    return this.drawerExample !== "content-right";
+  }
+
+  get drawerHasActions(): boolean {
+    return this.drawerExample !== "content-bottom";
+  }
+
+  get drawerHasOverflow(): boolean {
+    return this.drawerExample?.startsWith("overflow") ?? false;
+  }
+
+  get drawerHasFixedContent(): boolean {
+    return this.drawerExample?.startsWith("fixed") ?? false;
+  }
+
+  openDrawer(example: DrawerExample): void {
+    this.drawerExample = example;
+  }
+
+  closeDrawer(): void {
+    this.drawerExample = null;
+  }
+
+  openModal(example: ModalExample): void {
+    this.modalExample = example;
+  }
+
+  closeModal(): void {
+    this.modalExample = null;
+  }
+}

--- a/apps/prs/angular/src/routes/bugs/bug4249/bug4249.route.json
+++ b/apps/prs/angular/src/routes/bugs/bug4249/bug4249.route.json
@@ -1,0 +1,6 @@
+{
+  "type": "bug",
+  "id": "4249",
+  "path": "bugs/bug4249",
+  "title": "Scrollable panel sizing"
+}

--- a/apps/prs/react/src/app/routes/bugs/bug4249.route.ts
+++ b/apps/prs/react/src/app/routes/bugs/bug4249.route.ts
@@ -1,0 +1,10 @@
+import { Bug4249Route } from "../../../routes/bugs/bug4249";
+import type { PrRouteDefinition } from "../../route-manifest";
+
+export default {
+  type: "bug",
+  id: "4249",
+  path: "bugs/4249",
+  title: "Scrollable panel sizing",
+  component: Bug4249Route,
+} satisfies PrRouteDefinition;

--- a/apps/prs/react/src/routes/bugs/bug4249.tsx
+++ b/apps/prs/react/src/routes/bugs/bug4249.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import {
+  GoabBlock,
+  GoabButton,
+  GoabButtonGroup,
+  GoabDivider,
+  GoabDrawer,
+  GoabLink,
+  GoabModal,
+  GoabScrollPanel,
+  GoabText,
+} from "@abgov/react-components";
+
+type DrawerExample =
+  | "content-left"
+  | "content-right"
+  | "content-bottom"
+  | "overflow-left"
+  | "overflow-right"
+  | "overflow-bottom"
+  | "fixed-left"
+  | "fixed-right"
+  | "fixed-bottom";
+
+type ModalExample = "content" | "overflow" | "fixed" | "missing-slots";
+
+const overflowRows = Array.from({ length: 30 }, (_, index) => index + 1);
+
+function panelSlot(region: "Header" | "Footer", label: string) {
+  return (
+    <div
+      style={{
+        padding: "var(--goa-space-m)",
+        backgroundColor:
+          region === "Header"
+            ? "var(--goa-color-greyscale-100)"
+            : "var(--goa-color-greyscale-200)",
+      }}
+    >
+      <strong>{region}:</strong> {label}
+    </div>
+  );
+}
+
+export function Bug4249Route() {
+  const [drawerExample, setDrawerExample] = useState<DrawerExample | null>(null);
+  const [modalExample, setModalExample] = useState<ModalExample | null>(null);
+
+  const drawerPosition = drawerExample?.endsWith("left")
+    ? "left"
+    : drawerExample?.endsWith("bottom")
+      ? "bottom"
+      : "right";
+  const drawerHasHeading = drawerExample !== "content-right";
+  const drawerHasActions = drawerExample !== "content-bottom";
+  const drawerHasOverflow = drawerExample?.startsWith("overflow");
+  const drawerHasFixedContent = drawerExample?.startsWith("fixed");
+
+  const closeDrawer = () => setDrawerExample(null);
+  const closeModal = () => setModalExample(null);
+
+  const actions = (close: () => void) => (
+    <GoabButtonGroup alignment="end">
+      <GoabButton type="primary" onClick={close}>
+        Done
+      </GoabButton>
+    </GoabButtonGroup>
+  );
+
+  return (
+    <>
+      <GoabText tag="h1" mt="m" mb="s">
+        Bug 4249 - Drawer, Modal, and ScrollPanel sizing
+      </GoabText>
+      <GoabLink trailingIcon="open">
+        <a
+          href="https://github.com/GovAlta/ui-components/issues/4249"
+          target="_blank"
+          rel="noreferrer"
+        >
+          View issue 4249 on GitHub
+        </a>
+      </GoabLink>
+      <GoabText tag="p">
+        Verify content-sized, overflowing, and fixed-height layouts. In scrolling
+        examples, the final numbered row must be reachable while the heading and actions
+        remain visible.
+      </GoabText>
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Drawer examples</GoabText>
+
+      <GoabText tag="h3">Content-sized Drawers</GoabText>
+      <GoabText tag="p">
+        These should be only as tall as their content. The right Drawer omits its heading,
+        and the bottom Drawer omits its actions.
+      </GoabText>
+      <GoabBlock direction="row" gap="s">
+        <GoabButton type="secondary" onClick={() => setDrawerExample("content-left")}>
+          Open left
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setDrawerExample("content-right")}>
+          Open right, no heading
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setDrawerExample("content-bottom")}>
+          Open bottom, no actions
+        </GoabButton>
+      </GoabBlock>
+
+      <GoabText tag="h3" mt="l">
+        Drawers requiring scrolling
+      </GoabText>
+      <GoabText tag="p">
+        Each Drawer contains 30 rows. Scroll to row 30 and confirm the page behind the
+        Drawer remains stationary.
+      </GoabText>
+      <GoabBlock direction="row" gap="s">
+        <GoabButton type="secondary" onClick={() => setDrawerExample("overflow-left")}>
+          Scroll left
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setDrawerExample("overflow-right")}>
+          Scroll right
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setDrawerExample("overflow-bottom")}>
+          Scroll bottom
+        </GoabButton>
+      </GoabBlock>
+
+      <GoabText tag="h3" mt="l">
+        Drawers with fixed-height content
+      </GoabText>
+      <GoabText tag="p">
+        Each Drawer contains an explicitly 18rem-tall body and should size around it.
+      </GoabText>
+      <GoabBlock direction="row" gap="s">
+        <GoabButton type="secondary" onClick={() => setDrawerExample("fixed-left")}>
+          Fixed left
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setDrawerExample("fixed-right")}>
+          Fixed right
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setDrawerExample("fixed-bottom")}>
+          Fixed bottom
+        </GoabButton>
+      </GoabBlock>
+
+      {drawerExample && (
+        <GoabDrawer
+          open={true}
+          position={drawerPosition}
+          heading={drawerHasHeading ? `${drawerPosition} Drawer` : undefined}
+          actions={drawerHasActions ? actions(closeDrawer) : undefined}
+          onClose={closeDrawer}
+        >
+          {drawerHasOverflow ? (
+            overflowRows.map((row) => (
+              <p key={row}>Drawer row {row} - row 30 must be reachable by scrolling.</p>
+            ))
+          ) : drawerHasFixedContent ? (
+            <div style={{ height: "18rem" }}>
+              <p>This body has a fixed height of 18rem.</p>
+              <p>The Drawer should include the complete body, heading, and actions.</p>
+            </div>
+          ) : (
+            <>
+              <p>This Drawer should remain content-sized.</p>
+              <p>There should be no unnecessary empty space or scrollbar.</p>
+            </>
+          )}
+        </GoabDrawer>
+      )}
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Modal examples</GoabText>
+      <GoabBlock direction="row" gap="s">
+        <GoabButton type="secondary" onClick={() => setModalExample("content")}>
+          Content-sized Modal
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setModalExample("overflow")}>
+          Scrolling Modal
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setModalExample("fixed")}>
+          Fixed-height content
+        </GoabButton>
+        <GoabButton type="secondary" onClick={() => setModalExample("missing-slots")}>
+          No heading or actions
+        </GoabButton>
+      </GoabBlock>
+
+      {modalExample && (
+        <GoabModal
+          open={true}
+          heading={modalExample === "missing-slots" ? undefined : "Modal sizing test"}
+          actions={modalExample === "missing-slots" ? undefined : actions(closeModal)}
+          onClose={closeModal}
+        >
+          {modalExample === "overflow" ? (
+            overflowRows.map((row) => (
+              <p key={row}>Modal row {row} - row 30 must be reachable by scrolling.</p>
+            ))
+          ) : modalExample === "fixed" ? (
+            <div style={{ height: "18rem" }}>
+              <p>This Modal body has a fixed height of 18rem.</p>
+            </div>
+          ) : (
+            <>
+              <p>This Modal should remain content-sized.</p>
+              <p>There should be no unnecessary empty space or scrollbar.</p>
+            </>
+          )}
+        </GoabModal>
+      )}
+
+      <GoabDivider mt="l" mb="l" />
+
+      <GoabText tag="h2">Standalone ScrollPanel examples</GoabText>
+
+      <GoabText tag="h3">Content-sized</GoabText>
+      <GoabScrollPanel
+        height="auto"
+        header={panelSlot("Header", "content-sized panel")}
+        footer={panelSlot("Footer", "content-sized panel")}
+      >
+        <p>This panel uses height=&quot;auto&quot; and should fit its short content.</p>
+      </GoabScrollPanel>
+
+      <GoabText tag="h3" mt="l">
+        Fixed height
+      </GoabText>
+      <GoabScrollPanel
+        height="18rem"
+        header={panelSlot("Header", "fixed-height panel")}
+        footer={panelSlot("Footer", "fixed-height panel")}
+      >
+        {overflowRows.map((row) => (
+          <p key={row}>Fixed panel row {row}</p>
+        ))}
+      </GoabScrollPanel>
+
+      <GoabText tag="h3" mt="l">
+        Missing header and footer
+      </GoabText>
+      <GoabScrollPanel height="12rem">
+        {overflowRows.slice(0, 12).map((row) => (
+          <p key={row}>No-slots row {row}</p>
+        ))}
+      </GoabScrollPanel>
+
+      <GoabText tag="h3" mt="l">
+        Horizontal scrolling
+      </GoabText>
+      <GoabScrollPanel height="10rem" direction="horizontal">
+        <div
+          style={{
+            width: "calc(100% + 40rem)",
+            display: "flex",
+            justifyContent: "space-between",
+            whiteSpace: "nowrap",
+          }}
+        >
+          <strong>Start of horizontal content</strong>
+          <span>Middle marker</span>
+          <strong>End of horizontal content</strong>
+        </div>
+      </GoabScrollPanel>
+    </>
+  );
+}
+
+export default Bug4249Route;

--- a/libs/react-components/specs/drawer.browser.spec.tsx
+++ b/libs/react-components/specs/drawer.browser.spec.tsx
@@ -1,6 +1,7 @@
 import { render } from "vitest-browser-react";
 import { expect, describe, it, vi } from "vitest";
 import { GoabDrawer } from "../src";
+import { page } from "vitest/browser";
 
 describe("Drawer", () => {
   const testId = "DrawerBrowserTestId";
@@ -66,4 +67,62 @@ describe("Drawer", () => {
       });
     });
   });
+
+  it.each(["left", "right"] as const)(
+    "scrolls overflowing content when positioned on the %s",
+    async (position) => {
+      await page.viewport(800, 600);
+      const rows = Array.from({ length: 30 }, (_, i) => i + 1);
+
+      const result = render(
+        <GoabDrawer
+          heading="Scrollable drawer"
+          position={position}
+          open={true}
+          onClose={handleOnClose}
+        >
+          {rows.map((row) => (
+            <p key={row} data-testid={`drawer-row-${row}`}>
+              Drawer row {row} — content that exceeds the viewport height.
+            </p>
+          ))}
+        </GoabDrawer>,
+      );
+
+      const drawerHost = result.baseElement.querySelector("goa-drawer") as HTMLElement;
+
+      await vi.waitFor(() => {
+        const scrollPanel = drawerHost.shadowRoot?.querySelector(
+          "goa-scroll-panel",
+        ) as HTMLElement | null;
+        const scrollContainer = scrollPanel?.shadowRoot?.querySelector(
+          ".scroll-panel-scroll-container",
+        ) as HTMLElement | null;
+        expect(
+          scrollContainer &&
+            scrollContainer.clientHeight > 100 &&
+            scrollContainer.scrollHeight > scrollContainer.clientHeight,
+        ).toBe(true);
+      });
+
+      const scrollPanel = drawerHost.shadowRoot?.querySelector(
+        "goa-scroll-panel",
+      ) as HTMLElement | null;
+      const scrollContainer = scrollPanel?.shadowRoot?.querySelector(
+        ".scroll-panel-scroll-container",
+      ) as HTMLElement | null;
+      if (!scrollContainer) throw new Error("Drawer scroll container was not rendered");
+      const finalRow = result.getByTestId("drawer-row-30");
+
+      scrollContainer.scrollTop =
+        scrollContainer.scrollHeight - scrollContainer.clientHeight;
+
+      await vi.waitFor(() => {
+        expect(scrollContainer.scrollTop).toBeGreaterThan(0);
+        expect(finalRow.element().getBoundingClientRect().bottom).toBeLessThanOrEqual(
+          scrollContainer.getBoundingClientRect().bottom,
+        );
+      });
+    },
+  );
 });

--- a/libs/react-components/specs/modal.browser.spec.tsx
+++ b/libs/react-components/specs/modal.browser.spec.tsx
@@ -9,7 +9,7 @@ import {
   GoabFormItem,
 } from "../src";
 import { expect, describe, it, vi } from "vitest";
-import { page, userEvent } from "@vitest/browser/context";
+import { page, userEvent } from "vitest/browser";
 import { useState } from "react";
 
 describe("Modal", () => {
@@ -141,6 +141,61 @@ describe("Modal", () => {
 
     expect(testLink1.element()).toBeTruthy();
     expect(testLink2.element()).toBeTruthy();
+  });
+
+  it("scrolls overflowing content on mobile", async () => {
+    await page.viewport(375, 600);
+    const rows = Array.from({ length: 30 }, (_, i) => i + 1);
+
+    const result = render(
+      <GoabModal
+        heading="Scrollable modal"
+        open={true}
+        onClose={vi.fn()}
+        testId="mobile-modal"
+      >
+        {rows.map((row) => (
+          <p key={row} data-testid={`modal-row-${row}`}>
+            Modal row {row} — content that exceeds the mobile viewport height.
+          </p>
+        ))}
+      </GoabModal>,
+    );
+
+    const modalHost = result.baseElement.querySelector("goa-modal") as HTMLElement;
+
+    await vi.waitFor(() => {
+      const scrollPanel = modalHost.shadowRoot?.querySelector(
+        "goa-scroll-panel",
+      ) as HTMLElement | null;
+      const scrollContainer = scrollPanel?.shadowRoot?.querySelector(
+        ".scroll-panel-scroll-container",
+      ) as HTMLElement | null;
+      expect(
+        scrollContainer &&
+          scrollContainer.clientHeight > 100 &&
+          scrollContainer.scrollHeight > scrollContainer.clientHeight,
+      ).toBe(true);
+    });
+
+    const scrollPanel = modalHost.shadowRoot?.querySelector(
+      "goa-scroll-panel",
+    ) as HTMLElement | null;
+    const scrollContainer = scrollPanel?.shadowRoot?.querySelector(
+      ".scroll-panel-scroll-container",
+    ) as HTMLElement | null;
+    if (!scrollContainer) throw new Error("Modal scroll container was not rendered");
+    const finalRow = result.getByTestId("modal-row-30");
+
+    scrollContainer.scrollTop =
+      scrollContainer.scrollHeight - scrollContainer.clientHeight;
+
+    await vi.waitFor(() => {
+      expect(scrollContainer.scrollTop).toBeGreaterThan(0);
+      expect(finalRow.element().getBoundingClientRect().bottom).toBeLessThanOrEqual(
+        scrollContainer.getBoundingClientRect().bottom,
+      );
+    });
   });
 
   it("should allow dropdown selection within a modal", async () => {

--- a/libs/web-components/src/components/drawer/Drawer.svelte
+++ b/libs/web-components/src/components/drawer/Drawer.svelte
@@ -57,6 +57,14 @@
   // ========
   $: _showCloseButton = closeButtonVisibility !== "hidden";
   $: maxsize = maxsize || (position === "bottom" ? "80vh" : "320px");
+  $: _scrollPanelMaxHeight =
+    version === "2"
+      ? position === "bottom"
+        ? `min(${maxsize}, calc(100vh - var(--goa-drawer-offset, 0px) - var(--goa-drawer-offset, 0px)))`
+        : position === "left" || position === "right"
+          ? "calc(100vh - var(--goa-drawer-offset, 0px) - var(--goa-drawer-offset, 0px))"
+          : undefined
+      : undefined;
   $: _flyParams = {
     duration: 200,
     x: position === "right" ? 200 : position === "left" ? -200 : 0,
@@ -148,7 +156,7 @@
           position === "bottom"
             ? "unset"
             : version === "2"
-              ? `min(${maxsize}, calc(100vw - 2 * var(--goa-drawer-offset, 0)))`
+              ? `min(${maxsize}, calc(100vw - var(--goa-drawer-offset, 0px) - var(--goa-drawer-offset, 0px)))`
               : `min(${maxsize}, 100vw)`,
         ),
         style(
@@ -156,14 +164,14 @@
           position === "bottom"
             ? "100%"
             : version === "2"
-              ? `min(${maxsize}, calc(100vw - 2 * var(--goa-drawer-offset, 0)))`
+              ? `min(${maxsize}, calc(100vw - var(--goa-drawer-offset, 0px) - var(--goa-drawer-offset, 0px)))`
               : `min(${maxsize}, 100vw)`,
         ),
         style(
           "max-height",
           position === "bottom"
             ? version === "2"
-              ? `min(${maxsize}, calc(100vh - 2 * var(--goa-drawer-offset, 0)))`
+              ? `min(${maxsize}, calc(100vh - var(--goa-drawer-offset, 0px) - var(--goa-drawer-offset, 0px)))`
               : `min(${maxsize}, 100vh)`
             : undefined,
         ),
@@ -184,7 +192,7 @@
       data-first-focus="true"
       aria-labelledby={_showCloseButton ? "goa-drawer-heading" : undefined}
     >
-      <goa-scroll-panel>
+      <goa-scroll-panel maxheight={_scrollPanelMaxHeight}>
         {#if _showCloseButton}
           <div slot="header" class="header" id="goa-drawer-heading">
             {#if heading || $$slots.heading}
@@ -417,7 +425,9 @@
     /* No bottom positioning - allows height: auto to work naturally */
     height: auto;
     /* Max-height accounts for BOTH top and bottom margins (modal stays floating) */
-    max-height: calc(100vh - 2 * var(--goa-drawer-offset, 0));
+    max-height: calc(
+      100vh - var(--goa-drawer-offset, 0px) - var(--goa-drawer-offset, 0px)
+    );
     overflow-y: hidden; /* No scroll on drawer itself */
     border-radius: var(--goa-drawer-border-radius, 24px);
     box-shadow: var(--goa-drawer-shadow);
@@ -456,7 +466,9 @@
     /* No bottom positioning - allows height: auto to work naturally */
     height: auto;
     /* Max-height accounts for BOTH top and bottom margins (modal stays floating) */
-    max-height: calc(100vh - 2 * var(--goa-drawer-offset, 0));
+    max-height: calc(
+      100vh - var(--goa-drawer-offset, 0px) - var(--goa-drawer-offset, 0px)
+    );
     overflow-y: hidden; /* No scroll on drawer itself */
     border-radius: var(--goa-drawer-border-radius, 24px);
     box-shadow: var(--goa-drawer-shadow);

--- a/libs/web-components/src/components/modal/Modal.svelte
+++ b/libs/web-components/src/components/modal/Modal.svelte
@@ -213,7 +213,7 @@
           </div>
         {/if}
         <div class="content">
-          <goa-scroll-panel>
+          <goa-scroll-panel maxheight="calc(100vh - 10rem)">
             <header
               slot="header"
               class:has-content={_headerHasContent}
@@ -471,11 +471,11 @@
     border: none;
   }
 
-  /* Bound the pane so scroll-panel inside has a flex height context. 160px =
-     128px edge margin (64px top + 64px bottom) + 32px (matches the prior V1
+  /* Bound the pane so scroll-panel inside has a flex height context. 10rem =
+     8rem edge margin (4rem top + 4rem bottom) + 2rem (matches the prior V1
      maxheight calc's extra --goa-space-xl term), */
   .modal-pane {
-    max-height: calc(100vh - 160px);
+    max-height: calc(100vh - 10rem);
     overflow: hidden;
   }
 

--- a/libs/web-components/src/components/scroll-panel/ScrollPanel.spec.ts
+++ b/libs/web-components/src/components/scroll-panel/ScrollPanel.spec.ts
@@ -1,11 +1,9 @@
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import GoAScrollPanelWrapper from "./ScrollPanelWrapper.test.svelte";
 import GoAScrollPanel from "./ScrollPanel.svelte";
 import { it, describe, expect, beforeAll, afterEach, vi } from "vitest";
 
-// The node test environment has no `CSS` global, so stub it. Tests drive the
-// branch via mockReturnValue; the real validation runs against the browser's
-// CSS.supports in the browser spec.
+// The node test environment has no `CSS` global, so stub it for sizing fallback.
 const cssSupports = vi.fn().mockReturnValue(true);
 
 beforeAll(() => {
@@ -57,31 +55,35 @@ describe("GoA ScrollPanel", () => {
     expect(el.getAttribute("role")).toBe("region");
   });
 
-  // Validation defers to CSS.supports (stubbed above); the real fallback
-  // behaviour is covered in the browser spec.
-  it("does not log an error when CSS.supports accepts the height", () => {
-    cssSupports.mockReturnValue(true);
-    const errorSpy = vi.spyOn(console, "error").mockReturnValue(undefined);
-    render(GoAScrollPanel, {
-      testid: "panel-valid-height",
-      height: "calc(100vh - 4rem)",
+  it("uses content-driven height when an internal maximum height is provided", async () => {
+    render(GoAScrollPanelWrapper, {
+      height: "100%",
+      maxheight: "20rem",
     });
-    expect(errorSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining("not a valid CSS height"),
-    );
-    errorSpy.mockRestore();
+    const host = document.querySelector("goa-scroll-panel") as HTMLElement;
+
+    await waitFor(() => {
+      expect(host.style.height).toBe("auto");
+      expect(host.style.maxHeight).toBe("20rem");
+    });
   });
 
-  it("logs an error when CSS.supports rejects the height", () => {
+  it("logs invalid heights and falls back to 100%", async () => {
     cssSupports.mockReturnValue(false);
     const errorSpy = vi.spyOn(console, "error").mockReturnValue(undefined);
-    render(GoAScrollPanel, {
-      testid: "panel-invalid-height",
-      height: "not-a-dimension",
+
+    render(GoAScrollPanelWrapper, {
+      height: "not-a-valid-height",
     });
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("not a valid CSS height"),
-    );
+    const host = document.querySelector("goa-scroll-panel") as HTMLElement;
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        'ScrollPanel: "not-a-valid-height" is not a valid CSS height. Falling back to "100%".',
+      );
+      expect(host.style.height).toBe("100%");
+    });
+
     errorSpy.mockRestore();
   });
 });

--- a/libs/web-components/src/components/scroll-panel/ScrollPanel.svelte
+++ b/libs/web-components/src/components/scroll-panel/ScrollPanel.svelte
@@ -27,6 +27,9 @@
    */
   export let height: string = "100%";
 
+  /** @internal Sets a maximum height while allowing the panel to remain content-sized. */
+  export let maxheight: string = "";
+
   /**
    * The scroll direction(s). When content overflows, enables scrolling and shadow
    * indicators for the specified direction(s). Defaults to "vertical".
@@ -44,6 +47,7 @@
     "both",
   ]);
   $: validateDirection(direction);
+  $: if (_hostEl) setHostSizing(height, maxheight);
 
   // Internal edge state, shared by both axes. "at-start" is top/left,
   // "at-end" is bottom/right depending on the axis.
@@ -60,7 +64,9 @@
   };
 
   let _hostEl: HTMLElement | null = null;
+  let _scrollWrapperEl: HTMLElement | null = null;
   let _scrollEl: HTMLElement | null = null;
+  let _isMaxHeightConstrained = false;
   let _scrollStateV: EdgeState = "no-scroll";
   let _scrollStateH: EdgeState = "no-scroll";
   let _isVerticalScrollable: boolean = false;
@@ -95,25 +101,23 @@
   // Hooks
   // *****
   onMount(() => {
-    if (
-      typeof CSS !== "undefined" &&
-      typeof CSS.supports === "function" &&
-      !CSS.supports("height", height)
-    ) {
+    if (!supportsHeight(height)) {
       console.error(
-        `ScrollPanel: "${height}" is not a valid CSS height; falling back to "100%".`,
+        `ScrollPanel: "${height}" is not a valid CSS height. Falling back to "100%".`,
       );
+      height = "100%";
     }
 
     if (_scrollEl) {
       const root = _scrollEl.getRootNode();
       _hostEl = root instanceof ShadowRoot ? (root.host as HTMLElement) : null;
-      setHostHeight(height);
+      setHostSizing(height, maxheight);
 
       // Re-measure when the viewport resizes, including when it goes from
       // hidden (height 0) to visible — e.g. a push drawer toggled via display.
       _resizeObserver = new ResizeObserver(() => updateScrollState());
       _resizeObserver.observe(_scrollEl);
+      if (_scrollWrapperEl) _resizeObserver.observe(_scrollWrapperEl);
     }
     tick().then(() => updateScrollState());
   });
@@ -125,12 +129,24 @@
   // *********
   // Functions
   // *********
-  function setHostHeight(h: string) {
-    if (!_scrollEl) return;
-    const root = _scrollEl.getRootNode();
-    if (root instanceof ShadowRoot) {
-      (root.host as HTMLElement).style.height = h;
-    }
+  function supportsHeight(value: string) {
+    return (
+      typeof CSS === "undefined" ||
+      typeof CSS.supports !== "function" ||
+      CSS.supports("height", value)
+    );
+  }
+
+  function setHostSizing(panelHeight: string, panelMaxHeight: string) {
+    if (!_hostEl) return;
+
+    _hostEl.style.height =
+      panelMaxHeight && panelHeight === "100%"
+        ? _isMaxHeightConstrained
+          ? panelMaxHeight
+          : "auto"
+        : panelHeight;
+    _hostEl.style.maxHeight = panelMaxHeight;
   }
 
   function calculateScrollState(
@@ -174,6 +190,19 @@
 
   function updateScrollState() {
     if (!_scrollEl) return;
+
+    const isMaxHeightConstrained = Boolean(
+      maxheight &&
+      _scrollWrapperEl &&
+      _scrollEl.scrollHeight > _scrollWrapperEl.clientHeight + 1,
+    );
+    if (isMaxHeightConstrained !== _isMaxHeightConstrained) {
+      _isMaxHeightConstrained = isMaxHeightConstrained;
+      setHostSizing(height, maxheight);
+      tick().then(() => updateScrollState());
+      return;
+    }
+
     const {
       scrollTop,
       scrollHeight,
@@ -218,8 +247,13 @@
 
 <div
   class="scroll-panel-scroll-wrapper"
-  class:scroll-panel-scroll-wrapper--shadow-left={_trackHorizontal && _isHorizontallyScrollable && _scrollStateH !== "at-start"}
-  class:scroll-panel-scroll-wrapper--shadow-right={_trackHorizontal && _isHorizontallyScrollable && _scrollStateH !== "at-end"}
+  class:scroll-panel-scroll-wrapper--shadow-left={_trackHorizontal &&
+    _isHorizontallyScrollable &&
+    _scrollStateH !== "at-start"}
+  class:scroll-panel-scroll-wrapper--shadow-right={_trackHorizontal &&
+    _isHorizontallyScrollable &&
+    _scrollStateH !== "at-end"}
+  bind:this={_scrollWrapperEl}
 >
   <div
     class="scroll-panel-scroll-container"
@@ -248,10 +282,14 @@
 {/if}
 
 <style>
-  /* The host element IS the flex container — height is set on it via JS. */
+  /* The host is the grid container; height is set on it via JS. */
   :host {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-areas:
+      "header"
+      "body"
+      "footer";
+    grid-template-rows: auto minmax(0, 1fr) auto;
     overflow: hidden;
     box-sizing: border-box;
     font-family: var(--goa-font-family-sans);
@@ -272,7 +310,7 @@
      above it. Drop shadow (not inset) so it stays visible over slotted content
      that has its own opaque background (e.g. notification cards). */
   .scroll-panel-header {
-    flex: 0 0 auto;
+    grid-area: header;
     background-color: var(
       --goa-scroll-panel-header-color-bg,
       var(--goa-color-greyscale-white)
@@ -305,7 +343,7 @@
 
   /* Scrollable content */
   .scroll-panel-scroll-wrapper {
-    flex: 1 1 auto;
+    grid-area: body;
     position: relative;
     min-height: 0;
     min-width: 0;
@@ -342,8 +380,8 @@
     pointer-events: none;
     z-index: 1;
     opacity: 0;
-    transition:
-      opacity var(--goa-motion-duration-medium-1) var(--goa-motion-curve-expressive);
+    transition: opacity var(--goa-motion-duration-medium-1)
+      var(--goa-motion-curve-expressive);
   }
 
   .scroll-panel-scroll-wrapper::before {
@@ -376,7 +414,7 @@
 
   /* Footer — casts a drop shadow up onto the content when content is below it. */
   .scroll-panel-footer {
-    flex: 0 0 auto;
+    grid-area: footer;
     background-color: var(
       --goa-scroll-panel-footer-color-bg,
       var(--goa-color-greyscale-white)

--- a/libs/web-components/src/components/scroll-panel/ScrollPanelWrapper.test.svelte
+++ b/libs/web-components/src/components/scroll-panel/ScrollPanelWrapper.test.svelte
@@ -5,9 +5,10 @@
   export let content: string = "";
   export let footer: string = "";
   export let height: string = "400px";
+  export let maxheight: string = "";
 </script>
 
-<goa-scroll-panel {height}>
+<goa-scroll-panel {height} {maxheight}>
   {#if header}
     <div slot="header" class="header-content">{header}</div>
   {/if}


### PR DESCRIPTION
# Before (the change)

Previously other components that used GoabScrollPanel had to force their own specific height in order to have scrolling (Scrolling was broken in GoabDrawer and GoabModal).

# After (the change)

Now there's an internal `maxHeight` property for GoabScrollPanel, this can be used by both GoabDrawer and GoabModal in order to set a proper height if scrolling is needed (the component is larger than viewport).

I also updated the Scroll Panel from using `layout: flex` to using `layout: grid` as that made more sense for the actual layout of the component (header, body, footer, always)

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [x] I have created necessary unit tests
- [x] I have tested the functionality in both React and Angular.

## Steps needed to test

Use PR bug4249 for both Angular and React. Make sure you test for both Desktop and Mobile. Feel free to do any other testing you think is good, this hits ScrollPanel, so a lot more vast of a fix than changing GoabDrawer and GoabModal.
