### PR TITLE
fix(#4242): Connect components and examples to each other in the MCP

### DIFF
--- a/libs/design-system-mcp/src/data-loader.ts
+++ b/libs/design-system-mcp/src/data-loader.ts
@@ -86,6 +86,7 @@ export interface SearchOptions {
 export class DataLoader {
   private index = new InvertedIndex();
   private aliasMap = new Map<string, string>(); // lowercase alias -> canonical id
+  private examplesByComponent = new Map<string, string[]>(); // canonical component id -> example ids
   private initialized = false;
 
   async initialize(): Promise<void> {
@@ -102,6 +103,8 @@ export class DataLoader {
     await this.loadFolder(join(dataDir, 'foundations'), 'foundation');
     await this.loadFolder(join(dataDir, 'get-started'), 'get-started');
     await this.loadFolder(join(dataDir, 'productTypes'), 'productType');
+
+    this.buildComponentExampleIndex();
 
     this.initialized = true;
 
@@ -225,20 +228,13 @@ export class DataLoader {
   }
 
   /**
-   * Find component IDs that list this example in their relatedExamples field.
-   * Reverse lookup: examples don't list their components directly, but
-   * components list the examples that use them.
+   * Example ids that use a component, from the reverse index built at load
+   * time. Accepts the component name in any form (see normalizeComponentId).
    */
-  findComponentsRelatedToExample(exampleId: string): string[] {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const components = this.index.getItemsByType('component' as any);
-    return components
-      .filter(
-        (c) =>
-          Array.isArray(c.data.relatedExamples) &&
-          c.data.relatedExamples.includes(exampleId),
-      )
-      .map((c) => c.id);
+  getExamplesForComponent(componentId: string): string[] {
+    return (
+      this.examplesByComponent.get(this.normalizeComponentId(componentId)) ?? []
+    );
   }
 
   /**
@@ -379,6 +375,30 @@ export class DataLoader {
   }
 
   // Private methods
+
+  /**
+   * Build the component -> examples reverse index from each example's
+   * `components` list (the generator records the relationship on the example
+   * side only). Runs once, after all folders are loaded, so alias
+   * registration is complete before ids are normalized.
+   */
+  private buildComponentExampleIndex(): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const examples = this.index.getItemsByType('example' as any);
+    for (const example of examples) {
+      if (!Array.isArray(example.data.components)) continue;
+      for (const ref of example.data.components) {
+        if (typeof ref !== 'string' || ref.length === 0) continue;
+        const componentId = this.normalizeComponentId(ref);
+        const list = this.examplesByComponent.get(componentId);
+        if (!list) {
+          this.examplesByComponent.set(componentId, [example.id]);
+        } else if (!list.includes(example.id)) {
+          list.push(example.id);
+        }
+      }
+    }
+  }
 
   /**
    * Load one collection. Every collection is required: a folder only goes

--- a/libs/design-system-mcp/src/main.ts
+++ b/libs/design-system-mcp/src/main.ts
@@ -352,10 +352,10 @@ function buildGetNext(
     );
   } else if (collection === 'examples') {
     if (
-      Array.isArray(data.relatedPatterns) &&
-      data.relatedPatterns.length > 0
+      Array.isArray(data.relatedExamples) &&
+      data.relatedExamples.length > 0
     ) {
-      suggested_calls.push(`get({ id: '${data.relatedPatterns[0]}' })`);
+      suggested_calls.push(`get({ id: '${data.relatedExamples[0]}' })`);
     }
   }
 
@@ -365,11 +365,13 @@ function buildGetNext(
 /**
  * Build the related block for a get response.
  *
- * For components: relatedComponents and relatedExamples are read directly;
- * guidance ids on the component are resolved against the guidance collection
- * and returned as lightweight summaries so an agent can act without a
- * second round-trip per atom.
- * For examples: components are reverse-looked-up; relatedPatterns surface as examples.
+ * For components: relatedComponents are read directly; examples are
+ * reverse-looked-up from each example's own components list; guidance ids on
+ * the component are resolved against the guidance collection and returned as
+ * lightweight summaries so an agent can act without a second round-trip per
+ * atom.
+ * For examples: components are read directly; relatedExamples surface as
+ * sibling examples.
  */
 function buildGetRelated(
   collection: string,
@@ -392,9 +394,9 @@ function buildGetRelated(
         components.push({ id: cid }),
       );
     }
-    if (Array.isArray(data.relatedExamples)) {
-      data.relatedExamples.forEach((eid: string) => examples.push({ id: eid }));
-    }
+    dataLoader
+      .getExamplesForComponent(id)
+      .forEach((eid) => examples.push({ id: eid }));
     if (Array.isArray(data.relatedGuidance)) {
       for (const gid of data.relatedGuidance) {
         const entry = resolveGuidanceSummary(gid, dataLoader);
@@ -402,11 +404,11 @@ function buildGetRelated(
       }
     }
   } else if (collection === 'examples') {
-    dataLoader
-      .findComponentsRelatedToExample(id)
-      .forEach((cid) => components.push({ id: cid }));
-    if (Array.isArray(data.relatedPatterns)) {
-      data.relatedPatterns.forEach((pid: string) => examples.push({ id: pid }));
+    if (Array.isArray(data.components)) {
+      data.components.forEach((cid: string) => components.push({ id: cid }));
+    }
+    if (Array.isArray(data.relatedExamples)) {
+      data.relatedExamples.forEach((eid: string) => examples.push({ id: eid }));
     }
   }
 


### PR DESCRIPTION
Closes #4242.

Ask the MCP about a component and it says there are no worked examples for it. That is wrong for 50 of the 75 components. Ask about an example and it does not tell you which components the example is built from.

Nothing errors, because a missing field just gives back an empty list. Guidance still resolves, so the answers look complete.

The server and the generator disagree about field names in two places, which leaves four connections dead:

1. Component to its examples. The server looks for a field on the component that the generator never writes.
2. Example to its components. Same missing field, looked up from the other side, so it always comes back empty.
3. Example to related examples. The server looks for relatedPatterns, the generator writes relatedExamples.
4. Example to a suggested next call. Same name mismatch, so asking for an example never suggests anything to look at next.

This is a server side fix only. No generator change, no data change, nothing to regenerate. Every one of the 76 examples already lists the components it uses and nothing was reading it, so that becomes the source of truth and a reverse index built when the data loads gives the other direction. It follows the recommended fix in the issue exactly.

Checked against freshly generated data by driving the server over a real client session, asking for every component and every example:

- 50 of 75 components now return examples, up from 0
- all 271 connections between examples and components are served, up from 0
- all 76 examples now list their components, up from 0
- button returns 38 examples, form item 28, input 16
- the two examples that link to each other now do so in both directions, and each suggests the other as the next call