### PR TITLE
docs(#4283): Point the public form demo links at the template repo

### DIFF
--- a/docs/src/content/productTypes/public-form/index.mdx
+++ b/docs/src/content/productTypes/public-form/index.mdx
@@ -3,7 +3,7 @@ id: public-form
 title: Public form
 summary: For citizen-facing services where users apply for a benefit, request a service, or submit information. Designed around simplicity and low cognitive load, with plain-language questions, focused pages that ask one thing at a time, save-and-resume, and a clear confirmation of what happens next.<br><span style="display:block;height:0.5rem"></span>The reference example is a starting point to expand on, not a rigid template. Adapt it to fit each service's context.
 heroImage: /images/examples/my-applications-page.png
-demoUrl: https://digital-service-demo-v2.netlify.app/
+demoUrl: https://govalta.github.io/goa-public-form-playground/
 tags:
   - form
   - public
@@ -13,7 +13,7 @@ components: []
 status: published
 ---
 
-<goa-button version="2" type="tertiary" mt="s" mb="l" onclick="window.open('https://digital-service-demo-v2.netlify.app/', '_blank')">View demo</goa-button>
+<goa-button version="2" type="tertiary" mt="s" mb="l" onclick="window.open('https://govalta.github.io/goa-public-form-playground/', '_blank')">View demo</goa-button>
 
 import PreviewContainer from "../../../components/PreviewContainer.astro";
 


### PR DESCRIPTION
# Before (the change)

The public form product page points its demo at digital-service-demo-v2.netlify.app, a manual deploy from a personal Netlify account. Both the View demo button on /examples/public-form/ and the full page preview at /examples/public-form/preview/ go there.

# After (the change)

Both point at the template repo's own deploy, https://govalta.github.io/goa-public-form-playground/. It lives in the GoA org and rebuilds from main on every merge, so the demo and the source agree. Same reasoning as #4221 for the workspace side, and this is the last docs reference to a personal Netlify host.

Closes #4283

## Make sure that you've checked the boxes below before you submit the PR

- [x] I have read and followed the [setup steps](https://goa-dio.atlassian.net/wiki/spaces/DS/pages/3086385489/Contribution+-+web+content#%5BinlineExtension%5DCode-contributions)
- [ ] I have created necessary unit tests (content only, no code changed)
- [ ] I have tested the functionality in both React and Angular (not applicable, a docs page)

## Steps needed to test

- Open /examples/public-form/ on the preview and check the View demo button lands on the template's task list
- Open /examples/public-form/preview/ and check the iframe shows the same task list
